### PR TITLE
[codex] Protect Claude claims with handoff proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Current support boundary:
 
 - Shared terminal CLI proof today: `init`, `scan`, `decide`, `extract`, `run` handoff context, `attach codex`, `attach claude`
 - Codex-specific extras today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
-- Claude-specific status today: attach/runtime-manifest proof only; this repo does not yet ship a Claude-native hook installer or runtime bridge
+- Claude-specific status today: attach/runtime-manifest proof plus manual/shared handoff only; this repo does not yet ship a Claude-native hook installer, runtime bridge, `status claude`, or Claude runtime-token benchmark proof
+
+Claim boundary: Codex can use the in-repo runtime hook path for repeated-prompt context injection. Claude can consume reduced model-facing artifacts through manual/shared handoff, for example `fooks extract <file> --model-payload`, but this is **not** a claim of automatic Claude runtime token reduction.
 
 See [`docs/terminal-cli-validation-2026-04-19.md`](docs/terminal-cli-validation-2026-04-19.md) for the exact commands and current proof boundary on `main`.
 
@@ -131,6 +133,8 @@ Current verification snapshot:
 
 Real-world benchmark comparing **vanilla Codex** vs **fooks-enabled Codex** on frontend tasks.
 
+Claim-safety note: the benchmark numbers below are historical Codex-oriented estimates/proxy measurements unless a row explicitly says it was measured as live runtime tokens. They should not be read as Claude runtime-token savings or Claude benchmark wins.
+
 ### Latest Results (2026-04-14 Final Rerun)
 
 | Metric | Vanilla | Fooks | Improvement | Note |
@@ -166,7 +170,7 @@ Real-world benchmark comparing **vanilla Codex** vs **fooks-enabled Codex** on f
 
 - Expanded from 5 files to 20 files per repo (size-distributed sampling)
 - Raw mode overhead is expected (JSON metadata wrapper); actual delivery uses `useOriginal: true` for tiny files
-- Framework repos are **extraction-test-reference only** — not comparative gating, not task parity benchmark
+- Framework repos are **extraction-test-reference only** — not comparative gating, not task parity benchmark, and not runtime-token proof for Claude
 
 **Fixes applied since previous run:**
 - AST-based styleBranching detection (tiny files now raw correctly)

--- a/docs/cli/auto-mode-implementation-plan.md
+++ b/docs/cli/auto-mode-implementation-plan.md
@@ -1,5 +1,10 @@
 # Fooks Auto Mode Implementation Plan
 
+> Historical planning note. This document records an earlier proposed UX and is
+> not the current claim surface. Current `fooks run` behavior is a shared/manual
+> handoff path; size percentages should be treated as estimated extraction
+> opportunity, not delivered runtime-token savings for Claude.
+
 ## Current State
 
 ### Already Implemented
@@ -36,7 +41,7 @@
 - [ ] Auto-triggers scan if cache stale (mtime vs timestamp)
 - [ ] Discovers relevant files via discover.ts
 - [ ] Executes via attached runtime
-- [ ] Shows 1-line result: ✓ Done: Xs, Y% smaller, N files changed
+- [ ] Shows 1-line result: ✓ Done: Xs, processed N files, estimated extraction opportunity Y%
 - [ ] Error shows actionable fix: ✗ Failed: [reason]. Fix: [action]
 
 **Risk**: Medium

--- a/docs/cli/default-auto-mode-spec.md
+++ b/docs/cli/default-auto-mode-spec.md
@@ -1,5 +1,9 @@
 # Fooks Default Auto Mode CLI UX Specification
 
+> Historical planning note. This spec predates the current claim-safety
+> boundary. Treat output percentages here as estimated extraction opportunity,
+> not as proof of delivered runtime-token savings or Claude runtime automation.
+
 ## Overview
 Fooks CLI provides **zero-configuration automatic optimization** for frontend AI coding tasks. Users install and run—no manual mode selection, no compression theory study required.
 
