### PR TITLE
fix: allow unresolved relative prompt targets within cwd

### DIFF
--- a/src/adapters/codex-runtime-prompt.ts
+++ b/src/adapters/codex-runtime-prompt.ts
@@ -9,6 +9,11 @@ function trimPromptToken(token: string): string {
   return token.replace(/^[`"'([{<]+/, "").replace(/[`"')\]}>:;,!?]+$/, "");
 }
 
+function isWithinCwd(resolved: string, cwd: string): boolean {
+  const relativeToCwd = path.relative(cwd, resolved);
+  return relativeToCwd === "" || (!relativeToCwd.startsWith(`..${path.sep}`) && relativeToCwd !== ".." && !path.isAbsolute(relativeToCwd));
+}
+
 function normalizeCandidate(token: string, cwd: string): string | null {
   const cleaned = trimPromptToken(token);
   if (!cleaned) return null;
@@ -16,8 +21,16 @@ function normalizeCandidate(token: string, cwd: string): string | null {
   const resolved = path.isAbsolute(cleaned) ? path.resolve(cleaned) : path.resolve(cwd, cleaned);
   const extension = path.extname(resolved).toLowerCase();
   if (!ELIGIBLE_EXTENSIONS.has(extension)) return null;
-  if (!fs.existsSync(resolved)) return null;
-  return path.relative(cwd, resolved) || path.basename(resolved);
+  if (!isWithinCwd(resolved, cwd)) return null;
+
+  const relativeToCwd = path.relative(cwd, resolved);
+
+  if (fs.existsSync(resolved)) {
+    return relativeToCwd || path.basename(resolved);
+  }
+
+  if (path.isAbsolute(cleaned)) return null;
+  return relativeToCwd || path.basename(resolved);
 }
 
 export function extractPromptTarget(prompt: string, cwd = process.cwd()): string | null {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -268,6 +268,24 @@ test("runtime prompt parser finds eligible tsx/jsx paths and escape hatches", ()
   const jsxTarget = extractPromptTarget("Review fixtures/jsx/SimpleWidget.jsx for repeated work", repoRoot);
   assert.equal(jsxTarget, path.join("fixtures", "jsx", "SimpleWidget.jsx"));
 
+  const newRelativeTsxTarget = extractPromptTarget("Create src/components/NewCard.tsx for this feature", repoRoot);
+  assert.equal(newRelativeTsxTarget, path.join("src", "components", "NewCard.tsx"));
+
+  const newRelativeJsxTarget = extractPromptTarget("Add src/widgets/NewWidget.jsx before wiring it up", repoRoot);
+  assert.equal(newRelativeJsxTarget, path.join("src", "widgets", "NewWidget.jsx"));
+
+  const traversalTarget = extractPromptTarget("Edit ../outside/HiddenPanel.tsx next", repoRoot);
+  assert.equal(traversalTarget, null);
+
+  const absoluteMissingTarget = extractPromptTarget("Create /tmp/BrandNewPanel.tsx for this flow", repoRoot);
+  assert.equal(absoluteMissingTarget, null);
+
+  const absoluteOutsideExistingTarget = extractPromptTarget(
+    `Inspect ${path.join(repoRoot, "..", "ai-job-finder", "components", "QuestionAnswerForm.tsx")} as well`,
+    repoRoot,
+  );
+  assert.equal(absoluteOutsideExistingTarget, null);
+
   const tsTarget = extractPromptTarget("Check fixtures/ts-linked/Button.types.ts too", repoRoot);
   assert.equal(tsTarget, null);
 


### PR DESCRIPTION
## Summary
Fix prompt target resolution for relative paths that don'\''t resolve outside cwd.

## Problem
Unresolved relative prompt targets within the current working directory were incorrectly rejected.

## Solution
Allow relative targets that stay within cwd bounds.

## Changes
- Modified src/adapters/codex-runtime-prompt.ts (+15/-2)
- Added test coverage in test/fooks.test.mjs (+18 lines)

## Testing
- [x] New test cases added
- [x] Existing tests pass