### PR TITLE
Clarify fooks benchmark context policy

### DIFF
--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../account/components/DeleteAccountModal/index.tsx   | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch
@@ -1,0 +1,53 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..041f823 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,19 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const isEmailFormatValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inputValue);
++  const isConfirmationEmailValid = isEmailFormatValid && inputValue === user.email;
++  const showConfirmationEmailError = inputValue.length > 0 && !isConfirmationEmailValid;
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +74,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +118,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={showConfirmationEmailError}
+           />
++          {showConfirmationEmailError && (
++            <p className="mt-2 text-sm text-red-500">
++              {isEmailFormatValid
++                ? t("environments.actions.does_not_exactly_match")
++                : t("auth.verification-requested.invalid_email_address")}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 30 ++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch
@@ -1,0 +1,70 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..aa5569b 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,28 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasInputValue = inputValue.length > 0;
++  const isInputValueValidEmail = isValidEmail(inputValue);
++  const isConfirmationEmailMalformed = hasInputValue && !isInputValueValidEmail;
++  const isConfirmationEmailMismatch =
++    hasInputValue && !isConfirmationEmailMalformed && inputValue !== user.email;
++  const confirmationEmailError = isConfirmationEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : isConfirmationEmailMismatch
++      ? t("auth.invite.email_does_not_match")
++      : "";
++  const isConfirmationEmailValid = isInputValueValidEmail && inputValue === user.email;
++  const isDeleteDisabled = !isConfirmationEmailValid || deleting;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isDeleteDisabled) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +85,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isDeleteDisabled}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +129,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={!!confirmationEmailError}
++            aria-describedby={confirmationEmailError ? "deleteAccountConfirmation-error" : undefined}
++            aria-invalid={!!confirmationEmailError}
+           />
++          {confirmationEmailError && (
++            <p id="deleteAccountConfirmation-error" className="mt-1 text-sm text-red-500">
++              {confirmationEmailError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch
@@ -1,0 +1,64 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..b7cbf2a 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,19 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const isConfirmationEmailMalformed = inputValue.length > 0 && !isValidEmail(inputValue);
++  const isConfirmationEmailValid = isValidEmail(inputValue) && inputValue === user.email;
++  const showConfirmationEmailError = inputValue.length > 0 && !isConfirmationEmailValid;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +76,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +120,21 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={showConfirmationEmailError}
++            aria-describedby={showConfirmationEmailError ? "deleteAccountConfirmationError" : undefined}
+           />
++          {showConfirmationEmailError && (
++            <p id="deleteAccountConfirmationError" className="mt-2 text-sm text-red-600">
++              {isConfirmationEmailMalformed
++                ? t("auth.verification-requested.invalid_email_address")
++                : t("environments.settings.profile.please_enter_email_to_confirm_account_deletion", {
++                    email: user.email,
++                  })}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 28 +++++++++++++++++++---
+ 1 file changed, 25 insertions(+), 3 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch
@@ -1,0 +1,61 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..045ba0f 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,24 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const [isEmailMalformed, setIsEmailMalformed] = useState(false);
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++
++  const isConfirmationEmailValid = inputValue === user.email && !isEmailMalformed;
++  const showInputError = inputValue.length > 0 && !isConfirmationEmailValid;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+-    setInputValue(e.target.value);
++    const value = e.target.value;
++
++    setInputValue(value);
++    setIsEmailMalformed(value.length > 0 && !e.target.validity.valid);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +79,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +123,20 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={showInputError}
++            aria-invalid={showInputError}
++            aria-describedby={showInputError ? "deleteAccountConfirmation-error" : undefined}
+           />
++          {showInputError && (
++            <p className="mt-1 text-sm text-red-500" id="deleteAccountConfirmation-error">
++              {isEmailMalformed
++                ? t("auth.verification-requested.invalid_email_address")
++                : t("environments.actions.does_not_exactly_match")}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch
@@ -1,0 +1,64 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..56aa35d 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,22 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasConfirmationEmail = inputValue.length > 0;
++  const isConfirmationEmailMalformed = hasConfirmationEmail && !isValidEmail(inputValue);
++  const isConfirmationEmailInvalid = isConfirmationEmailMalformed || inputValue !== user.email;
++  const confirmationEmailError = isConfirmationEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : hasConfirmationEmail && isConfirmationEmailInvalid
++      ? t("environments.actions.does_not_exactly_match")
++      : undefined;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isConfirmationEmailInvalid || deleting) return;
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +79,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isConfirmationEmailInvalid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +123,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={!!confirmationEmailError}
++            aria-describedby={confirmationEmailError ? "deleteAccountConfirmation-error" : undefined}
++            isInvalid={!!confirmationEmailError}
+           />
++          {confirmationEmailError && (
++            <p id="deleteAccountConfirmation-error" className="mt-1 text-xs text-red-500">
++              {confirmationEmailError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 25 ++++++++++++++++++++--
+ 1 file changed, 23 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch
@@ -1,0 +1,66 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..d095bf3 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,25 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const [isEmailMalformed, setIsEmailMalformed] = useState(false);
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasInputValue = inputValue.length > 0;
++  const isEmailMismatch = hasInputValue && !isEmailMalformed && inputValue !== user.email;
++  const emailConfirmationError = isEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : isEmailMismatch
++      ? t("auth.invite.email_does_not_match")
++      : undefined;
++  const isDeleteDisabled = deleting || inputValue !== user.email || isEmailMalformed;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
++    setIsEmailMalformed(e.target.validity.typeMismatch);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isDeleteDisabled) return;
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +80,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isDeleteDisabled}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -96,6 +109,7 @@ export const DeleteAccountModal = ({
+         </ul>
+         <form
+           data-testid="deleteAccountForm"
++          noValidate
+           onSubmit={async (e) => {
+             e.preventDefault();
+             await deleteAccount();
+@@ -111,10 +125,17 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={!!emailConfirmationError}
++            aria-describedby={emailConfirmationError ? "deleteAccountConfirmationError" : undefined}
+           />
++          {emailConfirmationError && (
++            <p className="mt-1 text-sm text-red-500" id="deleteAccountConfirmationError">
++              {emailConfirmationError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch
@@ -1,0 +1,38 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..2250f32 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -147,6 +147,11 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
++
++  const handlePasswordKeyEvent = (event: React.KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +243,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => {
++                              field.onBlur();
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch
@@ -1,0 +1,47 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..5bcd4f0 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,18 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => {
++                              field.onBlur();
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p role="alert" aria-live="polite" className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_warning", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../web/modules/auth/login/components/login-form.tsx | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch
@@ -1,0 +1,46 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..ebdc383 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -5,6 +5,7 @@ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+ import { useEffect, useMemo, useRef, useState } from "react";
++import type { KeyboardEvent } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -147,6 +148,11 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
++
++  const updateCapsLockState = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +244,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={updateCapsLockState}
++                            onKeyUp={updateCapsLockState}
++                            onBlur={() => {
++                              setIsCapsLockOn(false);
++                              field.onBlur();
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs font-medium text-red-600">
++                              {t("auth.login.caps_lock_warning", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch
@@ -1,0 +1,34 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..1759680 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -147,6 +147,7 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +239,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={(event) => {
++                              setIsCapsLockOn(event.getModifierState("CapsLock"));
++                            }}
++                            onKeyUp={(event) => {
++                              setIsCapsLockOn(event.getModifierState("CapsLock"));
++                            }}
++                            onBlur={() => {
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p role="status" aria-live="polite" className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch
@@ -1,0 +1,46 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..4e5f5a2 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,17 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch
@@ -1,0 +1,47 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..8a09a68 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,18 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => setIsCapsLockOn(false)}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              className="mt-1 text-left text-xs font-medium text-red-600"
++                              role="status"
++                              aria-live="polite">
++                              {t("auth.login.caps_lock_is_on", "Caps Lock is on")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776325941.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776325941.json
@@ -1,0 +1,1042 @@
+{
+  "timestamp": "2026-04-16T17:15:59.221237",
+  "summary": {
+    "total_benchmarks": 3,
+    "successful_pairs": 3,
+    "vanilla_success": 3,
+    "fooks_success": 3,
+    "same_file_pairs": 3,
+    "avg_token_reduction": 69.01720464251308,
+    "avg_tokens_saved": 714642.3333333334,
+    "median_exec_improvement": -13.695065740563733,
+    "median_total_improvement": -15.784638586206166,
+    "median_runtime_token_reduction": 3.8182079781302827,
+    "runtime_token_reductions": [
+      14.861176103571985,
+      3.8182079781302827,
+      -14.514797576183366
+    ],
+    "acceptance_pairs": [
+      {
+        "iteration": 1,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 8,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": false
+            },
+            {
+              "name": "aria_describedby",
+              "passed": false
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 2,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 3,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    },
+    "artifactCapture": {
+      "scope": "git diff patch, git diff --stat, git diff --check, changed file list, task-specific acceptance score when available.",
+      "purpose": "Separate output parity and quality evidence from runtime/token measurements."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "medium",
+        "evidence": "3 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "artifact_quality",
+        "level": "high",
+        "evidence": "acceptance_scored_pairs=3, fooks_lower_score_pairs=1",
+        "interpretation": "Output parity matters as much as time/token deltas; inspect captured patches when fooks scores lower."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "low",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "high",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 1/3 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941",
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 1,
+      "timestamp": "2026-04-16T16:52:21.976758",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3403197.0,
+        "compressed_bytes": 1134281.4,
+        "raw_tokens": 850799.0,
+        "compressed_tokens": 283570.0,
+        "tokens_saved": 567228.0,
+        "reduction_pct": 66.67012224093992,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 276417,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 76932,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat",
+          "patch_bytes": 3175,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 30 ++++++++++++++++++++--\n 1 file changed, 28 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation text after the user types a malformed email or a valid-but-nonmatching email.\n- Kept existing translation keys and deletion flow.\n- Disabled and guarded deletion unless the confirmation email is both valid and exactly matches `user.email`, or while deletion is already running.\n\nValidation:\n- `git diff --check` passed.\n- Could not run prettier/eslint/typecheck because this checkout does not have the local toolchain installed (`eslint`, `prettier`, and `tsc` are missing from `node_modules`).\n",
+        "stderr_tail": "tion_consequences_warning\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={isDeleteDisabled}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +129,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={!!confirmationEmailError}\n+            aria-describedby={confirmationEmailError ? \"deleteAccountConfirmation-error\" : undefined}\n+            aria-invalid={!!confirmationEmailError}\n           />\n+          {confirmationEmailError && (\n+            <p id=\"deleteAccountConfirmation-error\" className=\"mt-1 text-sm text-red-500\">\n+              {confirmationEmailError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n76,932\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 216978,
+        "scan_time": 3157,
+        "total_time": 220135,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 65499,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat",
+          "patch_bytes": 2299,
+          "diffstat": " .../account/components/DeleteAccountModal/index.tsx   | 19 +++++++++++++++++--\n 1 file changed, 17 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 8,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": false
+              },
+              {
+                "name": "aria_describedby",
+                "passed": false
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3157,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 95,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2593,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 836.17\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 145.69\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 80.14\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 72.4\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 62.65\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 468,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T07:57:16.701Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex/fooks/attachments/bm-t5-fooks-1776326232.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex/fooks/attachments/bm-t5-fooks-1776326232.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T07:57:16.691Z\",\"attachedAt\":\"2026-04-16T07:57:16.689Z\",\"lastScanAt\":\"2026-04-16T07:57:16.689Z\",\"lastRefreshAt\":\"2026-04-16T07:57:16.689Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation text under the input after the user types an invalid or non-matching email.\n- Kept deletion disabled while the confirmation email is invalid or deletion is already running.\n- Added a guard inside `deleteAccount` so submitting the form with Enter cannot bypass validation.\n- Reused existing translation keys; no translation files changed.\n\nVerification:\n- `git diff --check` passed.\n- `prettier` and `eslint` could not be run because neither binary is installed in this workspace\u2019s `node_modules`.\n",
+        "stderr_tail": "ettings.profile.account_deletion_consequences_warning\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={!isConfirmationEmailValid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +118,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={showConfirmationEmailError}\n           />\n+          {showConfirmationEmailError && (\n+            <p className=\"mt-2 text-sm text-red-500\">\n+              {isEmailFormatValid\n+                ? t(\"environments.actions.does_not_exactly_match\")\n+                : t(\"auth.verification-requested.invalid_email_address\")}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n65,499\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 21.503380761675295,
+        "total": 20.361265768747945
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 2,
+      "timestamp": "2026-04-16T17:01:01.135052",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 5015375.399999999,
+        "compressed_bytes": 1152685.8,
+        "raw_tokens": 1253843.0,
+        "compressed_tokens": 288171.0,
+        "tokens_saved": 965672.0,
+        "reduction_pct": 77.0169586906695,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 188433,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 55602,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat",
+          "patch_bytes": 2566,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 28 +++++++++++++++++++---\n 1 file changed, 25 insertions(+), 3 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user types an invalid or non-matching value.\n- Reused existing translation keys for the validation messages.\n- Kept deletion disabled while the email confirmation is invalid or deletion is already running.\n- Added a guard inside `deleteAccount()` so form submission via Enter cannot bypass the disabled button state.\n\nVerification:\n- `git diff --check` passed.\n- Could not run `prettier`, `eslint`, or `tsc` because those binaries are not available in the current checkout\u2019s executable path.\n",
+        "stderr_tail": "isConfirmationEmailValid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +123,20 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={showInputError}\n+            aria-invalid={showInputError}\n+            aria-describedby={showInputError ? \"deleteAccountConfirmation-error\" : undefined}\n           />\n+          {showInputError && (\n+            <p className=\"mt-1 text-sm text-red-500\" id=\"deleteAccountConfirmation-error\">\n+              {isEmailMalformed\n+                ? t(\"auth.verification-requested.invalid_email_address\")\n+                : t(\"environments.actions.does_not_exactly_match\")}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n55,602\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 255035,
+        "scan_time": 3174,
+        "total_time": 258209,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 53479,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat",
+          "patch_bytes": 3006,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--\n 1 file changed, 22 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3174,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 88,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2636,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 906.54\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 148.1\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 86.89\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 76.62\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 65.77\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 449,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:04:27.022Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex/fooks/attachments/bm-t5-fooks-1776326663.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex/fooks/attachments/bm-t5-fooks-1776326663.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:04:27.011Z\",\"attachedAt\":\"2026-04-16T08:04:27.009Z\",\"lastScanAt\":\"2026-04-16T08:04:27.009Z\",\"lastRefreshAt\":\"2026-04-16T08:04:27.009Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion email confirmation update in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user enters a malformed or non-matching email.\n- Kept deletion disabled while the confirmation email is invalid or deletion is running.\n- Added a guard in `deleteAccount()` so form submit/Enter cannot bypass the disabled delete button.\n- Reused existing translations; no locale files were changed.\n\nValidation:\n- `git diff --check -- apps/web/modules/account/components/DeleteAccountModal/index.tsx` passed.\n- Could not run Prettier/ESLint/TypeScript because local `node_modules` tooling is missing in this worktree (`prettier`, `eslint`, and `tsc` are not available).\n",
+        "stderr_tail": "pb-6 pl-6\">\n           <li>\n@@ -111,10 +120,21 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={showConfirmationEmailError}\n+            aria-describedby={showConfirmationEmailError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {showConfirmationEmailError && (\n+            <p id=\"deleteAccountConfirmationError\" className=\"mt-2 text-sm text-red-600\">\n+              {isConfirmationEmailMalformed\n+                ? t(\"auth.verification-requested.invalid_email_address\")\n+                : t(\"environments.settings.profile.please_enter_email_to_confirm_account_deletion\", {\n+                    email: user.email,\n+                  })}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n53,479\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -35.34518900617196,
+        "total": -37.02960734054014
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 3,
+      "timestamp": "2026-04-16T17:08:50.554909",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3857221.1999999997,
+        "compressed_bytes": 1413111.0,
+        "raw_tokens": 964305.0,
+        "compressed_tokens": 353277.0,
+        "tokens_saved": 611027.0,
+        "reduction_pct": 63.364532995929814,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 188316,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 56935,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat",
+          "patch_bytes": 2800,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 25 ++++++++++++++++++++--\n 1 file changed, 23 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user types a malformed email or a non-matching email.\n- Kept existing translation usage by reusing existing `t()` keys.\n- Disabled deletion while the email is invalid or deletion is already running.\n- Added a guard in `deleteAccount()` so form submission cannot bypass the disabled delete button.\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `node_modules` is missing and the commands are not installed in this workspace.\n",
+        "stderr_tail": ">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -96,6 +109,7 @@\n         </ul>\n         <form\n           data-testid=\"deleteAccountForm\"\n+          noValidate\n           onSubmit={async (e) => {\n             e.preventDefault();\n             await deleteAccount();\n@@ -111,10 +125,17 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={!!emailConfirmationError}\n+            aria-describedby={emailConfirmationError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {emailConfirmationError && (\n+            <p className=\"mt-1 text-sm text-red-500\" id=\"deleteAccountConfirmationError\">\n+              {emailConfirmationError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n56,935\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 214106,
+        "scan_time": 3935,
+        "total_time": 218041,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 65199,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat",
+          "patch_bytes": 3020,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--\n 1 file changed, 22 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3935,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 107,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 3349,
+              "stdout_tail": "lveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 1015.49\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 157.96\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 102.3\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 99.27\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 69.99\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 477,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:12:17.626Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex/fooks/attachments/bm-t5-fooks-1776327132.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex/fooks/attachments/bm-t5-fooks-1776327132.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:12:17.616Z\",\"attachedAt\":\"2026-04-16T08:12:17.614Z\",\"lastScanAt\":\"2026-04-16T08:12:17.614Z\",\"lastRefreshAt\":\"2026-04-16T08:12:17.614Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the form validation change in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added an inline red validation message after the user types an invalid or non-matching email.\n- Reused existing translation keys for the error messages.\n- Kept deletion disabled while the email is invalid or deletion is already running.\n- Added a guard in `deleteAccount()` so Enter-submit cannot bypass the disabled delete button.\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `prettier` and `eslint` executables are not available in this checkout.\n",
+        "stderr_tail": "ing\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={isConfirmationEmailInvalid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +123,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={!!confirmationEmailError}\n+            aria-describedby={confirmationEmailError ? \"deleteAccountConfirmation-error\" : undefined}\n+            isInvalid={!!confirmationEmailError}\n           />\n+          {confirmationEmailError && (\n+            <p id=\"deleteAccountConfirmation-error\" className=\"mt-1 text-xs text-red-500\">\n+              {confirmationEmailError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n65,199\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -13.695065740563733,
+        "total": -15.784638586206166
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776327829.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776327829.json
@@ -1,0 +1,1042 @@
+{
+  "timestamp": "2026-04-16T17:45:30.437381",
+  "summary": {
+    "total_benchmarks": 3,
+    "successful_pairs": 3,
+    "vanilla_success": 3,
+    "fooks_success": 3,
+    "same_file_pairs": 3,
+    "avg_token_reduction": 69.85156645128036,
+    "avg_tokens_saved": 718148.3333333334,
+    "median_exec_improvement": -18.17825989711474,
+    "median_total_improvement": -19.907179601878774,
+    "median_runtime_token_reduction": -49.74528921998247,
+    "runtime_token_reductions": [
+      4.11093257653221,
+      -49.74528921998247,
+      -169.0504768347773
+    ],
+    "acceptance_pairs": [
+      {
+        "iteration": 1,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 2,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 3,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    },
+    "artifactCapture": {
+      "scope": "git diff patch, git diff --stat, git diff --check, changed file list, task-specific acceptance score when available.",
+      "purpose": "Separate output parity and quality evidence from runtime/token measurements."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "medium",
+        "evidence": "3 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "artifact_quality",
+        "level": "low",
+        "evidence": "acceptance_scored_pairs=3, fooks_lower_score_pairs=0",
+        "interpretation": "Output parity matters as much as time/token deltas; inspect captured patches when fooks scores lower."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "low",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "high",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 2/3 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829",
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 1,
+      "timestamp": "2026-04-16T17:23:49.979260",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 5308052.399999999,
+        "compressed_bytes": 1318296.0,
+        "raw_tokens": 1327013.0,
+        "compressed_tokens": 329574.0,
+        "tokens_saved": 997439.0,
+        "reduction_pct": 75.16422407585878,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 232586,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 47921,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat",
+          "patch_bytes": 2630,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-\n 1 file changed, 17 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838/apps/web/modules/auth/login/components/login-form.tsx:148).\n\nWhat changed:\n- Added React state for Caps Lock status.\n- Updated the password field to detect Caps Lock on `onKeyDown` and `onKeyUp`.\n- Resets the warning on password field blur.\n- Renders a small red inline warning under the password field with `role=\"alert\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Left email sign-in, password reset, and two-factor flows untouched.\n\nModified file:\n- `apps/web/modules/auth/login/components/login-form.tsx`\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- `pnpm exec prettier` and `pnpm exec eslint` could not run because those binaries are not installed in this checkout.\n",
+        "stderr_tail": "sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => {\n+                              field.onBlur();\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p role=\"alert\" aria-live=\"polite\" className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n47,921\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 196514,
+        "scan_time": 3213,
+        "total_time": 199727,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 45951,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat",
+          "patch_bytes": 2033,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 19 +++++++++++++++++++\n 1 file changed, 19 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3213,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 93,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2638,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 881.77\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 149.23\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 84.18\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 74.14\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 63.75\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 482,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:28:00.778Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex/fooks/attachments/bm-t5-fooks-1776328076.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex/fooks/attachments/bm-t5-fooks-1776328076.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:28:00.768Z\",\"attachedAt\":\"2026-04-16T08:28:00.765Z\",\"lastScanAt\":\"2026-04-16T08:28:00.765Z\",\"lastRefreshAt\":\"2026-04-16T08:28:00.765Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added React state for Caps Lock detection.\n- Updated the password input to track `CapsLock` via keyboard events.\n- Added a small red inline warning under the password field with `role=\"status\"` and `aria-live=\"polite\"`.\n- Kept the existing email sign-in, password reset, and two-factor flows unchanged.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Could not run ESLint/Prettier because `pnpm exec eslint` and `pnpm exec prettier` are unavailable in this checkout (`Command \"eslint\"/\"prettier\" not found`).\n",
+        "stderr_tail": "Change={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => {\n+                              field.onBlur();\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n45,951\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 15.509102009579253,
+        "total": 14.127677504234992
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 2,
+      "timestamp": "2026-04-16T17:31:24.829390",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 4348113.0,
+        "compressed_bytes": 1238945.4,
+        "raw_tokens": 1087028.0,
+        "compressed_tokens": 309736.0,
+        "tokens_saved": 777291.0,
+        "reduction_pct": 71.5061361100781,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 178840,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 36512,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat",
+          "patch_bytes": 1950,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 15 +++++++++++++++\n 1 file changed, 15 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the inline Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added `isCapsLockOn` React state.\n- Updated the password field to detect Caps Lock via `event.getModifierState(\"CapsLock\")` on key down/up.\n- Rendered a small red Tailwind warning under the password field with `role=\"status\"` and `aria-live=\"polite\"`.\n- Left email sign-in, password reset, and two-factor flows untouched.\n\nVerification:\n- `git diff --check` passed.\n- I could not run Prettier or ESLint because this checkout has no `node_modules`, and `pnpm exec prettier` / `pnpm --filter @formbricks/web exec eslint` reported the commands were unavailable.\n",
+        "stderr_tail": "       onKeyDown={(event) => {\n+                              setIsCapsLockOn(event.getModifierState(\"CapsLock\"));\n+                            }}\n+                            onKeyUp={(event) => {\n+                              setIsCapsLockOn(event.getModifierState(\"CapsLock\"));\n+                            }}\n+                            onBlur={() => {\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p role=\"status\" aria-live=\"polite\" className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n36,512\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 211350,
+        "scan_time": 3092,
+        "total_time": 214442,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 54675,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat",
+          "patch_bytes": 2439,
+          "diffstat": " .../web/modules/auth/login/components/login-form.tsx | 20 ++++++++++++++++++++\n 1 file changed, 20 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3092,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 107,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2546,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 853.45\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 140.41\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 80.94\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 73.56\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 61.02\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 438,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:34:42.059Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex/fooks/attachments/bm-t5-fooks-1776328477.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex/fooks/attachments/bm-t5-fooks-1776328477.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:34:42.049Z\",\"attachedAt\":\"2026-04-16T08:34:42.047Z\",\"lastScanAt\":\"2026-04-16T08:34:42.047Z\",\"lastRefreshAt\":\"2026-04-16T08:34:42.047Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/apps/web/modules/auth/login/components/login-form.tsx:151).\n\nChanged only:\n`apps/web/modules/auth/login/components/login-form.tsx`\n\nWhat changed:\n- Added `isCapsLockOn` React state.\n- Detects Caps Lock from password field `onKeyDown` / `onKeyUp` via `event.getModifierState(\"CapsLock\")`.\n- Clears the warning on password field blur while preserving `field.onBlur()`.\n- Renders a small red Tailwind warning under the password input with `role=\"status\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Used `t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })` so the string remains i18n-compatible without modifying locale files.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Targeted ESLint could not run because this checkout does not have an installed `eslint` binary in `node_modules`.\n",
+        "stderr_tail": "(password) => field.onChange(password)}\n+                            onKeyDown={updateCapsLockState}\n+                            onKeyUp={updateCapsLockState}\n+                            onBlur={() => {\n+                              setIsCapsLockOn(false);\n+                              field.onBlur();\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs font-medium text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n54,675\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -18.17825989711474,
+        "total": -19.907179601878774
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 3,
+      "timestamp": "2026-04-16T17:38:21.290986",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 2415327.6,
+        "compressed_bytes": 896464.7999999999,
+        "raw_tokens": 603831.0,
+        "compressed_tokens": 224116.0,
+        "tokens_saved": 379715.0,
+        "reduction_pct": 62.88433916790419,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 172430,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 45823,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat",
+          "patch_bytes": 2604,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-\n 1 file changed, 17 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added React state for Caps Lock status.\n- Detects Caps Lock via password field `onKeyDown` / `onKeyUp`.\n- Clears the warning on password field blur.\n- Renders a small red Tailwind warning under the password field only while Caps Lock is on.\n- Uses `role=\"status\"` and `aria-live=\"polite\"` for accessible announcement.\n- Kept the existing login, reset-password link, and two-factor flow structure unchanged.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Targeted ESLint could not run because `eslint` is not installed/available in this worktree via `pnpm`.\n- Modified file: `apps/web/modules/auth/login/components/login-form.tsx`.\n",
+        "stderr_tail": "ark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              className=\"mt-1 text-left text-xs font-medium text-red-600\"\n+                              role=\"status\"\n+                              aria-live=\"polite\">\n+                              {t(\"auth.login.caps_lock_is_on\", \"Caps Lock is on\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n45,823\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 233158,
+        "scan_time": 3105,
+        "total_time": 236263,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 123287,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat",
+          "patch_bytes": 2543,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 17 ++++++++++++++++-\n 1 file changed, 16 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3105,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 85,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2573,
+              "stdout_tail": "tResolveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 849.34\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 146.37\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 84.3\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 77\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 65.56\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 447,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:41:31.227Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex/fooks/attachments/bm-t5-fooks-1776328887.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex/fooks/attachments/bm-t5-fooks-1776328887.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:41:31.217Z\",\"attachedAt\":\"2026-04-16T08:41:31.214Z\",\"lastScanAt\":\"2026-04-16T08:41:31.214Z\",\"lastRefreshAt\":\"2026-04-16T08:41:31.214Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/apps/web/modules/auth/login/components/login-form.tsx:148).\n\nChanged only `apps/web/modules/auth/login/components/login-form.tsx`:\n- Added React state for Caps Lock detection.\n- Updated the password field with `onKeyDown` / `onKeyUp` handlers using `getModifierState(\"CapsLock\")`.\n- Rendered a small red Tailwind warning under the password input with `role=\"status\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Left the existing email sign-in, password reset link, and two-factor branches unchanged.\n\nValidation:\n- `git diff --check` passed.\n- Targeted ESLint could not run because dependencies are not installed in this workspace: `Command \"eslint\" not found`.\n",
+        "stderr_tail": "nded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n123,287\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -35.21892942063446,
+        "total": -37.019660151945715
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/formbricks-n6-interpretation.md
+++ b/benchmarks/frontend-harness/reports/formbricks-n6-interpretation.md
@@ -1,0 +1,37 @@
+# Formbricks Direct-Codex N=6 Benchmark Interpretation
+
+Source artifacts preserved from `benchmark/formbricks-n3-quality` onto latest `main` without merging the stale branch:
+
+- `benchmark-full-1776325941.json` — Formbricks delete-account email validation, N=3
+- `benchmark-full-1776327829.json` — Formbricks login Caps Lock warning follow-up, N=3
+- `artifacts/benchmark-full-1776325941/**` and `artifacts/benchmark-full-1776327829/**` — per-iteration patches and diffstats
+- `round1-risk-followup-1776327829.md` — original follow-up risk note
+
+## What can be claimed
+
+These runs are useful for product decisions, not public performance claims:
+
+- Direct Codex runner parity was used for both variants.
+- All 6 paired runs succeeded and changed the same target file class.
+- Proxy extraction/model-facing token estimates stayed strongly positive.
+- Runtime token and wall-clock outcomes were mixed, including clear fooks regressions.
+
+## Aggregate read
+
+| Evidence slice | Pairs | Same-file pairs | Median total-time improvement | Median runtime-token reduction | Quality caveat |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Delete-account email validation | 3 | 3 | -15.78% | +3.82% | fooks lower-quality in 1/3 |
+| Login Caps Lock warning | 3 | 3 | -19.91% | -49.75% | artifact parity 3/3 |
+| Combined directional read | 6 | 6 | negative | mixed / often negative | round-1 only |
+
+Negative improvement means fooks was slower or used more runtime tokens than vanilla.
+
+## Product implication
+
+The current evidence says fooks extraction can compress model-facing payloads, but exact-file task prompts may over-inject context relative to vanilla. The next product step is therefore the shared context policy added in this branch:
+
+- first-turn exact-file runtime hook behavior: `no-op` / record only
+- repeated exact-file behavior: `light` or `light-minimal`
+- ambiguous or multi-file prompts: `auto` / broader discovery
+
+Do not market runtime token savings from these Formbricks artifacts until post-policy reruns show stable actual runtime-token wins.

--- a/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md
+++ b/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md
@@ -1,0 +1,61 @@
+# Round-one risk follow-up: direct Codex Formbricks repeats
+
+Date: 2026-04-16
+Runner: direct `codex exec --full-auto`
+Repo: `formbricks/formbricks`
+Framework surface: Next.js app components with Tailwind classes
+Variant contract: vanilla and fooks use the same prompt, same runner, isolated `CODEX_HOME`; fooks additionally runs `fooks init` / `fooks scan` / `fooks attach codex`.
+
+## Why this follow-up exists
+
+The first direct-Codex Formbricks N=1 run showed a promising fooks result, but the risk assessment still had three important gaps:
+
+1. Sample size was too small.
+2. The task mix only covered one feature type.
+3. Runtime-token regressions needed to be separated from proxy compression claims.
+
+This follow-up adds a second N=3 task and preserves patch artifacts so output quality can be checked alongside time and token deltas.
+
+## Included evidence
+
+| Report | Task | Pairs | Same target file | Acceptance result | Median total-time improvement | Median runtime-token reduction |
+| --- | --- | ---: | ---: | --- | ---: | ---: |
+| `benchmark-full-1776325941.json` | Delete account email confirmation validation | 3 | 3/3 | fooks lower in 1/3 | -15.78% | +3.82% |
+| `benchmark-full-1776327829.json` | Login password Caps Lock warning | 3 | 3/3 | parity in 3/3 | -19.91% | -49.75% |
+
+Rollup across both direct-Codex N=3 runs:
+
+- Successful paired runs: 6/6
+- Same-file pairs: 6/6
+- Fooks lower acceptance score: 1/6
+- Median total-time improvement: -17.85%
+- Median runtime-token reduction: -5.35%
+- Fooks used more runtime tokens in 3/6 pairs
+
+## Interpretation
+
+This evidence does **not** support a stable direct-Codex speed or runtime-token reduction claim yet. The honest current read is:
+
+- fooks reliably kept the agent on the intended file in these targeted Formbricks tasks.
+- fooks proxy compression remains positive, but proxy compression is not the same as actual Codex runtime token usage.
+- On explicit single-file tasks, fooks preparation can add context without reducing the agent's reasoning path enough to offset it.
+- More runtime tokens on the fooks side is a negative result, not a marketing win; it should be treated as a regression signal until a task class shows repeated savings.
+
+## Token regression note
+
+The Caps Lock task is the clearest warning sign. Patch sizes were comparable across variants, but fooks runtime tokens were higher in 2/3 pairs and much higher in iteration 3. That means the extra token use is unlikely to be explained by a larger output patch alone. The likely causes to investigate next are:
+
+1. fooks-injected context is helpful for navigation but too heavy for explicitly targeted single-file prompts.
+2. The current attach/runtime-hook path may add context even when the prompt already names the exact file.
+3. Codex hidden reasoning/service variability can amplify small prompt/context differences, so N>=5 and multiple task classes are needed before making claims.
+
+## Next recommended benchmark class
+
+Do not repeat only explicit single-file tasks. The next run should target cases where fooks should theoretically help:
+
+- ambiguous file discovery across a feature folder,
+- multi-file refactor where imports/types matter,
+- migration that requires preserving existing patterns across related components,
+- large TSX component extraction without naming the exact file.
+
+Until those pass, public wording should say: fooks has promising context-compression mechanics and file-targeting behavior, but direct runtime token/time wins are not yet stable in the current Formbricks evidence.

--- a/benchmarks/frontend-harness/runners/full-benchmark-suite.py
+++ b/benchmarks/frontend-harness/runners/full-benchmark-suite.py
@@ -18,6 +18,8 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 BENCHMARK_DIR = SCRIPT_DIR.parent.resolve()
 FOOKS_DIR = BENCHMARK_DIR.parent.parent.resolve()  # fooks repo root
 DEFAULT_REPORTS_DIR = BENCHMARK_DIR / "reports"
+REPORT_SCHEMA_VERSION = "frontend-harness.v2-context-mode"
+CONTEXT_POLICY_VERSION = "context-policy.v1"
 
 # Test repos location (can be overridden via env var)
 REPOS_DIR = Path(os.environ.get("BENCHMARK_REPOS_DIR", Path.home() / "Workspace/fooks-test-repos"))
@@ -152,6 +154,61 @@ def resolve_task(task_id, prompt_override=None):
     if prompt_override:
         resolved["prompt"] = prompt_override
     return resolved
+
+def classify_task_context(task):
+    """Classify benchmark task prompts for report-level interpretation.
+
+    The Python harness cannot call the TypeScript policy during dry-run without
+    building/running the package, so it records an equivalent task taxonomy for
+    product report interpretation. Exact file prompts are intentionally rare in
+    public tasks; ambiguous prompts are where fooks should have room to win.
+    """
+    prompt = task.get("prompt", "")
+    has_explicit_file = bool(re.search(r"[A-Za-z0-9_./\\-]+\.(tsx|jsx)\b", prompt))
+    if has_explicit_file:
+        return {
+            "taskClass": "targeted-edit",
+            "promptSpecificity": "exact-file",
+            "expectedContextPolicy": "light",
+        }
+    if task.get("id") in {"T4", "T5"}:
+        return {
+            "taskClass": "ambiguous-multi-file",
+            "promptSpecificity": "ambiguous",
+            "expectedContextPolicy": "auto",
+        }
+    return {
+        "taskClass": "ambiguous-single-file",
+        "promptSpecificity": "ambiguous",
+        "expectedContextPolicy": "auto",
+    }
+
+def variant_context_metadata(task, variant):
+    classification = classify_task_context(task)
+    if variant == "vanilla":
+        context_mode = "no-op"
+        reason = "vanilla-baseline-no-fooks-context"
+        max_files = 0
+        selected_files = 0
+    else:
+        context_mode = classification["expectedContextPolicy"]
+        reason = f"fooks-{classification['promptSpecificity']}-policy"
+        max_files = 1 if context_mode == "light" else 5 if context_mode == "auto" else 0
+        # The harness records expected policy metadata here. Runtime-observed
+        # selected file counts belong to the fooks hook/run context policy.
+        selected_files = 0 if context_mode == "auto" else max_files
+    return {
+        "contextMode": context_mode,
+        "contextModeReason": reason,
+        "contextBudget": {
+            "maxFiles": max_files,
+            "selectedFiles": selected_files,
+            "totalBytes": 0,
+            "skippedFiles": 0,
+        },
+        "contextPolicyVersion": CONTEXT_POLICY_VERSION,
+        "contextBudgetSource": "expected-policy",
+    }
 
 def get_session_token_estimate(repo_path):
     """Estimate session-level token savings"""
@@ -647,6 +704,7 @@ def run_vanilla_agent(worktree, task, runner):
             "files_list": files,
             "tokens_used": parse_tokens_used(result.stderr),
             "command": command_metadata(worktree, task, runner),
+            **variant_context_metadata(task, "vanilla"),
             "stdout_tail": output_tail(result.stdout),
             "stderr_tail": output_tail(result.stderr, 1000),
             "error": None if result.returncode == 0 else result.stderr[:200],
@@ -674,6 +732,7 @@ def run_fooks_agent(worktree, task, runner):
             "files_list": [],
             "prepare": prepare,
             "command": command_metadata(worktree, task, runner),
+            **variant_context_metadata(task, "fooks"),
             "error": prepare["error"],
         }
 
@@ -700,6 +759,7 @@ def run_fooks_agent(worktree, task, runner):
             "tokens_used": parse_tokens_used(result.stderr),
             "prepare": prepare,
             "command": command_metadata(worktree, task, runner),
+            **variant_context_metadata(task, "fooks"),
             "stdout_tail": output_tail(result.stdout),
             "stderr_tail": output_tail(result.stderr, 1000),
             "error": None if result.returncode == 0 else result.stderr[:200],
@@ -727,8 +787,13 @@ def run_benchmark(task, repo_name, runner):
     repo_path = REPOS[repo_name]
     if not repo_path.exists():
         raise FileNotFoundError(f"Repository checkout not found at {repo_path}")
+    classification = classify_task_context(task)
     results = {"task": task['id'], "task_name": task['name'], "repo": repo_name,
-               "difficulty": task['difficulty'], "timestamp": datetime.now().isoformat()}
+               "difficulty": task['difficulty'], "timestamp": datetime.now().isoformat(),
+               "repoClass": "external-oss-nextjs-tailwind" if repo_name in {"formbricks", "cal.com", "shadcn-ui", "documenso", "nextjs"} else "external-oss-frontend",
+               "taskClass": classification["taskClass"],
+               "promptSpecificity": classification["promptSpecificity"],
+               "expectedContextPolicy": classification["expectedContextPolicy"]}
 
     # Token estimate (once per repo)
     print("  Calculating token estimates...")
@@ -784,6 +849,7 @@ def main():
         resolved_tasks = []
         for task_id, repo_name in test_cases:
             task = resolve_task(task_id, args.task_prompt if (args.repo and args.task == task_id) else None)
+            classification = classify_task_context(task)
             resolved_tasks.append({
                 "task": task["id"],
                 "task_name": task["name"],
@@ -791,8 +857,12 @@ def main():
                 "repo_path": str(REPOS[repo_name]),
                 "repo_exists": REPOS[repo_name].exists(),
                 "prompt": task["prompt"],
+                "taskClass": classification["taskClass"],
+                "promptSpecificity": classification["promptSpecificity"],
+                "expectedContextPolicy": classification["expectedContextPolicy"],
             })
         print(json.dumps({
+            "reportSchemaVersion": REPORT_SCHEMA_VERSION,
             "reportsDir": str(reports_dir),
             "defaultReportsDir": str(DEFAULT_REPORTS_DIR),
             "reposDir": str(REPOS_DIR),
@@ -871,6 +941,7 @@ def main():
     report_path.parent.mkdir(parents=True, exist_ok=True)
     with open(report_path, 'w') as f:
         json.dump({
+            "reportSchemaVersion": REPORT_SCHEMA_VERSION,
             "timestamp": datetime.now().isoformat(),
             "summary": {
                 "total_benchmarks": len(all_results),

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -9,11 +9,15 @@ import {
   markCodexRuntimeSeenFile,
   resolveCodexRuntimeSessionKey,
 } from "./codex-runtime-session";
-import type { CodexRuntimeHookDecision, CodexRuntimeHookInput, ModelFacingPayload } from "../core/schema";
+import type { CodexRuntimeHookDecision, CodexRuntimeHookInput, ContextMode, ModelFacingPayload } from "../core/schema";
 
-function buildAdditionalContext(filePath: string, payload: ModelFacingPayload): string {
+function payloadContextMode(payload: ModelFacingPayload): ContextMode {
+  return payload.useOriginal ? "light-minimal" : "light";
+}
+
+function buildAdditionalContext(filePath: string, payload: ModelFacingPayload, contextMode: ContextMode): string {
   return [
-    `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · use ${codexRuntimeEscapeHatches()[0]} for full source`,
+    `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · context-mode: ${contextMode} · use ${codexRuntimeEscapeHatches()[0]} for full source`,
     "",
     JSON.stringify(payload, null, 2),
   ].join("\n");
@@ -28,6 +32,7 @@ function fallbackDecision(
   eligible: boolean,
   escapeHatchUsed: boolean,
   fallbackReason: string,
+  policy?: ReturnType<typeof resolvePromptFileContext>["policy"],
   decision?: ReturnType<typeof decideCodexPreRead>,
 ): CodexRuntimeHookDecision {
   return {
@@ -43,6 +48,11 @@ function fallbackDecision(
       escapeHatchUsed,
       decision,
     },
+    contextMode: "full",
+    contextModeReason: fallbackReason,
+    contextBudget: policy?.contextBudget,
+    promptSpecificity: policy?.promptSpecificity,
+    contextPolicyVersion: policy?.contextPolicyVersion,
     fallback: {
       action: "full-read",
       reason: fallbackReason,
@@ -63,6 +73,8 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       action: "noop",
       reasons: [],
       statePath,
+      contextMode: "no-op",
+      contextModeReason: "session-start",
       debug: {
         repeatedFile: false,
         eligible: false,
@@ -80,6 +92,8 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       action: "noop",
       reasons: [],
       statePath,
+      contextMode: "no-op",
+      contextModeReason: "session-stop",
       debug: {
         repeatedFile: false,
         eligible: false,
@@ -91,6 +105,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   const prompt = input.prompt ?? "";
   const promptContext = resolvePromptFileContext(prompt, cwd);
   const target = promptContext.filePath;
+  const policy = promptContext.policy;
   const escapeHatchUsed = hasFullReadEscapeHatch(prompt);
 
   if (!target) {
@@ -99,6 +114,11 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       hookEventName,
       action: "noop",
       reasons: ["no-eligible-file-in-prompt"],
+      contextMode: policy.contextMode,
+      contextModeReason: policy.contextModeReason,
+      contextBudget: policy.contextBudget,
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
       debug: {
         repeatedFile: false,
         eligible: false,
@@ -118,6 +138,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       true,
       true,
       "escape-hatch-full-read",
+      policy,
     );
   }
 
@@ -132,8 +153,13 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       hookEventName,
       action: "record",
       filePath: target,
-      reasons: ["first-seen-file"],
+      reasons: ["first-seen-file", "context-mode:no-op"],
       statePath,
+      contextMode: "no-op",
+      contextModeReason: "first-turn-exact-file-record-only",
+      contextBudget: { ...policy.contextBudget, selectedFiles: 0, totalBytes: 0, skippedFiles: policy.contextBudget.selectedFiles },
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
       debug: {
         repeatedFile: false,
         eligible: true,
@@ -144,6 +170,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
   const decision = decideCodexPreRead(path.join(cwd, target), cwd);
   if (decision.decision === "payload" && decision.payload) {
+    const contextMode = payloadContextMode(decision.payload);
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     return {
       runtime: "codex",
@@ -152,7 +179,12 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       filePath: target,
       reasons: freshness.refreshed ? ["repeated-file", "refreshed-before-attach"] : ["repeated-file"],
       statePath,
-      additionalContext: buildAdditionalContext(target, decision.payload),
+      additionalContext: buildAdditionalContext(target, decision.payload, contextMode),
+      contextMode,
+      contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
+      contextBudget: policy.contextBudget,
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
       debug: {
         repeatedFile: true,
         eligible: true,
@@ -172,6 +204,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     decision.eligible,
     false,
     decision.fallback?.reason ?? decision.reasons[0] ?? "raw-mode",
+    policy,
     decision,
   );
 }

--- a/src/adapters/codex-runtime-prompt.ts
+++ b/src/adapters/codex-runtime-prompt.ts
@@ -1,56 +1,17 @@
-import fs from "node:fs";
-import path from "node:path";
+export {
+  codexRuntimeEscapeHatches,
+  extractPromptTarget,
+  extractPromptTargets,
+  hasFullReadEscapeHatch,
+  resolvePromptFileContext,
+  classifyPromptContext,
+  discoverRelevantFilesByPolicy,
+} from "../core/context-policy";
 
-const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
-const ESCAPE_HATCH_TOKENS = ["#fooks-full-read", "#fooks-disable-pre-read"] as const;
-const FILE_TOKEN_PATTERN = /(?:[A-Za-z]:)?[A-Za-z0-9_./\\-]+\.(?:tsx|jsx)\b/g;
-
-function trimPromptToken(token: string): string {
-  return token.replace(/^[`"'([{<]+/, "").replace(/[`"')\]}>:;,!?]+$/, "");
-}
-
-function isWithinCwd(resolved: string, cwd: string): boolean {
-  const relativeToCwd = path.relative(cwd, resolved);
-  return relativeToCwd === "" || (!relativeToCwd.startsWith(`..${path.sep}`) && relativeToCwd !== ".." && !path.isAbsolute(relativeToCwd));
-}
-
-function normalizeCandidate(token: string, cwd: string): string | null {
-  const cleaned = trimPromptToken(token);
-  if (!cleaned) return null;
-
-  const resolved = path.isAbsolute(cleaned) ? path.resolve(cleaned) : path.resolve(cwd, cleaned);
-  const extension = path.extname(resolved).toLowerCase();
-  if (!ELIGIBLE_EXTENSIONS.has(extension)) return null;
-  if (!isWithinCwd(resolved, cwd)) return null;
-
-  const relativeToCwd = path.relative(cwd, resolved);
-
-  if (fs.existsSync(resolved)) {
-    return relativeToCwd || path.basename(resolved);
-  }
-
-  if (path.isAbsolute(cleaned)) return null;
-  return relativeToCwd || path.basename(resolved);
-}
-
-export function extractPromptTarget(prompt: string, cwd = process.cwd()): string | null {
-  for (const match of prompt.matchAll(FILE_TOKEN_PATTERN)) {
-    const normalized = normalizeCandidate(match[0], cwd);
-    if (normalized) return normalized;
-  }
-  return null;
-}
-
-export function hasFullReadEscapeHatch(prompt: string): boolean {
-  return ESCAPE_HATCH_TOKENS.some((token) => prompt.includes(token));
-}
-
-export function codexRuntimeEscapeHatches(): readonly string[] {
-  return ESCAPE_HATCH_TOKENS;
-}
-
-
-export function resolvePromptFileContext(prompt: string, cwd = process.cwd()): { filePath?: string; source: "prompt-target" | "none" } {
-  const filePath = extractPromptTarget(prompt, cwd);
-  return filePath ? { filePath, source: "prompt-target" } : { source: "none" };
-}
+export type {
+  ContextBudget,
+  ContextMode,
+  PromptContextPolicy,
+  PromptSpecificity,
+  PromptTarget,
+} from "../core/context-policy";

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -2,6 +2,8 @@ import { scanProject } from "../core/scan";
 import { extractFile } from "../core/extract";
 import { detectAccountContext, finalizeAttach, installRuntimeManifest } from "./shared";
 import { codexRuntimeEscapeHatches } from "./codex-runtime-prompt";
+import { classifyPromptContext } from "../core/context-policy";
+import type { PromptContextPolicy } from "../core/context-policy";
 import { completeCodexInitialScan, initializeCodexTrustStatus } from "./codex-runtime-trust";
 import { defaultCodexHookCommand } from "./codex-hook-preset";
 import type { AttachResult } from "../core/schema";
@@ -58,6 +60,11 @@ export interface ExecutionContext {
   totalSize: number;
   prompt: string;
   handoffCommand: string;
+  contextMode: PromptContextPolicy["contextMode"];
+  contextModeReason: string;
+  contextBudget: PromptContextPolicy["contextBudget"];
+  promptSpecificity: PromptContextPolicy["promptSpecificity"];
+  contextPolicyVersion: PromptContextPolicy["contextPolicyVersion"];
 }
 
 // Prepare context for AI execution - execution is handed off to external runtime
@@ -65,20 +72,31 @@ export async function prepareExecutionContext(
   prompt: string,
   contextFiles: string[],
   cwd = process.cwd(),
+  contextPolicy: PromptContextPolicy = classifyPromptContext(prompt, cwd),
 ): Promise<ExecutionContext> {
   const fs = await import("node:fs");
   const path = await import("node:path");
 
-  // Read and combine context files into a temporary context file
-  let contextContent = "# Context Files\n\n";
+  // Read and combine context files into a temporary context file.
+  // Relative paths are resolved against cwd so handoff behavior is stable when
+  // callers run fooks from another process directory.
   let totalSize = 0;
+  const metadata = {
+    contextMode: contextPolicy.contextMode,
+    contextModeReason: contextPolicy.contextModeReason,
+    contextBudget: contextPolicy.contextBudget,
+    promptSpecificity: contextPolicy.promptSpecificity,
+    contextPolicyVersion: contextPolicy.contextPolicyVersion,
+  };
+  let contextContent = `# Context Files\n\n<!-- fooks-context-policy ${JSON.stringify(metadata)} -->\n\n`;
 
   for (const filePath of contextFiles) {
     try {
-      const content = fs.readFileSync(filePath, "utf8");
+      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+      const content = fs.readFileSync(resolvedPath, "utf8");
       const size = Buffer.byteLength(content, "utf8");
       totalSize += size;
-      contextContent += `## ${path.basename(filePath)}\n\n${content}\n\n`;
+      contextContent += `## ${path.relative(cwd, resolvedPath) || path.basename(resolvedPath)}\n\n${content}\n\n`;
     } catch (err) {
       console.error(`Failed to read ${filePath}:`, err);
     }
@@ -99,6 +117,11 @@ export async function prepareExecutionContext(
     totalSize,
     prompt,
     handoffCommand,
+    contextMode: contextPolicy.contextMode,
+    contextModeReason: contextPolicy.contextModeReason,
+    contextBudget: contextPolicy.contextBudget,
+    promptSpecificity: contextPolicy.promptSpecificity,
+    contextPolicyVersion: contextPolicy.contextPolicyVersion,
   };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -206,7 +206,7 @@ async function run(): Promise<void> {
     }
     case "run": {
       const { runTask } = await import("./run.js");
-      const prompt = process.argv[3];
+      const prompt = rest.join(" ");
       if (!prompt) {
         console.error("Usage: fooks run <prompt>");
         process.exit(1);
@@ -332,7 +332,8 @@ async function run(): Promise<void> {
     }
     default:
       console.error(`Unknown command: ${command ?? "<none>"}`);
-      console.error(`Usage: ${displayCliName} <init|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>`);
+      console.error(`Usage: ${displayCliName} <init|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>`);
+      console.error(`       ${displayCliName} run <prompt>`);
       console.error(`       ${displayCliName} extract <file> [--model-payload] [--json]`);
       console.error(`       ${displayCliName} install codex-hooks`);
       console.error(`       ${displayCliName} codex-pre-read <file> [--json]`);

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2,7 +2,8 @@
 import { scanProject } from "../core/scan.js";
 import { extractFile } from "../core/extract.js";
 import { decideMode } from "../core/decide.js";
-import { discoverProjectFiles, discoverRelevantFiles } from "../core/discover.js";
+import { discoverProjectFiles } from "../core/discover.js";
+import { discoverRelevantFilesByPolicy } from "../core/context-policy.js";
 import { prepareExecutionContext } from "../adapters/codex.js";
 
 export interface RunOptions {
@@ -27,11 +28,13 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
   
   try {
     // 1. Scan if stale
-    const scanResult = scanProject();
+    const cwd = process.cwd();
+    scanProject(cwd);
     
     // 2. Discover relevant files
-    const allFiles = discoverProjectFiles();
-    const relevantFiles = discoverRelevantFiles(options.prompt, allFiles);
+    const allFiles = discoverProjectFiles(cwd);
+    const selection = discoverRelevantFilesByPolicy(options.prompt, allFiles, cwd);
+    const relevantFiles = selection.files;
     
     // 3. Process each file with fallback chain
     let totalTokensSaved = 0;
@@ -66,10 +69,11 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
     
     let executionContext;
     if (runner === "codex" || runner === "omx") {
-      executionContext = await prepareExecutionContext(options.prompt, processedFiles);
+      executionContext = await prepareExecutionContext(options.prompt, processedFiles, cwd, selection.policy);
       console.log("\n=== Handoff Summary ===");
       console.log(`Context ready: ${executionContext.contextPath}`);
       console.log(`Files: ${executionContext.fileCount}, Size: ${(executionContext.totalSize / 1024).toFixed(1)}KB`);
+      console.log(`Context mode: ${executionContext.contextMode} (${executionContext.contextModeReason})`);
       console.log(`Prompt: "${executionContext.prompt}"`);
       console.log(`\nNext: Execute with your preferred runtime (omx, codex, claude, etc.)`);
       console.log(`Context file: ${executionContext.contextPath}`);

--- a/src/core/context-policy.ts
+++ b/src/core/context-policy.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { FileTarget } from "./discover";
+
+const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+const ESCAPE_HATCH_TOKENS = ["#fooks-full-read", "#fooks-disable-pre-read"] as const;
+const FILE_TOKEN_PATTERN = /(?:[A-Za-z]:)?[A-Za-z0-9_./\\-]+\.(?:tsx|jsx)\b/g;
+const STOPWORDS = new Set(["add", "the", "fix", "update", "to", "for", "with", "from", "and", "this", "that"]);
+
+export type PromptSpecificity = "exact-file" | "file-hinted" | "ambiguous";
+export type ContextMode = "no-op" | "light" | "light-minimal" | "full" | "auto";
+export type ContextSelectionSource = "explicit-path" | "keyword-discovery" | "none";
+
+export type PromptTarget = {
+  filePath: string;
+  exists: boolean;
+  source: "explicit-path";
+};
+
+export type ContextBudget = {
+  maxFiles: number;
+  selectedFiles: number;
+  totalBytes: number;
+  skippedFiles: number;
+};
+
+export type PromptContextPolicy = {
+  promptSpecificity: PromptSpecificity;
+  targets: PromptTarget[];
+  selectionSource: ContextSelectionSource;
+  contextMode: ContextMode;
+  contextModeReason: string;
+  contextBudget: ContextBudget;
+  contextPolicyVersion: "context-policy.v1";
+};
+
+function trimPromptToken(token: string): string {
+  return token.replace(/^[`"'([{<]+/, "").replace(/[`"')\]}>:;,!?]+$/, "");
+}
+
+function isWithinCwd(resolved: string, cwd: string): boolean {
+  const relativeToCwd = path.relative(cwd, resolved);
+  return relativeToCwd === "" || (!relativeToCwd.startsWith(`..${path.sep}`) && relativeToCwd !== ".." && !path.isAbsolute(relativeToCwd));
+}
+
+function normalizeCandidate(token: string, cwd: string): PromptTarget | null {
+  const cleaned = trimPromptToken(token);
+  if (!cleaned) return null;
+
+  const resolved = path.isAbsolute(cleaned) ? path.resolve(cleaned) : path.resolve(cwd, cleaned);
+  const extension = path.extname(resolved).toLowerCase();
+  if (!ELIGIBLE_EXTENSIONS.has(extension)) return null;
+  if (!isWithinCwd(resolved, cwd)) return null;
+
+  const relativeToCwd = path.relative(cwd, resolved) || path.basename(resolved);
+  if (path.isAbsolute(cleaned) && !fs.existsSync(resolved)) return null;
+
+  return {
+    filePath: relativeToCwd,
+    exists: fs.existsSync(resolved),
+    source: "explicit-path",
+  };
+}
+
+function uniqueTargets(targets: PromptTarget[]): PromptTarget[] {
+  const seen = new Set<string>();
+  const unique: PromptTarget[] = [];
+  for (const target of targets) {
+    if (seen.has(target.filePath)) continue;
+    seen.add(target.filePath);
+    unique.push(target);
+  }
+  return unique;
+}
+
+function emptyBudget(maxFiles: number): ContextBudget {
+  return { maxFiles, selectedFiles: 0, totalBytes: 0, skippedFiles: 0 };
+}
+
+function totalBytes(cwd: string, files: string[]): number {
+  let total = 0;
+  for (const filePath of files) {
+    try {
+      total += fs.statSync(path.resolve(cwd, filePath)).size;
+    } catch {
+      // Missing files are intentionally skipped in the budget.
+    }
+  }
+  return total;
+}
+
+export function extractPromptTargets(prompt: string, cwd = process.cwd()): PromptTarget[] {
+  return uniqueTargets([...prompt.matchAll(FILE_TOKEN_PATTERN)].map((match) => normalizeCandidate(match[0], cwd)).filter((target): target is PromptTarget => Boolean(target)));
+}
+
+export function extractPromptTarget(prompt: string, cwd = process.cwd()): string | null {
+  return extractPromptTargets(prompt, cwd)[0]?.filePath ?? null;
+}
+
+export function hasFullReadEscapeHatch(prompt: string): boolean {
+  return ESCAPE_HATCH_TOKENS.some((token) => prompt.includes(token));
+}
+
+export function codexRuntimeEscapeHatches(): readonly string[] {
+  return ESCAPE_HATCH_TOKENS;
+}
+
+export function classifyPromptContext(prompt: string, cwd = process.cwd()): PromptContextPolicy {
+  const targets = extractPromptTargets(prompt, cwd);
+  if (targets.length > 0) {
+    const selected = targets.filter((target) => target.exists).slice(0, 1);
+    return {
+      promptSpecificity: "exact-file",
+      targets,
+      selectionSource: "explicit-path",
+      contextMode: selected.length > 0 ? "light" : "no-op",
+      contextModeReason: selected.length > 0 ? "exact-file-existing-target" : "exact-file-new-or-missing-target",
+      contextBudget: {
+        maxFiles: 1,
+        selectedFiles: selected.length,
+        totalBytes: totalBytes(cwd, selected.map((target) => target.filePath)),
+        skippedFiles: targets.length - selected.length,
+      },
+      contextPolicyVersion: "context-policy.v1",
+    };
+  }
+
+  return {
+    promptSpecificity: "ambiguous",
+    targets: [],
+    selectionSource: "none",
+    contextMode: "auto",
+    contextModeReason: "no-explicit-file-target",
+    contextBudget: emptyBudget(5),
+    contextPolicyVersion: "context-policy.v1",
+  };
+}
+
+export function resolvePromptFileContext(prompt: string, cwd = process.cwd()): { filePath?: string; source: "prompt-target" | "none"; policy: PromptContextPolicy } {
+  const policy = classifyPromptContext(prompt, cwd);
+  const filePath = policy.targets[0]?.filePath;
+  return filePath ? { filePath, source: "prompt-target", policy } : { source: "none", policy };
+}
+
+function promptKeywords(prompt: string): string[] {
+  return prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 2 && !STOPWORDS.has(word));
+}
+
+export function discoverRelevantFilesByPolicy(prompt: string, allFiles: FileTarget[], cwd = process.cwd(), maxFiles = 5): { files: string[]; policy: PromptContextPolicy } {
+  const explicitPolicy = classifyPromptContext(prompt, cwd);
+  if (explicitPolicy.promptSpecificity === "exact-file") {
+    const files = explicitPolicy.targets.filter((target) => target.exists).slice(0, 1).map((target) => target.filePath);
+    return {
+      files,
+      policy: {
+        ...explicitPolicy,
+        contextMode: files.length > 0 ? "light" : "no-op",
+        contextModeReason: files.length > 0 ? "exact-file-existing-target" : "exact-file-new-or-missing-target",
+        contextBudget: {
+          maxFiles: 1,
+          selectedFiles: files.length,
+          totalBytes: totalBytes(cwd, files),
+          skippedFiles: explicitPolicy.targets.length - files.length,
+        },
+      },
+    };
+  }
+
+  const keywords = promptKeywords(prompt);
+  const scored = allFiles.map((target) => {
+    const fileName = path.basename(target.filePath).toLowerCase();
+    const fileDir = path.dirname(target.filePath).toLowerCase();
+    let score = 0;
+    for (const keyword of keywords) {
+      if (fileName.includes(keyword)) score += 10;
+      if (fileDir.includes(keyword)) score += 5;
+    }
+    if (target.kind === "component") score += 3;
+    return { filePath: target.filePath, score };
+  });
+
+  const files = scored
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxFiles)
+    .map((entry) => entry.filePath);
+
+  return {
+    files,
+    policy: {
+      ...explicitPolicy,
+      selectionSource: files.length > 0 ? "keyword-discovery" : "none",
+      contextMode: files.length > 0 ? "auto" : "no-op",
+      contextModeReason: files.length > 0 ? "ambiguous-keyword-discovery" : "ambiguous-no-relevant-files",
+      contextBudget: {
+        maxFiles,
+        selectedFiles: files.length,
+        totalBytes: totalBytes(cwd, files),
+        skippedFiles: Math.max(0, allFiles.length - files.length),
+      },
+    },
+  };
+}

--- a/src/core/discover.ts
+++ b/src/core/discover.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { discoverRelevantFilesByPolicy } from "./context-policy";
 
 const IGNORE = new Set([".git", "node_modules", "dist", ".omx", ".fooks"]);
 const COMPONENT_EXTS = new Set([".tsx", ".jsx"]);
@@ -161,39 +162,13 @@ export function discoverProjectFiles(cwd = process.cwd()): FileTarget[] {
   return discoverProjectFilesWithStats(cwd).targets;
 }
 
-// Simple keyword-based relevance discovery for task prompts
+// Simple relevance discovery for task prompts. Exact file prompts are routed
+// through the shared context policy first so fooks does not over-inject broad
+// context when the user already named the target file.
 export function discoverRelevantFiles(
   prompt: string,
   allFiles: FileTarget[],
+  cwd = process.cwd(),
 ): string[] {
-  // Extract keywords from prompt (component names, file hints)
-  const keywords = prompt
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .filter((w) => w.length > 2 && !["add", "the", "fix", "update", "to", "for", "with", "from"].includes(w));
-
-  // Score files by keyword matches
-  const scored = allFiles.map((target) => {
-    const fileName = path.basename(target.filePath).toLowerCase();
-    const fileDir = path.dirname(target.filePath).toLowerCase();
-    
-    let score = 0;
-    for (const kw of keywords) {
-      if (fileName.includes(kw)) score += 10;
-      if (fileDir.includes(kw)) score += 5;
-    }
-    
-    // Prefer component files
-    if (target.kind === "component") score += 3;
-    
-    return { filePath: target.filePath, score };
-  });
-
-  // Return top 5 files with score > 0
-  return scored
-    .filter((s) => s.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 5)
-    .map((s) => s.filePath);
+  return discoverRelevantFilesByPolicy(prompt, allFiles, cwd).files;
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -124,6 +124,17 @@ export type CodexPreReadDecision = {
   };
 };
 
+
+export type PromptSpecificity = "exact-file" | "file-hinted" | "ambiguous";
+export type ContextMode = "no-op" | "light" | "light-minimal" | "full" | "auto";
+
+export type ContextBudget = {
+  maxFiles: number;
+  selectedFiles: number;
+  totalBytes: number;
+  skippedFiles: number;
+};
+
 export type CodexRuntimeHookEvent = "SessionStart" | "UserPromptSubmit" | "Stop";
 
 export type CodexRuntimeHookInput = {
@@ -143,6 +154,11 @@ export type CodexRuntimeHookDecision = {
   reasons: string[];
   statePath?: string;
   additionalContext?: string;
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  contextBudget?: ContextBudget;
+  promptSpecificity?: PromptSpecificity;
+  contextPolicyVersion?: "context-policy.v1";
   debug?: {
     repeatedFile: boolean;
     eligible: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { extractFile } from "./core/extract";
 export { toModelFacingPayload } from "./core/payload/model-facing";
 export { assessPayloadReadiness } from "./core/payload/readiness";
 export { decideMode } from "./core/decide";
+export { classifyPromptContext, discoverRelevantFilesByPolicy, extractPromptTargets } from "./core/context-policy";
 export { attachCodex } from "./adapters/codex";
 export { attachClaude } from "./adapters/claude";
 export { decideCodexPreRead } from "./adapters/codex-pre-read";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -27,6 +27,8 @@ const {
   codexRuntimeSessionPath,
 } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-session.js"));
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
+const { prepareExecutionContext } = require(path.join(repoRoot, "dist", "adapters", "codex.js"));
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
 
 function run(args, cwd = repoRoot, envOverrides = {}) {
@@ -332,6 +334,58 @@ test("runtime prompt parser finds eligible tsx/jsx paths and escape hatches", ()
   assert.equal(hasFullReadEscapeHatch("No override here"), false);
 });
 
+test("shared context policy distinguishes exact-file light/no-op from ambiguous auto", () => {
+  const tempDir = makeTempProject();
+  const exactExisting = classifyPromptContext("Modify exactly src/components/FormSection.tsx", tempDir);
+  assert.equal(exactExisting.promptSpecificity, "exact-file");
+  assert.equal(exactExisting.contextMode, "light");
+  assert.equal(exactExisting.selectionSource, "explicit-path");
+  assert.equal(exactExisting.contextBudget.maxFiles, 1);
+  assert.equal(exactExisting.contextBudget.selectedFiles, 1);
+
+  const exactNew = classifyPromptContext("Create src/components/NewPanel.tsx", tempDir);
+  assert.equal(exactNew.promptSpecificity, "exact-file");
+  assert.equal(exactNew.contextMode, "no-op");
+  assert.equal(exactNew.contextBudget.selectedFiles, 0);
+
+  const ambiguous = discoverRelevantFilesByPolicy("Add loading state to the form section", discoverProjectFilesForTest(tempDir), tempDir);
+  assert.equal(ambiguous.policy.promptSpecificity, "ambiguous");
+  assert.equal(ambiguous.policy.contextMode, "auto");
+  assert.ok(ambiguous.files.length > 0);
+  assert.ok(ambiguous.files.length <= 5);
+});
+
+function discoverProjectFilesForTest(cwd) {
+  return [
+    { filePath: path.join("src", "components", "FormSection.tsx"), kind: "component" },
+    { filePath: path.join("src", "components", "SimpleButton.tsx"), kind: "component" },
+    { filePath: path.join("src", "components", "DashboardPanel.tsx"), kind: "component" },
+  ];
+}
+
+test("prepareExecutionContext writes context policy metadata and resolves files from cwd", async () => {
+  const tempDir = makeTempProject();
+  const policy = classifyPromptContext("Modify src/components/FormSection.tsx", tempDir);
+  const result = await prepareExecutionContext("Modify src/components/FormSection.tsx", [path.join("src", "components", "FormSection.tsx")], tempDir, policy);
+  assert.equal(result.contextMode, "light");
+  assert.equal(result.promptSpecificity, "exact-file");
+  const context = fs.readFileSync(result.contextPath, "utf8");
+  assert.match(context, /fooks-context-policy/);
+  assert.match(context, /"contextMode":"light"/);
+  assert.match(context, /## src\/components\/FormSection.tsx/);
+});
+
+test("cli run keeps exact-file prompts to one light context file", () => {
+  const tempDir = makeTempProject();
+  const output = runText(["run", "Please", "update", "src/components/FormSection.tsx"], tempDir);
+  assert.match(output, /Context mode: light/);
+  assert.match(output, /1 files/);
+  const context = fs.readFileSync(path.join(tempDir, ".fooks", "temp-context.md"), "utf8");
+  assert.match(context, /"contextMode":"light"/);
+  assert.match(context, /## src\/components\/FormSection.tsx/);
+  assert.doesNotMatch(context, /## src\/components\/SimpleButton.tsx/);
+});
+
 test("runtime hook reuses payload only on repeated same-file prompts in one session", () => {
   const sessionId = `hook-repeat-${Date.now()}`;
   const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
@@ -348,6 +402,8 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   );
   assert.equal(first.action, "record");
   assert.equal(first.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(first.contextMode, "no-op");
+  assert.equal(first.promptSpecificity, "exact-file");
   assert.equal(first.additionalContext, undefined);
 
   const second = handleCodexRuntimeHook(
@@ -359,6 +415,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
     repoRoot,
   );
   assert.equal(second.action, "inject");
+  assert.equal(second.contextMode, "light");
   assert.equal(second.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
   assert.ok(
     second.additionalContext.startsWith(
@@ -389,6 +446,7 @@ test("runtime hook injects tiny raw originals and still honors escape hatch fall
     repoRoot,
   );
   assert.equal(rawSecond.action, "inject");
+  assert.equal(rawSecond.contextMode, "light-minimal");
   assert.match(rawSecond.additionalContext, /"useOriginal": true/);
   assert.match(rawSecond.additionalContext, /"rawText":/);
 
@@ -403,6 +461,7 @@ test("runtime hook injects tiny raw originals and still honors escape hatch fall
     repoRoot,
   );
   assert.equal(overridden.action, "fallback");
+  assert.equal(overridden.contextMode, "full");
   assert.ok(overridden.reasons.includes("escape-hatch-full-read"));
   assert.equal(overridden.fallback.reason, "escape-hatch-full-read");
   assert.equal(overridden.debug.escapeHatchUsed, true);

--- a/test/frontend-harness.test.mjs
+++ b/test/frontend-harness.test.mjs
@@ -22,6 +22,7 @@ function runRunnerConfig(args = [], envOverrides = {}) {
 
 test("frontend harness defaults to repo-local reports and preserves the legacy case matrix", () => {
   const result = runRunnerConfig();
+  assert.equal(result.reportSchemaVersion, "frontend-harness.v2-context-mode");
   assert.equal(result.reportsDir, defaultReportsDir);
   assert.equal(result.defaultReportsDir, defaultReportsDir);
   assert.equal(result.runner, "omx");
@@ -38,6 +39,9 @@ test("frontend harness defaults to repo-local reports and preserves the legacy c
     ],
   );
   assert.equal(result.tokenEstimateNotes.scope, "tsx-only proxy");
+  assert.equal(result.selectedCases[0].taskClass, "ambiguous-single-file");
+  assert.equal(result.selectedCases[0].promptSpecificity, "ambiguous");
+  assert.equal(result.selectedCases[0].expectedContextPolicy, "auto");
 });
 
 test("frontend harness supports single-case round-1 configuration and report dir overrides", () => {
@@ -57,4 +61,7 @@ test("frontend harness supports single-case round-1 configuration and report dir
   assert.equal(result.selectedCases[0].task, "T5");
   assert.equal(result.selectedCases[0].prompt, customPrompt);
   assert.equal(result.selectedCases[0].repo_exists, false);
+  assert.equal(result.selectedCases[0].taskClass, "ambiguous-multi-file");
+  assert.equal(result.selectedCases[0].promptSpecificity, "ambiguous");
+  assert.equal(result.selectedCases[0].expectedContextPolicy, "auto");
 });


### PR DESCRIPTION
## Summary
- adds a shared context-policy classifier for exact-file/light/no-op vs ambiguous/full benchmark behavior
- wires fooks run and Codex runtime hooks to expose context-mode metadata
- preserves historical Formbricks evidence and interpretation without claiming public runtime-token wins yet

## Risk controls
- exact-file first turn records only/no-op; repeated exact-file turns stay light/minimal
- benchmark reports now include schema/context-policy metadata
- historical negative/mixed evidence is kept as product-decision input

## Verification
- npm test
- npm run lint
- python3 -m py_compile benchmarks/frontend-harness/runners/full-benchmark-suite.py
- node --test test/frontend-harness.test.mjs
- git diff --check

Not-tested: post-policy live Codex benchmark rerun is being executed as follow-up because it requires external runtime/auth and longer wall-clock time.