### PR TITLE
Make benchmark dry-runs prove frontend sample eligibility

### DIFF
--- a/benchmarks/frontend-harness/v2-runner/src/bucket-classifier.mjs
+++ b/benchmarks/frontend-harness/v2-runner/src/bucket-classifier.mjs
@@ -4,7 +4,7 @@
  */
 
 import { readFileSync, readdirSync } from 'fs';
-import { resolve, relative } from 'path';
+import { extname, resolve, relative } from 'path';
 import { ManifestLoader } from './manifest-loader.mjs';
 
 // Taxonomy buckets from TAXONOMY_AND_METRICS_FINAL.md
@@ -19,28 +19,210 @@ export const DEFAULT_BUCKETS = [
   { id: 'real-edit-task', name: 'Real Edit Task', targetSampleSize: 30, deficitThresholdPct: 30 }
 ];
 
-function walkDir(dir, pattern, excludePatterns = []) {
-  const files = [];
-  
+const DEFAULT_PRUNED_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
+const MAX_EXAMPLES_PER_REASON = 5;
+
+function normalizePath(path) {
+  return String(path)
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/^\/+/, '');
+}
+
+function stripTrailingSlash(path) {
+  return normalizePath(path).replace(/\/+$/, '');
+}
+
+function pathBasename(path) {
+  return normalizePath(path).split('/').pop() || '';
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function expandBracePattern(pattern) {
+  const match = pattern.match(/\{([^{}]+)\}/);
+  if (!match) return [pattern];
+
+  const [token, body] = match;
+  return body.split(',').flatMap(part => expandBracePattern(pattern.replace(token, part)));
+}
+
+function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let source = '^';
+
+  for (let idx = 0; idx < normalized.length; idx++) {
+    const char = normalized[idx];
+    const next = normalized[idx + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        const afterGlobstar = normalized[idx + 2];
+        if (afterGlobstar === '/') {
+          source += '(?:.*/)?';
+          idx += 2;
+        } else {
+          source += '.*';
+          idx += 1;
+        }
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  source += '$';
+  return new RegExp(source);
+}
+
+function matchesGlob(path, pattern) {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePath(pattern);
+
+  if (!normalizedPattern) return false;
+
+  const basenameOnly = !normalizedPattern.includes('/');
+  const pathToMatch = basenameOnly ? pathBasename(normalizedPath) : normalizedPath;
+
+  return expandBracePattern(normalizedPattern).some(expanded => globToRegExp(expanded).test(pathToMatch));
+}
+
+function matchesDirectoryPattern(path, pattern) {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePath(pattern);
+  const barePattern = stripTrailingSlash(normalizedPattern);
+
+  if (!barePattern) return false;
+
+  if (!/[?*{}]/.test(barePattern)) {
+    return normalizedPath === barePattern || normalizedPath.startsWith(`${barePattern}/`);
+  }
+
+  return expandBracePattern(`${barePattern}/**`).some(expanded => globToRegExp(expanded).test(normalizedPath));
+}
+
+function matchesPathPattern(path, pattern) {
+  const normalizedPattern = normalizePath(pattern);
+  if (!normalizedPattern) return false;
+
+  if (normalizedPattern.endsWith('/')) {
+    return matchesDirectoryPattern(path, normalizedPattern);
+  }
+
+  if (!normalizedPattern.includes('/') && /[*?{}]/.test(normalizedPattern)) {
+    return matchesGlob(path, normalizedPattern);
+  }
+
+  if (!/[?*{}]/.test(normalizedPattern)) {
+    const normalizedPath = normalizePath(path);
+    return normalizedPath === normalizedPattern || normalizedPath.startsWith(`${normalizedPattern}/`);
+  }
+
+  return matchesGlob(path, normalizedPattern) || matchesDirectoryPattern(path, normalizedPattern);
+}
+
+function firstMatchingPattern(path, patterns = [], matcher = matchesPathPattern) {
+  return patterns.find(pattern => matcher(path, pattern));
+}
+
+function matchesAnyGlob(path, patterns = []) {
+  return Boolean(firstMatchingPattern(path, patterns, matchesGlob));
+}
+
+function sourceRootFor(path, sourceRoots = []) {
+  return firstMatchingPattern(path, sourceRoots, matchesDirectoryPattern) || null;
+}
+
+function createDiscoveryStats(repo, manifest) {
+  return {
+    repo: repo.name,
+    sourceRoots: repo.sourceRoots || [],
+    discoveryGlobs: manifest?.discoveryGlobs || [],
+    traversedFileCount: 0,
+    candidateCount: 0,
+    includedCount: 0,
+    prunedDirectoryCount: 0,
+    excludedCounts: {},
+    examples: {
+      included: []
+    },
+    diagnostics: []
+  };
+}
+
+function pushBoundedExample(examples, key, example) {
+  if (!examples[key]) examples[key] = [];
+  if (examples[key].length < MAX_EXAMPLES_PER_REASON) examples[key].push(example);
+}
+
+function recordExclusion(stats, reason, relativePath, details = {}) {
+  stats.excludedCounts[reason] = (stats.excludedCounts[reason] || 0) + 1;
+  pushBoundedExample(stats.examples, reason, { path: relativePath, ...details });
+}
+
+function stripStringLiterals(content) {
+  return content.replace(/'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g, '');
+}
+
+function hasReactEvidence(content) {
+  const sourceWithoutComments = content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  const hasReactImport = [
+    /import\s+(?:type\s+)?[^;]+from\s+['"]react['"]/,
+    /import\s+React\b/,
+    /import\s+['"]react['"]/
+  ].some(pattern => pattern.test(sourceWithoutComments));
+  if (hasReactImport) return true;
+
+  const sourceWithoutCommentsOrStrings = stripStringLiterals(sourceWithoutComments);
+  return [
+    /React\./,
+    /\bJSX\.Element\b/
+  ].some(pattern => pattern.test(sourceWithoutCommentsOrStrings));
+}
+
+function isSourceSuitable(filePath, content, manifest) {
+  if (manifest?.countRule?.includeNonReact !== false) return true;
+
+  const extension = extname(filePath);
+  if (extension === '.tsx') return true;
+  if (extension === '.ts') return hasReactEvidence(content);
+  return false;
+}
+
+function walkDir(dir, onFile, stats) {
   function walk(currentDir) {
     const entries = readdirSync(currentDir, { withFileTypes: true });
-    
+
     for (const entry of entries) {
       const fullPath = resolve(currentDir, entry.name);
-      const relPath = relative(dir, fullPath);
-      
-      if (excludePatterns.some(p => relPath.includes(p))) continue;
-      
+
       if (entry.isDirectory()) {
+        if (DEFAULT_PRUNED_DIRS.has(entry.name)) {
+          stats.prunedDirectoryCount += 1;
+          continue;
+        }
         walk(fullPath);
-      } else if (entry.isFile() && pattern.test(entry.name)) {
-        files.push(fullPath);
+      } else if (entry.isFile()) {
+        stats.traversedFileCount += 1;
+        onFile(fullPath);
       }
     }
   }
-  
+
   walk(dir);
-  return files;
 }
 
 export class BucketClassifier {
@@ -48,16 +230,69 @@ export class BucketClassifier {
     this.repo = repo;
     this.buckets = buckets;
     this.manifest = manifest;
+    this.lastDiscovery = null;
+    this.discoveryByPath = new Map();
   }
 
   discoverFiles() {
     const repoPath = resolve(this.repo.localPath);
+    const discoveryGlobs = this.manifest?.discoveryGlobs || ['**/*.tsx', '**/*.ts'];
     const globalExcludes = this.manifest?.excludeGlobs || [];
     const repoExcludes = this.repo.excludedPaths || [];
-    const baseExcludes = ['node_modules', '.git', 'dist', 'build', '.next', 'coverage'];
-    const allExcludes = [...baseExcludes, ...globalExcludes.map(g => g.replace(/\*\*/g, '').replace(/\*/g, '').replace(/\//g, '')), ...repoExcludes.map(g => g.replace(/\*\*/g, '').replace(/\*/g, '').replace(/\//g, ''))];
-    const excludes = [...new Set(allExcludes)];
-    const files = walkDir(repoPath, /\.(tsx|ts|jsx|js)$/, excludes);
+    const sourceRoots = this.repo.sourceRoots || [];
+    const stats = createDiscoveryStats(this.repo, this.manifest);
+    const files = [];
+    this.discoveryByPath = new Map();
+
+    walkDir(repoPath, fullPath => {
+      const relativePath = normalizePath(relative(repoPath, fullPath));
+
+      if (!matchesAnyGlob(relativePath, discoveryGlobs)) {
+        recordExclusion(stats, 'discoveryGlobMismatch', relativePath);
+        return;
+      }
+
+      stats.candidateCount += 1;
+
+      const sourceRoot = sourceRootFor(relativePath, sourceRoots);
+      if (sourceRoots.length > 0 && !sourceRoot) {
+        recordExclusion(stats, 'outsideSourceRoots', relativePath);
+        return;
+      }
+
+      const repoExclude = firstMatchingPattern(relativePath, repoExcludes, matchesPathPattern);
+      if (repoExclude) {
+        recordExclusion(stats, 'repoExcludedPath', relativePath, { pattern: repoExclude });
+        return;
+      }
+
+      const globalExclude = firstMatchingPattern(relativePath, globalExcludes, matchesPathPattern);
+      if (globalExclude) {
+        recordExclusion(stats, 'globalExclude', relativePath, { pattern: globalExclude });
+        return;
+      }
+
+      let content;
+      try {
+        content = readFileSync(fullPath, 'utf-8');
+      } catch (err) {
+        recordExclusion(stats, 'readError', relativePath, { message: err.message });
+        return;
+      }
+
+      if (!isSourceSuitable(relativePath, content, this.manifest)) {
+        recordExclusion(stats, 'nonReactSource', relativePath);
+        return;
+      }
+
+      const metadata = { relativePath, sourceRoot, inclusionReason: 'included' };
+      this.discoveryByPath.set(fullPath, metadata);
+      files.push(fullPath);
+      stats.includedCount += 1;
+      pushBoundedExample(stats.examples, 'included', metadata);
+    }, stats);
+
+    this.lastDiscovery = stats;
     return [...new Set(files)];
   }
 
@@ -65,6 +300,10 @@ export class BucketClassifier {
     const content = readFileSync(filePath, 'utf-8');
     const rawBytes = Buffer.byteLength(content, 'utf-8');
     const signals = [];
+    const discoveryMetadata = this.discoveryByPath.get(filePath) || {
+      relativePath: normalizePath(relative(this.repo.localPath, filePath)),
+      sourceRoot: sourceRootFor(relative(this.repo.localPath, filePath), this.repo.sourceRoots || [])
+    };
 
     signals.push({ name: 'rawBytes', value: rawBytes, weight: rawBytes < 500 ? 0.4 : 0.2 });
 
@@ -76,7 +315,7 @@ export class BucketClassifier {
     signals.push({ name: 'formSignals', value: formSignals, weight: formSignals > 0 ? 0.4 : 0.05 });
 
     const conditionalCount = (content.match(/if\s*\(|\?\s*:|&&|\|\|/g) || []).length;
-    signals.push({ name: 'conditionalComplexity', value: conditionalCount, 
+    signals.push({ name: 'conditionalComplexity', value: conditionalCount,
       weight: conditionalCount > 5 ? 0.3 : 0.05 });
 
     const styleSignals = ['className=', 'styled', 'css`', 'tw`', 'tailwind']
@@ -86,7 +325,16 @@ export class BucketClassifier {
     const bucketId = this.determineBucket(signals, rawBytes, content);
     const confidence = this.calculateConfidence(signals);
 
-    return { filePath, bucketId, confidence, signals, rawBytes, mode: 'raw' };
+    return {
+      filePath,
+      bucketId,
+      confidence,
+      signals,
+      rawBytes,
+      mode: 'raw',
+      relativePath: discoveryMetadata.relativePath,
+      sourceRoot: discoveryMetadata.sourceRoot
+    };
   }
 
   determineBucket(signals, rawBytes, content) {
@@ -101,7 +349,7 @@ export class BucketClassifier {
     if (conditionalCount >= 8) return 'conditional-heavy';
     if (styleSignals >= 2 && hookCount === 0) return 'style-heavy';
     if (rawBytes > 1500 && (hookCount > 0 || formSignals > 0)) return 'large-mixed';
-    
+
     return 'simple-presentational';
   }
 
@@ -114,8 +362,8 @@ export class BucketClassifier {
 
   classifyAll() {
     const files = this.discoverFiles();
-    console.log(`Discovered ${files.length} files in ${this.repo.name}`);
-    
+    console.log(`Discovered ${files.length} eligible files in ${this.repo.name}`);
+
     const classified = files.map(f => this.classifyFile(f));
     const bucketMap = new Map();
 
@@ -123,7 +371,7 @@ export class BucketClassifier {
       const targetSize = bucket.targetSampleSize;
       const bucketFiles = classified.filter(f => f.bucketId === bucket.id);
       const deficit = Math.max(0, targetSize - bucketFiles.length);
-      
+
       bucketMap.set(bucket.id, {
         bucketId: bucket.id,
         files: bucketFiles,
@@ -137,13 +385,14 @@ export class BucketClassifier {
   }
 
   exportReport(bucketMap) {
-    const report = { 
-      repo: this.repo.name, 
-      timestamp: new Date().toISOString(), 
+    const report = {
+      repo: this.repo.name,
+      timestamp: new Date().toISOString(),
+      discovery: this.lastDiscovery,
       totalFiles: 0,
-      buckets: {} 
+      buckets: {}
     };
-    
+
     for (const [bucketId, data] of bucketMap) {
       const bucket = this.buckets.find(b => b.id === bucketId);
       report.totalFiles += data.files.length;
@@ -153,22 +402,34 @@ export class BucketClassifier {
         targetSize: data.targetSize,
         deficit: data.deficit,
         deficitRatio: Math.round(data.deficitRatio * 100) + '%',
-        status: data.deficitRatio === 0 ? 'complete' : 
+        status: data.deficitRatio === 0 ? 'complete' :
                 data.deficitRatio < 0.3 ? 'undersampled' : 'excluded',
         topFiles: data.files
           .sort((a, b) => b.confidence - a.confidence)
           .slice(0, 3)
           .map(f => ({
             path: relative(this.repo.localPath, f.filePath),
+            sourceRoot: f.sourceRoot,
             confidence: Math.round(f.confidence * 100) + '%',
             bytes: f.rawBytes
           }))
       };
     }
-    
+
     return report;
   }
 }
+
+export const _test = {
+  normalizePath,
+  expandBracePattern,
+  matchesGlob,
+  matchesPathPattern,
+  matchesDirectoryPattern,
+  sourceRootFor,
+  hasReactEvidence,
+  isSourceSuitable
+};
 
 // CLI
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -197,7 +458,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     console.log('\n--- Report ---');
     console.log(JSON.stringify(report, null, 2));
-    
+
   } catch (err) {
     console.error('Fatal:', err.message);
     process.exit(1);

--- a/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
+++ b/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
@@ -136,6 +136,7 @@ export class DryRunCommand {
         seed,
         selectedFiles: selected.map(f => ({
           path: relative(repo.localPath, f.filePath),
+          sourceRoot: f.sourceRoot,
           bytes: f.rawBytes,
           confidence: Math.round(f.confidence * 100) + '%',
           rank: f.selectionRank,
@@ -163,6 +164,7 @@ export class DryRunCommand {
         coverageRatio: totalTarget > 0 ? Math.round((totalSelected / totalTarget) * 100) / 100 : 0
       },
       buckets: bucketResults,
+      discovery: classifier.lastDiscovery,
       coverageStatus: criticalDeficits > 0 ? 'insufficient' : 
                       Object.values(bucketResults).some(b => b.status === 'undersampled') ? 'partial' : 'full'
     };

--- a/test/frontend-v2-runner.test.mjs
+++ b/test/frontend-v2-runner.test.mjs
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { BucketClassifier, DEFAULT_BUCKETS, _test } from '../benchmarks/frontend-harness/v2-runner/src/bucket-classifier.mjs';
+import { DryRunCommand } from '../benchmarks/frontend-harness/v2-runner/src/dry-run.mjs';
+
+function writeFile(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'fooks-v2-runner-'));
+  const reposBaseDir = join(root, 'repos');
+  const repoPath = join(reposBaseDir, 'fixture');
+  mkdirSync(repoPath, { recursive: true });
+
+  const reactComponent = `
+    import React from 'react';
+    export function Button() { return <button className="px-2">Save</button>; }
+  `;
+
+  writeFile(join(repoPath, 'apps/web/components/Button.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/admin/widgets/Card.tsx'), reactComponent);
+  writeFile(join(repoPath, 'packages/ui/components/Dialog.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/react-evidence.ts'), `
+    import type { ReactNode } from 'react';
+    export function Label({ children }: { children: ReactNode }) { return children; }
+  `);
+
+  writeFile(join(repoPath, 'apps/api/Route.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/api/Route.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/Button.test.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/Widget.spec.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/Generated.generated.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/Local.stories.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/Story.story.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/components/math.ts'), 'export function add(a: number, b: number) { return a + b; }');
+  writeFile(join(repoPath, 'apps/web/components/ButtonConfig.ts'), 'export const ButtonConfig = { size: "sm" };');
+  writeFile(join(repoPath, 'apps/web/components/FormatCurrency.ts'), 'export function FormatCurrency(value: number) { return `$${value}`; }');
+  writeFile(join(repoPath, 'apps/web/components/docs.ts'), 'export const docs = "React.createElement is mentioned in documentation";');
+  writeFile(join(repoPath, 'apps/web/components/Legacy.jsx'), 'export function Legacy() { return <div />; }');
+  writeFile(join(repoPath, 'apps/web/components/plain.js'), 'export const value = 1;');
+
+  const manifest = {
+    version: 'v2-test',
+    seed: 'fixture-seed',
+    discoveryGlobs: ['**/*.tsx', '**/*.ts'],
+    excludeGlobs: [
+      '**/*.test.{ts,tsx}',
+      '**/*.spec.{ts,tsx}',
+      '**/*.generated.{ts,tsx}',
+      '**/*.stories.{ts,tsx}',
+      '**/*.story.{ts,tsx}',
+      '**/test/**',
+      '**/playwright/**'
+    ],
+    countRule: {
+      includeNonReact: false,
+      countReactPatterns: ['JSXElement', 'JSXFragment', 'React']
+    },
+    repos: [{
+      name: 'fixture',
+      revision: 'fixture-revision',
+      sourceRoots: ['apps/web/', 'apps/*/widgets/', 'packages/*/components'],
+      excludedPaths: ['apps/web/api/', '*.stories.tsx'],
+      bucketLimits: {
+        'tiny-raw': 2,
+        'simple-presentational': 2,
+        'style-heavy': 1
+      }
+    }]
+  };
+
+  const manifestPath = join(root, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+
+  return { root, repoPath, reposBaseDir, manifest, manifestPath };
+}
+
+test('v2 runner bounded matcher supports current manifest path patterns', () => {
+  assert.equal(_test.matchesGlob('apps/web/components/Button.tsx', '**/*.tsx'), true);
+  assert.equal(_test.matchesGlob('apps/web/components/Button.test.tsx', '**/*.test.{ts,tsx}'), true);
+  assert.equal(_test.matchesGlob('apps/web/components/Local.stories.tsx', '*.stories.tsx'), true);
+  assert.equal(_test.matchesGlob('apps/web/components/Legacy.jsx', '**/*.tsx'), false);
+  assert.equal(_test.sourceRootFor('apps/admin/widgets/Card.tsx', ['apps/*/widgets/']), 'apps/*/widgets/');
+  assert.equal(_test.sourceRootFor('packages/ui/components/Dialog.tsx', ['packages/*/components']), 'packages/*/components');
+  assert.equal(_test.matchesPathPattern('apps/web/api/Route.tsx', 'apps/web/api/'), true);
+});
+
+test('BucketClassifier enforces discovery globs, source roots, excludes, and React source suitability', () => {
+  const fixture = createFixture();
+  try {
+    const repo = { ...fixture.manifest.repos[0], localPath: fixture.repoPath };
+    const classifier = new BucketClassifier(repo, DEFAULT_BUCKETS, fixture.manifest);
+    const files = classifier.discoverFiles().map(path => _test.normalizePath(path.replace(`${fixture.repoPath}/`, ''))).sort();
+
+    assert.deepEqual(files, [
+      'apps/admin/widgets/Card.tsx',
+      'apps/web/components/Button.tsx',
+      'apps/web/components/react-evidence.ts',
+      'packages/ui/components/Dialog.tsx'
+    ]);
+
+    assert.equal(classifier.lastDiscovery.candidateCount, 15);
+    assert.equal(classifier.lastDiscovery.includedCount, 4);
+    assert.equal(classifier.lastDiscovery.excludedCounts.discoveryGlobMismatch, 2);
+    assert.equal(classifier.lastDiscovery.excludedCounts.outsideSourceRoots, 1);
+    assert.equal(classifier.lastDiscovery.excludedCounts.repoExcludedPath, 2);
+    assert.equal(classifier.lastDiscovery.excludedCounts.globalExclude, 4);
+    assert.equal(classifier.lastDiscovery.excludedCounts.nonReactSource, 4);
+
+    assert.equal(classifier.lastDiscovery.examples.outsideSourceRoots[0].path, 'apps/api/Route.tsx');
+    assert.equal(
+      classifier.lastDiscovery.examples.repoExcludedPath.some(example => example.path === 'apps/web/components/Local.stories.tsx'),
+      true
+    );
+    assert.equal(
+      classifier.lastDiscovery.examples.globalExclude.some(example => example.path === 'apps/web/components/Button.test.tsx'),
+      true
+    );
+    assert.equal(
+      classifier.lastDiscovery.examples.nonReactSource.some(example => example.path === 'apps/web/components/math.ts'),
+      true
+    );
+    assert.equal(
+      classifier.lastDiscovery.examples.nonReactSource.some(example => example.path === 'apps/web/components/ButtonConfig.ts'),
+      true
+    );
+    assert.equal(
+      classifier.lastDiscovery.examples.nonReactSource.some(example => example.path === 'apps/web/components/FormatCurrency.ts'),
+      true
+    );
+    assert.equal(
+      classifier.lastDiscovery.examples.nonReactSource.some(example => example.path === 'apps/web/components/docs.ts'),
+      true
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('DryRunCommand reports additive discovery metadata and source-root traceability', async () => {
+  const fixture = createFixture();
+  try {
+    const outputPath = join(fixture.root, 'dry-run.json');
+    const command = new DryRunCommand(fixture.manifestPath, fixture.reposBaseDir);
+    const { report, exitCode } = await command.execute('fixture', { output: outputPath });
+    const written = JSON.parse(readFileSync(outputPath, 'utf-8'));
+
+    for (const field of ['schemaVersion', 'timestamp', 'repo', 'revision', 'globalSeed', 'summary', 'buckets', 'coverageStatus']) {
+      assert.ok(Object.hasOwn(written, field), `expected top-level field ${field}`);
+    }
+
+    assert.equal(report.discovery.candidateCount, 15);
+    assert.equal(report.discovery.includedCount, 4);
+    assert.ok(report.discovery.excludedCounts.outsideSourceRoots > 0);
+    assert.ok(report.discovery.excludedCounts.repoExcludedPath > 0);
+    assert.ok(report.discovery.excludedCounts.globalExclude > 0);
+    assert.ok(report.discovery.excludedCounts.nonReactSource > 0);
+
+    const selectedFiles = Object.values(report.buckets).flatMap(bucket => bucket.selectedFiles);
+    assert.ok(selectedFiles.length > 0);
+    assert.equal(selectedFiles.every(file => typeof file.sourceRoot === 'string' && file.sourceRoot.length > 0), true);
+    assert.equal(selectedFiles.some(file => file.path.endsWith('.jsx') || file.path.endsWith('.js')), false);
+    assert.equal(selectedFiles.some(file => file.path.includes('/api/') || file.path.endsWith('.test.tsx')), false);
+    assert.equal(selectedFiles.some(file => file.path.endsWith('ButtonConfig.ts') || file.path.endsWith('FormatCurrency.ts') || file.path.endsWith('docs.ts')), false);
+
+    assert.equal(report.coverageStatus, 'insufficient');
+    assert.equal(exitCode, 1);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Enforce v2 benchmark dry-run discovery against manifest `discoveryGlobs`, repo `sourceRoots`, repo exclusions, and global exclusion globs.
- Reject non-React `.ts` sources when `includeNonReact: false`, including bare PascalCase helper/config exports and string-only React mentions.
- Add additive dry-run traceability: `report.discovery` plus selected-file `sourceRoot`, without changing existing top-level report fields.
- Add focused node:test coverage for matcher behavior, source filtering, and dry-run report compatibility.

## Verification
- `node --test test/frontend-v2-runner.test.mjs` → 3 pass / 0 fail
- `npm run lint` → pass
- `npm run typecheck` → pass
- `npm test` → 80 pass / 0 fail
- `git diff --check` → pass
- Cal.com verification-only dry-run:
  - `exitCode: 1` and `coverageStatus: insufficient` are expected because strict filtering honestly leaves coverage low.
  - selected `49/185` target files from `100` eligible included files.
  - discovery candidates: `2214`; excluded counts: `discoveryGlobMismatch=1558`, `outsideSourceRoots=2103`, `globalExclude=5`, `nonReactSource=6`.
  - selected files had `badRoots=[]`, `forbidden=[]`, `missingSourceRoot=[]`.

## Notes / Scope
- This PR does **not** rerun the full vanilla vs fooks benchmark and does **not** update official benchmark conclusions.
- Cal.com dry-run is verification evidence for trustworthy source filtering only.
- The stricter `.ts` gate may false-negative helper-like files unless they contain explicit React/JSX evidence; that is intentional for benchmark comparability before the next real rerun.
