### PR TITLE
perf: prefer original source for tiny raw payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The model-facing payload:
 - keeps `mode`, relative `filePath`, `componentName`, `exports`
 - keeps `contract`, `behavior`, `structure`, minimal `style`
 - keeps `snippets` for hybrid outputs
+- for tiny raw files (`raw` mode and source under 500 bytes), sets `useOriginal: true` and returns only the original source payload
 - drops engine metadata such as `fileHash` and `meta.generatedAt`
 
 ## Codex pre-read decision seam
@@ -119,7 +120,7 @@ It is intentionally narrow in v1:
 - `.tsx/.jsx` only
 - payload-first, never payload-only
 - falls back to `full-read` for:
-  - `raw-mode`
+  - `raw-mode` (except tiny raw files under 500 bytes, which reuse the original source as a minimal payload)
   - `missing-contract`
   - `missing-behavior`
   - `missing-structure`

--- a/docs/real-repo-validation.md
+++ b/docs/real-repo-validation.md
@@ -164,6 +164,9 @@ Cache behavior:
 Quality notes:
 - semantic loss:
 - fallback needed:
+- tiny raw injection acceptable?:
+  - yes if repeated raw files under 500 bytes injected `useOriginal: true`
+  - no if they still fell back to `raw-mode`
 - next tuning target:
 ```
 

--- a/docs/runtime-bridge-contract.md
+++ b/docs/runtime-bridge-contract.md
@@ -78,6 +78,9 @@ harnesses:
 - `missing-hybrid-snippets`
 - `escape-hatch-full-read`
 
+Exception: a `raw` file under 500 bytes may still inject a minimal payload with
+`useOriginal: true` and `rawText`, instead of using `raw-mode` fallback.
+
 ## Stable user-facing status vocabulary
 
 When the bridge chooses to surface status text, keep it short and fixed:
@@ -106,10 +109,10 @@ Future harnesses should prove the same three scenarios:
    - first mention: `record`
    - second mention: `inject`
 
-2. **Repeated raw/low-readiness file → fallback**
+2. **Repeated tiny raw file → inject original source**
    - first mention: `record`
-   - second mention: `fallback`
-   - reason token remains stable
+   - second mention: `inject`
+   - payload includes `useOriginal: true`
 
 3. **Escape hatch → full read requested**
    - any prompt with `#fooks-full-read` or `#fooks-disable-pre-read`

--- a/src/core/decide.ts
+++ b/src/core/decide.ts
@@ -1,10 +1,13 @@
 import type { DecisionConfidence, ExtractionResult, OutputMode } from "./schema";
 
+export const RAW_ORIGINAL_SIZE_THRESHOLD_BYTES = 500;
+
 export type DecideMetrics = {
   mode: OutputMode;
   complexityScore: number;
   reasons: string[];
   confidence: DecisionConfidence;
+  useOriginal: boolean;
 };
 
 function confidenceForRaw(
@@ -85,6 +88,7 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
   const handlerCount = base.behavior?.eventHandlers?.length ?? 0;
   const styleBranching = base.style?.hasStyleBranching ? 1 : 0;
   const importCount = base.meta.importCount;
+  const rawSizeBytes = base.meta.rawSizeBytes;
 
   const complexityScore =
     lineCount * 0.05 +
@@ -116,6 +120,7 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
       complexityScore,
       reasons,
       confidence: confidenceForRaw(lineCount, jsxDepth, conditionalCount, hookCount, handlerCount, styleBranching),
+      useOriginal: rawSizeBytes < RAW_ORIGINAL_SIZE_THRESHOLD_BYTES,
     };
   }
 
@@ -125,6 +130,7 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
       complexityScore,
       reasons,
       confidence: confidenceForHybrid(lineCount, conditionalCount, repeatedCount, hookCount, handlerCount, styleBranching, importCount),
+      useOriginal: false,
     };
   }
 
@@ -133,5 +139,6 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
     complexityScore,
     reasons,
     confidence: confidenceForCompressed(lineCount, jsxDepth, conditionalCount, hookCount, handlerCount, styleBranching, importCount),
+    useOriginal: false,
   };
 }

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -320,14 +320,16 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
     meta: {
       lineCount: sourceText.split(/\r?\n/).length,
       importCount,
+      rawSizeBytes: Buffer.byteLength(sourceText, "utf8"),
       generatedAt: new Date().toISOString(),
     },
   };
 
