### PR TITLE
Reopen the terminal CLI proof track with a retention-safe first success pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Phase 1 is intentionally narrow:
 
 ```bash
 fooks init
+fooks run "<prompt>"
 fooks scan
 fooks extract <file> --json
 fooks extract <file> --model-payload
@@ -41,6 +42,26 @@ fooks attach claude
 ```
 
 The shipping product name and all supported runtime/storage names are `fooks`.
+
+## First success
+
+Minimal shared path from a clean checkout:
+
+```bash
+npm run build
+fooks attach codex   # or: fooks attach claude
+fooks run "Update src/components/FormSection.tsx"
+```
+
+`fooks run` prepares a shared handoff context file, then leaves execution to the runtime you already use (`codex`, `claude`, `omx`, etc.).
+
+Current support boundary:
+
+- Shared terminal CLI proof today: `init`, `scan`, `decide`, `extract`, `run` handoff context, `attach codex`, `attach claude`
+- Codex-specific extras today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
+- Claude-specific status today: attach/runtime-manifest proof only; this repo does not yet ship a Claude-native hook installer or runtime bridge
+
+See [`docs/terminal-cli-validation-2026-04-19.md`](docs/terminal-cli-validation-2026-04-19.md) for the exact commands and current proof boundary on `main`.
 
 ## Account context
 

--- a/docs/terminal-cli-validation-2026-04-19.md
+++ b/docs/terminal-cli-validation-2026-04-19.md
@@ -1,14 +1,22 @@
 # Terminal CLI Validation - 2026-04-19
 
-This note records the smallest concrete validation pass run from current `main` to verify that `fooks` supports both Codex and Claude Code as a terminal CLI integration surface.
+This note records the concrete proof passes run on 2026-04-19 to verify that `fooks` supports both Codex and Claude Code as a terminal CLI integration surface, plus the follow-up first-success wording pass reopened from clean `main`.
 
-## Starting point
+## Previous proof context
 
-- Branch at validation start: `main`
-- Commit at validation start: `bf3c6afa100351c8dd6c1fc30a287f3188566f3a`
+- PR #35, `docs: agent-neutral CLI workflow for Codex/Claude`, was closed on 2026-04-19 without merge because it mixed a broader docs package into what should have been a narrower proof track.
+- PR #37, `docs: record concrete Codex and Claude CLI validation`, merged on 2026-04-19 and established the first small proof artifact on `main`.
+- This rerun keeps the proof track narrow: verify current `main`, make the first-success path more retention-safe, and avoid inventing Claude parity that the repo does not ship.
+
+## Current rerun starting point
+
+- Branch at rerun start: `validation/agent-neutral-first-success-20260419`
+- Base branch: `main`
+- Commit at rerun start: `9e5be1c4a4a5b3c95ac8a08b4ac51f5d26f62597`
 - Prior docs/PR context inspected:
   - closed PR #35, `docs: agent-neutral CLI workflow for Codex/Claude`, closed on 2026-04-19
-  - current `main` already contains the supporting CLI and adapter code paths, but not a merged validation note for the support boundary
+  - merged PR #37 / commit `9e5be1c`, `docs: validate fooks as agent-neutral terminal CLI`
+  - current `main` already contains the supporting CLI and adapter code paths, plus the merged validation note, but still leaves `fooks run` with Codex/OMX-flavored first-success wording
 - Hermes note:
   - no Hermes-specific integration surface was found in this repo during this pass
 
@@ -79,22 +87,41 @@ Observed result:
 
 This proves the shared prep surface works independently of Codex-only hook wiring.
 
+### 4. Shared first-success handoff path
+
+Command:
+
+```bash
+node dist/cli/index.js run "Please update fixtures/compressed/FormSection.tsx"
+```
+
+Observed result after the first-success wording pass:
+
+- output heading is `Shared Handoff Context`
+- output no longer labels the flow as a detected Codex/OMX runner
+- next-step text says `Open this context with your preferred runtime (codex, claude, omx, etc.)`
+- context file still contains the same light exact-file selection for `fixtures/compressed/FormSection.tsx`
+
+This keeps the value proof intact while making the first-success path honest about the product surface: `fooks run` prepares a reusable context handoff and does not claim Claude-native runtime automation.
+
 ## Current support boundary
 
