### PR TITLE
Gate Cal.com T4 benchmark claims on quality evidence

### DIFF
--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.diffstat
@@ -1,0 +1,3 @@
+ .../components/security/TwoFactorAuthSection.tsx   | 25 +++++++++---------
+ .../security/TwoFactorAuthSectionHeader.tsx        | 30 ++++++++++++++++++++++
+ 2 files changed, 42 insertions(+), 13 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.patch
@@ -1,0 +1,85 @@
+diff --git a/apps/web/components/security/TwoFactorAuthSection.tsx b/apps/web/components/security/TwoFactorAuthSection.tsx
+index 59928e3..d6605b7 100644
+--- a/apps/web/components/security/TwoFactorAuthSection.tsx
++++ b/apps/web/components/security/TwoFactorAuthSection.tsx
+@@ -6,6 +6,7 @@ import { Button } from "@calcom/ui/components/button";
+ 
+ import DisableTwoFactorModal from "./DisableTwoFactorModal";
+ import EnableTwoFactorModal from "./EnableTwoFactorModal";
++import TwoFactorAuthSectionHeader from "./TwoFactorAuthSectionHeader";
+ 
+ const TwoFactorAuthSection = ({ twoFactorEnabled }: { twoFactorEnabled: boolean }) => {
+   const [enabled, setEnabled] = useState(twoFactorEnabled);
+@@ -15,25 +16,23 @@ const TwoFactorAuthSection = ({ twoFactorEnabled }: { twoFactorEnabled: boolean
+ 
+   return (
+     <>
+-      <div className="flex flex-col justify-between pl-2 pt-9 sm:flex-row">
+-        <div>
+-          <div className="flex flex-row items-center">
+-            <h2 className="font-cal text-emphasis text-lg font-medium leading-6">{t("2fa")}</h2>
+-            <Badge className="ml-2 text-xs" variant={enabled ? "success" : "gray"}>
+-              {enabled ? t("enabled") : t("disabled")}
+-            </Badge>
+-          </div>
+-          <p className="text-subtle mt-1 text-sm">{t("add_an_extra_layer_of_security")}</p>
+-        </div>
+-        <div className="mt-5 sm:mt-0 sm:self-center">
++      <TwoFactorAuthSectionHeader
++        title={t("2fa")}
++        subtitle={t("add_an_extra_layer_of_security")}
++        titleSuffix={
++          <Badge className="ml-2 text-xs" variant={enabled ? "success" : "gray"}>
++            {enabled ? t("enabled") : t("disabled")}
++          </Badge>
++        }
++        actions={
+           <Button
+             type="submit"
+             color="secondary"
+             onClick={() => (enabled ? setDisableModalOpen(true) : setEnableModalOpen(true))}>
+             {enabled ? t("disable") : t("enable")}
+           </Button>
+-        </div>
+-      </div>
++        }
++      />
+       {enableModalOpen && (
+         <EnableTwoFactorModal
+           onEnable={() => {
+diff --git a/apps/web/components/security/TwoFactorAuthSectionHeader.tsx b/apps/web/components/security/TwoFactorAuthSectionHeader.tsx
+new file mode 100644
+index 0000000..e418e73
+--- /dev/null
++++ b/apps/web/components/security/TwoFactorAuthSectionHeader.tsx
+@@ -0,0 +1,30 @@
++import type { ReactNode } from "react";
++
++type TwoFactorAuthSectionHeaderProps = {
++  title: string;
++  subtitle: string;
++  titleSuffix?: ReactNode;
++  actions?: ReactNode;
++};
++
++const TwoFactorAuthSectionHeader = ({
++  title,
++  subtitle,
++  titleSuffix,
++  actions,
++}: TwoFactorAuthSectionHeaderProps) => {
++  return (
++    <div className="flex flex-col justify-between pl-2 pt-9 sm:flex-row">
++      <div>
++        <div className="flex flex-row items-center">
++          <h2 className="font-cal text-emphasis text-lg font-medium leading-6">{title}</h2>
++          {titleSuffix}
++        </div>
++        <p className="text-subtle mt-1 text-sm">{subtitle}</p>
++      </div>
++      {actions && <div className="mt-5 sm:mt-0 sm:self-center">{actions}</div>}
++    </div>
++  );
++};
++
++export default TwoFactorAuthSectionHeader;

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.diffstat
@@ -1,0 +1,3 @@
+ .../ui/components/app-list-card/AppListCard.tsx    | 79 ++++--------------
+ .../components/app-list-card/AppListCardHeader.tsx | 96 ++++++++++++++++++++++
+ 2 files changed, 112 insertions(+), 63 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.patch
@@ -1,0 +1,215 @@
+diff --git a/packages/ui/components/app-list-card/AppListCard.tsx b/packages/ui/components/app-list-card/AppListCard.tsx
+index cd87280..10c9af6 100644
+--- a/packages/ui/components/app-list-card/AppListCard.tsx
++++ b/packages/ui/components/app-list-card/AppListCard.tsx
+@@ -1,14 +1,13 @@
+ "use client";
+ 
+-import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+-import { useLocale } from "@calcom/lib/hooks/useLocale";
+ import type { CredentialOwner } from "@calcom/types/CredentialOwner";
+ import classNames from "@calcom/ui/classNames";
+-import { CircleAlertIcon } from "@coss/ui/icons";
+ import type { ReactNode } from "react";
+-import { Avatar } from "../avatar/Avatar";
+-import { Badge } from "../badge/Badge";
+-import { ListItemText } from "../list/List";
++
++import { AppListCardHeader } from "./AppListCardHeader";
++import type { AppCardClassNames } from "./AppListCardHeader";
++
++export type { AppCardClassNames } from "./AppListCardHeader";
+ 
+ type ShouldHighlight =
+   | {
+@@ -20,12 +19,6 @@ type ShouldHighlight =
+       slug?: never;
+     };
+ 
+-export type AppCardClassNames = {
+-  container: string;
+-  title?: string;
+-  description?: string;
+-};
+-
+ export type AppListCardProps = {
+   logo?: string;
+   title: string;
+@@ -41,7 +34,6 @@ export type AppListCardProps = {
+ } & ShouldHighlight;
+ 
+ export const AppListCard = (props: AppListCardProps & { highlight?: boolean }) => {
+-  const { t } = useLocale();
+   const {
+     logo,
+     title,
+@@ -63,56 +55,17 @@ export const AppListCard = (props: AppListCardProps & { highlight?: boolean }) =
+         highlight && "dark:bg-cal-muted bg-yellow-100",
+         className || classNameObject?.container
+       )}>
+-      <div className="flex items-start gap-x-3 px-4 py-4 sm:px-6">
+-        {logo ? (
+-          <img
+-            className={classNames(logo.includes("-dark") && "dark:invert", "h-10 w-10 shrink-0")}
+-            src={logo}
+-            alt={`${title} logo`}
+-          />
+-        ) : null}
+-        <div className="flex min-w-0 grow flex-col gap-y-1">
+-          <div className="flex items-center gap-x-2">
+-            <h3
+-              className={classNames("text-emphasis truncate text-sm font-semibold", classNameObject?.title)}>
+-              {title}
+-            </h3>
+-            <div className="flex shrink-0 items-center gap-x-2">
+-              {isDefault && <Badge variant="green">{t("default")}</Badge>}
+-              {isTemplate && <Badge variant="red">Template</Badge>}
+-            </div>
+-          </div>
+-          <ListItemText
+-            component="p"
+-            className={classNames("whitespace-normal wrap-break-word", classNameObject?.description)}>
+-            {description}
+-          </ListItemText>
+-          {invalidCredential && (
+-            <div className="flex gap-x-2 pt-2">
+-              <CircleAlertIcon className="h-8 w-8 shrink-0 text-red-500 sm:h-4 sm:w-4" />
+-              <ListItemText component="p" className="whitespace-pre-wrap wrap-break-word text-red-500">
+-                {t("invalid_credential", { appName: title })}
+-              </ListItemText>
+-            </div>
+-          )}
+-        </div>
+-        {credentialOwner && (
+-          <div className="shrink-0">
+-            <Badge variant="gray">
+-              <div className="flex items-center">
+-                <Avatar
+-                  className="mr-2"
+-                  alt={credentialOwner.name || "Nameless"}
+-                  size="xs"
+-                  imageSrc={getPlaceholderAvatar(credentialOwner.avatar, credentialOwner?.name as string)}
+-                />
+-                {credentialOwner.name}
+-              </div>
+-            </Badge>
+-          </div>
+-        )}
+-        {actions && <div className="shrink-0">{actions}</div>}
+-      </div>
++      <AppListCardHeader
++        logo={logo}
++        title={title}
++        subtitle={description}
++        actions={actions}
++        isDefault={isDefault}
++        isTemplate={isTemplate}
++        invalidCredential={invalidCredential}
++        credentialOwner={credentialOwner}
++        classNameObject={classNameObject}
++      />
+       <div className="w-full">{children}</div>
+     </div>
+   );
+diff --git a/packages/ui/components/app-list-card/AppListCardHeader.tsx b/packages/ui/components/app-list-card/AppListCardHeader.tsx
+new file mode 100644
+index 0000000..a778dc5
+--- /dev/null
++++ b/packages/ui/components/app-list-card/AppListCardHeader.tsx
+@@ -0,0 +1,96 @@
++"use client";
++
++import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
++import { useLocale } from "@calcom/lib/hooks/useLocale";
++import type { CredentialOwner } from "@calcom/types/CredentialOwner";
++import classNames from "@calcom/ui/classNames";
++import { CircleAlertIcon } from "@coss/ui/icons";
++import type { ReactNode } from "react";
++
++import { Avatar } from "../avatar/Avatar";
++import { Badge } from "../badge/Badge";
++import { ListItemText } from "../list/List";
++
++export type AppCardClassNames = {
++  container: string;
++  title?: string;
++  description?: string;
++};
++
++type AppListCardHeaderProps = {
++  logo?: string;
++  title: string;
++  subtitle: string;
++  actions?: ReactNode;
++  isDefault?: boolean;
++  isTemplate?: boolean;
++  invalidCredential?: boolean;
++  credentialOwner?: CredentialOwner;
++  classNameObject?: AppCardClassNames;
++};
++
++export function AppListCardHeader({
++  logo,
++  title,
++  subtitle,
++  actions,
++  isDefault,
++  isTemplate,
++  invalidCredential,
++  credentialOwner,
++  classNameObject,
++}: AppListCardHeaderProps) {
++  const { t } = useLocale();
++
++  return (
++    <div className="flex items-start gap-x-3 px-4 py-4 sm:px-6">
++      {logo ? (
++        <img
++          className={classNames(logo.includes("-dark") && "dark:invert", "h-10 w-10 shrink-0")}
++          src={logo}
++          alt={`${title} logo`}
++        />
++      ) : null}
++      <div className="flex min-w-0 grow flex-col gap-y-1">
++        <div className="flex items-center gap-x-2">
++          <h3 className={classNames("text-emphasis truncate text-sm font-semibold", classNameObject?.title)}>
++            {title}
++          </h3>
++          <div className="flex shrink-0 items-center gap-x-2">
++            {isDefault && <Badge variant="green">{t("default")}</Badge>}
++            {isTemplate && <Badge variant="red">Template</Badge>}
++          </div>
++        </div>
++        <ListItemText
++          component="p"
++          className={classNames("whitespace-normal wrap-break-word", classNameObject?.description)}>
++          {subtitle}
++        </ListItemText>
++        {invalidCredential && (
++          <div className="flex gap-x-2 pt-2">
++            <CircleAlertIcon className="h-8 w-8 shrink-0 text-red-500 sm:h-4 sm:w-4" />
++            <ListItemText component="p" className="whitespace-pre-wrap wrap-break-word text-red-500">
++              {t("invalid_credential", { appName: title })}
++            </ListItemText>
++          </div>
++        )}
++      </div>
++      {credentialOwner && (
++        <div className="shrink-0">
++          <Badge variant="gray">
++            <div className="flex items-center">
++              <Avatar
++                className="mr-2"
++                alt={credentialOwner.name || "Nameless"}
++                size="xs"
++                imageSrc={getPlaceholderAvatar(credentialOwner.avatar, credentialOwner.name)}
++              />
++              {credentialOwner.name}
++            </div>
++          </Badge>
++        </div>
++      )}
++      {actions && <div className="shrink-0">{actions}</div>}
++    </div>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/benchmark-full-1776504993.json
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/benchmark-full-1776504993.json
@@ -1,0 +1,441 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-18T18:49:30.204457",
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993",
+  "iterations": 1,
+  "qualityGatedDecision": {
+    "rawMedianTotalTimeImprovement": 59.957986103960046,
+    "rawMedianRuntimeTokenReduction": 54.39346015564557,
+    "qualityGatedPairCount": 1,
+    "qualityGatedMedianTotalTimeImprovement": 59.957986103960046,
+    "qualityGatedMedianRuntimeTokenReduction": 54.39346015564557,
+    "runtimeTokenClaimAvailable": true,
+    "fooksAcceptancePassRate": 1.0,
+    "broaderScopeRegressionCount": 0,
+    "severeTokenOutlierCount": 0,
+    "targetComparabilityBreakdown": {
+      "same_component_or_file": 0,
+      "semantically_comparable_target": 1,
+      "incomparable_target": 0
+    },
+    "proxyContextReductionLabel": "proxyContextReduction; context-size evidence only, not runtime token savings",
+    "verdict": "smoke-pass-proceed-to-n3",
+    "verdictReasons": [
+      "N=1 only validates candidate/scorer stability; no product win/loss claim."
+    ]
+  },
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 81.60405116610401,
+    "avg_tokens_saved": 912940.0,
+    "proxyContextReduction": {
+      "avg_reduction_pct": 81.60405116610401,
+      "avg_tokens_saved": 912940.0,
+      "label": "proxyContextReduction; context-size evidence only, not runtime token savings"
+    }
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant either runs fooks init/scan/attach before the same agent command or records an exact-file first-turn bypass when no fooks context would be injected; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "medium",
+        "evidence": "same_prompt=True, same_files=False, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks may prepare native context or explicitly bypass exact-file first-turn preparation."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "artifact_quality_scope",
+        "level": "low",
+        "evidence": "acceptance_available=True, fooks_acceptance_failures=0, scope_regressions=0",
+        "interpretation": "Do not cite wins unless fooks passes task acceptance and avoids broader edit scope than vanilla."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/1 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T4",
+      "task_name": "Component Extraction",
+      "repo": "cal.com",
+      "difficulty": "medium",
+      "timestamp": "2026-04-18T18:36:33.724774",
+      "iteration": null,
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "expectedFooksPrepare": "scan-attach",
+      "tokens": {
+        "total_files": 693,
+        "raw_bytes": 4474978.2,
+        "compressed_bytes": 823214.7000000001,
+        "raw_tokens": 1118744.0,
+        "compressed_tokens": 205803.0,
+        "tokens_saved": 912940.0,
+        "reduction_pct": 81.60405116610401,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 534109,
+        "files": 2,
+        "files_list": [
+          "packages/ui/components/app-list-card/AppListCard.tsx",
+          "packages/ui/components/app-list-card/AppListCardHeader.tsx"
+        ],
+        "tokens_used": 175784,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505002",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505002/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the header extraction.\n\nModified:\n- [AppListCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505002/packages/ui/components/app-list-card/AppListCard.tsx)\n\nCreated:\n- [AppListCardHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505002/packages/ui/components/app-list-card/AppListCardHeader.tsx)\n\nWhat changed:\n- Moved the inline `AppListCard` header JSX into `AppListCardHeader`.\n- The new header component takes `title`, `subtitle`, `actions`, logo, status flags, credential owner, and class name props.\n- `AppListCard` now delegates the header rendering and keeps its existing public props.\n- Preserved the `AppCardClassNames` type export from `AppListCard.tsx`.\n\nVerification:\n- `git diff --check` passed.\n- I could not run Biome or TypeScript checks because this checkout has no `node_modules` state, and `yarn` via Corepack is blocked by the sandbox trying to write under `/Users/veluga/.cache`.\n",
+        "stderr_tail": "Credential && (\n+          <div className=\"flex gap-x-2 pt-2\">\n+            <CircleAlertIcon className=\"h-8 w-8 shrink-0 text-red-500 sm:h-4 sm:w-4\" />\n+            <ListItemText component=\"p\" className=\"whitespace-pre-wrap wrap-break-word text-red-500\">\n+              {t(\"invalid_credential\", { appName: title })}\n+            </ListItemText>\n+          </div>\n+        )}\n+      </div>\n+      {credentialOwner && (\n+        <div className=\"shrink-0\">\n+          <Badge variant=\"gray\">\n+            <div className=\"flex items-center\">\n+              <Avatar\n+                className=\"mr-2\"\n+                alt={credentialOwner.name || \"Nameless\"}\n+                size=\"xs\"\n+                imageSrc={getPlaceholderAvatar(credentialOwner.avatar, credentialOwner.name)}\n+              />\n+              {credentialOwner.name}\n+            </div>\n+          </Badge>\n+        </div>\n+      )}\n+      {actions && <div className=\"shrink-0\">{actions}</div>}\n+    </div>\n+  );\n+}\n\ntokens used\n175,784\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": "! Corepack is about to download https://repo.yarnpkg.com/4.12.0/packages/yarnpkg-cli/bin/yarn.js\n",
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-vanilla.diffstat",
+          "patch_bytes": 7553,
+          "diffstat": " .../ui/components/app-list-card/AppListCard.tsx    | 79 ++++--------------\n .../components/app-list-card/AppListCardHeader.tsx | 96 ++++++++++++++++++++++\n 2 files changed, 112 insertions(+), 63 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 10,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=[], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['packages/ui/components/app-list-card/AppListCard.tsx', 'packages/ui/components/app-list-card/AppListCardHeader.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['packages']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": false,
+                "mandatory": false,
+                "details": "header_files=[]"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 210208,
+        "scan_time": 3660,
+        "total_time": 213868,
+        "files": 2,
+        "files_list": [
+          "apps/web/components/security/TwoFactorAuthSection.tsx",
+          "apps/web/components/security/TwoFactorAuthSectionHeader.tsx"
+        ],
+        "tokens_used": 80169,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3660,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 87,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2955,
+              "stdout_tail": "8,\n      \"importProbeCount\": 1873,\n      \"importResolveCacheHits\": 521\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/embed/components/Embed.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 842.03\n      },\n      {\n        \"filePath\": \"apps/docs/app/[[...mdxPath]]/page.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 144.3\n      },\n      {\n        \"filePath\": \"apps/web/modules/event-types/views/event-types-listing-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 125.23\n      },\n      {\n        \"filePath\": \"apps/web/modules/bookings/views/bookings-single-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 120.78\n      },\n      {\n        \"filePath\": \"packages/platform/atoms/event-types/payments/PaymentForm.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 66.95\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 616,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-18T09:45:51.784Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/.codex/fooks/attachments/bm-t4-fooks-1776505546.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/.codex/fooks/attachments/bm-t4-fooks-1776505546.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-18T09:45:51.774Z\",\"attachedAt\":\"2026-04-18T09:45:51.771Z\",\"lastScanAt\":\"2026-04-18T09:45:51.771Z\",\"lastRefreshAt\":\"2026-04-18T09:45:51.771Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Extracted the inline two-factor auth header JSX into a new component.\n\nModified/created files:\n- Modified [TwoFactorAuthSection.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/apps/web/components/security/TwoFactorAuthSection.tsx): replaced the inline title/subtitle/status/action header with `TwoFactorAuthSectionHeader`.\n- Created [TwoFactorAuthSectionHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776505546/apps/web/components/security/TwoFactorAuthSectionHeader.tsx): new header component with `title`, `subtitle`, `titleSuffix`, and `actions` props.\n\nValidation:\n- `git diff --check` passed.\n- `yarn biome check --write ...` and `yarn type-check:ci --force` could not run because this worktree is missing Yarn\u2019s install state: `Couldn't find the node_modules state file`.\n",
+        "stderr_tail": "00000000000..e418e73a2971ac5b69103cc290f305e087d82190\n--- /dev/null\n+++ b/apps/web/components/security/TwoFactorAuthSectionHeader.tsx\n@@ -0,0 +1,30 @@\n+import type { ReactNode } from \"react\";\n+\n+type TwoFactorAuthSectionHeaderProps = {\n+  title: string;\n+  subtitle: string;\n+  titleSuffix?: ReactNode;\n+  actions?: ReactNode;\n+};\n+\n+const TwoFactorAuthSectionHeader = ({\n+  title,\n+  subtitle,\n+  titleSuffix,\n+  actions,\n+}: TwoFactorAuthSectionHeaderProps) => {\n+  return (\n+    <div className=\"flex flex-col justify-between pl-2 pt-9 sm:flex-row\">\n+      <div>\n+        <div className=\"flex flex-row items-center\">\n+          <h2 className=\"font-cal text-emphasis text-lg font-medium leading-6\">{title}</h2>\n+          {titleSuffix}\n+        </div>\n+        <p className=\"text-subtle mt-1 text-sm\">{subtitle}</p>\n+      </div>\n+      {actions && <div className=\"mt-5 sm:mt-0 sm:self-center\">{actions}</div>}\n+    </div>\n+  );\n+};\n+\n+export default TwoFactorAuthSectionHeader;\n\ntokens used\n80,169\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...\n",
+            "package_manager": "yarn",
+            "method": "direct"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/artifacts/benchmark-full-1776504993/cal.com-T4-fooks.diffstat",
+          "patch_bytes": 3222,
+          "diffstat": " .../components/security/TwoFactorAuthSection.tsx   | 25 +++++++++---------\n .../security/TwoFactorAuthSectionHeader.tsx        | 30 ++++++++++++++++++++++\n 2 files changed, 42 insertions(+), 13 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 10,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=[], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['apps/web/components/security/TwoFactorAuthSection.tsx', 'apps/web/components/security/TwoFactorAuthSectionHeader.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=False, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['apps']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": false,
+                "mandatory": false,
+                "details": "header_files=[]"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 60.64323948856881,
+        "total": 59.957986103960046
+      },
+      "targetComparability": {
+        "classification": "semantically_comparable_target",
+        "reason": "Both variants produced T4-scored header extraction artifacts, but chose different targets."
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.diffstat
@@ -1,0 +1,3 @@
+ packages/ui/components/alert/Alert.tsx  | 11 ++---------
+ packages/ui/components/alert/Header.tsx | 21 +++++++++++++++++++++
+ 2 files changed, 23 insertions(+), 9 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.patch
@@ -1,0 +1,56 @@
+diff --git a/packages/ui/components/alert/Alert.tsx b/packages/ui/components/alert/Alert.tsx
+index 0e00a64..3b484c1 100644
+--- a/packages/ui/components/alert/Alert.tsx
++++ b/packages/ui/components/alert/Alert.tsx
+@@ -5,6 +5,7 @@ import { forwardRef } from "react";
+ 
+ import { Icon } from "../icon";
+ import type { IconName } from "../icon";
++import { Header } from "./Header";
+ 
+ export const alertStyles = cva("rounded-[10px] p-3", {
+   variants: {
+@@ -82,15 +83,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
+             )}
+           </div>
+         )}
+-        <div className="flex grow flex-col sm:flex-row">
+-          <div className="stack-y-1 ltr:ml-3 rtl:mr-3">
+-            {props.title && <h3 className="text-sm font-medium leading-none">{props.title}</h3>}
+-            {props.message && <div className="text-sm leading-5">{props.message}</div>}
+-          </div>
+-          {props.actions && (
+-            <div className="ml-auto mt-auto text-sm sm:mt-0 md:relative">{props.actions}</div>
+-          )}
+-        </div>
++        <Header title={props.title} subtitle={props.message} actions={props.actions} />
+       </div>
+     </div>
+   );
+diff --git a/packages/ui/components/alert/Header.tsx b/packages/ui/components/alert/Header.tsx
+new file mode 100644
+index 0000000..c65ea0c
+--- /dev/null
++++ b/packages/ui/components/alert/Header.tsx
+@@ -0,0 +1,21 @@
++import type { ReactNode } from "react";
++
++type HeaderProps = {
++  title?: ReactNode;
++  subtitle?: ReactNode;
++  actions?: ReactNode;
++};
++
++export function Header(props: HeaderProps) {
++  return (
++    <div className="flex grow flex-col sm:flex-row">
++      <div className="stack-y-1 ltr:ml-3 rtl:mr-3">
++        {props.title && <h3 className="text-sm font-medium leading-none">{props.title}</h3>}
++        {props.subtitle && <div className="text-sm leading-5">{props.subtitle}</div>}
++      </div>
++      {props.actions && (
++        <div className="ml-auto mt-auto text-sm sm:mt-0 md:relative">{props.actions}</div>
++      )}
++    </div>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.diffstat
@@ -1,0 +1,3 @@
+ apps/web/components/apps/AppPage.tsx       | 56 +++++-----------------
+ apps/web/components/apps/AppPageHeader.tsx | 77 ++++++++++++++++++++++++++++++
+ 2 files changed, 88 insertions(+), 45 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.patch
@@ -1,0 +1,168 @@
+diff --git a/apps/web/components/apps/AppPage.tsx b/apps/web/components/apps/AppPage.tsx
+index 73ac818..330a84e 100644
+--- a/apps/web/components/apps/AppPage.tsx
++++ b/apps/web/components/apps/AppPage.tsx
+@@ -1,4 +1,3 @@
+-import Link from "next/link";
+ import { useRouter } from "next/navigation";
+ import type { IframeHTMLAttributes } from "react";
+ import React, { useEffect, useState } from "react";
+@@ -17,7 +16,6 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
+ import { trpc, type RouterOutputs } from "@calcom/trpc/react";
+ import type { App as AppType } from "@calcom/types/App";
+ import classNames from "@calcom/ui/classNames";
+-import { Badge } from "@calcom/ui/components/badge";
+ import { Button } from "@calcom/ui/components/button";
+ import {
+   BookOpenIcon,
+@@ -31,6 +29,7 @@ import {
+ import { SkeletonButton, SkeletonText } from "@calcom/ui/components/skeleton";
+ import { showToast } from "@calcom/ui/components/toast";
+ 
++import { AppPageHeader } from "./AppPageHeader";
+ import { InstallAppButtonChild } from "./InstallAppButtonChild";
+ import { MultiDisconnectIntegration } from "./MultiDisconnectIntegration";
+ 
+@@ -340,49 +339,16 @@ export const AppPage = ({
+           "sticky top-0 -mt-4 max-w-xl basis-2/5 pb-12 text-sm lg:pb-0",
+           hasDescriptionItems && "lg:ml-8"
+         )}>
+-        <div className="mb-8 flex pt-4">
+-          <header>
+-            <div className="mb-4 flex items-center">
+-              {/* eslint-disable-next-line @next/next/no-img-element -- external app logo with unknown dimensions */}
+-              <img
+-                className={classNames(logo.includes("-dark") && "dark:invert", "min-h-16 min-w-16 h-16 w-16")}
+-                src={logo}
+-                alt={name}
+-              />
+-              <h1 className="font-cal text-emphasis ml-4 text-3xl">{name}</h1>
+-            </div>
+-            <h2 className="text-default text-sm font-medium">
+-              <Link
+-                href={`categories/${categories[0]}`}
+-                className="bg-subtle text-emphasis rounded-md p-1 text-xs capitalize">
+-                {categories[0]}
+-              </Link>{" "}
+-              {paid && (
+-                <>
+-                  <Badge className="mr-1">
+-                    {Intl.NumberFormat(i18n.language, {
+-                      style: "currency",
+-                      currency: "USD",
+-                      useGrouping: false,
+-                      maximumFractionDigits: 0,
+-                    }).format(paid.priceInUsd)}
+-                    /{t("month")}
+-                  </Badge>
+-                </>
+-              )}
+-              •{" "}
+-              <a target="_blank" rel="noreferrer" href={website}>
+-                {t("published_by", { author })}
+-              </a>
+-            </h2>
+-            {isTemplate && (
+-              <Badge variant="red" className="mt-4">
+-                Template - Available in Dev Environment only for testing
+-              </Badge>
+-            )}
+-          </header>
+-        </div>
+-        {installOrDisconnectAppButton()}
++        <AppPageHeader
++          name={name}
++          logo={logo}
++          category={categories[0]}
++          author={author}
++          website={website}
++          paid={paid}
++          isTemplate={isTemplate}
++          actions={installOrDisconnectAppButton()}
++        />
+ 
+         {slug === "msteams" && (
+           <div className="bg-info mt-4 rounded-md px-4 py-3">
+diff --git a/apps/web/components/apps/AppPageHeader.tsx b/apps/web/components/apps/AppPageHeader.tsx
+new file mode 100644
+index 0000000..90d781e
+--- /dev/null
++++ b/apps/web/components/apps/AppPageHeader.tsx
+@@ -0,0 +1,77 @@
++import Link from "next/link";
++import type { ReactNode } from "react";
++
++import { useLocale } from "@calcom/lib/hooks/useLocale";
++import type { App as AppType } from "@calcom/types/App";
++import classNames from "@calcom/ui/classNames";
++import { Badge } from "@calcom/ui/components/badge";
++
++type AppPageHeaderProps = {
++  name: string;
++  logo: string;
++  category?: string;
++  author: string;
++  website?: string;
++  paid?: AppType["paid"];
++  isTemplate?: boolean;
++  actions?: ReactNode;
++};
++
++export function AppPageHeader({
++  name,
++  logo,
++  category,
++  author,
++  website,
++  paid,
++  isTemplate,
++  actions,
++}: AppPageHeaderProps) {
++  const { t, i18n } = useLocale();
++
++  return (
++    <header className="pt-4">
++      <div className="mb-4 flex items-center">
++        {/* eslint-disable-next-line @next/next/no-img-element -- external app logo with unknown dimensions */}
++        <img
++          className={classNames(logo.includes("-dark") && "dark:invert", "min-h-16 min-w-16 h-16 w-16")}
++          src={logo}
++          alt={name}
++        />
++        <h1 className="font-cal text-emphasis ml-4 text-3xl">{name}</h1>
++      </div>
++      <h2 className="text-default text-sm font-medium">
++        {category ? (
++          <>
++            <Link
++              href={`categories/${category}`}
++              className="bg-subtle text-emphasis rounded-md p-1 text-xs capitalize">
++              {category}
++            </Link>{" "}
++          </>
++        ) : null}
++        {paid && (
++          <Badge className="mr-1">
++            {Intl.NumberFormat(i18n.language, {
++              style: "currency",
++              currency: "USD",
++              useGrouping: false,
++              maximumFractionDigits: 0,
++            }).format(paid.priceInUsd)}
++            /{t("month")}
++          </Badge>
++        )}
++        •{" "}
++        <a target="_blank" rel="noreferrer" href={website}>
++          {t("published_by", { author })}
++        </a>
++      </h2>
++      {isTemplate && (
++        <Badge variant="red" className="mt-4">
++          Template - Available in Dev Environment only for testing
++        </Badge>
++      )}
++      {actions ? <div className="mt-8">{actions}</div> : null}
++    </header>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.diffstat
@@ -1,0 +1,3 @@
+ .../(main-nav)/ShellMainAppDir.tsx                 | 44 +-------------
+ .../(main-nav)/ShellMainAppDirHeader.tsx           | 69 ++++++++++++++++++++++
+ 2 files changed, 71 insertions(+), 42 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.patch
@@ -1,0 +1,135 @@
+diff --git a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+index f625cdf..f8d1e53 100644
+--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
++++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+@@ -1,4 +1,5 @@
+ import { ShellMainAppDirBackButton } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDirBackButton";
++import { ShellMainAppDirHeader } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader";
+ import classNames from "classnames";
+ 
+ import type { LayoutProps } from "~/shell/Shell";
+@@ -15,48 +16,7 @@ export function ShellMainAppDir(props: LayoutProps) {
+             props.smallHeading ? "lg:mb-7" : "lg:mb-8"
+           )}>
+           {!!props.backPath && <ShellMainAppDirBackButton backPath={props.backPath} />}
+-          {props.heading && (
+-            <header
+-              className={classNames(
+-                props.large && "py-8",
+-                "flex w-full max-w-full items-center flex-wrap md:flex-nowrap gap-2 md:gap-0"
+-              )}>
+-              {props.HeadingLeftIcon && <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>}
+-              <div
+-                className={classNames(
+-                  "hidden min-w-0 flex-1 ltr:mr-4 rtl:ml-4 md:block",
+-                  props.headerClassName
+-                )}>
+-                {props.heading && (
+-                  <h3
+-                    className={classNames(
+-                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
+-                      props.smallHeading ? "text-base" : "text-xl"
+-                    )}>
+-                    {props.heading}
+-                  </h3>
+-                )}
+-                {props.subtitle && (
+-                  <p className="text-default hidden text-sm md:block" data-testid="subtitle">
+-                    {props.subtitle}
+-                  </p>
+-                )}
+-              </div>
+-              {props.beforeCTAactions}
+-              {props.CTA && (
+-                <div
+-                  className={classNames(
+-                    props.backPath
+-                      ? "relative"
+-                      : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
+-                    "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
+-                  )}>
+-                  {props.CTA}
+-                </div>
+-              )}
+-              {props.actions && props.actions}
+-            </header>
+-          )}
++          {props.heading && <ShellMainAppDirHeader {...props} />}
+         </div>
+       )}
+       {props.afterHeading && <>{props.afterHeading}</>}
+diff --git a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx
+new file mode 100644
+index 0000000..607a315
+--- /dev/null
++++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx
+@@ -0,0 +1,69 @@
++import classNames from "classnames";
++
++import type { LayoutProps } from "~/shell/Shell";
++
++type ShellMainAppDirHeaderProps = Pick<
++  LayoutProps,
++  | "actions"
++  | "backPath"
++  | "beforeCTAactions"
++  | "CTA"
++  | "HeadingLeftIcon"
++  | "headerClassName"
++  | "heading"
++  | "large"
++  | "smallHeading"
++  | "subtitle"
++>;
++
++export function ShellMainAppDirHeader({
++  actions,
++  backPath,
++  beforeCTAactions,
++  CTA,
++  HeadingLeftIcon,
++  headerClassName,
++  heading,
++  large,
++  smallHeading,
++  subtitle,
++}: ShellMainAppDirHeaderProps) {
++  return (
++    <header
++      className={classNames(
++        large && "py-8",
++        "flex w-full max-w-full items-center flex-wrap md:flex-nowrap gap-2 md:gap-0"
++      )}>
++      {HeadingLeftIcon && <div className="ltr:mr-4">{HeadingLeftIcon}</div>}
++      <div className={classNames("hidden min-w-0 flex-1 ltr:mr-4 rtl:ml-4 md:block", headerClassName)}>
++        {heading && (
++          <h3
++            className={classNames(
++              "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
++              smallHeading ? "text-base" : "text-xl"
++            )}>
++            {heading}
++          </h3>
++        )}
++        {subtitle && (
++          <p className="text-default hidden text-sm md:block" data-testid="subtitle">
++            {subtitle}
++          </p>
++        )}
++      </div>
++      {beforeCTAactions}
++      {CTA && (
++        <div
++          className={classNames(
++            backPath
++              ? "relative"
++              : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
++            "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
++          )}>
++          {CTA}
++        </div>
++      )}
++      {actions && actions}
++    </header>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.diffstat
@@ -1,0 +1,3 @@
+ .../(main-nav)/ShellMainAppDir.tsx                 | 53 +++++------------
+ .../(main-nav)/ShellMainAppDirHeader.tsx           | 66 ++++++++++++++++++++++
+ 2 files changed, 79 insertions(+), 40 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.patch
@@ -1,0 +1,140 @@
+diff --git a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+index f625cdf..f725432 100644
+--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
++++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+@@ -1,3 +1,4 @@
++import { ShellMainAppDirHeader } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader";
+ import { ShellMainAppDirBackButton } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDirBackButton";
+ import classNames from "classnames";
+ 
+@@ -16,46 +17,18 @@ export function ShellMainAppDir(props: LayoutProps) {
+           )}>
+           {!!props.backPath && <ShellMainAppDirBackButton backPath={props.backPath} />}
+           {props.heading && (
+-            <header
+-              className={classNames(
+-                props.large && "py-8",
+-                "flex w-full max-w-full items-center flex-wrap md:flex-nowrap gap-2 md:gap-0"
+-              )}>
+-              {props.HeadingLeftIcon && <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>}
+-              <div
+-                className={classNames(
+-                  "hidden min-w-0 flex-1 ltr:mr-4 rtl:ml-4 md:block",
+-                  props.headerClassName
+-                )}>
+-                {props.heading && (
+-                  <h3
+-                    className={classNames(
+-                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
+-                      props.smallHeading ? "text-base" : "text-xl"
+-                    )}>
+-                    {props.heading}
+-                  </h3>
+-                )}
+-                {props.subtitle && (
+-                  <p className="text-default hidden text-sm md:block" data-testid="subtitle">
+-                    {props.subtitle}
+-                  </p>
+-                )}
+-              </div>
+-              {props.beforeCTAactions}
+-              {props.CTA && (
+-                <div
+-                  className={classNames(
+-                    props.backPath
+-                      ? "relative"
+-                      : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
+-                    "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
+-                  )}>
+-                  {props.CTA}
+-                </div>
+-              )}
+-              {props.actions && props.actions}
+-            </header>
++            <ShellMainAppDirHeader
++              title={props.heading}
++              subtitle={props.subtitle}
++              actions={props.actions}
++              beforeActions={props.beforeCTAactions}
++              cta={props.CTA}
++              leadingIcon={props.HeadingLeftIcon}
++              large={props.large}
++              smallTitle={props.smallHeading}
++              headerClassName={props.headerClassName}
++              hasBackButton={!!props.backPath}
++            />
+           )}
+         </div>
+       )}
+diff --git a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx
+new file mode 100644
+index 0000000..6492ae6
+--- /dev/null
++++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx
+@@ -0,0 +1,66 @@
++import classNames from "classnames";
++
++import type { LayoutProps } from "~/shell/Shell";
++
++type ShellMainAppDirHeaderProps = {
++  title: NonNullable<LayoutProps["heading"]>;
++  subtitle?: LayoutProps["subtitle"];
++  actions?: LayoutProps["actions"];
++  beforeActions?: LayoutProps["beforeCTAactions"];
++  cta?: LayoutProps["CTA"];
++  leadingIcon?: LayoutProps["HeadingLeftIcon"];
++  large?: LayoutProps["large"];
++  smallTitle?: LayoutProps["smallHeading"];
++  headerClassName?: LayoutProps["headerClassName"];
++  hasBackButton?: boolean;
++};
++
++export function ShellMainAppDirHeader({
++  title,
++  subtitle,
++  actions,
++  beforeActions,
++  cta,
++  leadingIcon,
++  large,
++  smallTitle,
++  headerClassName,
++  hasBackButton,
++}: ShellMainAppDirHeaderProps) {
++  return (
++    <header
++      className={classNames(
++        large && "py-8",
++        "flex w-full max-w-full items-center flex-wrap md:flex-nowrap gap-2 md:gap-0"
++      )}>
++      {leadingIcon && <div className="ltr:mr-4">{leadingIcon}</div>}
++      <div className={classNames("hidden min-w-0 flex-1 ltr:mr-4 rtl:ml-4 md:block", headerClassName)}>
++        <h3
++          className={classNames(
++            "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
++            smallTitle ? "text-base" : "text-xl"
++          )}>
++          {title}
++        </h3>
++        {subtitle && (
++          <p className="text-default hidden text-sm md:block" data-testid="subtitle">
++            {subtitle}
++          </p>
++        )}
++      </div>
++      {beforeActions}
++      {cta && (
++        <div
++          className={classNames(
++            hasBackButton
++              ? "relative"
++              : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
++            "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
++          )}>
++          {cta}
++        </div>
++      )}
++      {actions}
++    </header>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.diffstat
@@ -1,0 +1,3 @@
+ packages/ui/components/layout/ShellSubHeading.tsx  | 24 ++++------------------
+ .../ui/components/layout/ShellSubHeadingHeader.tsx | 24 ++++++++++++++++++++++
+ 2 files changed, 28 insertions(+), 20 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.patch
@@ -1,0 +1,61 @@
+diff --git a/packages/ui/components/layout/ShellSubHeading.tsx b/packages/ui/components/layout/ShellSubHeading.tsx
+index 244e153..19506de 100644
+--- a/packages/ui/components/layout/ShellSubHeading.tsx
++++ b/packages/ui/components/layout/ShellSubHeading.tsx
+@@ -1,22 +1,6 @@
+-import type { ReactNode } from "react";
++import type { ShellSubHeadingHeaderProps } from "./ShellSubHeadingHeader";
++import { ShellSubHeadingHeader } from "./ShellSubHeadingHeader";
+ 
+-import classNames from "@calcom/ui/classNames";
+-
+-export function ShellSubHeading(props: {
+-  title: ReactNode;
+-  subtitle?: ReactNode;
+-  actions?: ReactNode;
+-  className?: string;
+-}) {
+-  return (
+-    <header className={classNames("mb-3 block justify-between sm:flex", props.className)}>
+-      <div>
+-        <h2 className="text-emphasis flex content-center items-center space-x-2 text-base font-bold leading-6 rtl:space-x-reverse">
+-          {props.title}
+-        </h2>
+-        {props.subtitle && <p className="text-subtle text-sm ltr:mr-4">{props.subtitle}</p>}
+-      </div>
+-      {props.actions && <div className="mt-2 shrink-0 sm:mt-0">{props.actions}</div>}
+-    </header>
+-  );
++export function ShellSubHeading(props: ShellSubHeadingHeaderProps) {
++  return <ShellSubHeadingHeader {...props} />;
+ }
+diff --git a/packages/ui/components/layout/ShellSubHeadingHeader.tsx b/packages/ui/components/layout/ShellSubHeadingHeader.tsx
+new file mode 100644
+index 0000000..ee0eb33
+--- /dev/null
++++ b/packages/ui/components/layout/ShellSubHeadingHeader.tsx
+@@ -0,0 +1,24 @@
++import type { ReactNode } from "react";
++
++import classNames from "@calcom/ui/classNames";
++
++export type ShellSubHeadingHeaderProps = {
++  title: ReactNode;
++  subtitle?: ReactNode;
++  actions?: ReactNode;
++  className?: string;
++};
++
++export function ShellSubHeadingHeader({ title, subtitle, actions, className }: ShellSubHeadingHeaderProps) {
++  return (
++    <header className={classNames("mb-3 block justify-between sm:flex", className)}>
++      <div>
++        <h2 className="text-emphasis flex content-center items-center space-x-2 text-base font-bold leading-6 rtl:space-x-reverse">
++          {title}
++        </h2>
++        {subtitle && <p className="text-subtle text-sm ltr:mr-4">{subtitle}</p>}
++      </div>
++      {actions && <div className="mt-2 shrink-0 sm:mt-0">{actions}</div>}
++    </header>
++  );
++}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.diffstat
@@ -1,0 +1,3 @@
+ .../my-account/components/HolidaysHeader.tsx       | 19 +++++++++++++++
+ .../modules/settings/my-account/holidays-view.tsx  | 27 +++++++++++-----------
+ 2 files changed, 33 insertions(+), 13 deletions(-)

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.patch
@@ -1,0 +1,70 @@
+diff --git a/apps/web/modules/settings/my-account/components/HolidaysHeader.tsx b/apps/web/modules/settings/my-account/components/HolidaysHeader.tsx
+new file mode 100644
+index 0000000..10422d4
+--- /dev/null
++++ b/apps/web/modules/settings/my-account/components/HolidaysHeader.tsx
+@@ -0,0 +1,19 @@
++import type { ReactNode } from "react";
++
++type HolidaysHeaderProps = {
++  title: ReactNode;
++  subtitle?: ReactNode;
++  actions?: ReactNode;
++};
++
++export function HolidaysHeader({ title, subtitle, actions }: HolidaysHeaderProps) {
++  return (
++    <div className="mb-4 flex items-center justify-between">
++      <div>
++        <h3 className="text-emphasis font-semibold">{title}</h3>
++        {subtitle && <p className="text-subtle text-sm">{subtitle}</p>}
++      </div>
++      {actions}
++    </div>
++  );
++}
+diff --git a/apps/web/modules/settings/my-account/holidays-view.tsx b/apps/web/modules/settings/my-account/holidays-view.tsx
+index 9ae6787..96b8fad 100644
+--- a/apps/web/modules/settings/my-account/holidays-view.tsx
++++ b/apps/web/modules/settings/my-account/holidays-view.tsx
+@@ -16,6 +16,8 @@ import { showToast } from "@calcom/ui/components/toast";
+ import { memo, useCallback, useMemo } from "react";
+ import { OutOfOfficeToggleGroup } from "~/settings/outOfOffice/OutOfOfficeToggleGroup";
+ 
++import { HolidaysHeader } from "./components/HolidaysHeader";
++
+ function HolidaysCTA() {
+   const { t } = useLocale();
+   return (
+@@ -290,19 +292,18 @@ export function HolidaysView() {
+           )}
+ 
+           <div className="border-subtle bg-muted overflow-hidden rounded-lg border p-5">
+-            {/* Header with title and country selector */}
+-            <div className="mb-4 flex items-center justify-between">
+-              <div>
+-                <h3 className="text-emphasis font-semibold">{t("holidays")}</h3>
+-                <p className="text-subtle text-sm">{t("holidays_description")}</p>
+-              </div>
+-              <CountrySelector
+-                countries={countries || []}
+-                value={settings?.countryCode || ""}
+-                onChange={handleCountryChange}
+-                isLoading={isLoadingCountries}
+-              />
+-            </div>
++            <HolidaysHeader
++              title={t("holidays")}
++              subtitle={t("holidays_description")}
++              actions={
++                <CountrySelector
++                  countries={countries || []}
++                  value={settings?.countryCode || ""}
++                  onChange={handleCountryChange}
++                  isLoading={isLoadingCountries}
++                />
++              }
++            />
+ 
+             {/* Holidays list - inner container */}
+             {settings?.countryCode ? (

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/benchmark-full-1776505820.json
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/benchmark-full-1776505820.json
@@ -1,0 +1,1072 @@
+{
+  "reportSchemaVersion": "frontend-harness.v2-context-mode",
+  "timestamp": "2026-04-18T20:30:23.753272",
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820",
+  "iterations": 3,
+  "qualityGatedDecision": {
+    "rawMedianTotalTimeImprovement": 2.1458522872454506,
+    "rawMedianRuntimeTokenReduction": 26.595939444168817,
+    "qualityGatedPairCount": 1,
+    "qualityGatedMedianTotalTimeImprovement": -4.267697563058529,
+    "qualityGatedMedianRuntimeTokenReduction": 23.483431555916294,
+    "runtimeTokenClaimAvailable": true,
+    "fooksAcceptancePassRate": 1.0,
+    "broaderScopeRegressionCount": 0,
+    "severeTokenOutlierCount": 0,
+    "targetComparabilityBreakdown": {
+      "same_component_or_file": 0,
+      "semantically_comparable_target": 2,
+      "incomparable_target": 1
+    },
+    "proxyContextReductionLabel": "proxyContextReduction; context-size evidence only, not runtime token savings",
+    "verdict": "provisional-loss-or-non-goal",
+    "verdictReasons": [
+      "N=3 quality-gated total time does not improve."
+    ]
+  },
+  "summary": {
+    "total_benchmarks": 3,
+    "vanilla_success": 2,
+    "fooks_success": 3,
+    "avg_token_reduction": 75.58121705337071,
+    "avg_tokens_saved": 738377.3333333334,
+    "proxyContextReduction": {
+      "avg_reduction_pct": 75.58121705337071,
+      "avg_tokens_saved": 738377.3333333334,
+      "label": "proxyContextReduction; context-size evidence only, not runtime token savings"
+    }
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant either runs fooks init/scan/attach before the same agent command or records an exact-file first-turn bypass when no fooks context would be injected; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "2 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "medium",
+        "evidence": "same_prompt=True, same_files=False, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks may prepare native context or explicitly bypass exact-file first-turn preparation."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "low",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "artifact_quality_scope",
+        "level": "low",
+        "evidence": "acceptance_available=True, fooks_acceptance_failures=0, scope_regressions=0",
+        "interpretation": "Do not cite wins unless fooks passes task acceptance and avoids broader edit scope than vanilla."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 0/2 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T4",
+      "task_name": "Component Extraction",
+      "repo": "cal.com",
+      "difficulty": "medium",
+      "timestamp": "2026-04-18T18:50:20.635375",
+      "iteration": 1,
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "expectedFooksPrepare": "scan-attach",
+      "tokens": {
+        "total_files": 693,
+        "raw_bytes": 4574215.800000001,
+        "compressed_bytes": 970384.8,
+        "raw_tokens": 1143553.0,
+        "compressed_tokens": 242596.0,
+        "tokens_saved": 900957.0,
+        "reduction_pct": 78.78576695047926,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 282473,
+        "files": 2,
+        "files_list": [
+          "apps/web/components/apps/AppPage.tsx",
+          "apps/web/components/apps/AppPageHeader.tsx"
+        ],
+        "tokens_used": 116960,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505828",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505828/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Extracted the app detail header into a new component.\n\nModified:\n- [AppPage.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505828/apps/web/components/apps/AppPage.tsx:32) now imports `AppPageHeader` and passes title/logo/category/subtitle data plus the install/disconnect `actions` slot.\n\nCreated:\n- [AppPageHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776505828/apps/web/components/apps/AppPageHeader.tsx:9) contains the extracted header JSX with typed props for `name`, `logo`, `category`, `author`, `website`, `paid`, `isTemplate`, and `actions`.\n\nVerification:\n- `git diff --check -- apps/web/components/apps/AppPage.tsx apps/web/components/apps/AppPageHeader.tsx` passed.\n- `yarn biome check --write ...` and `yarn type-check:ci --force` could not run because this worktree is missing Yarn\u2019s node_modules state file: `Couldn't find the node_modules state file`.\n",
+        "stderr_tail": "    <Link\n+              href={`categories/${category}`}\n+              className=\"bg-subtle text-emphasis rounded-md p-1 text-xs capitalize\">\n+              {category}\n+            </Link>{\" \"}\n+          </>\n+        ) : null}\n+        {paid && (\n+          <Badge className=\"mr-1\">\n+            {Intl.NumberFormat(i18n.language, {\n+              style: \"currency\",\n+              currency: \"USD\",\n+              useGrouping: false,\n+              maximumFractionDigits: 0,\n+            }).format(paid.priceInUsd)}\n+            /{t(\"month\")}\n+          </Badge>\n+        )}\n+        \u2022{\" \"}\n+        <a target=\"_blank\" rel=\"noreferrer\" href={website}>\n+          {t(\"published_by\", { author })}\n+        </a>\n+      </h2>\n+      {isTemplate && (\n+        <Badge variant=\"red\" className=\"mt-4\">\n+          Template - Available in Dev Environment only for testing\n+        </Badge>\n+      )}\n+      {actions ? <div className=\"mt-8\">{actions}</div> : null}\n+    </header>\n+  );\n+}\n\ntokens used\n116,960\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-vanilla.diffstat",
+          "patch_bytes": 5931,
+          "diffstat": " apps/web/components/apps/AppPage.tsx       | 56 +++++-----------------\n apps/web/components/apps/AppPageHeader.tsx | 77 ++++++++++++++++++++++++++++++\n 2 files changed, 88 insertions(+), 45 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 10,
+            "max_score": 11,
+            "passed": false,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=['apps/web/components/apps/AppPageHeader.tsx'], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['apps/web/components/apps/AppPage.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": false,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=False, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['apps']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": true,
+                "mandatory": false,
+                "details": "header_files=['apps/web/components/apps/AppPageHeader.tsx']"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 254707,
+        "scan_time": 3588,
+        "total_time": 258295,
+        "files": 2,
+        "files_list": [
+          "packages/ui/components/alert/Alert.tsx",
+          "packages/ui/components/alert/Header.tsx"
+        ],
+        "tokens_used": 82213,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3588,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 86,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2900,
+              "stdout_tail": "18,\n      \"importProbeCount\": 1873,\n      \"importResolveCacheHits\": 521\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/embed/components/Embed.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 835.8\n      },\n      {\n        \"filePath\": \"apps/docs/app/[[...mdxPath]]/page.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 144.79\n      },\n      {\n        \"filePath\": \"apps/web/modules/event-types/views/event-types-listing-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 122.03\n      },\n      {\n        \"filePath\": \"apps/web/modules/bookings/views/bookings-single-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 117.89\n      },\n      {\n        \"filePath\": \"packages/platform/atoms/event-types/payments/PaymentForm.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 66.9\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 601,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-18T09:55:24.781Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/.codex/fooks/attachments/bm-t4-fooks-1776506119.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/.codex/fooks/attachments/bm-t4-fooks-1776506119.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-18T09:55:24.772Z\",\"attachedAt\":\"2026-04-18T09:55:24.769Z\",\"lastScanAt\":\"2026-04-18T09:55:24.769Z\",\"lastRefreshAt\":\"2026-04-18T09:55:24.769Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Extracted the inline alert header JSX into a new component.\n\nModified:\n- [Alert.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/packages/ui/components/alert/Alert.tsx): imports and uses the new `Header` component, passing `title`, `message` as `subtitle`, and `actions`.\n\nCreated:\n- [Header.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776506119/packages/ui/components/alert/Header.tsx): new header component with `title`, `subtitle`, and `actions` props.\n\nVerification:\n- `git diff --check` passed.\n- `yarn biome check --write ...`, `yarn test packages/ui/components/alert/alert.test.tsx`, and `yarn workspace @calcom/ui type-check` could not run because this worktree is missing Yarn\u2019s install state: `Couldn't find the node_modules state file`.\n",
+        "stderr_tail": "s.actions} />\n       </div>\n     </div>\n   );\ndiff --git a/packages/ui/components/alert/Header.tsx b/packages/ui/components/alert/Header.tsx\nnew file mode 100644\nindex 0000000000000000000000000000000000000000..c65ea0cb98a2671e5eb1cf9abca25561c7b54dbd\n--- /dev/null\n+++ b/packages/ui/components/alert/Header.tsx\n@@ -0,0 +1,21 @@\n+import type { ReactNode } from \"react\";\n+\n+type HeaderProps = {\n+  title?: ReactNode;\n+  subtitle?: ReactNode;\n+  actions?: ReactNode;\n+};\n+\n+export function Header(props: HeaderProps) {\n+  return (\n+    <div className=\"flex grow flex-col sm:flex-row\">\n+      <div className=\"stack-y-1 ltr:ml-3 rtl:mr-3\">\n+        {props.title && <h3 className=\"text-sm font-medium leading-none\">{props.title}</h3>}\n+        {props.subtitle && <div className=\"text-sm leading-5\">{props.subtitle}</div>}\n+      </div>\n+      {props.actions && (\n+        <div className=\"ml-auto mt-auto text-sm sm:mt-0 md:relative\">{props.actions}</div>\n+      )}\n+    </div>\n+  );\n+}\n\ntokens used\n82,213\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...\n",
+            "package_manager": "yarn",
+            "method": "direct"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter1-fooks.diffstat",
+          "patch_bytes": 2060,
+          "diffstat": " packages/ui/components/alert/Alert.tsx  | 11 ++---------\n packages/ui/components/alert/Header.tsx | 21 +++++++++++++++++++++\n 2 files changed, 23 insertions(+), 9 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 11,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=['packages/ui/components/alert/Header.tsx'], header_component_declared=False"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['packages/ui/components/alert/Alert.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['packages']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": true,
+                "mandatory": false,
+                "details": "header_files=['packages/ui/components/alert/Header.tsx']"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 9.829612033716497,
+        "total": 8.55940213754943
+      },
+      "targetComparability": {
+        "classification": "semantically_comparable_target",
+        "reason": "Both variants produced T4-scored header extraction artifacts, but chose different targets."
+      }
+    },
+    {
+      "task": "T4",
+      "task_name": "Component Extraction",
+      "repo": "cal.com",
+      "difficulty": "medium",
+      "timestamp": "2026-04-18T18:59:47.756598",
+      "iteration": 2,
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "expectedFooksPrepare": "scan-attach",
+      "tokens": {
+        "total_files": 693,
+        "raw_bytes": 4747743.0,
+        "compressed_bytes": 1021089.3,
+        "raw_tokens": 1186935.0,
+        "compressed_tokens": 255272.0,
+        "tokens_saved": 931663.0,
+        "reduction_pct": 78.49316401498565,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": false,
+        "duration_ms": 600000,
+        "files": 0,
+        "files_list": [],
+        "error": "Timeout",
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-vanilla.diffstat",
+          "patch_bytes": 5553,
+          "diffstat": " .../(main-nav)/ShellMainAppDir.tsx                 | 53 +++++------------\n .../(main-nav)/ShellMainAppDirHeader.tsx           | 66 ++++++++++++++++++++++\n 2 files changed, 79 insertions(+), 40 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 8,
+            "max_score": 11,
+            "passed": false,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=[], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": false,
+                "mandatory": true,
+                "details": "non_header_source_files=[]"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": false,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=0, roots=[]"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=0, source_files=0"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": false,
+                "mandatory": false,
+                "details": "header_files=[]"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 225781,
+        "scan_time": 3704,
+        "total_time": 229485,
+        "files": 2,
+        "files_list": [
+          "apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx",
+          "apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx"
+        ],
+        "tokens_used": 85871,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3704,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 87,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 3013,
+              "stdout_tail": ",\n      \"importProbeCount\": 1873,\n      \"importResolveCacheHits\": 521\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/embed/components/Embed.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 881.46\n      },\n      {\n        \"filePath\": \"apps/docs/app/[[...mdxPath]]/page.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 148.97\n      },\n      {\n        \"filePath\": \"apps/web/modules/event-types/views/event-types-listing-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 123.07\n      },\n      {\n        \"filePath\": \"apps/web/modules/bookings/views/bookings-single-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 120.73\n      },\n      {\n        \"filePath\": \"packages/platform/atoms/event-types/payments/PaymentForm.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 67.83\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 602,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-18T11:17:08.393Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/.codex/fooks/attachments/bm-t4-fooks-1776511022.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/.codex/fooks/attachments/bm-t4-fooks-1776511022.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-18T11:17:08.383Z\",\"attachedAt\":\"2026-04-18T11:17:08.380Z\",\"lastScanAt\":\"2026-04-18T11:17:08.380Z\",\"lastRefreshAt\":\"2026-04-18T11:17:08.380Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Extracted the inline shell header JSX into a new component.\n\nModified/created files:\n- Modified [ShellMainAppDir.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx:1)\n- Created [ShellMainAppDirHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511022/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx:1)\n\nWhat changed:\n- `ShellMainAppDir` now keeps the outer heading/back-button wrapper and delegates the header markup to `ShellMainAppDirHeader`.\n- `ShellMainAppDirHeader` accepts a typed `Pick<LayoutProps, ...>` for heading, subtitle, CTA, pre-CTA actions, actions, icon, sizing, and header class props.\n\nValidation:\n- `git diff --check` passed.\n- `yarn biome check --write ...` and `yarn type-check:ci --force` could not run because this worktree is missing Yarn\u2019s `node_modules` state file.\n",
+        "stderr_tail": "Names(\n+              \"font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full\",\n+              smallHeading ? \"text-base\" : \"text-xl\"\n+            )}>\n+            {heading}\n+          </h3>\n+        )}\n+        {subtitle && (\n+          <p className=\"text-default hidden text-sm md:block\" data-testid=\"subtitle\">\n+            {subtitle}\n+          </p>\n+        )}\n+      </div>\n+      {beforeCTAactions}\n+      {CTA && (\n+        <div\n+          className={classNames(\n+            backPath\n+              ? \"relative\"\n+              : \"pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0\",\n+            \"shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto\"\n+          )}>\n+          {CTA}\n+        </div>\n+      )}\n+      {actions && actions}\n+    </header>\n+  );\n+}\n\ntokens used\n85,871\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...\n",
+            "package_manager": "yarn",
+            "method": "direct"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter2-fooks.diffstat",
+          "patch_bytes": 5153,
+          "diffstat": " .../(main-nav)/ShellMainAppDir.tsx                 | 44 +-------------\n .../(main-nav)/ShellMainAppDirHeader.tsx           | 69 ++++++++++++++++++++++\n 2 files changed, 71 insertions(+), 42 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 11,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=['apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx'], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['apps']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": true,
+                "mandatory": false,
+                "details": "header_files=['apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx']"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 0,
+        "total": 0
+      },
+      "targetComparability": {
+        "classification": "incomparable_target",
+        "reason": "The variants did not produce comparable changed targets."
+      }
+    },
+    {
+      "task": "T4",
+      "task_name": "Component Extraction",
+      "repo": "cal.com",
+      "difficulty": "medium",
+      "timestamp": "2026-04-18T20:21:03.202781",
+      "iteration": 3,
+      "repoClass": "external-oss-nextjs-tailwind",
+      "taskClass": "ambiguous-multi-file",
+      "promptSpecificity": "ambiguous",
+      "expectedContextPolicy": "auto",
+      "expectedFirstTurnRuntimeContext": "auto",
+      "expectedFooksPrepare": "scan-attach",
+      "tokens": {
+        "total_files": 693,
+        "raw_bytes": 2202631.2,
+        "compressed_bytes": 672579.6000000001,
+        "raw_tokens": 550657.0,
+        "compressed_tokens": 168144.0,
+        "tokens_saved": 382512.0,
+        "reduction_pct": 69.4647201946472,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 262296,
+        "files": 2,
+        "files_list": [
+          "apps/web/modules/settings/my-account/components/HolidaysHeader.tsx",
+          "apps/web/modules/settings/my-account/holidays-view.tsx"
+        ],
+        "tokens_used": 113348,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776511270",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776511270/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "no-op",
+        "contextModeReason": "vanilla-baseline-no-fooks-context",
+        "contextBudget": {
+          "maxFiles": 0,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Implemented the header extraction.\n\nCreated:\n- [HolidaysHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776511270/apps/web/modules/settings/my-account/components/HolidaysHeader.tsx:1) with `title`, `subtitle`, and `actions` props.\n\nModified:\n- [holidays-view.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776511270/apps/web/modules/settings/my-account/holidays-view.tsx:19) to import `HolidaysHeader` and replace the inline holidays section header JSX with the extracted component.\n\nVerification:\n- Attempted `yarn biome check --write apps/web/modules/settings/my-account/holidays-view.tsx apps/web/modules/settings/my-account/components/HolidaysHeader.tsx`, but Yarn could not run because `node_modules` is missing in this worktree.\n- I left the pre-existing untracked `.codex/` directory untouched.\n",
+        "stderr_tail": "-                <h3 className=\"text-emphasis font-semibold\">{t(\"holidays\")}</h3>\n-                <p className=\"text-subtle text-sm\">{t(\"holidays_description\")}</p>\n-              </div>\n-              <CountrySelector\n-                countries={countries || []}\n-                value={settings?.countryCode || \"\"}\n-                onChange={handleCountryChange}\n-                isLoading={isLoadingCountries}\n-              />\n-            </div>\n+            <HolidaysHeader\n+              title={t(\"holidays\")}\n+              subtitle={t(\"holidays_description\")}\n+              actions={\n+                <CountrySelector\n+                  countries={countries || []}\n+                  value={settings?.countryCode || \"\"}\n+                  onChange={handleCountryChange}\n+                  isLoading={isLoadingCountries}\n+                />\n+              }\n+            />\n \n             {/* Holidays list - inner container */}\n             {settings?.countryCode ? (\n\ntokens used\n113,348\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "skipped": true,
+            "reason": "build validation not run for vanilla"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-vanilla.diffstat",
+          "patch_bytes": 2729,
+          "diffstat": " .../my-account/components/HolidaysHeader.tsx       | 19 +++++++++++++++\n .../modules/settings/my-account/holidays-view.tsx  | 27 +++++++++++-----------\n 2 files changed, 33 insertions(+), 13 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 11,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=['apps/web/modules/settings/my-account/components/HolidaysHeader.tsx'], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['apps/web/modules/settings/my-account/holidays-view.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=False, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['apps']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": true,
+                "mandatory": false,
+                "details": "header_files=['apps/web/modules/settings/my-account/components/HolidaysHeader.tsx']"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 269872,
+        "scan_time": 3618,
+        "total_time": 273490,
+        "files": 2,
+        "files_list": [
+          "packages/ui/components/layout/ShellSubHeading.tsx",
+          "packages/ui/components/layout/ShellSubHeadingHeader.tsx"
+        ],
+        "tokens_used": 86730,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3618,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 89,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2920,
+              "stdout_tail": ",\n      \"importProbeCount\": 1873,\n      \"importResolveCacheHits\": 521\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/embed/components/Embed.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 836.58\n      },\n      {\n        \"filePath\": \"apps/docs/app/[[...mdxPath]]/page.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 144.28\n      },\n      {\n        \"filePath\": \"apps/web/modules/event-types/views/event-types-listing-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 121.01\n      },\n      {\n        \"filePath\": \"apps/web/modules/bookings/views/bookings-single-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 119.12\n      },\n      {\n        \"filePath\": \"packages/platform/atoms/event-types/payments/PaymentForm.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 66.75\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 608,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-18T11:25:45.727Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/.codex/fooks/attachments/bm-t4-fooks-1776511540.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/.codex/fooks/attachments/bm-t4-fooks-1776511540.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-18T11:25:45.717Z\",\"attachedAt\":\"2026-04-18T11:25:45.714Z\",\"lastScanAt\":\"2026-04-18T11:25:45.714Z\",\"lastRefreshAt\":\"2026-04-18T11:25:45.714Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/.codex",
+          "prompt_sha256": "e27c632963ecab52f14da20d2acd5ac7df95d613c024ec466fae2e1595339ff6",
+          "codex_bin": "codex"
+        },
+        "contextMode": "auto",
+        "contextModeReason": "fooks-ambiguous-policy",
+        "contextBudget": {
+          "maxFiles": 5,
+          "selectedFiles": 0,
+          "totalBytes": 0,
+          "skippedFiles": 0
+        },
+        "contextPolicyVersion": "context-policy.v1",
+        "contextBudgetSource": "expected-policy",
+        "stdout_tail": "Extracted the inline header JSX from `ShellSubHeading` into a new header component.\n\nModified:\n- [ShellSubHeading.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/packages/ui/components/layout/ShellSubHeading.tsx:1) now delegates to the extracted header component.\n\nCreated:\n- [ShellSubHeadingHeader.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776511540/packages/ui/components/layout/ShellSubHeadingHeader.tsx:1) with `title`, `subtitle`, `actions`, and `className` props.\n\nVerification:\n- `git diff --check -- packages/ui/components/layout/ShellSubHeading.tsx packages/ui/components/layout/ShellSubHeadingHeader.tsx` passed.\n- `yarn biome check --write ...`, `TZ=UTC yarn test packages/ui/components/layout/shellSubHeading.test.tsx`, and `yarn workspace @calcom/ui type-check:ci` could not run because this worktree is missing Yarn\u2019s `node_modules` state file.\n",
+        "stderr_tail": "000000000000000000000000..ee0eb3303f7c2d8aef92bdbcfaf1ad89c25630ce\n--- /dev/null\n+++ b/packages/ui/components/layout/ShellSubHeadingHeader.tsx\n@@ -0,0 +1,24 @@\n+import type { ReactNode } from \"react\";\n+\n+import classNames from \"@calcom/ui/classNames\";\n+\n+export type ShellSubHeadingHeaderProps = {\n+  title: ReactNode;\n+  subtitle?: ReactNode;\n+  actions?: ReactNode;\n+  className?: string;\n+};\n+\n+export function ShellSubHeadingHeader({ title, subtitle, actions, className }: ShellSubHeadingHeaderProps) {\n+  return (\n+    <header className={classNames(\"mb-3 block justify-between sm:flex\", className)}>\n+      <div>\n+        <h2 className=\"text-emphasis flex content-center items-center space-x-2 text-base font-bold leading-6 rtl:space-x-reverse\">\n+          {title}\n+        </h2>\n+        {subtitle && <p className=\"text-subtle text-sm ltr:mr-4\">{subtitle}</p>}\n+      </div>\n+      {actions && <div className=\"mt-2 shrink-0 sm:mt-0\">{actions}</div>}\n+    </header>\n+  );\n+}\n\ntokens used\n86,730\n",
+        "error": null,
+        "validation": {
+          "typecheck": {
+            "success": false,
+            "error_count": 0,
+            "stderr": null,
+            "stdout": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn exec <commandName> ...\n",
+            "package_manager": "yarn",
+            "method": "tsc",
+            "tsconfig_path": "apps/web/tsconfig.json"
+          },
+          "build": {
+            "success": false,
+            "env_gated": false,
+            "error": null,
+            "stdout_tail": "Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)\n\n$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...\n",
+            "package_manager": "yarn",
+            "method": "direct"
+          }
+        },
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820/cal.com-T4-iter3-fooks.diffstat",
+          "patch_bytes": 2362,
+          "diffstat": " packages/ui/components/layout/ShellSubHeading.tsx  | 24 ++++------------------\n .../ui/components/layout/ShellSubHeadingHeader.tsx | 24 ++++++++++++++++++++++\n 2 files changed, 28 insertions(+), 20 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "kind": "component-extraction",
+            "score": 11,
+            "max_score": 11,
+            "passed": true,
+            "checks": [
+              {
+                "name": "header_component_created_or_extracted",
+                "passed": true,
+                "mandatory": true,
+                "details": "header_files=['packages/ui/components/layout/ShellSubHeadingHeader.tsx'], header_component_declared=True"
+              },
+              {
+                "name": "original_component_uses_header",
+                "passed": true,
+                "mandatory": true,
+                "details": "non_header_source_files=['packages/ui/components/layout/ShellSubHeading.tsx']"
+              },
+              {
+                "name": "header_semantics_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "title_signal=True, subtitle_signal=True, removed_semantics=True"
+              },
+              {
+                "name": "header_actions_preserved",
+                "passed": true,
+                "mandatory": true,
+                "details": "action_removed=True, action_preserved=True"
+              },
+              {
+                "name": "no_unused_header_false_positive",
+                "passed": true,
+                "mandatory": true
+              },
+              {
+                "name": "file_scope_capped",
+                "passed": true,
+                "mandatory": true,
+                "details": "source_files=2, roots=['packages']"
+              },
+              {
+                "name": "runtime_files_excluded",
+                "passed": true,
+                "mandatory": true,
+                "details": "files=2, source_files=2"
+              },
+              {
+                "name": "diff_check_passed",
+                "passed": true,
+                "mandatory": true,
+                "details": "ok"
+              },
+              {
+                "name": "style_continuity_present",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "props_are_reasonably_named",
+                "passed": true,
+                "mandatory": false
+              },
+              {
+                "name": "new_file_location_matches_local_pattern",
+                "passed": true,
+                "mandatory": false,
+                "details": "header_files=['packages/ui/components/layout/ShellSubHeadingHeader.tsx']"
+              }
+            ]
+          }
+        },
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -2.888339890810382,
+        "total": -4.267697563058529
+      },
+      "targetComparability": {
+        "classification": "semantically_comparable_target",
+        "reason": "Both variants produced T4-scored header extraction artifacts, but chose different targets."
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/cal-t4-component-extraction-decision-report.md
+++ b/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/cal-t4-component-extraction-decision-report.md
@@ -1,0 +1,64 @@
+# Cal.com T4 Component Extraction Benchmark Decision Report
+
+Generated: 2026-04-18T11:32:31.627349+00:00
+
+## Verdict
+
+- N=1 smoke verdict: `smoke-pass-proceed-to-n3`
+- N=3 routing verdict: `provisional-loss-or-non-goal`
+  - N=3 quality-gated total time does not improve.
+- Product interpretation: do **not** proceed to N=5 for a win claim from this candidate. The N=3 quality-gated pair regressed on total time, so this lane is currently a provisional loss/non-goal for acceleration claims despite fooks often producing valid artifacts and lower runtime tokens.
+
+## Commands
+
+```bash
+python3 benchmarks/frontend-harness/runners/full-benchmark-suite.py --runner codex --repo cal.com --task T4 --iterations 1 --reports-dir benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z
+python3 benchmarks/frontend-harness/runners/full-benchmark-suite.py --runner codex --repo cal.com --task T4 --iterations 3 --reports-dir benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z
+```
+
+Both variants used direct `codex exec --full-auto`; fooks differed only by the harness `init/scan/attach-codex` preparation before the same Codex command.
+
+## Report paths
+
+- N=1 JSON: `benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/benchmark-full-1776504993.json`
+- N=3 JSON: `benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/benchmark-full-1776505820.json`
+- N=3 artifacts: `/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/artifacts/benchmark-full-1776505820`
+
+## Aggregate fields
+
+| Field | Value |
+| --- | ---: |
+| `rawMedianTotalTimeImprovement` | +2.1% |
+| `rawMedianRuntimeTokenReduction` | +26.6% |
+| `qualityGatedPairCount` | 1 |
+| `qualityGatedMedianTotalTimeImprovement` | -4.3% |
+| `qualityGatedMedianRuntimeTokenReduction` | +23.5% |
+| `fooksAcceptancePassRate` | 100.0% |
+| `broaderScopeRegressionCount` | 0 |
+| `severeTokenOutlierCount` | 0 |
+| `runtimeTokenClaimAvailable` | true |
+
+Target comparability breakdown:
+- `same_component_or_file`: 0
+- `semantically_comparable_target`: 2
+- `incomparable_target`: 1
+
+## Per-run table
+
+| Iter | Pair status | Target comparability | Vanilla files | Fooks files | Vanilla acceptance | Fooks acceptance | Total-time improvement | Runtime-token reduction |
+| ---: | --- | --- | --- | --- | --- | --- | ---: | ---: |
+| 1 | paired-success | `semantically_comparable_target` | apps/web/components/apps/AppPage.tsx, apps/web/components/apps/AppPageHeader.tsx | packages/ui/components/alert/Alert.tsx, packages/ui/components/alert/Header.tsx | no: header_semantics_preserved | yes: none | +8.6% | +29.7% |
+| 2 | partial/failed | `incomparable_target` | none | apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx, apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirHeader.tsx | no: original_component_uses_header, no_unused_header_false_positive | yes: none | n/a | n/a |
+| 3 | paired-success | `semantically_comparable_target` | apps/web/modules/settings/my-account/components/HolidaysHeader.tsx, apps/web/modules/settings/my-account/holidays-view.tsx | packages/ui/components/layout/ShellSubHeading.tsx, packages/ui/components/layout/ShellSubHeadingHeader.tsx | yes: none | yes: none | -4.3% | +23.5% |
+
+## Evidence notes
+
+- N=1 smoke passed candidate/scorer stability and routed to N=3; it is not a product win/loss claim.
+- N=3 produced two successful paired runs and one vanilla timeout. Only one pair was quality-gated because one successful vanilla artifact failed the mandatory `header_semantics_preserved` check.
+- Fooks acceptance was 3/3 among successful fooks artifacts, with zero broader-scope regressions and zero severe runtime-token outliers.
+- The single quality-gated pair showed runtime-token reduction but a negative total-time improvement, so the current rules correctly route to provisional loss/non-goal rather than N=5.
+- Proxy context reduction is recorded only as `proxyContextReduction` context-size evidence; runtime-token claims use parsed `tokens_used` only.
+
+## Recommendation
+
+Do not spend N=5 on this exact candidate for a win claim. The useful product finding is narrower: fooks can produce valid T4 artifacts and may reduce runtime tokens, but the current ambiguous Cal.com T4 prompt does not yet show quality-gated total-time advantage. Next best step is prompt/scorer refinement focused on target comparability and stable vanilla/fooks target selection, then rerun N=1 before another N=3.

--- a/benchmarks/frontend-harness/runners/full-benchmark-suite.py
+++ b/benchmarks/frontend-harness/runners/full-benchmark-suite.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 from pathlib import Path
 from datetime import datetime
+from statistics import median
 
 # Auto-detect paths
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -90,7 +91,7 @@ TASK_REPO_MAPPING = {
     "T1": ["shadcn-ui", "cal.com", "nextjs", "tailwindcss"],
     "T2": ["shadcn-ui", "cal.com", "nextjs", "tailwindcss"],
     "T3": ["shadcn-ui", "cal.com", "nextjs", "tailwindcss"],
-    "T4": ["shadcn-ui", "documenso", "nextjs"],
+    "T4": ["shadcn-ui", "cal.com", "documenso", "nextjs"],
     "T5": ["shadcn-ui", "cal.com", "nextjs", "tailwindcss"]
 }
 
@@ -136,13 +137,24 @@ def parse_args():
     )
     parser.add_argument("--task-prompt", help="Override the selected task prompt for one-off benchmark runs")
     parser.add_argument("--reports-dir", help="Override the directory used to save benchmark reports")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Repeat a single task/repo case N times and aggregate quality-gated metrics.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print resolved configuration and exit")
     parser.add_argument("--list-cases", action="store_true", help="Print the selected task/repo cases and exit")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    return args
 
 def resolve_test_cases(args):
     if bool(args.repo) != bool(args.task):
         raise SystemExit("--repo and --task must be provided together for a single-case run")
+    if args.iterations != 1 and not (args.repo and args.task):
+        raise SystemExit("--iterations > 1 requires a single-case --repo/--task run")
     if args.repo and args.task:
         return [(args.task, args.repo)]
     return DEFAULT_TEST_CASES
@@ -297,9 +309,209 @@ def evaluate_caps_lock_acceptance(files, patch_text, prompt):
     }
 
 
-def evaluate_acceptance(task, files, patch_text):
+def is_t4_component_extraction_task(task):
+    prompt = task.get("prompt", "").lower()
+    return (
+        task.get("id") == "T4"
+        or (
+            "component" in prompt
+            and "extract" in prompt
+            and "header" in prompt
+            and ("title" in prompt or "subtitle" in prompt or "actions" in prompt)
+        )
+    )
+
+
+def added_patch_lines(patch_text):
+    return "\n".join(
+        line[1:]
+        for line in patch_text.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
+def removed_patch_lines(patch_text):
+    return "\n".join(
+        line[1:]
+        for line in patch_text.splitlines()
+        if line.startswith("-") and not line.startswith("---")
+    )
+
+
+def source_files_only(files):
+    return [f for f in files if f and not is_runtime_path(f)]
+
+
+def header_like_files(files):
+    return [
+        f
+        for f in source_files_only(files)
+        if Path(f).suffix.lower() in {".tsx", ".jsx", ".ts", ".js"}
+        and re.search(
+            r"(^|[-_/])header(s)?(\.|[-_/])|[A-Z][A-Za-z0-9]*Header\.(tsx|jsx|ts|js)$",
+            f,
+            flags=re.IGNORECASE,
+        )
+    ]
+
+
+def build_acceptance_check(name, passed, details=None, mandatory=True):
+    check = {"name": name, "passed": bool(passed), "mandatory": mandatory}
+    if details is not None:
+        check["details"] = details
+    return check
+
+
+def evaluate_component_extraction_acceptance(files, patch_text, diff_check=None):
+    """Heuristic scorer for T4 header component extraction artifacts.
+
+    This intentionally scores only the benchmark artifact shape, not arbitrary
+    React correctness. Mandatory checks block benchmark claims; advisory checks
+    add review signal without making style-only weaknesses fail the task.
+    """
+    changed_source_files = source_files_only(files)
+    added = added_patch_lines(patch_text)
+    removed = removed_patch_lines(patch_text)
+    header_files = header_like_files(changed_source_files)
+    non_header_source_files = [f for f in changed_source_files if f not in header_files]
+
+    header_component_declared = check_patch_contains(
+        added,
+        r"(?:function|const|export\s+(?:function|const))\s+[A-Z][A-Za-z0-9]*Header\b",
+        r"\bHeader\s*[:=]\s*\(",
+        r"\b[A-Z][A-Za-z0-9]*HeaderProps\b",
+    )
+    header_component_created = bool(header_files) or header_component_declared
+
+    original_uses_header = bool(non_header_source_files) and any(
+        re.search(pattern, added)
+        for pattern in (
+            r"import\s+.*Header.*from\s+[\"'][./@]",
+            r"<[A-Z][A-Za-z0-9]*Header\b",
+            r"<Header\b",
+        )
+    )
+
+    has_title_signal = check_patch_contains(
+        added,
+        r"\btitle\b",
+        r"<h[1-3]\b",
+        r"heading",
+    )
+    has_subtitle_signal = check_patch_contains(
+        added,
+        r"\bsubtitle\b",
+        r"\bdescription\b",
+        r"<p\b",
+    )
+    removed_header_semantics = check_patch_contains(
+        removed,
+        r"<h[1-3]\b",
+        r"\btitle\b",
+        r"\bsubtitle\b",
+        r"\bdescription\b",
+    )
+    header_semantics_preserved = has_title_signal and (has_subtitle_signal or not removed_header_semantics)
+
+    action_removed = check_patch_contains(
+        removed,
+        r"<(?:button|Button|a)\b",
+        r"\bactions?\b",
+        r"\bchildren\b",
+    )
+    action_preserved = check_patch_contains(
+        added,
+        r"\bactions?\b",
+        r"\bchildren\b",
+        r"<(?:button|Button|a)\b",
+        r"href=",
+    )
+    header_actions_preserved = action_preserved or not action_removed
+
+    broad_scope_roots = {
+        f.split("/", 1)[0]
+        for f in changed_source_files
+        if "/" in f
+    }
+    file_scope_capped = len(changed_source_files) <= 4 and len(broad_scope_roots) <= 2
+    runtime_files_excluded = len(changed_source_files) == len(files)
+    if diff_check is None:
+        diff_check_passed = True
+        diff_details = "diff_check not supplied to standalone scorer"
+    else:
+        diff_check_passed = bool(diff_check.get("success"))
+        diff_details = (diff_check.get("stderr") or diff_check.get("stdout") or "ok")[:300]
+
+    checks = [
+        build_acceptance_check(
+            "header_component_created_or_extracted",
+            header_component_created,
+            f"header_files={header_files}, header_component_declared={header_component_declared}",
+        ),
+        build_acceptance_check(
+            "original_component_uses_header",
+            original_uses_header,
+            f"non_header_source_files={non_header_source_files}",
+        ),
+        build_acceptance_check(
+            "header_semantics_preserved",
+            header_semantics_preserved,
+            f"title_signal={has_title_signal}, subtitle_signal={has_subtitle_signal}, removed_semantics={removed_header_semantics}",
+        ),
+        build_acceptance_check(
+            "header_actions_preserved",
+            header_actions_preserved,
+            f"action_removed={action_removed}, action_preserved={action_preserved}",
+        ),
+        build_acceptance_check(
+            "no_unused_header_false_positive",
+            header_component_created and original_uses_header,
+        ),
+        build_acceptance_check(
+            "file_scope_capped",
+            file_scope_capped,
+            f"source_files={len(changed_source_files)}, roots={sorted(broad_scope_roots)}",
+        ),
+        build_acceptance_check(
+            "runtime_files_excluded",
+            runtime_files_excluded,
+            f"files={len(files)}, source_files={len(changed_source_files)}",
+        ),
+        build_acceptance_check("diff_check_passed", diff_check_passed, diff_details),
+        build_acceptance_check(
+            "style_continuity_present",
+            check_patch_contains(added, r"className=", r"cn\(", r"twMerge", r"tailwind"),
+            mandatory=False,
+        ),
+        build_acceptance_check(
+            "props_are_reasonably_named",
+            check_patch_contains(added, r"\btitle\b", r"\bsubtitle\b", r"\bactions\b", r"\bchildren\b"),
+            mandatory=False,
+        ),
+        build_acceptance_check(
+            "new_file_location_matches_local_pattern",
+            bool(header_files) and all("/" in f for f in header_files),
+            details=f"header_files={header_files}",
+            mandatory=False,
+        ),
+    ]
+    score = sum(1 for check in checks if check["passed"])
+    mandatory_passed = all(check["passed"] for check in checks if check.get("mandatory", True))
+    return {
+        "available": True,
+        "kind": "component-extraction",
+        "score": score,
+        "max_score": len(checks),
+        "passed": mandatory_passed,
+        "checks": checks,
+    }
+
+
+def evaluate_acceptance(task, files, patch_text, diff_check=None):
     if is_caps_lock_task(task):
         return evaluate_caps_lock_acceptance(files, patch_text, task.get("prompt", ""))
+    if is_t4_component_extraction_task(task):
+        return evaluate_component_extraction_acceptance(files, patch_text, diff_check)
     return {"available": False, "reason": "no scorer for task prompt"}
 
 
@@ -476,7 +688,7 @@ def capture_artifact_with_acceptance(worktree_path, artifact_dir, stem, task, fi
         patch_text = Path(artifact["patch_path"]).read_text()
     except Exception:
         patch_text = ""
-    artifact["acceptance"] = evaluate_acceptance(task, files, patch_text)
+    artifact["acceptance"] = evaluate_acceptance(task, files, patch_text, artifact.get("diff_check"))
     return artifact
 
 
@@ -650,10 +862,16 @@ def output_tail(value, limit=2000):
 def parse_tokens_used(output):
     if not output:
         return None
-    match = re.search(r"tokens used\s*\n\s*([0-9,]+)", output, flags=re.IGNORECASE)
-    if not match:
-        return None
-    return int(match.group(1).replace(",", ""))
+    patterns = [
+        r"tokens used\s*[:=]?\s*\n\s*([0-9,]+)",
+        r"tokens used\s*[:=]\s*([0-9,]+)",
+        r"\b([0-9,]+)\s+tokens used\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, output, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1).replace(",", ""))
+    return None
 
 def agent_prompt(task):
     return f"Task: {task['name']}\n{task['prompt']}"
@@ -858,6 +1076,223 @@ def assess_benchmark_risks(results):
         "risks": risks,
     }
 
+
+def pct_improvement(baseline, candidate):
+    if baseline in (None, 0) or candidate is None:
+        return None
+    return (baseline - candidate) / baseline * 100
+
+
+def median_or_none(values):
+    clean = [value for value in values if value is not None]
+    if not clean:
+        return None
+    return median(clean)
+
+
+def acceptance_passed(result, variant):
+    acceptance = result.get(variant, {}).get("artifact", {}).get("acceptance", {})
+    return bool(acceptance.get("available") and acceptance.get("passed"))
+
+
+def acceptance_available(result, variant):
+    acceptance = result.get(variant, {}).get("artifact", {}).get("acceptance", {})
+    return bool(acceptance.get("available"))
+
+
+def target_signature(files):
+    source_files = source_files_only(files)
+    header_files = header_like_files(source_files)
+    if header_files:
+        return sorted(header_files)
+    return sorted(source_files)
+
+
+def classify_target_comparability(result):
+    vanilla_files = result.get("vanilla", {}).get("files_list", [])
+    fooks_files = result.get("fooks", {}).get("files_list", [])
+    if vanilla_files and sorted(vanilla_files) == sorted(fooks_files):
+        return {
+            "classification": "same_component_or_file",
+            "reason": "Both variants changed the same file set.",
+        }
+    vanilla_signature = target_signature(vanilla_files)
+    fooks_signature = target_signature(fooks_files)
+    if vanilla_signature and fooks_signature and set(vanilla_signature).intersection(fooks_signature):
+        return {
+            "classification": "same_component_or_file",
+            "reason": "Both variants share at least one extracted/header target.",
+        }
+    if (
+        result.get("task") == "T4"
+        and acceptance_available(result, "vanilla")
+        and acceptance_available(result, "fooks")
+        and vanilla_signature
+        and fooks_signature
+    ):
+        return {
+            "classification": "semantically_comparable_target",
+            "reason": "Both variants produced T4-scored header extraction artifacts, but chose different targets.",
+        }
+    return {
+        "classification": "incomparable_target",
+        "reason": "The variants did not produce comparable changed targets.",
+    }
+
+
+def is_successful_pair(result):
+    return bool(result.get("vanilla", {}).get("success") and result.get("fooks", {}).get("success"))
+
+
+def has_broader_scope_regression(result):
+    vanilla_files = len(result.get("vanilla", {}).get("files_list", []))
+    fooks_files = len(result.get("fooks", {}).get("files_list", []))
+    return fooks_files > max(2, vanilla_files + 1)
+
+
+def is_quality_gated_pair(result):
+    comparability = result.get("targetComparability", {}).get("classification")
+    return (
+        is_successful_pair(result)
+        and comparability in {"same_component_or_file", "semantically_comparable_target"}
+        and acceptance_passed(result, "vanilla")
+        and acceptance_passed(result, "fooks")
+        and not has_broader_scope_regression(result)
+    )
+
+
+def runtime_token_reduction(result):
+    vanilla_tokens = result.get("vanilla", {}).get("tokens_used")
+    fooks_tokens = result.get("fooks", {}).get("tokens_used")
+    return pct_improvement(vanilla_tokens, fooks_tokens)
+
+
+def stage_verdict(iterations, aggregate):
+    reasons = []
+    if iterations <= 1:
+        if aggregate["qualityGatedPairCount"] >= 1:
+            return "smoke-pass-proceed-to-n3", ["N=1 only validates candidate/scorer stability; no product win/loss claim."]
+        if aggregate["targetComparabilityBreakdown"].get("incomparable_target", 0):
+            return "prompt-redesign-needed", ["N=1 produced incomparable targets."]
+        if aggregate["fooksAcceptancePassRate"] is not None and aggregate["fooksAcceptancePassRate"] < 1:
+            return "scorer-redesign-needed", ["N=1 fooks artifact did not pass the T4 scorer."]
+        return "candidate-invalid", ["N=1 did not produce a quality-gated pair."]
+
+    if iterations < 5:
+        if aggregate["qualityGatedPairCount"] == 0:
+            return "inconclusive-candidate-redesign", ["N=3 has no quality-gated pairs."]
+        if aggregate["fooksAcceptancePassRate"] is not None and aggregate["fooksAcceptancePassRate"] < 1:
+            return "provisional-loss-or-non-goal", ["N=3 fooks acceptance is below the level needed to justify N=5."]
+        if (
+            aggregate["qualityGatedMedianTotalTimeImprovement"] is not None
+            and aggregate["qualityGatedMedianTotalTimeImprovement"] <= 0
+        ):
+            return "provisional-loss-or-non-goal", ["N=3 quality-gated total time does not improve."]
+        if (
+            aggregate["runtimeTokenClaimAvailable"]
+            and aggregate["qualityGatedMedianRuntimeTokenReduction"] is not None
+            and aggregate["qualityGatedMedianRuntimeTokenReduction"] <= 0
+        ):
+            return "provisional-loss-or-non-goal", ["N=3 quality-gated runtime tokens do not improve."]
+        return "proceed-to-n5", ["N=3 is promising but cannot produce a claimable win because the threshold requires 4/5."]
+
+    if aggregate["fooksAcceptancePassRate"] is None or aggregate["fooksAcceptancePassRate"] < 0.8:
+        reasons.append("fooks acceptance pass rate is below 4/5.")
+    if aggregate["broaderScopeRegressionCount"] != 0:
+        reasons.append("broader scope regressions were observed.")
+    if (
+        aggregate["qualityGatedMedianTotalTimeImprovement"] is None
+        or aggregate["qualityGatedMedianTotalTimeImprovement"] <= 0
+    ):
+        reasons.append("quality-gated median total time does not improve.")
+    if not aggregate["runtimeTokenClaimAvailable"]:
+        reasons.append("actual runtime tokens are missing for at least one quality-gated pair.")
+    elif (
+        aggregate["qualityGatedMedianRuntimeTokenReduction"] is None
+        or aggregate["qualityGatedMedianRuntimeTokenReduction"] <= 0
+    ):
+        reasons.append("quality-gated median runtime tokens do not improve.")
+    if aggregate["severeTokenOutlierCount"] != 0:
+        reasons.append("severe fooks runtime-token outliers were observed.")
+    if reasons:
+        return "loss-non-goal-or-inconclusive", reasons
+    return "claimable-win", ["N=5 satisfies quality, scope, total-time, runtime-token, and outlier gates."]
+
+
+def aggregate_quality_gated_results(results, iterations):
+    for result in results:
+        if "targetComparability" not in result:
+            result["targetComparability"] = classify_target_comparability(result)
+
+    successful_pairs = [result for result in results if is_successful_pair(result)]
+
+    fooks_artifact_results = [
+        result for result in results
+        if result.get("fooks", {}).get("success") and acceptance_available(result, "fooks")
+    ]
+    fooks_acceptance_denominator = len(fooks_artifact_results)
+    fooks_acceptance_passes = sum(1 for result in fooks_artifact_results if acceptance_passed(result, "fooks"))
+    quality_pairs = [result for result in successful_pairs if is_quality_gated_pair(result)]
+
+    raw_total_improvements = [
+        pct_improvement(result.get("vanilla", {}).get("duration_ms"), result.get("fooks", {}).get("total_time"))
+        for result in successful_pairs
+    ]
+    raw_runtime_token_reductions = [runtime_token_reduction(result) for result in successful_pairs]
+    quality_total_improvements = [
+        pct_improvement(result.get("vanilla", {}).get("duration_ms"), result.get("fooks", {}).get("total_time"))
+        for result in quality_pairs
+    ]
+    quality_token_pairs = [
+        result
+        for result in quality_pairs
+        if result.get("vanilla", {}).get("tokens_used") is not None and result.get("fooks", {}).get("tokens_used") is not None
+    ]
+    runtime_claim_available = len(quality_pairs) > 0 and len(quality_token_pairs) == len(quality_pairs)
+    quality_runtime_token_reductions = (
+        [runtime_token_reduction(result) for result in quality_token_pairs]
+        if runtime_claim_available
+        else []
+    )
+
+    comparability_breakdown = {
+        "same_component_or_file": 0,
+        "semantically_comparable_target": 0,
+        "incomparable_target": 0,
+    }
+    for result in results:
+        classification = result.get("targetComparability", {}).get("classification", "incomparable_target")
+        comparability_breakdown[classification] = comparability_breakdown.get(classification, 0) + 1
+
+    severe_token_outliers = [
+        result for result in successful_pairs
+        if result.get("vanilla", {}).get("tokens_used") is not None
+        and result.get("fooks", {}).get("tokens_used") is not None
+        and result["fooks"]["tokens_used"] > result["vanilla"]["tokens_used"] * 1.2
+    ]
+
+    aggregate = {
+        "rawMedianTotalTimeImprovement": median_or_none(raw_total_improvements),
+        "rawMedianRuntimeTokenReduction": median_or_none(raw_runtime_token_reductions),
+        "qualityGatedPairCount": len(quality_pairs),
+        "qualityGatedMedianTotalTimeImprovement": median_or_none(quality_total_improvements),
+        "qualityGatedMedianRuntimeTokenReduction": median_or_none(quality_runtime_token_reductions),
+        "runtimeTokenClaimAvailable": runtime_claim_available,
+        "fooksAcceptancePassRate": (
+            fooks_acceptance_passes / fooks_acceptance_denominator
+            if fooks_acceptance_denominator
+            else None
+        ),
+        "broaderScopeRegressionCount": sum(1 for result in successful_pairs if has_broader_scope_regression(result)),
+        "severeTokenOutlierCount": len(severe_token_outliers),
+        "targetComparabilityBreakdown": comparability_breakdown,
+        "proxyContextReductionLabel": "proxyContextReduction; context-size evidence only, not runtime token savings",
+    }
+    verdict, verdict_reasons = stage_verdict(iterations, aggregate)
+    aggregate["verdict"] = verdict
+    aggregate["verdictReasons"] = verdict_reasons
+    return aggregate
+
 def run_vanilla_agent(worktree, task, runner):
     """Run vanilla agent runner"""
     start = time.time()
@@ -962,7 +1397,13 @@ def run_fooks_agent(worktree, task, runner):
                 "scan_time": fooks_scan_time, "total_time": fooks_scan_time + int((time.time() - start) * 1000),
                 "files": 0, "files_list": [], "error": str(e)}
 
-def run_benchmark(task, repo_name, runner, artifact_dir):
+def artifact_stem(repo_name, task_id, variant, iteration=None):
+    if iteration is None:
+        return f"{repo_name}-{task_id}-{variant}"
+    return f"{repo_name}-{task_id}-iter{iteration}-{variant}"
+
+
+def run_benchmark(task, repo_name, runner, artifact_dir, iteration=None):
     """Run full benchmark for one task on one repo"""
     print(f"\n{'='*70}")
     print(f"[{task['id']}] {task['name']} ({task['difficulty']})")
@@ -976,6 +1417,7 @@ def run_benchmark(task, repo_name, runner, artifact_dir):
     classification = classify_task_context(task)
     results = {"task": task['id'], "task_name": task['name'], "repo": repo_name,
                "difficulty": task['difficulty'], "timestamp": datetime.now().isoformat(),
+               "iteration": iteration,
                "repoClass": "external-oss-nextjs-tailwind" if repo_name in {"formbricks", "cal.com", "shadcn-ui", "documenso", "nextjs"} else "external-oss-frontend",
                "taskClass": classification["taskClass"],
                "promptSpecificity": classification["promptSpecificity"],
@@ -996,7 +1438,13 @@ def run_benchmark(task, repo_name, runner, artifact_dir):
     print("\n  [VANILLA] Running...")
     wt_v = create_worktree(repo_path, task['id'], "vanilla")
     res_v = run_vanilla_agent(wt_v, task, runner)
-    res_v["artifact"] = capture_artifact_with_acceptance(wt_v["path"], artifact_dir, f"{repo_name}-{task['id']}-vanilla", task, res_v.get("files_list", []))
+    res_v["artifact"] = capture_artifact_with_acceptance(
+        wt_v["path"],
+        artifact_dir,
+        artifact_stem(repo_name, task["id"], "vanilla", iteration),
+        task,
+        res_v.get("files_list", []),
+    )
     res_v["cleanup"] = remove_worktree(wt_v, repo_path)
     results["vanilla"] = res_v
     print(f"    {'✓' if res_v['success'] else '✗'} {res_v['duration_ms']:,}ms, {res_v['files']} files")
@@ -1009,7 +1457,13 @@ def run_benchmark(task, repo_name, runner, artifact_dir):
     print("\n  [FOOKS] Running...")
     wt_f = create_worktree(repo_path, task['id'], "fooks")
     res_f = run_fooks_agent(wt_f, task, runner)
-    res_f["artifact"] = capture_artifact_with_acceptance(wt_f["path"], artifact_dir, f"{repo_name}-{task['id']}-fooks", task, res_f.get("files_list", []))
+    res_f["artifact"] = capture_artifact_with_acceptance(
+        wt_f["path"],
+        artifact_dir,
+        artifact_stem(repo_name, task["id"], "fooks", iteration),
+        task,
+        res_f.get("files_list", []),
+    )
     res_f["cleanup"] = remove_worktree(wt_f, repo_path)
     results["fooks"] = res_f
     print(f"    {'✓' if res_f['success'] else '✗'} exec:{res_f['duration_ms']:,}ms + scan:{res_f['scan_time']:,}ms = {res_f['total_time']:,}ms, {res_f['files']} files")
@@ -1025,8 +1479,10 @@ def run_benchmark(task, repo_name, runner, artifact_dir):
         total_improvement = 0
 
     results["improvement"] = {"exec": exec_improvement, "total": total_improvement}
+    results["targetComparability"] = classify_target_comparability(results)
     print(f"\n  Execution time diff: {exec_improvement:+.1f}%")
     print(f"  Total time diff: {total_improvement:+.1f}%")
+    print(f"  Target comparability: {results['targetComparability']['classification']}")
 
     return results
 
@@ -1052,6 +1508,7 @@ def main():
                 "expectedContextPolicy": classification["expectedContextPolicy"],
                 "expectedFirstTurnRuntimeContext": classification.get("expectedFirstTurnRuntimeContext", classification["expectedContextPolicy"]),
                 "expectedFooksPrepare": classification.get("expectedFooksPrepare", "scan-attach"),
+                "taskRepoMappingIncludesRepo": repo_name in TASK_REPO_MAPPING.get(task["id"], []),
             })
         print(json.dumps({
             "reportSchemaVersion": REPORT_SCHEMA_VERSION,
@@ -1060,6 +1517,7 @@ def main():
             "reposDir": str(REPOS_DIR),
             "runner": args.runner,
             "runnerLabel": runner_label(args.runner),
+            "iterations": args.iterations,
             "selectedCases": resolved_tasks,
             "availableRepos": sorted(REPOS.keys()),
             "availableTasks": sorted(build_task_index().keys()),
@@ -1074,6 +1532,7 @@ def main():
     print(f"Tasks: {', '.join(sorted(build_task_index().keys()))}")
     print(f"Repos: {', '.join(sorted(REPOS.keys()))}")
     print(f"Runner: {runner_label(args.runner)}")
+    print(f"Iterations: {args.iterations}")
     print(f"Variants: Vanilla vs Fooks (with token estimates)")
     print(f"Reports dir: {reports_dir}")
     print("="*70)
@@ -1083,20 +1542,33 @@ def main():
     artifact_dir = reports_dir / "artifacts" / f"benchmark-full-{report_timestamp}"
 
     for task_id, repo_name in test_cases:
-        task = resolve_task(task_id, args.task_prompt if (args.repo and args.task == task_id) else None)
+        for iteration in range(1, args.iterations + 1):
+            task = resolve_task(task_id, args.task_prompt if (args.repo and args.task == task_id) else None)
+            iteration_label = f" iteration {iteration}/{args.iterations}" if args.iterations > 1 else ""
+            if iteration_label:
+                print(f"\n---{iteration_label} ---")
 
-        try:
-            result = run_benchmark(task, repo_name, args.runner, artifact_dir)
-            all_results.append(result)
-        except Exception as e:
-            print(f"\n  ✗ Benchmark failed: {e}")
-            all_results.append({
-                "task": task_id, "repo": repo_name, "error": str(e),
-                "timestamp": datetime.now().isoformat()
-            })
+            try:
+                result = run_benchmark(
+                    task,
+                    repo_name,
+                    args.runner,
+                    artifact_dir,
+                    iteration if args.iterations > 1 else None,
+                )
+                all_results.append(result)
+            except Exception as e:
+                print(f"\n  ✗ Benchmark failed: {e}")
+                all_results.append({
+                    "task": task_id,
+                    "repo": repo_name,
+                    "iteration": iteration if args.iterations > 1 else None,
+                    "error": str(e),
+                    "timestamp": datetime.now().isoformat(),
+                })
 
-        # Cool down between tests
-        time.sleep(5)
+            # Cool down between tests
+            time.sleep(5)
 
     # Generate final report
     print("\n" + "="*70)
@@ -1130,6 +1602,8 @@ def main():
     print(f"\nAvg token reduction: {avg_reduction:.1f}%")
     print(f"Avg tokens saved: ~{avg_saved:,.0f} per session")
 
+    quality_gated_decision = aggregate_quality_gated_results(all_results, args.iterations)
+
     # Save report
     report_path = reports_dir / f"benchmark-full-{report_timestamp}.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1138,12 +1612,19 @@ def main():
             "reportSchemaVersion": REPORT_SCHEMA_VERSION,
             "timestamp": datetime.now().isoformat(),
             "artifactDir": str(artifact_dir),
+            "iterations": args.iterations,
+            "qualityGatedDecision": quality_gated_decision,
             "summary": {
                 "total_benchmarks": len(all_results),
                 "vanilla_success": len(vanilla_success),
                 "fooks_success": len(fooks_success),
                 "avg_token_reduction": avg_reduction,
-                "avg_tokens_saved": avg_saved
+                "avg_tokens_saved": avg_saved,
+                "proxyContextReduction": {
+                    "avg_reduction_pct": avg_reduction,
+                    "avg_tokens_saved": avg_saved,
+                    "label": "proxyContextReduction; context-size evidence only, not runtime token savings",
+                },
             },
             "notes": ROUND1_NOTES,
             "riskAssessment": assess_benchmark_risks(all_results),

--- a/test/frontend-harness.test.mjs
+++ b/test/frontend-harness.test.mjs
@@ -126,3 +126,141 @@ print(json.dumps({"good": good, "broad": broad}))
     false,
   );
 });
+
+test("frontend harness supports cal.com T4 dry-run metadata and iterations", () => {
+  const result = runRunnerConfig(["--runner", "codex", "--repo", "cal.com", "--task", "T4", "--iterations", "3"]);
+
+  assert.equal(result.runner, "codex");
+  assert.equal(result.runnerLabel, "codex exec --full-auto");
+  assert.equal(result.iterations, 3);
+  assert.equal(result.selectedCases.length, 1);
+  assert.equal(result.selectedCases[0].repo, "cal.com");
+  assert.equal(result.selectedCases[0].task, "T4");
+  assert.equal(result.selectedCases[0].taskClass, "ambiguous-multi-file");
+  assert.equal(result.selectedCases[0].expectedContextPolicy, "auto");
+  assert.equal(result.selectedCases[0].expectedFooksPrepare, "scan-attach");
+  assert.equal(result.selectedCases[0].taskRepoMappingIncludesRepo, true);
+});
+
+test("frontend harness scores T4 component extraction pass and mandatory/advisory checks", () => {
+  const snippet = `
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("bench", ${JSON.stringify(runnerPath)})
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+task = {"id": "T4", "prompt": "Find a component with inline header JSX (title, subtitle, actions). Extract this into a separate Header component."}
+files = ["apps/web/components/booking/booking-card.tsx", "apps/web/components/booking/booking-header.tsx"]
+patch = '''
+diff --git a/apps/web/components/booking/booking-card.tsx b/apps/web/components/booking/booking-card.tsx
+--- a/apps/web/components/booking/booking-card.tsx
++++ b/apps/web/components/booking/booking-card.tsx
++import { BookingHeader } from "./booking-header";
+-<section><h1>{title}</h1><p>{subtitle}</p><Button>Save</Button></section>
++<section><BookingHeader title={title} subtitle={subtitle} actions={<Button>Save</Button>} /></section>
+diff --git a/apps/web/components/booking/booking-header.tsx b/apps/web/components/booking/booking-header.tsx
+new file mode 100644
+--- /dev/null
++++ b/apps/web/components/booking/booking-header.tsx
++export function BookingHeader({ title, subtitle, actions, children }) {
++  return <header><h1>{title}</h1><p>{subtitle}</p><div>{actions}{children}</div></header>;
++}
+'''
+advisory_weak = patch.replace("<header>", "<header>").replace(" className=\\\"flex\\\"", "")
+good = bench.evaluate_acceptance(task, files, patch)
+weak = bench.evaluate_acceptance(task, files, advisory_weak)
+print(json.dumps({"good": good, "weak": weak}))
+`;
+  const result = runPythonHarnessSnippet(snippet);
+
+  assert.equal(result.good.available, true);
+  assert.equal(result.good.kind, "component-extraction");
+  assert.equal(result.good.passed, true);
+  for (const name of [
+    "header_component_created_or_extracted",
+    "original_component_uses_header",
+    "header_semantics_preserved",
+    "header_actions_preserved",
+    "no_unused_header_false_positive",
+    "file_scope_capped",
+    "runtime_files_excluded",
+    "diff_check_passed",
+  ]) {
+    assert.equal(result.good.checks.find((check) => check.name === name).passed, true, name);
+  }
+  assert.equal(result.weak.passed, true);
+  assert.equal(result.weak.checks.find((check) => check.name === "style_continuity_present").mandatory, false);
+});
+
+test("frontend harness rejects T4 false positives and unrelated prompts", () => {
+  const snippet = `
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("bench", ${JSON.stringify(runnerPath)})
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+task = {"id": "T4", "prompt": "Find a component with inline header JSX (title, subtitle, actions). Extract this into a separate Header component."}
+files = ["apps/web/components/booking/booking-card.tsx", "apps/web/components/booking/booking-header.tsx"]
+base = '''
+diff --git a/apps/web/components/booking/booking-card.tsx b/apps/web/components/booking/booking-card.tsx
+--- a/apps/web/components/booking/booking-card.tsx
++++ b/apps/web/components/booking/booking-card.tsx
+-<section><h1>{title}</h1><p>{subtitle}</p><Button>Save</Button></section>
++REPLACEMENT
+diff --git a/apps/web/components/booking/booking-header.tsx b/apps/web/components/booking/booking-header.tsx
+new file mode 100644
+--- /dev/null
++++ b/apps/web/components/booking/booking-header.tsx
++export function BookingHeader({ title, subtitle, actions }) {
++  return <header className="flex"><h1>{title}</h1><p>{subtitle}</p><div>{actions}</div></header>;
++}
+'''
+unused = bench.evaluate_acceptance(task, files, base.replace("REPLACEMENT", "<section />"))
+drops_semantics = bench.evaluate_acceptance(task, files, base.replace("REPLACEMENT", "import { BookingHeader } from './booking-header';\\n<BookingHeader actions={<Button>Save</Button>} />").replace("{ title, subtitle, actions }", "{ actions }").replace("<h1>{title}</h1><p>{subtitle}</p>", ""))
+drops_actions = bench.evaluate_acceptance(task, files, base.replace("REPLACEMENT", "import { BookingHeader } from './booking-header';\\n<BookingHeader title={title} subtitle={subtitle} />").replace("{ title, subtitle, actions }", "{ title, subtitle }").replace("<div>{actions}</div>", ""))
+broad = bench.evaluate_acceptance(task, files + [f"apps/web/unrelated/file-{i}.tsx" for i in range(5)], base.replace("REPLACEMENT", "import { BookingHeader } from './booking-header';\\n<BookingHeader title={title} subtitle={subtitle} actions={<Button>Save</Button>} />"))
+other = bench.evaluate_acceptance({"id": "T1", "prompt": "Move a button"}, files, base)
+print(json.dumps({"unused": unused, "drops_semantics": drops_semantics, "drops_actions": drops_actions, "broad": broad, "other": other}))
+`;
+  const result = runPythonHarnessSnippet(snippet);
+
+  assert.equal(result.unused.available, true);
+  assert.equal(result.unused.passed, false);
+  assert.equal(result.unused.checks.find((check) => check.name === "original_component_uses_header").passed, false);
+  assert.equal(result.drops_semantics.passed, false);
+  assert.equal(result.drops_semantics.checks.find((check) => check.name === "header_semantics_preserved").passed, false);
+  assert.equal(result.drops_actions.passed, false);
+  assert.equal(result.drops_actions.checks.find((check) => check.name === "header_actions_preserved").passed, false);
+  assert.equal(result.broad.passed, false);
+  assert.equal(result.broad.checks.find((check) => check.name === "file_scope_capped").passed, false);
+  assert.equal(result.other.available, false);
+});
+
+test("frontend harness parses actual runtime tokens and suppresses missing-token claims", () => {
+  const snippet = `
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("bench", ${JSON.stringify(runnerPath)})
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+acceptance = {"available": True, "passed": True}
+result = {
+  "task": "T4",
+  "vanilla": {"success": True, "duration_ms": 1000, "tokens_used": 1000, "files_list": ["apps/web/a.tsx"], "artifact": {"acceptance": acceptance}},
+  "fooks": {"success": True, "total_time": 800, "tokens_used": None, "files_list": ["apps/web/a.tsx"], "artifact": {"acceptance": acceptance}},
+}
+aggregate = bench.aggregate_quality_gated_results([result], 1)
+print(json.dumps({
+  "newline": bench.parse_tokens_used("tokens used\\n1,234"),
+  "colon": bench.parse_tokens_used("tokens used: 2,345"),
+  "missing": bench.parse_tokens_used("no token block"),
+  "aggregate": aggregate
+}))
+`;
+  const result = runPythonHarnessSnippet(snippet);
+
+  assert.equal(result.newline, 1234);
+  assert.equal(result.colon, 2345);
+  assert.equal(result.missing, null);
+  assert.equal(result.aggregate.qualityGatedPairCount, 1);
+  assert.equal(result.aggregate.runtimeTokenClaimAvailable, false);
+  assert.equal(result.aggregate.qualityGatedMedianRuntimeTokenReduction, null);
+  assert.equal(result.aggregate.verdict, "smoke-pass-proceed-to-n3");
+});


### PR DESCRIPTION
## Summary

- Add a scorer-first Cal.com T4 component-extraction benchmark lane.
- Add `--iterations` support for single-case repeated paired runs.
- Add quality-gated aggregate fields that separate raw metrics, accepted pairs, target comparability, actual runtime tokens, scope regressions, severe token outliers, and staged verdicts.
- Add direct Codex N=1 and N=3 benchmark artifacts plus a decision report.

## Product interpretation

This PR does **not** claim a fooks win for Cal.com T4. The N=1 smoke passed and routed to N=3, but N=3 routed to `provisional-loss-or-non-goal` because the only quality-gated pair had negative total-time improvement.

Useful finding: fooks produced valid T4 artifacts in all successful fooks runs and showed runtime-token reductions in successful paired runs, but this candidate should not proceed to N=5 for a claimable win without prompt/scorer refinement.

## Evidence

- N=1 report: `benchmarks/frontend-harness/reports/cal-t4-component-extraction-20260418T093633Z/benchmark-full-1776504993.json`
- N=3 report: `benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/benchmark-full-1776505820.json`
- Decision report: `benchmarks/frontend-harness/reports/cal-t4-component-extraction-n3-20260418T095020Z/cal-t4-component-extraction-decision-report.md`

N=3 key fields:

- `qualityGatedPairCount`: 1
- `qualityGatedMedianTotalTimeImprovement`: -4.3%
- `qualityGatedMedianRuntimeTokenReduction`: +23.5%
- `fooksAcceptancePassRate`: 100%
- `broaderScopeRegressionCount`: 0
- `severeTokenOutlierCount`: 0
- `verdict`: `provisional-loss-or-non-goal`

## Verification

- `npm test`
- `npm run lint`
- `python3 -m py_compile benchmarks/frontend-harness/runners/full-benchmark-suite.py`
- `node --test test/frontend-harness.test.mjs`
- `git diff --check`
- Direct Codex N=1 Cal.com T4 benchmark
- Direct Codex N=3 Cal.com T4 benchmark

## Notes

Proxy context reduction remains labeled as `proxyContextReduction`; runtime-token reduction fields use parsed `tokens_used` only and suppress claims when missing.
