### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+- Trolling, insulting/derogatory comments
+- Public or private harassment
+- Publishing others' private information without permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and will take appropriate action in response to any behavior they deem inappropriate.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).


### PR DESCRIPTION
## Summary
Add community Code of Conduct for the fooks project.

## Changes
- +27 lines: CODE_OF_CONDUCT.md
- Based on Contributor Covenant standards
- Clear expectations for community participation

## Test
- npm test: pass ✅