-Validated on current `main`:
+Validated on current `main` and preserved by the follow-up wording pass:
 
 - Shared terminal CLI prep surfaces are agent-neutral: `init`, `scan`, `decide`, `extract`, and attach artifact generation
+- Shared first-success handoff is agent-neutral: `run` prepares a reusable context file and points users back to their preferred runtime
 - Codex has the richer in-repo runtime path today: attach metadata, trust status, pre-read bridge, native hook bridge, and hook preset installer
 - Claude support is real but narrower: attach/runtime-manifest support plus the shared prep flow
 
 Current gap, still present after validation:
 
 - this repo does not currently ship a Claude-native hook installer or a Claude-specific runtime execution bridge comparable to the Codex hook path
-- `fooks run` remains Codex/OMX-oriented in current code ownership and naming
+- internal `run` prep still uses the Codex execution-context helper under the hood, even though the user-facing handoff copy is now runtime-neutral
 
 ## Verification
 
 ```bash
+npm run build
 npm run typecheck
 npm test
 ```

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -69,17 +69,16 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
     
     // 4. Prepare execution context (handoff pattern)
     const runner = (options.runner === "auto" || !options.runner) ? detectRunner() : options.runner;
-    console.log("Detected runner:", runner);
-    
+
     let executionContext;
     if (runner === "codex" || runner === "omx") {
       executionContext = await prepareExecutionContext(options.prompt, processedFiles, cwd, selection.policy);
-      console.log("\n=== Handoff Summary ===");
+      console.log("\n=== Shared Handoff Context ===");
       console.log(`Context ready: ${executionContext.contextPath}`);
       console.log(`Files: ${executionContext.fileCount}, Size: ${(executionContext.totalSize / 1024).toFixed(1)}KB`);
       console.log(`Context mode: ${executionContext.contextMode} (${executionContext.contextModeReason})`);
       console.log(`Prompt: "${executionContext.prompt}"`);
-      console.log(`\nNext: Execute with your preferred runtime (omx, codex, claude, etc.)`);
+      console.log(`\nNext: Open this context with your preferred runtime (codex, claude, omx, etc.)`);
       console.log(`Context file: ${executionContext.contextPath}`);
       console.log("======================\n");
     }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -459,8 +459,11 @@ test("prepareExecutionContext writes context policy metadata and resolves files 
 test("cli run keeps exact-file prompts to one light context file", () => {
   const tempDir = makeTempProject();
   const output = runText(["run", "Please", "update", "src/components/FormSection.tsx"], tempDir);
+  assert.match(output, /Shared Handoff Context/);
   assert.match(output, /Context mode: light/);
   assert.match(output, /1 files/);
+  assert.match(output, /preferred runtime \(codex, claude, omx, etc\.\)/);
+  assert.doesNotMatch(output, /Detected runner:/);
   const context = fs.readFileSync(path.join(tempDir, ".fooks", "temp-context.md"), "utf8");
   assert.match(context, /"contextMode":"light"/);
   assert.match(context, /## src\/components\/FormSection.tsx/);


### PR DESCRIPTION
## Why
PR #37 proved the Codex and Claude terminal CLI support boundary on `main`, but the remaining `fooks run` wording still read like a Codex/OMX-owned first-success path. This follow-up keeps the proof track narrow and makes the shared handoff surface explicit without claiming missing Claude parity.

## What changed
- reframed `fooks run` output as a shared handoff context instead of a detected runner flow
- added a concise README first-success/support-boundary section for Codex and Claude terminal CLI usage
- extended the validation note with prior stalled-proof context and the reopened first-success rerun
- locked the new runtime-neutral wording with regression coverage

## Verification
- `npm run build`
- `npm run typecheck`
- `node --test test/*.test.mjs`
- `FOOKS_CODEX_HOME=$(mktemp -d) node dist/cli/index.js attach codex`
- `FOOKS_CLAUDE_HOME=$(mktemp -d) node dist/cli/index.js attach claude`
- `node dist/cli/index.js decide fixtures/compressed/FormSection.tsx`
- `node dist/cli/index.js extract fixtures/compressed/FormSection.tsx --model-payload`
- `node dist/cli/index.js run "Please update fixtures/compressed/FormSection.tsx"`

## Out of scope
- Claude-native hook installer or runtime bridge parity
- revival of the broader closed PR #35 docs package
