### PR TITLE
Keep Next API routes out of frontend benchmark samples

### DIFF
--- a/docs/benchmarks/v2/manifest.json
+++ b/docs/benchmarks/v2/manifest.json
@@ -13,6 +13,8 @@
     "**/.next/**",
     "**/dist/**",
     "**/coverage/**",
+    "**/app/api/**",
+    "**/pages/api/**",
     "**/*.test.{ts,tsx}",
     "**/*.spec.{ts,tsx}",
     "**/test/**",

--- a/test/frontend-v2-runner.test.mjs
+++ b/test/frontend-v2-runner.test.mjs
@@ -32,6 +32,8 @@ function createFixture() {
 
   writeFile(join(repoPath, 'apps/api/Route.tsx'), reactComponent);
   writeFile(join(repoPath, 'apps/web/api/Route.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/app/api/Route.tsx'), reactComponent);
+  writeFile(join(repoPath, 'apps/web/pages/api/Route.tsx'), reactComponent);
   writeFile(join(repoPath, 'apps/web/components/Button.test.tsx'), reactComponent);
   writeFile(join(repoPath, 'apps/web/components/Widget.spec.tsx'), reactComponent);
   writeFile(join(repoPath, 'apps/web/components/Generated.generated.tsx'), reactComponent);
@@ -55,7 +57,9 @@ function createFixture() {
       '**/*.stories.{ts,tsx}',
       '**/*.story.{ts,tsx}',
       '**/test/**',
-      '**/playwright/**'
+      '**/playwright/**',
+      '**/app/api/**',
+      '**/pages/api/**'
     ],
     countRule: {
       includeNonReact: false,
@@ -104,12 +108,12 @@ test('BucketClassifier enforces discovery globs, source roots, excludes, and Rea
       'packages/ui/components/Dialog.tsx'
     ]);
 
-    assert.equal(classifier.lastDiscovery.candidateCount, 15);
+    assert.equal(classifier.lastDiscovery.candidateCount, 17);
     assert.equal(classifier.lastDiscovery.includedCount, 4);
     assert.equal(classifier.lastDiscovery.excludedCounts.discoveryGlobMismatch, 2);
     assert.equal(classifier.lastDiscovery.excludedCounts.outsideSourceRoots, 1);
     assert.equal(classifier.lastDiscovery.excludedCounts.repoExcludedPath, 2);
-    assert.equal(classifier.lastDiscovery.excludedCounts.globalExclude, 4);
+    assert.equal(classifier.lastDiscovery.excludedCounts.globalExclude, 6);
     assert.equal(classifier.lastDiscovery.excludedCounts.nonReactSource, 4);
 
     assert.equal(classifier.lastDiscovery.examples.outsideSourceRoots[0].path, 'apps/api/Route.tsx');
@@ -154,7 +158,7 @@ test('DryRunCommand reports additive discovery metadata and source-root traceabi
       assert.ok(Object.hasOwn(written, field), `expected top-level field ${field}`);
     }
 
-    assert.equal(report.discovery.candidateCount, 15);
+    assert.equal(report.discovery.candidateCount, 17);
     assert.equal(report.discovery.includedCount, 4);
     assert.ok(report.discovery.excludedCounts.outsideSourceRoots > 0);
     assert.ok(report.discovery.excludedCounts.repoExcludedPath > 0);


### PR DESCRIPTION
## Summary
- Exclude common Next.js API route directories from the frontend benchmark v2 manifest:
  - `**/app/api/**`
  - `**/pages/api/**`
- Extend the v2-runner fixture to prove App Router and Pages Router API paths are excluded by global manifest rules.

## Why
After the source-filtering hardening landed on `main`, a fresh `formbricks` dry-run showed selected files under `apps/web/app/api/**`. Those paths are inside a broad source root but are server/API helpers, not UI-facing frontend samples. Keeping them would weaken vanilla vs fooks product interpretation for frontend developer work.

## Verification
- `node --test test/frontend-v2-runner.test.mjs` → 3 pass / 0 fail
- `npm run lint` → pass
- `npm run typecheck` → pass
- `npm test` → 81 pass / 0 fail
- `git diff --check` → pass
- Verification-only dry-runs:
  - `cal.com`: selected `49/185`, included `100`, `appApiCount=0`, `pagesApiCount=0`
  - `formbricks`: selected `97/185`, included `235`, `appApiCount=0`, `pagesApiCount=0`

## Notes
- This PR does not run or update full vanilla vs fooks benchmark conclusions.
- Coverage remains `insufficient`; that is expected and preferable to padding with backend/API files.
- If future work wants API-route benchmarks, that should be a separate backend/API corpus, not part of the frontend benchmark excludes.