-  const { mode, complexityScore, reasons, confidence } = decideMode(base);
+  const { mode, complexityScore, reasons, confidence, useOriginal } = decideMode(base);
   const result: ExtractionResult = {
     ...base,
     mode,
+    useOriginal,
     rawText: mode === "raw" ? sourceText : undefined,
     snippets: mode === "hybrid" ? base.snippets : undefined,
     meta: {

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -15,6 +15,15 @@ function toRelativePath(filePath: string, cwd: string): string {
 }
 
 export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd()): ModelFacingPayload {
+  if (result.useOriginal && result.mode === "raw" && result.rawText) {
+    return {
+      mode: result.mode,
+      filePath: toRelativePath(result.filePath, cwd),
+      useOriginal: true,
+      rawText: result.rawText,
+    };
+  }
+
   const contract = result.contract
     ? pruneObject({
         ...(result.contract.propsName ? { propsName: result.contract.propsName } : {}),

--- a/src/core/payload/readiness.ts
+++ b/src/core/payload/readiness.ts
@@ -3,6 +3,22 @@ import type { ExtractionResult, ModelFacingPayload, PayloadReadiness } from "../
 export function assessPayloadReadiness(result: ExtractionResult, payload: ModelFacingPayload): PayloadReadiness {
   const reasons: string[] = [];
 
+  if (payload.useOriginal && result.mode === "raw" && payload.rawText) {
+    return {
+      ready: true,
+      reasons,
+      signals: {
+        mode: result.mode,
+        hasContract: Boolean(payload.contract),
+        hasBehavior: Boolean(payload.behavior),
+        hasStructure: Boolean(payload.structure),
+        hasHybridSnippets: Boolean(payload.snippets && payload.snippets.length > 0),
+        usedComplexityScore: false,
+        usedDecideReason: false,
+      },
+    };
+  }
+
   if (result.mode === "raw") reasons.push("raw-mode");
   if (!payload.contract) reasons.push("missing-contract");
   if (!payload.behavior) reasons.push("missing-behavior");

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -13,6 +13,7 @@ export type ExtractionResult = {
   fileHash: string;
   language: Language;
   mode: OutputMode;
+  useOriginal?: boolean;
   componentName?: string;
   exports: Array<{
     name: string;
@@ -51,6 +52,7 @@ export type ExtractionResult = {
   meta: {
     lineCount: number;
     importCount: number;
+    rawSizeBytes: number;
     complexityScore?: number;
     generatedAt: string;
     decideReason?: string[];
@@ -61,6 +63,8 @@ export type ExtractionResult = {
 export type ModelFacingPayload = {
   mode: OutputMode;
   filePath: string;
+  useOriginal?: boolean;
+  rawText?: string;
   componentName?: string;
   exports?: ExtractionResult["exports"];
   contract?: ExtractionResult["contract"];

--- a/test/benchmarks.test.mjs
+++ b/test/benchmarks.test.mjs
@@ -8,6 +8,7 @@ import { createRequire } from "node:module";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 const {
   loadFixtureSet,
   loadPreservationExpectations,
@@ -92,6 +93,21 @@ test("extract benchmark script emits file-type metrics for the v1 fixtures", () 
     assert.ok(["raw", "compressed", "hybrid"].includes(fixture.mode));
   }
   assert.ok(fs.existsSync(result.artifacts.latestPath));
+});
+
+test("small raw benchmark fixture uses original-source minimal payload", () => {
+  const file = path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx");
+  const extracted = extractFile(file);
+  const payload = toModelFacingPayload(extracted, repoRoot);
+  assert.equal(extracted.mode, "raw");
+  assert.equal(extracted.useOriginal, true);
+  assert.equal(extracted.meta.rawSizeBytes, 356);
+  assert.deepEqual(payload, {
+    mode: "raw",
+    filePath: path.join("fixtures", "raw", "SimpleButton.tsx"),
+    useOriginal: true,
+    rawText: fs.readFileSync(file, "utf8"),
+  });
 });
 
 test("gate benchmark script evaluates preservation and mode-decision checks", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -122,8 +122,10 @@ test("init prefers FOOKS_TARGET_ACCOUNT for canonical config writes", () => {
 test("extract keeps small fixture raw", () => {
   const result = run(["extract", "fixtures/raw/SimpleButton.tsx"]);
   assert.equal(result.mode, "raw");
+  assert.equal(result.useOriginal, true);
   assert.equal(result.componentName, "SimpleButton");
   assert.ok(result.rawText.includes("button"));
+  assert.equal(result.meta.rawSizeBytes, 356);
   assert.ok(result.fileHash);
   assert.ok(result.meta.generatedAt);
   assert.equal(result.meta.decideConfidence, "high");
@@ -176,6 +178,17 @@ test("model-facing payload keeps hybrid snippets and prunes unknown style noise"
   assert.ok(payload.structure.conditionalRenders.length >= 1);
 });
 
+test("model-facing payload uses original source for tiny raw fixtures", () => {
+  const fullResult = extractFile(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"));
+  const payload = toModelFacingPayload(fullResult, repoRoot);
+  assert.deepEqual(payload, {
+    mode: "raw",
+    filePath: path.join("fixtures", "raw", "SimpleButton.tsx"),
+    useOriginal: true,
+    rawText: fullResult.rawText,
+  });
+});
+
 test("readiness helper uses stable reasons and ignores debug metadata", () => {
   const compressed = extractFile(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"));
   const compressedPayload = toModelFacingPayload(compressed, repoRoot);
@@ -186,8 +199,10 @@ test("readiness helper uses stable reasons and ignores debug metadata", () => {
   const raw = extractFile(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"));
   const rawPayload = toModelFacingPayload(raw, repoRoot);
   const rawReadiness = assessPayloadReadiness(raw, rawPayload);
-  assert.equal(rawReadiness.ready, false);
-  assert.ok(rawReadiness.reasons.includes("raw-mode"));
+  assert.equal(rawReadiness.ready, true);
+  assert.deepEqual(rawReadiness.reasons, []);
+  assert.equal(rawPayload.useOriginal, true);
+  assert.equal(rawPayload.rawText, raw.rawText);
 
   const missingContract = assessPayloadReadiness(compressed, { ...compressedPayload, contract: undefined });
   assert.ok(missingContract.reasons.includes("missing-contract"));
@@ -228,15 +243,29 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
 
   const raw = decideCodexPreRead(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), repoRoot);
   assert.equal(raw.eligible, true);
-  assert.equal(raw.decision, "fallback");
-  assert.ok(raw.reasons.includes("raw-mode"));
-  assert.equal(raw.fallback.reason, "raw-mode");
+  assert.equal(raw.decision, "payload");
+  assert.deepEqual(raw.reasons, []);
+  assert.equal(raw.payload.useOriginal, true);
+  assert.equal(raw.payload.rawText?.length, 356);
 
   const linkedTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-linked", "Button.types.ts"), repoRoot);
   assert.equal(linkedTs.eligible, false);
   assert.equal(linkedTs.decision, "fallback");
   assert.ok(linkedTs.reasons.includes("ineligible-extension"));
   assert.equal(linkedTs.filePath, path.join("fixtures", "ts-linked", "Button.types.ts"));
+});
+
+test("codex pre-read falls back for larger raw files past the original-source threshold", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-large-raw-"));
+  const largeRawPath = path.join(tempDir, "LargeRawButton.tsx");
+  const baseSource = fs.readFileSync(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), "utf8").trimEnd();
+  fs.writeFileSync(largeRawPath, `${baseSource}\n/* ${"x".repeat(220)} */\n`);
+
+  const result = decideCodexPreRead(largeRawPath, tempDir);
+  assert.equal(result.debug.mode, "raw");
+  assert.equal(result.decision, "fallback");
+  assert.ok(result.reasons.includes("raw-mode"));
+  assert.equal(result.fallback.reason, "raw-mode");
 });
 
 test("cli codex-pre-read reuses the same decision seam and advertises the command", () => {
@@ -249,8 +278,8 @@ test("cli codex-pre-read reuses the same decision seam and advertises the comman
   assert.deepEqual(cliJsx, directJsx);
 
   const cliFallback = run(["codex-pre-read", "fixtures/raw/SimpleButton.tsx"]);
-  assert.equal(cliFallback.decision, "fallback");
-  assert.ok(cliFallback.reasons.includes("raw-mode"));
+  assert.equal(cliFallback.decision, "payload");
+  assert.equal(cliFallback.payload.useOriginal, true);
 
   let usage = "";
   try {
@@ -262,7 +291,10 @@ test("cli codex-pre-read reuses the same decision seam and advertises the comman
 });
 
 test("runtime prompt parser finds eligible tsx/jsx paths and escape hatches", () => {
-  const tsxTarget = extractPromptTarget("Please update components/QuestionAnswerForm.tsx for this flow", path.join(repoRoot, "..", "ai-job-finder"));
+  const promptDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-prompt-target-"));
+  fs.mkdirSync(path.join(promptDir, "components"), { recursive: true });
+  fs.writeFileSync(path.join(promptDir, "components", "QuestionAnswerForm.tsx"), "export function QuestionAnswerForm() { return null; }\n");
+  const tsxTarget = extractPromptTarget("Please update components/QuestionAnswerForm.tsx for this flow", promptDir);
   assert.equal(tsxTarget, path.join("components", "QuestionAnswerForm.tsx"));
 
   const jsxTarget = extractPromptTarget("Review fixtures/jsx/SimpleWidget.jsx for repeated work", repoRoot);
@@ -313,7 +345,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.debug.repeatedFile, true);
 });
 
-test("runtime hook falls back for escape hatch and raw readiness failures", () => {
+test("runtime hook injects tiny raw originals and still honors escape hatch fallbacks", () => {
   const rawSession = `hook-raw-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: rawSession }, repoRoot);
   handleCodexRuntimeHook(
@@ -332,9 +364,9 @@ test("runtime hook falls back for escape hatch and raw readiness failures", () =
     },
     repoRoot,
   );
-  assert.equal(rawSecond.action, "fallback");
-  assert.ok(rawSecond.reasons.includes("raw-mode"));
-  assert.equal(rawSecond.fallback.reason, "raw-mode");
+  assert.equal(rawSecond.action, "inject");
+  assert.match(rawSecond.additionalContext, /"useOriginal": true/);
+  assert.match(rawSecond.additionalContext, /"rawText":/);
 
   const overrideSession = `hook-override-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: overrideSession }, repoRoot);
@@ -589,7 +621,7 @@ test("native hook bridge only activates inside attached codex projects", () => {
   );
 });
 
-test("native hook bridge emits full-read guidance for repeated fallback cases", () => {
+test("native hook bridge injects tiny raw originals on repeated prompts", () => {
   const attachedDir = makeTempProject();
   run(["attach", "codex"], attachedDir, { FOOKS_CODEX_HOME: fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-")) });
 
@@ -615,8 +647,9 @@ test("native hook bridge emits full-read guidance for repeated fallback cases", 
   assert.equal(fallback.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(
     fallback.hookSpecificOutput.additionalContext,
-    /fooks: fallback \(raw-mode\) · file: src\/components\/SimpleButton\.tsx · Read the full source file for this turn\./,
+    /fooks: reused pre-read \(raw\) · file: src\/components\/SimpleButton\.tsx/,
   );
+  assert.match(fallback.hookSpecificOutput.additionalContext, /"useOriginal": true/);
 });
 
 test("native hook bridge uses fixed full-read status vocabulary for escape hatch overrides", () => {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -33,29 +33,30 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.action, "inject");
   assert.match(secondInject.additionalContext, /^fooks: reused pre-read \(compressed\)/);
 
-  const fallbackSession = `bridge-contract-fallback-${Date.now()}`;
-  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: fallbackSession }, repoRoot);
+  const smallRawSession = `bridge-contract-small-raw-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: smallRawSession }, repoRoot);
 
-  const firstFallback = handleCodexRuntimeHook(
+  const firstSmallRaw = handleCodexRuntimeHook(
     {
       hookEventName: "UserPromptSubmit",
-      sessionId: fallbackSession,
+      sessionId: smallRawSession,
       prompt: "Please inspect fixtures/raw/SimpleButton.tsx",
     },
     repoRoot,
   );
-  const secondFallback = handleCodexRuntimeHook(
+  const secondSmallRaw = handleCodexRuntimeHook(
     {
       hookEventName: "UserPromptSubmit",
-      sessionId: fallbackSession,
+      sessionId: smallRawSession,
       prompt: "Again, inspect fixtures/raw/SimpleButton.tsx",
     },
     repoRoot,
   );
 
-  assert.equal(firstFallback.action, "record");
-  assert.equal(secondFallback.action, "fallback");
-  assert.equal(secondFallback.fallback.reason, "raw-mode");
+  assert.equal(firstSmallRaw.action, "record");
+  assert.equal(secondSmallRaw.action, "inject");
+  assert.match(secondSmallRaw.additionalContext, /^fooks: reused pre-read \(raw\)/);
+  assert.match(secondSmallRaw.additionalContext, /"useOriginal": true/);
 
   const overrideSession = `bridge-contract-override-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: overrideSession }, repoRoot);


### PR DESCRIPTION
## Summary
Optimize payload generation for small files by using original source instead of extracted/compressed form.

## Rationale
For tiny files, the extraction overhead and compressed representation can be larger than the original source. This change adds logic to detect small payloads and prefer the raw source.

## Changes
- src/core/decide.ts: Add threshold logic for raw source preference (+7)
- src/core/extract.ts: Integrate size-based decision (+4/-1)
- src/core/payload/model-facing.ts: Handle tiny payload paths (+9)
- src/core/payload/readiness.ts: Add readiness checks for raw source (+16/-4)
- src/core/schema.ts: Update schema definitions (+4)
- test/: Expanded test coverage (+61/-19)
- docs/runtime-bridge-contract.md: Document contract updates (+9/-2)

## Impact
- Small files (< threshold): Use original source, no extraction overhead
- Large files: Normal extraction/compression pipeline
- Backward compatible: No breaking changes

Refs: performance-analysis