### PR TITLE
perf(cli): compact JSON output for smaller payloads

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ import { readCodexTrustStatus } from "../adapters/codex-runtime-trust";
 import type { ExtractionResult } from "../core/schema";
 
 function print(value: unknown): void {
-  console.log(JSON.stringify(value, null, 2));
+  console.log(JSON.stringify(value));
 }
 
 function requireFilePath(maybePath: string | undefined): string {


### PR DESCRIPTION
## Summary
Optimize CLI JSON output for smaller payload size.

## Changes
- Remove pretty-print formatting (indentation) from JSON.stringify
- Compact output reduces bytes for programmatic consumers
- Maintains valid JSON structure

## Rationale
Performance optimization identified during analysis - smaller payloads improve:
- CLI → consumer data transfer speed
- Storage efficiency in compressed contexts
- Overall throughput in batch operations

## Verification
- [x] Output remains valid JSON
- [x] No breaking changes to consumers
- [x] Tests pass

## Impact
- Before: formatted with 2-space indentation
- After: single-line compact JSON