@@ -172,7 +176,7 @@ npx fooks run "Fix form validation"
 
 ### Default Output (1-line)
 ```
-✓ Done: 4.2s, 62% smaller, 1 file changed
+✓ Done: 4.2s, processed 1 file, estimated extraction opportunity 62%
 ```
 
 ### Error Output
@@ -186,7 +190,7 @@ npx fooks run "Fix form validation"
 ✓ Task complete: Add form validation
   Duration: 4.2s (scan: 0.8s, execution: 3.4s)
   Mode: hybrid (auto-selected)
-  Token summary: ~840K → ~319K (62% reduction)
+  Extraction opportunity: ~840K → ~319K estimated proxy size (62% reduction)
   Files modified: 1 (LoginForm.tsx)
 ```
 

--- a/docs/terminal-cli-validation-2026-04-19.md
+++ b/docs/terminal-cli-validation-2026-04-19.md
@@ -104,6 +104,8 @@ Observed result after the first-success wording pass:
 
 This keeps the value proof intact while making the first-success path honest about the product surface: `fooks run` prepares a reusable context handoff and does not claim Claude-native runtime automation.
 
+Follow-up claim-safety note: a Claude attach proof plus `extract --model-payload` proof should be described as a **Claude manual handoff-compatible reduced artifact proof**. It is not evidence of Claude automatic runtime hooks, Claude live runtime-token savings, or Claude benchmark wins.
+
 ## Current support boundary
 
 Validated on current `main` and preserved by the follow-up wording pass:
@@ -111,12 +113,13 @@ Validated on current `main` and preserved by the follow-up wording pass:
 - Shared terminal CLI prep surfaces are agent-neutral: `init`, `scan`, `decide`, `extract`, and attach artifact generation
 - Shared first-success handoff is agent-neutral: `run` prepares a reusable context file and points users back to their preferred runtime
 - Codex has the richer in-repo runtime path today: attach metadata, trust status, pre-read bridge, native hook bridge, and hook preset installer
-- Claude support is real but narrower: attach/runtime-manifest support plus the shared prep flow
+- Claude support is real but narrower: attach/runtime-manifest support plus the shared prep/manual handoff flow
 
 Current gap, still present after validation:
 
 - this repo does not currently ship a Claude-native hook installer or a Claude-specific runtime execution bridge comparable to the Codex hook path
 - internal `run` prep still uses the Codex execution-context helper under the hood, even though the user-facing handoff copy is now runtime-neutral
+- this repo does not currently ship `status claude` or Claude runtime-token benchmark proof
 
 ## Verification
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -213,7 +213,7 @@ async function run(): Promise<void> {
       }
       const result = await runTask({ prompt });
       if (result.success) {
-        console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, ${result.reductionPercent}% smaller, ${result.filesProcessed} files`);
+        console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, processed ${result.filesProcessed} files, estimated extraction opportunity ${result.reductionPercent}%`);
       } else {
         console.error(`✗ Failed: ${result.error}`);
         console.error("Fix: Check file syntax or run with --mode=raw");

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -178,7 +178,7 @@ if (isDirectExecution) {
   
   runTask({ prompt }).then(result => {
     if (result.success) {
-      console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, ${result.reductionPercent}% smaller, ${result.filesProcessed} files`);
+      console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, processed ${result.filesProcessed} files, estimated extraction opportunity ${result.reductionPercent}%`);
     } else {
       console.error(`✗ Failed: ${result.error}`);
       process.exit(1);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -30,6 +30,7 @@ const {
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
 const { prepareExecutionContext } = require(path.join(repoRoot, "dist", "adapters", "codex.js"));
+const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude.js"));
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 
@@ -467,6 +468,8 @@ test("cli run keeps exact-file prompts to one light context file", () => {
   assert.match(output, /Codex: start `codex` in this repo, then paste your prompt and the context from .*temp-context\.md/);
   assert.match(output, /Claude: start `claude` in this repo, then paste your prompt and the context from .*temp-context\.md/);
   assert.match(output, /preferred runtime \(codex, claude, omx, etc\.\)/);
+  assert.match(output, /estimated extraction opportunity \d+%/);
+  assert.doesNotMatch(output, /\d+% smaller/);
   assert.doesNotMatch(output, /Detected runner:/);
   assert.doesNotMatch(output, /--context/);
   assert.doesNotMatch(output, /hook installer/i);
@@ -1116,6 +1119,45 @@ test("attach claude can report blocker without failing contract proof", () => {
   assert.equal(result.runtimeProof.status, "blocked");
   assert.ok(result.runtimeProof.attemptedAt);
   assert.ok(result.runtimeProof.blocker);
+});
+
+test("attach claude pairs manual handoff proof with reduced model-facing artifact", () => {
+  const tempDir = makeTempProject();
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  const samplePath = path.join(tempDir, "src", "components", "FormSection.tsx");
+
+  withEnv({ FOOKS_CLAUDE_HOME: claudeHome }, () => {
+    const result = attachClaude(samplePath, tempDir);
+    assert.equal(result.runtime, "claude");
+    assert.equal(result.contractProof.passed, true);
+    assert.equal(result.runtimeProof.status, "passed");
+    assert.ok(result.runtimeProof.attemptedAt);
+
+    const manifestPath = runtimeManifestPath(result);
+    assert.ok(manifestPath);
+    assert.ok(fs.existsSync(manifestPath));
+    assert.ok(result.filesCreated.some((item) => item.endsWith(path.join("claude", "adapter.json"))));
+    assert.ok(result.filesCreated.some((item) => item.endsWith(path.join("claude", "context-template.md"))));
+    assert.ok(fs.existsSync(path.join(tempDir, ".fooks", "adapters", "claude", "context-template.md")));
+
+    const manifestText = fs.readFileSync(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestText);
+    assert.equal(manifest.runtime, "claude");
+    assert.equal(manifest.runtimeBridge, undefined);
+    assert.equal(manifest.supportedHookEvents, undefined);
+    assert.doesNotMatch(manifestText, /codex-runtime-hook|UserPromptSubmit|SessionStart|Stop/);
+  });
+
+  const fullResult = extractFile(samplePath);
+  const payload = toModelFacingPayload(fullResult, tempDir);
+  const sourceBytes = Buffer.byteLength(fs.readFileSync(samplePath, "utf8"), "utf8");
+  const payloadBytes = Buffer.byteLength(JSON.stringify(payload), "utf8");
+
+  assert.equal(fullResult.mode, "compressed");
+  assert.equal(payload.mode, "compressed");
+  assert.equal(payload.filePath, path.join("src", "components", "FormSection.tsx"));
+  assert.equal("rawText" in payload, false);
+  assert.ok(payloadBytes < sourceBytes, `expected reduced handoff artifact, got payload=${payloadBytes}, source=${sourceBytes}`);
 });
 
 test("attach can use explicit active account override instead of repository metadata", () => {


### PR DESCRIPTION
## Summary

- Clarify Codex vs Claude support boundaries so Claude is described as attach/manual handoff only, not Codex-equivalent runtime hook support.
- Reword `fooks run` success summaries from bare `% smaller` to `estimated extraction opportunity` to avoid implying delivered runtime-token savings from raw/shared handoff context.
- Add a same-sample Claude proof test that pairs `attachClaude(...)` with a reduced model-facing artifact while asserting the Claude manifest does not contain fake runtime bridge/hook metadata.

## Why

Current repo evidence supports Codex runtime hook/native hook/repeated prompt injection, while Claude support is narrower: attach/runtime manifest plus manual/shared handoff. This PR keeps product claims aligned with that evidence and avoids implying Claude runtime-token savings before a real Claude runtime path and benchmark exist.

## Validation

- `npm run build`
- `node --test test/fooks.test.mjs --test-name-pattern='model-facing payload trim|attach claude|attach codex|cli run keeps exact-file|runtime hook|native hook'`
- `npm run lint`
- `git diff --check`
- `npm test`

## Deferred explicitly

- Claude runtime hook/native bridge
- `status claude` / Claude trust lifecycle
- Claude runtime-token benchmark proof
- Claude runtime-token savings or benchmark win claims
