### PR TITLE
fix(payload): restore rawText in model-facing output for raw-mode

### DIFF
--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -62,6 +62,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
   return {
     mode: result.mode,
     filePath: toRelativePath(result.filePath, cwd),
+    ...(result.mode === "raw" && result.rawText ? { rawText: result.rawText } : {}),
     ...(result.componentName ? { componentName: result.componentName } : {}),
     ...(result.exports.length > 0 ? { exports: result.exports } : {}),
     ...(contract ? { contract } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -64,7 +64,7 @@ export type ModelFacingPayload = {
   mode: OutputMode;
   filePath: string;
   useOriginal?: boolean;
-  rawText?: string;
+  rawText?: ExtractionResult["rawText"];
   componentName?: string;
   exports?: ExtractionResult["exports"];
   contract?: ExtractionResult["contract"];


### PR DESCRIPTION
## Summary

Restore raw payload source text in model-facing output. The schema now reuses ExtractionResult's rawText type, and the model-facing payload includes rawText for raw-mode results even when not on the useOriginal fast path.

## Changes
- `src/core/payload/model-facing.ts`: +1 line — include rawText for raw-mode payloads  
- `src/core/schema.ts`: type alignment

## Scope
- Narrow fix: only affects raw-mode payloads
- Preserves useOriginal fast-path behavior for tiny raw fixtures
- 2 files changed, +2/-1 lines

## Tested
- `npm run build` ✓
- `npm run lint` ✓  
- `npm test` ✓
- CLI extract with --model-payload ✓

Ready for review.