### PR TITLE
Clarify fooks benchmark context policy

### DIFF
--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous-prompt.txt
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous-prompt.txt
@@ -1,0 +1,1 @@
+Find the Formbricks login password field and add an inline Tailwind red Caps Lock warning below the password field when getModifierState('CapsLock') is true. Keep existing login, email sign-in, password reset, and two-factor flows unchanged. Report which file you modified.

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776396673.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776396673.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:31:13.284995",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 73.82694061022411,
+    "avg_tokens_saved": 767758.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:20:23.583368",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 4159776.5999999996,
+        "compressed_bytes": 1088740.8,
+        "raw_tokens": 1039944.0,
+        "compressed_tokens": 272185.0,
+        "tokens_saved": 767758.0,
+        "reduction_pct": 73.82694061022411,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 277185,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 77999,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396031",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396031/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning for the login password field only.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396031/apps/web/modules/auth/login/components/login-form.tsx:148)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396031/apps/web/locales/en-US.json:58)\n\nWhat changed:\n- Added `getModifierState(\"CapsLock\")` handling on the login password input via `onKeyDown` / `onKeyUp`.\n- Shows an inline Tailwind red warning below the password field when Caps Lock is on.\n- Keeps the shared `PasswordInput` unchanged, so password reset, signup, and two-factor flows are unaffected.\n- Added the warning copy through `t(\"auth.login.caps_lock_warning\")`.\n\nVerification:\n- `en-US.json` parses successfully.\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` could not run because dependencies are not installed in this worktree (`prettier` command not found).\n",
+        "stderr_tail": "15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p role=\"status\" aria-live=\"polite\" className=\"mt-2 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n77,999\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 346213,
+        "scan_time": 3453,
+        "total_time": 349666,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 63427,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3453,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 99,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2858,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 958.9\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 149.77\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 94.82\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 82.22\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 73.51\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 495,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:25:19.143Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/.codex/fooks/attachments/bm-t5-fooks-1776396314.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/.codex/fooks/attachments/bm-t5-fooks-1776396314.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:25:19.132Z\",\"attachedAt\":\"2026-04-17T03:25:19.129Z\",\"lastScanAt\":\"2026-04-17T03:25:19.129Z\",\"lastRefreshAt\":\"2026-04-17T03:25:19.129Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning locally in the login form.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/apps/web/modules/auth/login/components/login-form.tsx)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396314/apps/web/locales/en-US.json)\n\nWhat changed:\n- Added `isCapsLockOn` state in the login form only.\n- Added `onKeyDown` / `onKeyUp` handlers on the login password field using `event.getModifierState(\"CapsLock\")`.\n- Renders an inline Tailwind red warning below the password field: `Caps Lock is on`.\n- Left the shared `PasswordInput` untouched, so password reset, 2FA, and other password flows are unchanged.\n\nVerification:\n- `git diff --check` passed.\n- `en-US.json` parses successfully.\n- Targeted ESLint could not run because `eslint` is not available via `pnpm exec` in this workspace.\n",
+        "stderr_tail": "@ -238,7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onBlur={() => setIsCapsLockOn(false)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-sm text-red-500\" aria-live=\"polite\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n63,427\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -24.903223478903982,
+        "total": -26.14896188466187
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397195.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397195.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:39:55.448269",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 75.97399877115566,
+    "avg_tokens_saved": 799775.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:31:13.394232",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 4210785.6,
+        "compressed_bytes": 1011683.3999999999,
+        "raw_tokens": 1052696.0,
+        "compressed_tokens": 252920.0,
+        "tokens_saved": 799775.0,
+        "reduction_pct": 75.97399877115566,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 283407,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 69689,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396681",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396681/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning in the login password field only.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396681/apps/web/modules/auth/login/components/login-form.tsx:183): tracks `getModifierState(\"CapsLock\")` on password key events and renders an inline Tailwind red warning below the password input.\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776396681/apps/web/locales/en-US.json:58): added `auth.login.caps_lock_warning`.\n\nVerification:\n- `node` JSON parse for `apps/web/locales/en-US.json` passed.\n- `git diff --check` passed.\n- Could not run ESLint because `node_modules` is missing and `eslint` is not installed in this worktree.\n",
+        "stderr_tail": "                          value={field.value}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\" role=\"status\" aria-live=\"polite\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\ndiff --git a/patch-root-probe b/patch-root-probe\ndeleted file mode 100644\nindex e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000\n\ntokens used\n69,689\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 211199,
+        "scan_time": 3396,
+        "total_time": 214595,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 55593,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3396,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 90,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2808,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 936.72\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 155.9\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 89.53\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 89.27\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 65.16\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 497,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:36:16.219Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/.codex/fooks/attachments/bm-t5-fooks-1776396971.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/.codex/fooks/attachments/bm-t5-fooks-1776396971.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:36:16.209Z\",\"attachedAt\":\"2026-04-17T03:36:16.206Z\",\"lastScanAt\":\"2026-04-17T03:36:16.206Z\",\"lastRefreshAt\":\"2026-04-17T03:36:16.206Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning for the Formbricks login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/apps/web/modules/auth/login/components/login-form.tsx): added local Caps Lock state, `getModifierState(\"CapsLock\")` key handlers, and the inline Tailwind red warning below the login password input.\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776396971/apps/web/locales/en-US.json): added `auth.login.caps_lock_warning`.\n\nValidation:\n- `git diff --check` passed.\n- `en-US.json` parses successfully.\n- Could not run ESLint because this checkout has no `node_modules`, and `pnpm exec eslint ...` failed with `Command \"eslint\" not found`.\n",
+        "stderr_tail": "15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p aria-live=\"polite\" className=\"mt-1 text-left text-xs text-red-600\" role=\"status\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n55,593\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 25.478552047056002,
+        "total": 24.280275363699555
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397646.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397646.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:47:26.235249",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 65.63495629442039,
+    "avg_tokens_saved": 472421.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:39:55.558678",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 2879083.1999999997,
+        "compressed_bytes": 989398.2,
+        "raw_tokens": 719770.0,
+        "compressed_tokens": 247349.0,
+        "tokens_saved": 472421.0,
+        "reduction_pct": 65.63495629442039,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 220959,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 65608,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397203",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397203/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning for the login password field only.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397203/apps/web/modules/auth/login/components/login-form.tsx:148)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397203/apps/web/locales/en-US.json:61)\n\nWhat changed:\n- Added local `isCapsLockOn` state in the login form.\n- Added `onKeyDown` / `onKeyUp` handling on the login password field using `event.getModifierState(\"CapsLock\")`.\n- Shows an inline Tailwind red warning below the password field: `Caps Lock is on`.\n- Clears the warning on password input blur.\n- Left shared `PasswordInput`, password reset, email sign-in submission, and 2FA components untouched.\n\nValidation:\n- `apps/web/locales/en-US.json` parses successfully.\n- `git diff --check` passed.\n- Could not run Prettier/lint because this checkout has no `node_modules`, and `pnpm exec prettier` reports `Command \"prettier\" not found`.\n",
+        "stderr_tail": "    required\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                             onChange={(password) => field.onChange(password)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs font-medium text-red-600\" role=\"status\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n65,608\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 203891,
+        "scan_time": 3185,
+        "total_time": 207076,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 58042,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3185,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 90,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2631,
+              "stdout_tail": "esolveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 854.68\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 152.33\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 84.1\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 75.88\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 64.9\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 463,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:43:54.554Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/.codex/fooks/attachments/bm-t5-fooks-1776397430.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/.codex/fooks/attachments/bm-t5-fooks-1776397430.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:43:54.544Z\",\"attachedAt\":\"2026-04-17T03:43:54.541Z\",\"lastScanAt\":\"2026-04-17T03:43:54.541Z\",\"lastRefreshAt\":\"2026-04-17T03:43:54.541Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning on the login password field only.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/apps/web/modules/auth/login/components/login-form.tsx:148)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776397430/apps/web/locales/en-US.json:62)\n\nWhat changed:\n- Added login-only Caps Lock state based on `event.getModifierState(\"CapsLock\")`.\n- Shows an inline Tailwind red warning below the login password field: `text-red-500`.\n- Left the shared `PasswordInput` component unchanged, so password reset and two-factor password flows are not affected.\n- Added the `auth.login.caps_lock_warning` translation key.\n\nVerification:\n- `en-US.json` parses successfully.\n- `git diff --check` passed.\n- `pnpm exec prettier` and `pnpm exec eslint` could not run because those executables are not available in the local `node_modules`.\n",
+        "stderr_tail": "               className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onClick={updateCapsLockState}\n+                            onKeyDown={updateCapsLockState}\n+                            onKeyUp={updateCapsLockState}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-500\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n58,042\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 7.724509976964051,
+        "total": 6.283066089183967
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-1.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-1.log
@@ -1,0 +1,50 @@
+===== POST-POLICY ambiguous run 1 START 2026-04-17T03:20:23Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:20:23.583211
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~1,039,944 tokens
+    Compressed: ~272,185 tokens
+    Saved: ~767,758 tokens (73.8%)
+
+  [VANILLA] Running...
+    ✓ 277,185ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:346,213ms + scan:3,453ms = 349,666ms, 2 files
+
+  Execution time diff: -24.9%
+  Total time diff: -26.1%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 277,185ms
+Avg Fooks exec: 346,213ms (-24.9%)
+Avg Fooks total: 349,666ms (-26.1%)
+
+Avg token reduction: 73.8%
+Avg tokens saved: ~767,758 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776396673.json
+======================================================================
+===== POST-POLICY ambiguous run 1 END 2026-04-17T03:31:13Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-2.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-2.log
@@ -1,0 +1,50 @@
+===== POST-POLICY ambiguous run 2 START 2026-04-17T03:31:13Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:31:13.394046
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~1,052,696 tokens
+    Compressed: ~252,920 tokens
+    Saved: ~799,775 tokens (76.0%)
+
+  [VANILLA] Running...
+    ✓ 283,407ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:211,199ms + scan:3,396ms = 214,595ms, 2 files
+
+  Execution time diff: +25.5%
+  Total time diff: +24.3%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 283,407ms
+Avg Fooks exec: 211,199ms (+25.5%)
+Avg Fooks total: 214,595ms (+24.3%)
+
+Avg token reduction: 76.0%
+Avg tokens saved: ~799,775 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397195.json
+======================================================================
+===== POST-POLICY ambiguous run 2 END 2026-04-17T03:39:55Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-3.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/run-3.log
@@ -1,0 +1,50 @@
+===== POST-POLICY ambiguous run 3 START 2026-04-17T03:39:55Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:39:55.558508
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~719,770 tokens
+    Compressed: ~247,349 tokens
+    Saved: ~472,421 tokens (65.6%)
+
+  [VANILLA] Running...
+    ✓ 220,959ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:203,891ms + scan:3,185ms = 207,076ms, 2 files
+
+  Execution time diff: +7.7%
+  Total time diff: +6.3%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 220,959ms
+Avg Fooks exec: 203,891ms (+7.7%)
+Avg Fooks total: 207,076ms (+6.3%)
+
+Avg token reduction: 65.6%
+Avg tokens saved: ~472,421 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/ambiguous/benchmark-full-1776397646.json
+======================================================================
+===== POST-POLICY ambiguous run 3 END 2026-04-17T03:47:26Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.diffstat
@@ -1,0 +1,16 @@
+ apps/web/locales/de-DE.json                        |    1 +
+ apps/web/locales/en-US.json                        |    1 +
+ apps/web/locales/es-ES.json                        |    1 +
+ apps/web/locales/fr-FR.json                        |    1 +
+ apps/web/locales/hu-HU.json                        |    1 +
+ apps/web/locales/ja-JP.json                        |    1 +
+ apps/web/locales/nl-NL.json                        |    1 +
+ apps/web/locales/pt-BR.json                        |    1 +
+ apps/web/locales/pt-PT.json                        |    1 +
+ apps/web/locales/ro-RO.json                        |    1 +
+ apps/web/locales/ru-RU.json                        |    1 +
+ apps/web/locales/sv-SE.json                        |    1 +
+ apps/web/locales/zh-Hans-CN.json                   |    1 +
+ apps/web/locales/zh-Hant-TW.json                   |    1 +
+ .../modules/auth/login/components/login-form.tsx   |   14 ++++++++++++++
+ 15 files changed, 28 insertions(+)

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.patch
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.patch
@@ -1,0 +1,208 @@
+diff --git a/apps/web/locales/de-DE.json b/apps/web/locales/de-DE.json
+index 824afcd..ad3b01b 100644
+--- a/apps/web/locales/de-DE.json
++++ b/apps/web/locales/de-DE.json
+@@ -55,6 +55,7 @@
+     "last_used": "Last used",
+     "login": {
+       "backup_code": "Backup-Code",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Konto erstellen",
+       "enter_your_backup_code": "Gib deinen Backup-Code ein",
+       "enter_your_two_factor_authentication_code": "Gib deinen Zwei-Faktor-Authentifizierungscode ein",
+diff --git a/apps/web/locales/en-US.json b/apps/web/locales/en-US.json
+index 6aef907..474f95c 100644
+--- a/apps/web/locales/en-US.json
++++ b/apps/web/locales/en-US.json
+@@ -55,6 +55,7 @@
+     "last_used": "Last Used",
+     "login": {
+       "backup_code": "Backup code",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Create an account",
+       "enter_your_backup_code": "Enter your backup code",
+       "enter_your_two_factor_authentication_code": "Enter your two-factor authentication code",
+diff --git a/apps/web/locales/es-ES.json b/apps/web/locales/es-ES.json
+index a77f9a2..b140030 100644
+--- a/apps/web/locales/es-ES.json
++++ b/apps/web/locales/es-ES.json
+@@ -55,6 +55,7 @@
+     "last_used": "Último uso",
+     "login": {
+       "backup_code": "Código de respaldo",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Crear una cuenta",
+       "enter_your_backup_code": "Introduce tu código de respaldo",
+       "enter_your_two_factor_authentication_code": "Introduce tu código de autenticación de dos factores",
+diff --git a/apps/web/locales/fr-FR.json b/apps/web/locales/fr-FR.json
+index 358ac53..efca251 100644
+--- a/apps/web/locales/fr-FR.json
++++ b/apps/web/locales/fr-FR.json
+@@ -55,6 +55,7 @@
+     "last_used": "Dernière utilisation",
+     "login": {
+       "backup_code": "Code de sauvegarde",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Créer un compte",
+       "enter_your_backup_code": "Entrez votre code de sauvegarde",
+       "enter_your_two_factor_authentication_code": "Entrez votre code d'authentification à deux facteurs.",
+diff --git a/apps/web/locales/hu-HU.json b/apps/web/locales/hu-HU.json
+index 2cf5bd2..21395e8 100644
+--- a/apps/web/locales/hu-HU.json
++++ b/apps/web/locales/hu-HU.json
+@@ -55,6 +55,7 @@
+     "last_used": "Legutóbb használt",
+     "login": {
+       "backup_code": "Visszaszerzési kód",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Fiók létrehozása",
+       "enter_your_backup_code": "Visszaszerzési kód megadása",
+       "enter_your_two_factor_authentication_code": "Kétfaktoros hitelesítési kód megadása",
+diff --git a/apps/web/locales/ja-JP.json b/apps/web/locales/ja-JP.json
+index 4b5b747..672efa8 100644
+--- a/apps/web/locales/ja-JP.json
++++ b/apps/web/locales/ja-JP.json
+@@ -55,6 +55,7 @@
+     "last_used": "最終使用",
+     "login": {
+       "backup_code": "バックアップコード",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "アカウントを作成",
+       "enter_your_backup_code": "バックアップコードを入力してください",
+       "enter_your_two_factor_authentication_code": "二段階認証コードを入力してください",
+diff --git a/apps/web/locales/nl-NL.json b/apps/web/locales/nl-NL.json
+index d2f2185..6dbbaac 100644
+--- a/apps/web/locales/nl-NL.json
++++ b/apps/web/locales/nl-NL.json
+@@ -55,6 +55,7 @@
+     "last_used": "Laatst gebruikt",
+     "login": {
+       "backup_code": "Back-upcode",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Maak een account aan",
+       "enter_your_backup_code": "Voer uw back-upcode in",
+       "enter_your_two_factor_authentication_code": "Voer uw tweefactorauthenticatiecode in",
+diff --git a/apps/web/locales/pt-BR.json b/apps/web/locales/pt-BR.json
+index 35adbf6..95e0929 100644
+--- a/apps/web/locales/pt-BR.json
++++ b/apps/web/locales/pt-BR.json
+@@ -55,6 +55,7 @@
+     "last_used": "Usado por último",
+     "login": {
+       "backup_code": "Código de backup",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Cria uma conta",
+       "enter_your_backup_code": "Digite seu código de backup",
+       "enter_your_two_factor_authentication_code": "Digite seu código de autenticação de dois fatores",
+diff --git a/apps/web/locales/pt-PT.json b/apps/web/locales/pt-PT.json
+index 4a28b38..069bbc5 100644
+--- a/apps/web/locales/pt-PT.json
++++ b/apps/web/locales/pt-PT.json
+@@ -55,6 +55,7 @@
+     "last_used": "Última Utilização",
+     "login": {
+       "backup_code": "Código de backup",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Criar uma conta",
+       "enter_your_backup_code": "Introduza o seu código de backup",
+       "enter_your_two_factor_authentication_code": "Introduza o seu código de autenticação de dois fatores",
+diff --git a/apps/web/locales/ro-RO.json b/apps/web/locales/ro-RO.json
+index af2858c..d41b4e6 100644
+--- a/apps/web/locales/ro-RO.json
++++ b/apps/web/locales/ro-RO.json
+@@ -55,6 +55,7 @@
+     "last_used": "Ultima utilizare",
+     "login": {
+       "backup_code": "Cod de rezervă",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Creează un cont",
+       "enter_your_backup_code": "Introduceți codul de rezervă",
+       "enter_your_two_factor_authentication_code": "Introduceți codul dvs. de autentificare în doi pași",
+diff --git a/apps/web/locales/ru-RU.json b/apps/web/locales/ru-RU.json
+index 26ecac2..4f7139a 100644
+--- a/apps/web/locales/ru-RU.json
++++ b/apps/web/locales/ru-RU.json
+@@ -55,6 +55,7 @@
+     "last_used": "Последнее использование",
+     "login": {
+       "backup_code": "Резервный код",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Создать аккаунт",
+       "enter_your_backup_code": "Введите резервный код",
+       "enter_your_two_factor_authentication_code": "Введите код двухфакторной аутентификации",
+diff --git a/apps/web/locales/sv-SE.json b/apps/web/locales/sv-SE.json
+index 48dc476..fd130e6 100644
+--- a/apps/web/locales/sv-SE.json
++++ b/apps/web/locales/sv-SE.json
+@@ -55,6 +55,7 @@
+     "last_used": "Senast använd",
+     "login": {
+       "backup_code": "Reservkod",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Skapa ett konto",
+       "enter_your_backup_code": "Ange din reservkod",
+       "enter_your_two_factor_authentication_code": "Ange din tvåfaktorsautentiseringskod",
+diff --git a/apps/web/locales/zh-Hans-CN.json b/apps/web/locales/zh-Hans-CN.json
+index 6290973..0ad0cc7 100644
+--- a/apps/web/locales/zh-Hans-CN.json
++++ b/apps/web/locales/zh-Hans-CN.json
+@@ -55,6 +55,7 @@
+     "last_used": "最近使用",
+     "login": {
+       "backup_code": "备用代码",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "创建一个帐户",
+       "enter_your_backup_code": "输入 你的 备用代码",
+       "enter_your_two_factor_authentication_code": "输入 你的 双因素 认证 代码",
+diff --git a/apps/web/locales/zh-Hant-TW.json b/apps/web/locales/zh-Hant-TW.json
+index b80b73b..1d9ce52 100644
+--- a/apps/web/locales/zh-Hant-TW.json
++++ b/apps/web/locales/zh-Hant-TW.json
+@@ -55,6 +55,7 @@
+     "last_used": "上次使用",
+     "login": {
+       "backup_code": "備份碼",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "建立帳戶",
+       "enter_your_backup_code": "輸入您的備份碼",
+       "enter_your_two_factor_authentication_code": "輸入您的雙重驗證碼",
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..91505f4 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -5,6 +5,7 @@ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+ import { useEffect, useMemo, useRef, useState } from "react";
++import type { KeyboardEvent } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -147,6 +148,11 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
++
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +244,15 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onBlur={() => setIsCapsLockOn(false)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
+                           />
++                          {isCapsLockOn && (
++                            <p className="mt-1 text-left text-xs text-red-600" role="alert">
++                              {t("auth.login.caps_lock_warning")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.diffstat
@@ -1,0 +1,3 @@
+ apps/web/locales/en-US.json                        |    1 +
+ .../modules/auth/login/components/login-form.tsx   |   15 ++++++++++++++-
+ 2 files changed, 15 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.patch
@@ -1,0 +1,56 @@
+diff --git a/apps/web/locales/en-US.json b/apps/web/locales/en-US.json
+index 6aef907..474f95c 100644
+--- a/apps/web/locales/en-US.json
++++ b/apps/web/locales/en-US.json
+@@ -55,6 +55,7 @@
+     "last_used": "Last Used",
+     "login": {
+       "backup_code": "Backup code",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Create an account",
+       "enter_your_backup_code": "Enter your backup code",
+       "enter_your_two_factor_authentication_code": "Enter your two-factor authentication code",
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..49a6e9d 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,15 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => setIsCapsLockOn(false)}
+                           />
++                          {isCapsLockOn && (
++                            <p className="mt-1 text-left text-xs text-red-600" role="status">
++                              {t("auth.login.caps_lock_warning")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/benchmark-full-1776398249.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/benchmark-full-1776398249.json
@@ -1,0 +1,271 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T13:09:26.150282",
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 64.98037416526482,
+    "avg_tokens_saved": 468459.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "medium",
+        "evidence": "same_prompt=True, same_files=False, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "high",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 1/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:57:29.844414",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 2883699.0,
+        "compressed_bytes": 1009860.6,
+        "raw_tokens": 720924.0,
+        "compressed_tokens": 252465.0,
+        "tokens_saved": 468459.0,
+        "reduction_pct": 64.98037416526482,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 265821,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 67777,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776398257",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776398257/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning on the Formbricks login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776398257/apps/web/modules/auth/login/components/login-form.tsx:148) - added password-field Caps Lock state, key handlers using `getModifierState(\"CapsLock\")`, and the inline red Tailwind warning below the login password input.\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776398257/apps/web/locales/en-US.json:58) - added the localized warning text.\n\nVerification:\n- `git diff --check` passed.\n- `apps/web/locales/en-US.json` parses successfully.\n- `prettier` and `eslint` could not run because local binaries are not installed in this worktree.\n",
+        "stderr_tail": "\");\n@@ -238,7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\" role=\"status\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n67,777\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-vanilla.diffstat",
+          "patch_bytes": 2986,
+          "diffstat": " apps/web/locales/en-US.json                        |    1 +\n .../modules/auth/login/components/login-form.tsx   |   15 ++++++++++++++-\n 2 files changed, 15 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 422244,
+        "scan_time": 3162,
+        "total_time": 425406,
+        "files": 15,
+        "files_list": [
+          "apps/web/locales/de-DE.json",
+          "apps/web/locales/en-US.json",
+          "apps/web/locales/es-ES.json",
+          "apps/web/locales/fr-FR.json",
+          "apps/web/locales/hu-HU.json",
+          "apps/web/locales/ja-JP.json",
+          "apps/web/locales/nl-NL.json",
+          "apps/web/locales/pt-BR.json",
+          "apps/web/locales/pt-PT.json",
+          "apps/web/locales/ro-RO.json",
+          "apps/web/locales/ru-RU.json",
+          "apps/web/locales/sv-SE.json",
+          "apps/web/locales/zh-Hans-CN.json",
+          "apps/web/locales/zh-Hant-TW.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 105585,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3162,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 94,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2596,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 833.14\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 161.91\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 83.15\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 72.42\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 62.39\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 471,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T04:02:15.303Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/.codex/fooks/attachments/bm-t5-fooks-1776398530.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/.codex/fooks/attachments/bm-t5-fooks-1776398530.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T04:02:15.292Z\",\"attachedAt\":\"2026-04-17T04:02:15.289Z\",\"lastScanAt\":\"2026-04-17T04:02:15.289Z\",\"lastRefreshAt\":\"2026-04-17T04:02:15.289Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/.codex",
+          "prompt_sha256": "17b97eb3c79180aab7e9045179183f49131b8d1920971673432dd4d6400024f2",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning on the login email/password form only.\n\nModified:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398530/apps/web/modules/auth/login/components/login-form.tsx:151)\n- Web locale JSON files in `apps/web/locales/*.json` for the new `auth.login.caps_lock_warning` key.\n\nWhat changed:\n- Added local `isCapsLockOn` state in the login form.\n- Checks `event.getModifierState(\"CapsLock\")` on password `onKeyDown` and `onKeyUp`.\n- Shows an inline `text-red-600` warning below the login password field.\n- Resets the warning on password field blur.\n- Did not change the shared `PasswordInput`, password reset form, email sign-in logic, or two-factor components.\n\nVerification:\n- `git diff --check` passed.\n- All web locale JSON files parse successfully.\n- Confirmed the new translation key exists in every web locale file.\n- Could not run ESLint or the translation scanner because this checkout is missing installed binaries: `eslint` and `tsx`.\n",
+        "stderr_tail": "\");\n@@ -238,7 +244,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onBlur={() => setIsCapsLockOn(false)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\" role=\"alert\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n105,585\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/artifacts/benchmark-full-1776398249/formbricks-T5-fooks.diffstat",
+          "patch_bytes": 9918,
+          "diffstat": " apps/web/locales/de-DE.json                        |    1 +\n apps/web/locales/en-US.json                        |    1 +\n apps/web/locales/es-ES.json                        |    1 +\n apps/web/locales/fr-FR.json                        |    1 +\n apps/web/locales/hu-HU.json                        |    1 +\n apps/web/locales/ja-JP.json                        |    1 +\n apps/web/locales/nl-NL.json                        |    1 +\n apps/web/locales/pt-BR.json                        |    1 +\n apps/web/locales/pt-PT.json                        |    1 +\n apps/web/locales/ro-RO.json                        |    1 +\n apps/web/locales/ru-RU.json                        |    1 +\n apps/web/locales/sv-SE.json                        |    1 +\n apps/web/locales/zh-Hans-CN.json                   |    1 +\n apps/web/locales/zh-Hant-TW.json                   |    1 +\n .../modules/auth/login/components/login-form.tsx   |   14 ++++++++++++++\n 15 files changed, 28 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -58.84523796088346,
+        "total": -60.03476023339014
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/run.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/run.log
@@ -1,0 +1,50 @@
+===== ARTIFACT-VERIFY ambiguous START 2026-04-17T03:57:29Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:57:29.844152
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~720,924 tokens
+    Compressed: ~252,465 tokens
+    Saved: ~468,459 tokens (65.0%)
+
+  [VANILLA] Running...
+    ✓ 265,821ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:422,244ms + scan:3,162ms = 425,406ms, 15 files
+
+  Execution time diff: -58.8%
+  Total time diff: -60.0%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 265,821ms
+Avg Fooks exec: 422,244ms (-58.8%)
+Avg Fooks total: 425,406ms (-60.0%)
+
+Avg token reduction: 65.0%
+Avg tokens saved: ~468,459 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/ambiguous/benchmark-full-1776398249.json
+======================================================================
+===== ARTIFACT-VERIFY ambiguous END 2026-04-17T04:09:26Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.diffstat
@@ -1,0 +1,3 @@
+ apps/web/locales/en-US.json                        |    1 +
+ .../modules/auth/login/components/login-form.tsx   |   15 ++++++++++++++-
+ 2 files changed, 15 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.patch
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.patch
@@ -1,0 +1,58 @@
+diff --git a/apps/web/locales/en-US.json b/apps/web/locales/en-US.json
+index 6aef907..474f95c 100644
+--- a/apps/web/locales/en-US.json
++++ b/apps/web/locales/en-US.json
+@@ -55,6 +55,7 @@
+     "last_used": "Last Used",
+     "login": {
+       "backup_code": "Backup code",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Create an account",
+       "enter_your_backup_code": "Enter your backup code",
+       "enter_your_two_factor_authentication_code": "Enter your two-factor authentication code",
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..448d98c 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -143,11 +143,16 @@ export const LoginForm = ({
+   };
+ 
+   const [showLogin, setShowLogin] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const updateCapsLockState = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,15 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onBlur={() => setIsCapsLockOn(false)}
++                            onKeyDown={updateCapsLockState}
++                            onKeyUp={updateCapsLockState}
+                           />
++                          {isCapsLockOn && (
++                            <p className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_warning")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.diffstat
@@ -1,0 +1,3 @@
+ apps/web/locales/en-US.json                        |    1 +
+ .../modules/auth/login/components/login-form.tsx   |    9 +++++++++
+ 2 files changed, 10 insertions(+)

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.patch
@@ -1,0 +1,40 @@
+diff --git a/apps/web/locales/en-US.json b/apps/web/locales/en-US.json
+index 6aef907..474f95c 100644
+--- a/apps/web/locales/en-US.json
++++ b/apps/web/locales/en-US.json
+@@ -55,6 +55,7 @@
+     "last_used": "Last Used",
+     "login": {
+       "backup_code": "Backup code",
++      "caps_lock_warning": "Caps Lock is on",
+       "create_an_account": "Create an account",
+       "enter_your_backup_code": "Enter your backup code",
+       "enter_your_two_factor_authentication_code": "Enter your two-factor authentication code",
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..629201f 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -147,6 +147,7 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +239,15 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={(event) => setIsCapsLockOn(event.getModifierState("CapsLock"))}
++                            onKeyUp={(event) => setIsCapsLockOn(event.getModifierState("CapsLock"))}
++                            onBlur={() => setIsCapsLockOn(false)}
+                           />
++                          {isCapsLockOn && (
++                            <p className="mt-1 text-left text-xs text-red-600" role="alert">
++                              {t("auth.login.caps_lock_warning")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/benchmark-full-1776397764.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/benchmark-full-1776397764.json
@@ -1,0 +1,258 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:57:29.745201",
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 81.37907030706164,
+    "avg_tokens_saved": 1391994.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:49:24.096094",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "targeted-edit",
+      "promptSpecificity": "exact-file",
+      "expectedContextPolicy": "light",
+      "expectedFirstTurnRuntimeContext": "no-op",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 6842026.8,
+        "compressed_bytes": 1274049.0,
+        "raw_tokens": 1710506.0,
+        "compressed_tokens": 318512.0,
+        "tokens_saved": 1391994.0,
+        "reduction_pct": 81.37907030706164,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 291388,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 47511,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397771",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397771/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning below the login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397771/apps/web/modules/auth/login/components/login-form.tsx:150)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776397771/apps/web/locales/en-US.json:58)\n\nValidation:\n- `git diff --check` passed.\n- `apps/web/locales/en-US.json` parses successfully.\n- Prettier could not run because `node_modules` is missing and `prettier` is not available in this workspace install.\n",
+        "stderr_tail": "ounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={(event) => setIsCapsLockOn(event.getModifierState(\"CapsLock\"))}\n+                            onKeyUp={(event) => setIsCapsLockOn(event.getModifierState(\"CapsLock\"))}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\" role=\"alert\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n47,511\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-vanilla.diffstat",
+          "patch_bytes": 2223,
+          "diffstat": " apps/web/locales/en-US.json                        |    1 +\n .../modules/auth/login/components/login-form.tsx   |    9 +++++++++\n 2 files changed, 10 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 166459,
+        "scan_time": 3222,
+        "total_time": 169681,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 43058,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3222,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 90,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2659,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 854.03\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 148.53\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 82.42\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 75.89\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 60.87\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 472,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:54:34.471Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/.codex/fooks/attachments/bm-t5-fooks-1776398070.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/.codex/fooks/attachments/bm-t5-fooks-1776398070.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:54:34.461Z\",\"attachedAt\":\"2026-04-17T03:54:34.458Z\",\"lastScanAt\":\"2026-04-17T03:54:34.458Z\",\"lastRefreshAt\":\"2026-04-17T03:54:34.458Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "fooks-first-turn-exact-file-record-only",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning below the login password field. It updates from `event.getModifierState(\"CapsLock\")` on password key events and clears on blur, without touching the login, email sign-in, password reset, or two-factor flow logic.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/apps/web/modules/auth/login/components/login-form.tsx:145)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776398070/apps/web/locales/en-US.json:58) for the required `t()` translation key\n\nValidation:\n- `git diff --check` passed\n- `en-US.json` parses successfully\n- Targeted ESLint could not run because `eslint` is not installed in the current checkout\u2019s dependency tree.\n",
+        "stderr_tail": "GED_IN_WITH_LS) || \"\");\n@@ -238,7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onBlur={() => setIsCapsLockOn(false)}\n+                            onKeyDown={updateCapsLockState}\n+                            onKeyUp={updateCapsLockState}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n43,058\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/artifacts/benchmark-full-1776397764/formbricks-T5-fooks.diffstat",
+          "patch_bytes": 2972,
+          "diffstat": " apps/web/locales/en-US.json                        |    1 +\n .../modules/auth/login/components/login-form.tsx   |   15 ++++++++++++++-\n 2 files changed, 15 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 42.87376281796093,
+        "total": 41.76802064601151
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/run.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/run.log
@@ -1,0 +1,50 @@
+===== ARTIFACT-VERIFY exact START 2026-04-17T03:49:24Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:49:24.095938
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~1,710,506 tokens
+    Compressed: ~318,512 tokens
+    Saved: ~1,391,994 tokens (81.4%)
+
+  [VANILLA] Running...
+    ✓ 291,388ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:166,459ms + scan:3,222ms = 169,681ms, 2 files
+
+  Execution time diff: +42.9%
+  Total time diff: +41.8%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 291,388ms
+Avg Fooks exec: 166,459ms (+42.9%)
+Avg Fooks total: 169,681ms (+41.8%)
+
+Avg token reduction: 81.4%
+Avg tokens saved: ~1,391,994 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/artifact-verify/exact/benchmark-full-1776397764.json
+======================================================================
+===== ARTIFACT-VERIFY exact END 2026-04-17T03:57:29Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/decision-matrix.md
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/decision-matrix.md
@@ -1,0 +1,67 @@
+# Post-policy Formbricks benchmark decision matrix
+
+Date: 2026-04-17
+Runner: direct `codex exec --full-auto` for both vanilla and fooks variants
+Repo: external OSS `formbricks/formbricks` checkout under `~/Workspace/fooks-test-repos/formbricks`
+Surface: Next.js app components with Tailwind classes
+Task family: login password Caps Lock warning
+
+## Why this run exists
+
+Earlier Formbricks evidence showed mixed/negative runtime outcomes and fooks sometimes used more runtime tokens. This run retests after the shared context policy change that keeps exact-file first-turn Codex hooks at `no-op` while leaving ambiguous prompts in `auto` discovery mode.
+
+## Prompts
+
+- Exact-file prompt: `In apps/web/modules/auth/login/components/login-form.tsx add an inline Tailwind red Caps Lock warning below the password field when getModifierState('CapsLock') is true. Keep existing login, email sign-in, password reset, and two-factor flows unchanged. Report which file you modified.`
+- Ambiguous prompt: `Find the Formbricks login password field and add an inline Tailwind red Caps Lock warning below the password field when getModifierState('CapsLock') is true. Keep existing login, email sign-in, password reset, and two-factor flows unchanged. Report which file you modified.`
+
+## N=3 timing/token read
+
+| Slice | Pairs | Fooks context mode | Same changed-file list | Median total-time improvement | Median runtime-token reduction | Read |
+| --- | ---: | --- | --- | ---: | ---: | --- |
+| Exact-file single-turn | 3 | `no-op` | 3/3 | -17.05% | +11.45% | Damage-control only: runtime tokens improved, but wall-clock still regressed because scan/attach overhead remains and no extra context is injected. |
+| Ambiguous login discovery | 3 | `auto` | 3/3 | +6.28% | +18.68% | Promising but not stable: median time and tokens improved, but variance remains high and artifact verification found a scope-expansion failure. |
+
+### Per-run values
+
+| Slice | Report | Vanilla | Fooks total | Total improvement | Vanilla tokens | Fooks tokens | Runtime-token reduction | Fooks mode |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| exact | `exact/benchmark-full-1776395105.json` | 220.6s | 331.3s | -50.14% | 93,261 | 82,580 | +11.45% | `no-op` |
+| exact | `exact/benchmark-full-1776395556.json` | 212.6s | 214.6s | -0.98% | 70,735 | 68,984 | +2.48% | `no-op` |
+| exact | `exact/benchmark-full-1776396023.json` | 204.4s | 239.3s | -17.05% | 60,566 | 48,297 | +20.26% | `no-op` |
+| ambiguous | `ambiguous/benchmark-full-1776396673.json` | 277.2s | 349.7s | -26.15% | 77,999 | 63,427 | +18.68% | `auto` |
+| ambiguous | `ambiguous/benchmark-full-1776397195.json` | 283.4s | 214.6s | +24.28% | 69,689 | 55,593 | +20.23% | `auto` |
+| ambiguous | `ambiguous/benchmark-full-1776397646.json` | 221.0s | 207.1s | +6.28% | 65,608 | 58,042 | +11.53% | `auto` |
+
+## Artifact verification read
+
+The first N=3 post-policy run did not persist full patches. The harness now captures patch/diffstat artifacts and excludes `.omx`, `.codex`, and `.fooks` runtime files. A follow-up N=1 per slice was run only to inspect output quality/scope.
+
+| Slice | Report | Total improvement | Runtime-token reduction | File-scope parity | Manual quality read |
+| --- | --- | ---: | ---: | --- | --- |
+| exact | `artifact-verify/exact/benchmark-full-1776397764.json` | +41.77% | +9.37% | same | Both solve the requested component change; vanilla adds `role="alert"`, fooks adds the warning but lacks an accessibility role in this artifact, so treat as slight fooks quality risk. |
+| ambiguous | `artifact-verify/ambiguous/benchmark-full-1776398249.json` | -60.03% | -55.78% | different: vanilla 2 files vs fooks 15 files | Fooks over-expanded into 14 locale files with English strings while vanilla touched `en-US` only; this is a scope/quality regression despite the earlier N=3 median win. |
+
+## Product decision interpretation
+
+- **When fooks currently looks useful:** ambiguous discovery tasks where the agent must find the right large Next.js/Tailwind component and fooks does not broaden the edit scope. In the N=3 ambiguous slice, median total time improved by `+6.28%` and median runtime tokens dropped by `+18.68%`.
+- **When fooks currently loses:** exact-file first-turn edits. The new policy reduces token risk (`+11.45%` median runtime-token reduction in N=3), but because the benchmark still pays scan/attach overhead while injecting no context, median total time was `-17.05%`.
+- **Most important warning:** any run where fooks uses more runtime tokens or edits many more files is bad product evidence, not a marketing edge case. The artifact-verification ambiguous run is the clearest current regression: fooks was `-60.02%` total time, `-55.78%` runtime-token reduction, and changed 15 files vs vanilla 2.
+
+## Risk resolution plan
+
+| Risk | Current status | Resolution before public claim |
+| --- | --- | --- |
+| Runtime tokens worse than vanilla | Improved in the N=3 exact and ambiguous medians, but not universally fixed because artifact-verification ambiguous regressed hard. | Keep runtime-token claims gated by per-slice medians plus no severe outliers; add automatic outlier flags for `fooks_tokens > vanilla_tokens`. |
+| Exact-file overhead | Context injection is now `no-op` on first-turn exact-file prompts, but scan/attach overhead remains. | Add an exact-file preflight bypass that skips scan/attach entirely for single-turn targeted edits, or report exact-file as a non-goal for fooks acceleration. |
+| Output quality and scope | N=3 reports show same changed-file lists, but full patch artifacts were missing; artifact verification found accessibility and over-localization risks. | Add a Caps Lock acceptance scorer: target component changed, CapsLock state/events, Tailwind red warning, accessibility role/aria-live, preserved auth flows, locale scope capped unless requested. |
+| Benchmark artifact trust | Fixed going forward: harness now persists patch/diffstat and excludes runtime hidden files. | Do not cite the first N=3 as quality-evidence; cite it for time/token/file-list only and cite artifact verification separately for output quality. |
+| Broad benchmark sweep cost/noise | Still high. | Stay with targeted N=3/N=5 slices until exact-file bypass and acceptance scoring are implemented. No broad sweep yet. |
+
+## Recommended next sequence
+
+1. Implement benchmark acceptance scoring for the Caps Lock task and make over-broad locale edits fail or lower score.
+2. Implement an exact-file single-turn bypass so fooks can skip scan/attach when it will inject `no-op` context.
+3. Rerun two slices with artifacts enabled: exact N=3 and ambiguous N=5. Product claims require: quality parity, same intended target, and no severe runtime-token outliers.
+4. Only after that, add a second ambiguous class: multi-file refactor/component extraction where fooks should have a stronger theoretical advantage than this Caps Lock task.
+

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact-prompt.txt
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact-prompt.txt
@@ -1,0 +1,1 @@
+In apps/web/modules/auth/login/components/login-form.tsx add an inline Tailwind red Caps Lock warning below the password field when getModifierState('CapsLock') is true. Keep existing login, email sign-in, password reset, and two-factor flows unchanged. Report which file you modified.

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395105.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395105.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:05:05.659168",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 72.26297450944435,
+    "avg_tokens_saved": 753029.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T11:55:29.631937",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "targeted-edit",
+      "promptSpecificity": "exact-file",
+      "expectedContextPolicy": "light",
+      "expectedFirstTurnRuntimeContext": "no-op",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 4168273.1999999997,
+        "compressed_bytes": 1156155.0,
+        "raw_tokens": 1042068.0,
+        "compressed_tokens": 289038.0,
+        "tokens_saved": 753029.0,
+        "reduction_pct": 72.26297450944435,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 220642,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 93261,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776394537",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776394537/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning below the login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776394537/apps/web/modules/auth/login/components/login-form.tsx)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776394537/apps/web/locales/en-US.json)\n\nWhat changed:\n- Added Caps Lock state driven by `event.getModifierState(\"CapsLock\")` on password `onKeyDown` / `onKeyUp`.\n- Shows an inline Tailwind red warning: `Caps Lock is on`.\n- Keeps existing submit, email login reveal, password reset link, and two-factor flow logic unchanged.\n- Added the translation key required by the repo\u2019s i18n rules.\n\nVerification:\n- `git diff --check` passed.\n- Could not run Prettier or ESLint because the workspace does not currently have `prettier` or `eslint` binaries installed.\n",
+        "stderr_tail": ",7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setCapsLockEnabled(false)}\n                           />\n+                          {capsLockEnabled && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\" aria-live=\"polite\">\n+                              {t(\"auth.login.caps_lock_enabled\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n93,261\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 328145,
+        "scan_time": 3136,
+        "total_time": 331281,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 82580,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3136,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 91,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2586,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 873.17\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 144.17\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 82.17\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 77.84\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 64.88\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 459,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T02:59:29.015Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/.codex/fooks/attachments/bm-t5-fooks-1776394764.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/.codex/fooks/attachments/bm-t5-fooks-1776394764.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T02:59:29.005Z\",\"attachedAt\":\"2026-04-17T02:59:29.002Z\",\"lastScanAt\":\"2026-04-17T02:59:29.002Z\",\"lastRefreshAt\":\"2026-04-17T02:59:29.002Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "fooks-first-turn-exact-file-record-only",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning under the login password field. It tracks `event.getModifierState(\"CapsLock\")` on password key events, clears on blur, and does not touch submit, reset, email sign-in, SSO, or two-factor flow logic.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/apps/web/modules/auth/login/components/login-form.tsx:150)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776394764/apps/web/locales/en-US.json:58)\n\nVerification:\n- `node` JSON parse for `apps/web/locales/en-US.json`: passed\n- `git diff --check`: passed\n- `pnpm exec prettier --check ...`: not runnable because workspace dependencies/binaries are not installed (`Command \"prettier\" not found`)\n",
+        "stderr_tail": "     className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => {\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n82,580\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -48.722817958502915,
+        "total": -50.144124871964536
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395556.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395556.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:12:36.345810",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 64.04264833536462,
+    "avg_tokens_saved": 536844.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:05:05.765180",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "targeted-edit",
+      "promptSpecificity": "exact-file",
+      "expectedContextPolicy": "light",
+      "expectedFirstTurnRuntimeContext": "no-op",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3353040.5999999996,
+        "compressed_bytes": 1205664.5999999999,
+        "raw_tokens": 838260.0,
+        "compressed_tokens": 301416.0,
+        "tokens_saved": 536844.0,
+        "reduction_pct": 64.04264833536462,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 212563,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 70735,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395113",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395113/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395113/apps/web/modules/auth/login/components/login-form.tsx:148)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395113/apps/web/locales/en-US.json:58)\n\nWhat changed:\n- Added password-field-only Caps Lock detection using `event.getModifierState(\"CapsLock\")` on `onKeyDown` / `onKeyUp`.\n- Shows an inline Tailwind red warning below the password field: `text-xs text-red-600`.\n- Hides the warning on password blur.\n- Added the i18n key `auth.login.caps_lock_warning`.\n\nValidation:\n- `apps/web/locales/en-US.json` parses successfully.\n- `git diff --check` passed.\n- Full formatting/lint/typecheck could not run because local dependencies are not installed/exposed: `prettier`, `eslint`, and `typescript` were not found.\n",
+        "stderr_tail": "me=\"text-center\">\n@@ -238,7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onBlur={() => setIsCapsLockOn(false)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n70,735\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 210943,
+        "scan_time": 3700,
+        "total_time": 214643,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 68984,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3700,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 98,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 3088,
+              "stdout_tail": "lveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 1153.46\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 170.65\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 89.38\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 77.69\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 71.03\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 512,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:08:58.040Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/.codex/fooks/attachments/bm-t5-fooks-1776395333.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/.codex/fooks/attachments/bm-t5-fooks-1776395333.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:08:58.029Z\",\"attachedAt\":\"2026-04-17T03:08:58.023Z\",\"lastScanAt\":\"2026-04-17T03:08:58.023Z\",\"lastRefreshAt\":\"2026-04-17T03:08:58.023Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "fooks-first-turn-exact-file-record-only",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning below the password field. It tracks `event.getModifierState(\"CapsLock\")` on password key events and clears the warning on blur, without changing submit, reset, email sign-in, or two-factor logic.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/apps/web/modules/auth/login/components/login-form.tsx:148)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395333/apps/web/locales/en-US.json:58)\n\nValidation:\n- `git diff --check` passed.\n- `pnpm exec eslint apps/web/modules/auth/login/components/login-form.tsx` could not run because `eslint` is not installed in this checkout (`Command \"eslint\" not found`).\n",
+        "stderr_tail": "_WITH_LS) || \"\");\n@@ -238,7 +243,15 @@\n                             className=\"block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onBlur={() => setIsCapsLockOn(false)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n68,984\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 0.7621269929385641,
+        "total": -0.9785334230322305
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776396023.json
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776396023.json
@@ -1,0 +1,235 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-17T12:20:23.475127",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 69.86065410860589,
+    "avg_tokens_saved": 697551.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-17T12:12:36.447707",
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "targeted-edit",
+      "promptSpecificity": "exact-file",
+      "expectedContextPolicy": "light",
+      "expectedFirstTurnRuntimeContext": "no-op",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3993960.5999999996,
+        "compressed_bytes": 1203753.5999999999,
+        "raw_tokens": 998490.0,
+        "compressed_tokens": 300938.0,
+        "tokens_saved": 697551.0,
+        "reduction_pct": 69.86065410860589,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 204426,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 60566,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395563",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395563/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning for the login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395563/apps/web/modules/auth/login/components/login-form.tsx:145)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776395563/apps/web/locales/en-US.json:58)\n\nWhat changed:\n- Added `isCapsLockOn` state in the login form.\n- Updated it from password `onKeyDown` / `onKeyUp` using `event.getModifierState(\"CapsLock\")`.\n- Clears the warning on password blur.\n- Renders an inline Tailwind red warning below the password field with localized text.\n\nValidation:\n- `apps/web/locales/en-US.json` parses successfully.\n- `git diff --check` passed.\n- `pnpm exec prettier --write ...` could not run because `prettier` is not installed in the current workspace.\n",
+        "stderr_tail": "ocus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n+                            onBlur={() => {\n+                              field.onBlur();\n+                              setIsCapsLockOn(false);\n+                            }}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs font-medium text-red-600\" role=\"status\">\n+                              {t(\"auth.login.caps_lock_is_on\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n60,566\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 235985,
+        "scan_time": 3288,
+        "total_time": 239273,
+        "files": 2,
+        "files_list": [
+          "apps/web/locales/en-US.json",
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 48297,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3288,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 100,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2723,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 847.69\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 166.43\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 81.25\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 80.98\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 60.39\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 463,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-17T03:16:19.870Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/.codex/fooks/attachments/bm-t5-fooks-1776395775.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/.codex/fooks/attachments/bm-t5-fooks-1776395775.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-17T03:16:19.860Z\",\"attachedAt\":\"2026-04-17T03:16:19.857Z\",\"lastScanAt\":\"2026-04-17T03:16:19.857Z\",\"lastRefreshAt\":\"2026-04-17T03:16:19.857Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/.codex",
+          "prompt_sha256": "987a9d9db0f371bd58681eb3961d4754c7791f513478917ae8335486a0949954",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "fooks-first-turn-exact-file-record-only",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the Caps Lock warning below the login password field.\n\nModified files:\n- [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/apps/web/modules/auth/login/components/login-form.tsx:150)\n- [en-US.json](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776395775/apps/web/locales/en-US.json:58)\n\nWhat changed:\n- Added Caps Lock state tracking using `getModifierState(\"CapsLock\")` on password key and mouse events.\n- Renders an inline Tailwind red warning with `role=\"alert\"` when Caps Lock is on.\n- Clears the warning on password field blur.\n- Added the i18n key `auth.login.caps_lock_is_on`.\n\nValidation:\n- `git diff --check` passed.\n- `apps/web/locales/en-US.json` parses successfully.\n- `pnpm exec prettier --check ...` could not run because `prettier` is not available in this checkout.\n",
+        "stderr_tail": "lock w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={updateCapsLockState}\n+                            onKeyUp={updateCapsLockState}\n+                            onMouseDown={updateCapsLockState}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p className=\"mt-1 text-left text-xs font-medium text-red-600\" role=\"alert\">\n+                              {t(\"auth.login.caps_lock_is_on\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n48,297\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"tsc\" not found\n",
+            "package_manager": "pnpm",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "undefined\n\u2009ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL\u2009 Command \"turbo\" not found\n",
+            "package_manager": "pnpm",
+            "method": "turbo"
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -15.437860154774832,
+        "total": -17.04626613053134
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-1.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-1.log
@@ -1,0 +1,50 @@
+===== POST-POLICY exact run 1 START 2026-04-17T02:55:29Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T11:55:29.631785
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~1,042,068 tokens
+    Compressed: ~289,038 tokens
+    Saved: ~753,029 tokens (72.3%)
+
+  [VANILLA] Running...
+    ✓ 220,642ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:328,145ms + scan:3,136ms = 331,281ms, 2 files
+
+  Execution time diff: -48.7%
+  Total time diff: -50.1%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 220,642ms
+Avg Fooks exec: 328,145ms (-48.7%)
+Avg Fooks total: 331,281ms (-50.1%)
+
+Avg token reduction: 72.3%
+Avg tokens saved: ~753,029 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395105.json
+======================================================================
+===== POST-POLICY exact run 1 END 2026-04-17T03:05:05Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-2.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-2.log
@@ -1,0 +1,50 @@
+===== POST-POLICY exact run 2 START 2026-04-17T03:05:05Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:05:05.765036
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~838,260 tokens
+    Compressed: ~301,416 tokens
+    Saved: ~536,844 tokens (64.0%)
+
+  [VANILLA] Running...
+    ✓ 212,563ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:210,943ms + scan:3,700ms = 214,643ms, 2 files
+
+  Execution time diff: +0.8%
+  Total time diff: -1.0%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 212,563ms
+Avg Fooks exec: 210,943ms (+0.8%)
+Avg Fooks total: 214,643ms (-1.0%)
+
+Avg token reduction: 64.0%
+Avg tokens saved: ~536,844 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776395556.json
+======================================================================
+===== POST-POLICY exact run 2 END 2026-04-17T03:12:36Z =====

--- a/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-3.log
+++ b/benchmarks/frontend-harness/reports/post-policy-20260417/exact/run-3.log
@@ -1,0 +1,50 @@
+===== POST-POLICY exact run 3 START 2026-04-17T03:12:36Z =====
+======================================================================
+Fooks Full Benchmark Suite
+======================================================================
+Start time: 2026-04-17T12:12:36.447557
+Tasks: T1, T2, T3, T4, T5
+Repos: cal.com, documenso, formbricks, nextjs, saleor-storefront, shadcn-ui, tailwindcss
+Runner: codex exec --full-auto
+Variants: Vanilla vs Fooks (with token estimates)
+Reports dir: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact
+======================================================================
+
+======================================================================
+[T5] Form Validation (hard)
+Repo: formbricks
+Runner: codex exec --full-auto
+======================================================================
+  Calculating token estimates...
+    Repo: 882 TSX files
+    Raw: ~998,490 tokens
+    Compressed: ~300,938 tokens
+    Saved: ~697,551 tokens (69.9%)
+
+  [VANILLA] Running...
+    ✓ 204,426ms, 2 files
+
+  [FOOKS] Running...
+    ✓ exec:235,985ms + scan:3,288ms = 239,273ms, 2 files
+
+  Execution time diff: -15.4%
+  Total time diff: -17.0%
+
+======================================================================
+FINAL SUMMARY
+======================================================================
+
+Completed: 1 benchmarks
+Vanilla success: 1/1
+Fooks success: 1/1
+
+Avg Vanilla time: 204,426ms
+Avg Fooks exec: 235,985ms (-15.4%)
+Avg Fooks total: 239,273ms (-17.0%)
+
+Avg token reduction: 69.9%
+Avg tokens saved: ~697,551 per session
+
+Report saved: /Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/post-policy-20260417/exact/benchmark-full-1776396023.json
+======================================================================
+===== POST-POLICY exact run 3 END 2026-04-17T03:20:23Z =====

--- a/benchmarks/frontend-harness/runners/full-benchmark-suite.py
+++ b/benchmarks/frontend-harness/runners/full-benchmark-suite.py
@@ -170,17 +170,20 @@ def classify_task_context(task):
             "taskClass": "targeted-edit",
             "promptSpecificity": "exact-file",
             "expectedContextPolicy": "light",
+            "expectedFirstTurnRuntimeContext": "no-op",
         }
     if task.get("id") in {"T4", "T5"}:
         return {
             "taskClass": "ambiguous-multi-file",
             "promptSpecificity": "ambiguous",
             "expectedContextPolicy": "auto",
+            "expectedFirstTurnRuntimeContext": "auto",
         }
     return {
         "taskClass": "ambiguous-single-file",
         "promptSpecificity": "ambiguous",
         "expectedContextPolicy": "auto",
+        "expectedFirstTurnRuntimeContext": "auto",
     }
 
 def variant_context_metadata(task, variant):
@@ -191,12 +194,18 @@ def variant_context_metadata(task, variant):
         max_files = 0
         selected_files = 0
     else:
-        context_mode = classification["expectedContextPolicy"]
-        reason = f"fooks-{classification['promptSpecificity']}-policy"
+        context_mode = classification.get("expectedFirstTurnRuntimeContext", classification["expectedContextPolicy"])
+        reason = (
+            "fooks-first-turn-exact-file-record-only"
+            if classification["promptSpecificity"] == "exact-file" and context_mode == "no-op"
+            else f"fooks-{classification['promptSpecificity']}-policy"
+        )
         max_files = 1 if context_mode == "light" else 5 if context_mode == "auto" else 0
-        # The harness records expected policy metadata here. Runtime-observed
-        # selected file counts belong to the fooks hook/run context policy.
-        selected_files = 0 if context_mode == "auto" else max_files
+        # The harness records expected single-turn runtime metadata here.
+        # Runtime-observed selected file counts belong to the fooks hook/run
+        # context policy and should be measured separately from top-level
+        # extraction policy.
+        selected_files = 0 if context_mode in {"auto", "no-op"} else max_files
     return {
         "contextMode": context_mode,
         "contextModeReason": reason,
@@ -324,6 +333,50 @@ def changed_files(worktree_path):
         capture_output=True, text=True
     )
     return [f for f in files_result.stdout.strip().split('\n') if f]
+
+def mark_untracked_intent(worktree_path):
+    """Make safe untracked source files visible to git diff without staging contents."""
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+    )
+    candidates = [
+        f
+        for f in result.stdout.splitlines()
+        if f and not f.startswith((".codex/", ".fooks/", ".omx/", "node_modules/"))
+    ]
+    if candidates:
+        subprocess.run(["git", "add", "-N", "--", *candidates], cwd=worktree_path, capture_output=True, text=True)
+
+
+def capture_artifact(worktree_path, artifact_dir, stem):
+    """Persist patch, diffstat, and whitespace check before the worktree is removed."""
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    mark_untracked_intent(worktree_path)
+
+    diff_pathspec = ["--", ".", ":(exclude).codex", ":(exclude).fooks", ":(exclude).omx"]
+    patch = subprocess.run(["git", "diff", "--binary", *diff_pathspec], cwd=worktree_path, capture_output=True, text=True)
+    diffstat = subprocess.run(["git", "diff", "--stat", *diff_pathspec], cwd=worktree_path, capture_output=True, text=True)
+    diff_check = subprocess.run(["git", "diff", "--check", *diff_pathspec], cwd=worktree_path, capture_output=True, text=True)
+
+    patch_path = artifact_dir / f"{stem}.patch"
+    diffstat_path = artifact_dir / f"{stem}.diffstat"
+    patch_path.write_text(patch.stdout)
+    diffstat_path.write_text(diffstat.stdout)
+
+    return {
+        "patch_path": str(patch_path),
+        "diffstat_path": str(diffstat_path),
+        "patch_bytes": len(patch.stdout.encode()),
+        "diffstat": diffstat.stdout,
+        "diff_check": {
+            "success": diff_check.returncode == 0,
+            "stdout": output_tail(diff_check.stdout, 1000),
+            "stderr": output_tail(diff_check.stderr, 1000),
+        },
+    }
 
 def detect_package_manager(worktree_path):
     """Detect package manager (npm, pnpm, yarn) based on lock files"""
@@ -776,7 +829,7 @@ def run_fooks_agent(worktree, task, runner):
                 "scan_time": fooks_scan_time, "total_time": fooks_scan_time + int((time.time() - start) * 1000),
                 "files": 0, "files_list": [], "error": str(e)}
 
-def run_benchmark(task, repo_name, runner):
+def run_benchmark(task, repo_name, runner, artifact_dir):
     """Run full benchmark for one task on one repo"""
     print(f"\n{'='*70}")
     print(f"[{task['id']}] {task['name']} ({task['difficulty']})")
@@ -793,7 +846,8 @@ def run_benchmark(task, repo_name, runner):
                "repoClass": "external-oss-nextjs-tailwind" if repo_name in {"formbricks", "cal.com", "shadcn-ui", "documenso", "nextjs"} else "external-oss-frontend",
                "taskClass": classification["taskClass"],
                "promptSpecificity": classification["promptSpecificity"],
-               "expectedContextPolicy": classification["expectedContextPolicy"]}
+               "expectedContextPolicy": classification["expectedContextPolicy"],
+               "expectedFirstTurnRuntimeContext": classification.get("expectedFirstTurnRuntimeContext", classification["expectedContextPolicy"])}
 
     # Token estimate (once per repo)
     print("  Calculating token estimates...")
@@ -808,6 +862,7 @@ def run_benchmark(task, repo_name, runner):
     print("\n  [VANILLA] Running...")
     wt_v = create_worktree(repo_path, task['id'], "vanilla")
     res_v = run_vanilla_agent(wt_v, task, runner)
+    res_v["artifact"] = capture_artifact(wt_v["path"], artifact_dir, f"{repo_name}-{task['id']}-vanilla")
     res_v["cleanup"] = remove_worktree(wt_v, repo_path)
     results["vanilla"] = res_v
     print(f"    {'✓' if res_v['success'] else '✗'} {res_v['duration_ms']:,}ms, {res_v['files']} files")
@@ -820,6 +875,7 @@ def run_benchmark(task, repo_name, runner):
     print("\n  [FOOKS] Running...")
     wt_f = create_worktree(repo_path, task['id'], "fooks")
     res_f = run_fooks_agent(wt_f, task, runner)
+    res_f["artifact"] = capture_artifact(wt_f["path"], artifact_dir, f"{repo_name}-{task['id']}-fooks")
     res_f["cleanup"] = remove_worktree(wt_f, repo_path)
     results["fooks"] = res_f
     print(f"    {'✓' if res_f['success'] else '✗'} exec:{res_f['duration_ms']:,}ms + scan:{res_f['scan_time']:,}ms = {res_f['total_time']:,}ms, {res_f['files']} files")
@@ -860,6 +916,7 @@ def main():
                 "taskClass": classification["taskClass"],
                 "promptSpecificity": classification["promptSpecificity"],
                 "expectedContextPolicy": classification["expectedContextPolicy"],
+                "expectedFirstTurnRuntimeContext": classification.get("expectedFirstTurnRuntimeContext", classification["expectedContextPolicy"]),
             })
         print(json.dumps({
             "reportSchemaVersion": REPORT_SCHEMA_VERSION,
@@ -887,12 +944,14 @@ def main():
     print("="*70)
 
     all_results = []
+    report_timestamp = int(time.time())
+    artifact_dir = reports_dir / "artifacts" / f"benchmark-full-{report_timestamp}"
 
     for task_id, repo_name in test_cases:
         task = resolve_task(task_id, args.task_prompt if (args.repo and args.task == task_id) else None)
 
         try:
-            result = run_benchmark(task, repo_name, args.runner)
+            result = run_benchmark(task, repo_name, args.runner, artifact_dir)
             all_results.append(result)
         except Exception as e:
             print(f"\n  ✗ Benchmark failed: {e}")
@@ -937,12 +996,13 @@ def main():
     print(f"Avg tokens saved: ~{avg_saved:,.0f} per session")
 
     # Save report
-    report_path = reports_dir / f"benchmark-full-{int(time.time())}.json"
+    report_path = reports_dir / f"benchmark-full-{report_timestamp}.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
     with open(report_path, 'w') as f:
         json.dump({
             "reportSchemaVersion": REPORT_SCHEMA_VERSION,
             "timestamp": datetime.now().isoformat(),
+            "artifactDir": str(artifact_dir),
             "summary": {
                 "total_benchmarks": len(all_results),
                 "vanilla_success": len(vanilla_success),

--- a/test/frontend-harness.test.mjs
+++ b/test/frontend-harness.test.mjs
@@ -42,6 +42,7 @@ test("frontend harness defaults to repo-local reports and preserves the legacy c
   assert.equal(result.selectedCases[0].taskClass, "ambiguous-single-file");
   assert.equal(result.selectedCases[0].promptSpecificity, "ambiguous");
   assert.equal(result.selectedCases[0].expectedContextPolicy, "auto");
+  assert.equal(result.selectedCases[0].expectedFirstTurnRuntimeContext, "auto");
 });
 
 test("frontend harness supports single-case round-1 configuration and report dir overrides", () => {
@@ -64,4 +65,17 @@ test("frontend harness supports single-case round-1 configuration and report dir
   assert.equal(result.selectedCases[0].taskClass, "ambiguous-multi-file");
   assert.equal(result.selectedCases[0].promptSpecificity, "ambiguous");
   assert.equal(result.selectedCases[0].expectedContextPolicy, "auto");
+  assert.equal(result.selectedCases[0].expectedFirstTurnRuntimeContext, "auto");
+});
+
+test("frontend harness marks exact-file single-turn Codex context as no-op", () => {
+  const customPrompt =
+    "In apps/web/modules/auth/login/components/login-form.tsx add a red Tailwind Caps Lock warning below the password field.";
+  const result = runRunnerConfig(["--runner", "codex", "--repo", "formbricks", "--task", "T5", "--task-prompt", customPrompt]);
+
+  assert.equal(result.selectedCases.length, 1);
+  assert.equal(result.selectedCases[0].taskClass, "targeted-edit");
+  assert.equal(result.selectedCases[0].promptSpecificity, "exact-file");
+  assert.equal(result.selectedCases[0].expectedContextPolicy, "light");
+  assert.equal(result.selectedCases[0].expectedFirstTurnRuntimeContext, "no-op");
 });


### PR DESCRIPTION
## Summary
- adds a shared context-policy classifier for exact-file/no-op/light vs ambiguous/auto benchmark behavior
- wires fooks run and Codex runtime hooks to expose context-mode metadata
- adds post-policy Formbricks direct-Codex measurements and a decision matrix for when fooks wins vs loses
- preserves benchmark patch/diffstat artifacts while excluding runtime hidden files

## Product read
- exact-file first-turn: runtime token median improved, but total time still regressed because scan/attach overhead remains
- ambiguous login discovery: N=3 median improved, but artifact verification found a scope-expansion regression, so this is not yet a public performance claim

## Verification
- npm test
- npm run lint
- python3 -m py_compile benchmarks/frontend-harness/runners/full-benchmark-suite.py
- node --test test/frontend-harness.test.mjs
- git diff --check

Not-tested: browser/E2E validation of generated Formbricks patches.