### PR TITLE
[codex] Add explicit fooks setup activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,44 @@ Phase 1 is intentionally narrow:
 - local scan / extract / decide / attach flow
 - runtime-agnostic core schema with thin adapters
 
-## Commands
+## Quick start
+
+Regular Codex users should use the one-time setup path:
+
+```bash
+npm install -g fooks
+fooks setup
+# then open Codex in this repo and work normally
+```
+
+From a local checkout, build first and run the same explicit setup step:
+
+```bash
+npm run build
+fooks setup
+```
+
+`fooks setup` initializes local `.fooks/` state, attaches the current repo to the Codex runtime, merges the fooks Codex hook preset into `~/.codex/hooks.json`, and reports whether the activation is `ready`, `partial`, or `blocked`. The setup command is explicit by design: package installation does **not** silently edit your Codex hooks.
+
+The shipping product name and all supported runtime/storage names are `fooks`.
+
+## Everyday commands
+
+```bash
+fooks setup
+fooks run "<prompt>"
+fooks status codex
+fooks status cache
+```
+
+`fooks run` prepares a shared handoff context file, then leaves execution to the runtime you already use (`codex`, `claude`, `omx`, etc.).
+
+## Advanced / validation commands
+
+These remain available for maintainers, benchmark validation, and debugging, but regular users should not need them for the first-success path:
 
 ```bash
 fooks init
-fooks run "<prompt>"
 fooks scan
 fooks extract <file> --json
 fooks extract <file> --model-payload
@@ -35,30 +68,15 @@ fooks codex-pre-read <file>
 fooks codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop>
 fooks codex-runtime-hook --native-hook
 fooks install codex-hooks
-fooks status codex
-fooks status cache
 fooks attach codex
 fooks attach claude
 ```
 
-The shipping product name and all supported runtime/storage names are `fooks`.
-
-## First success
-
-Minimal shared path from a clean checkout:
-
-```bash
-npm run build
-fooks attach codex   # or: fooks attach claude
-fooks run "Update src/components/FormSection.tsx"
-```
-
-`fooks run` prepares a shared handoff context file, then leaves execution to the runtime you already use (`codex`, `claude`, `omx`, etc.).
-
 Current support boundary:
 
+- Primary Codex user path today: `fooks setup`, then normal Codex usage through the installed hook preset
 - Shared terminal CLI proof today: `init`, `scan`, `decide`, `extract`, `run` handoff context, `attach codex`, `attach claude`
-- Codex-specific extras today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
+- Codex-specific advanced surfaces today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
 - Claude-specific status today: attach/runtime-manifest proof plus manual/shared handoff only; this repo does not yet ship a Claude-native hook installer, runtime bridge, `status claude`, or Claude runtime-token benchmark proof
 
 Claim boundary: Codex can use the in-repo runtime hook path for repeated-prompt context injection. Claude can consume reduced model-facing artifacts through manual/shared handoff, for example `fooks extract <file> --model-payload`, but this is **not** a claim of automatic Claude runtime token reduction.
@@ -241,7 +259,7 @@ The v1 bridge is intentionally narrow:
 - Repeated same-file work in one session
 - Quiet by default
 - Full-read escape hatch via `#fooks-full-read` or `#fooks-disable-pre-read`
-- Only active inside repos that already ran `fooks attach codex`
+- Only active inside repos that already ran `fooks setup` or `fooks attach codex`
 
 **Scope**: This is adapter-layer integration (CLI hooks), not browser/E2E runtime interception—those remain out of current Layer 2 scope.
 
@@ -268,7 +286,13 @@ For Codex native hook wiring, the repo-side bridge can also read the hook payloa
 fooks codex-runtime-hook --native-hook
 ```
 
-Preferred install path (writes or merges the Codex hook preset into `~/.codex/hooks.json`):
+Preferred user setup path (initializes the repo, attaches Codex, and writes or merges the Codex hook preset into `~/.codex/hooks.json`):
+
+```bash
+fooks setup
+```
+
+Advanced direct hook install path:
 
 ```bash
 fooks install codex-hooks

--- a/docs/cli/auto-mode-implementation-plan.md
+++ b/docs/cli/auto-mode-implementation-plan.md
@@ -142,9 +142,21 @@ compressed → hybrid → raw → error (no native degrade)
 
 ---
 
+## Current Setup Addendum
+
+The current preferred Codex activation path is now:
+
+```bash
+npm install -g fooks
+fooks setup
+# then use Codex normally
+```
+
+`fooks setup` is intentionally explicit and must not be replaced by an npm `postinstall` hook that silently edits `~/.codex/hooks.json`.
+
 ## Summary
 
-**Goal**: `npm install -g fooks && fooks init && fooks run "task"` first-success path
+**Goal**: `npm install -g fooks && fooks setup` one-time activation, followed by normal Codex usage. The older `fooks init && fooks run "task"` path remains useful as a handoff/validation flow, not the primary automatic activation path.
 
 **Key Decisions**:
 - Orchestration-centered: scan → decide → extract → fallback → execute

--- a/docs/cli/default-auto-mode-spec.md
+++ b/docs/cli/default-auto-mode-spec.md
@@ -152,7 +152,23 @@ Internal tooling exists for fooks vs vanilla comparison studies. Not exposed in 
 
 ## Quick Start Flow
 
-### First-Time User (3 steps)
+### Current preferred Codex setup flow
+
+The current safe activation contract is an explicit one-time setup command, not an npm install side effect:
+
+```bash
+# 1. Install
+npm install -g fooks
+
+# 2. Activate in the project root
+fooks setup
+
+# 3. Use Codex normally
+```
+
+`fooks setup` composes project initialization, Codex attach, hook preset install, and status-style reporting. Lower-level commands such as `init`, `attach codex`, and `install codex-hooks` remain available for validation/debugging.
+
+### Historical first-time user flow
 ```bash
 # 1. Install
 npm install -g fooks

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -80,6 +80,110 @@ async function resolveAttachSampleFile(cwd = process.cwd()): Promise<string> {
   return target.filePath;
 }
 
+async function initializeProject(cwd = process.cwd()): Promise<{ config: string; cacheDir: string; created: boolean }> {
+  const { ensureProjectDataDirs, configPath } = await import("../core/paths.js");
+  ensureProjectDataDirs(cwd);
+  const config = configPath(cwd);
+  const created = !fs.existsSync(config);
+  if (created) {
+    fs.writeFileSync(
+      config,
+      JSON.stringify(
+        {
+          version: 1,
+          createdAt: new Date().toISOString(),
+          targetAccount: process.env.FOOKS_TARGET_ACCOUNT ?? "minislively",
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  return { config, cacheDir: path.join(cwd, ".fooks", "cache"), created };
+}
+
+type SetupState = "ready" | "partial" | "blocked";
+
+async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Record<string, unknown>> {
+  const initialized = await initializeProject(cwd);
+  const blockers: string[] = [];
+
+  let sampleFile: string | null = null;
+  try {
+    sampleFile = await resolveAttachSampleFile(cwd);
+  } catch (error) {
+    blockers.push(error instanceof Error ? error.message : String(error));
+  }
+
+  if (!sampleFile) {
+    const { readCodexTrustStatus } = await import("../adapters/codex-runtime-trust.js");
+    return {
+      command: "setup",
+      runtime: "codex",
+      ready: false,
+      state: "blocked" satisfies SetupState,
+      initialized,
+      attach: null,
+      hooks: null,
+      status: readCodexTrustStatus(cwd),
+      blockers,
+      nextSteps: [
+        "Add a React/TSX component to this project, then run fooks setup again.",
+        "For non-React projects, use fooks extract/scan manually only if you know the files are supported.",
+      ],
+    };
+  }
+
+  const [{ attachCodex }, { installCodexHookPreset }, { readCodexTrustStatus }] = await Promise.all([
+    import("../adapters/codex.js"),
+    import("../adapters/codex-hook-preset.js"),
+    import("../adapters/codex-runtime-trust.js"),
+  ]);
+
+  const bridgeCommand = `${displayCliName} codex-runtime-hook --native-hook`;
+  const attach = attachCodex(sampleFile, cwd, bridgeCommand);
+  if (attach.runtimeProof.status === "blocked") {
+    blockers.push(attach.runtimeProof.blocker ?? "Codex attach blocked");
+  }
+
+  let hooks: ReturnType<typeof installCodexHookPreset> | null = null;
+  try {
+    hooks = installCodexHookPreset(displayCliName);
+  } catch (error) {
+    blockers.push(`Codex hook preset install failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const status = readCodexTrustStatus(cwd);
+  const allHookEventsReady = hooks ? hooks.installedEvents.length + hooks.skippedEvents.length === 3 : false;
+  const ready =
+    attach.runtimeProof.status === "passed" &&
+    allHookEventsReady &&
+    status.connectionState === "connected" &&
+    status.lifecycleState === "ready";
+  const state: SetupState = ready ? "ready" : "partial";
+
+  return {
+    command: "setup",
+    runtime: "codex",
+    ready,
+    state,
+    initialized,
+    attach,
+    hooks,
+    status,
+    blockers,
+    nextSteps: ready
+      ? [
+          "Open Codex in this repo and work normally; fooks will run through the installed Codex hooks.",
+          "Use fooks status codex if you want to inspect the runtime trust state.",
+        ]
+      : [
+          "Fix setup blockers, then run fooks setup again.",
+          "Use fooks status codex for current runtime state and inspect the blockers field above.",
+        ],
+  };
+}
+
 function parseExtractArgs(args: string[]): { filePath: string; modelPayload: boolean } {
   let filePath: string | undefined;
   let modelPayload = false;
@@ -184,24 +288,12 @@ async function run(): Promise<void> {
 
   switch (command) {
     case "init": {
-      const { ensureProjectDataDirs, configPath } = await import("../core/paths.js");
-      ensureProjectDataDirs();
-      const config = configPath();
-      if (!fs.existsSync(config)) {
-        fs.writeFileSync(
-          config,
-          JSON.stringify(
-            {
-              version: 1,
-              createdAt: new Date().toISOString(),
-              targetAccount: process.env.FOOKS_TARGET_ACCOUNT ?? "minislively",
-            },
-            null,
-            2,
-          ),
-        );
-      }
-      print({ config, cacheDir: path.join(process.cwd(), ".fooks", "cache") });
+      const { config, cacheDir } = await initializeProject(process.cwd());
+      print({ config, cacheDir });
+      return;
+    }
+    case "setup": {
+      print(await runSetup(displayCliName, process.cwd()));
       return;
     }
     case "run": {
@@ -339,7 +431,8 @@ async function run(): Promise<void> {
     }
     default:
       console.error(`Unknown command: ${command ?? "<none>"}`);
-      console.error(`Usage: ${displayCliName} <init|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>`);
+      console.error(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>`);
+      console.error(`       ${displayCliName} setup`);
       console.error(`       ${displayCliName} run <prompt>`);
       console.error(`       ${displayCliName} extract <file> [--model-payload] [--json]`);
       console.error(`       ${displayCliName} install codex-hooks`);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -995,6 +995,137 @@ test("model-facing payload trim hits >=15% reduction on at least two compressed/
   }
 });
 
+test("setup prepares explicit one-time Codex activation", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "minislively",
+    FOOKS_CODEX_HOME: codexHome,
+  });
+
+  assert.equal(result.command, "setup");
+  assert.equal(result.runtime, "codex");
+  assert.equal(result.ready, true);
+  assert.equal(result.state, "ready");
+  assert.ok(result.initialized.config.endsWith(path.join(".fooks", "config.json")));
+  assert.ok(fs.existsSync(path.join(tempDir, ".fooks", "config.json")));
+  assert.equal(result.attach.runtimeProof.status, "passed");
+  assert.ok(fs.existsSync(runtimeManifestPath(result.attach)));
+  assert.equal(result.hooks.command, "fooks codex-runtime-hook --native-hook");
+  assert.deepEqual(result.hooks.installedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
+  assert.equal(result.status.connectionState, "connected");
+  assert.equal(result.status.lifecycleState, "ready");
+  assert.ok(result.nextSteps.some((item) => item.includes("Codex")));
+
+  const hooks = JSON.parse(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"));
+  assert.equal(hooks.hooks.SessionStart[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
+  assert.equal(hooks.hooks.UserPromptSubmit[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
+  assert.equal(hooks.hooks.Stop[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
+});
+
+test("setup is idempotent and preserves unrelated Codex hooks", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const hooksPath = path.join(codexHome, "hooks.json");
+  fs.writeFileSync(hooksPath, JSON.stringify({
+    hooks: {
+      SessionStart: [{ matcher: "startup|resume", hooks: [{ type: "command", command: "node /tmp/omx-start.js" }] }],
+      UserPromptSubmit: [{ hooks: [{ type: "command", command: "node /tmp/omx.js" }] }],
+      Stop: [{ hooks: [{ type: "command", command: "node /tmp/omx-stop.js" }] }],
+    },
+  }, null, 2));
+
+  const env = { FOOKS_ACTIVE_ACCOUNT: "minislively", FOOKS_CODEX_HOME: codexHome };
+  const first = run(["setup"], tempDir, env);
+  assert.equal(first.ready, true);
+  assert.equal(first.hooks.modified, true);
+  assert.ok(first.hooks.backupPath);
+
+  const second = run(["setup"], tempDir, env);
+  assert.equal(second.ready, true);
+  assert.equal(second.hooks.modified, false);
+  assert.deepEqual(second.hooks.skippedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
+
+  const merged = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+  for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+    const commands = merged.hooks[event].flatMap((matcher) => matcher.hooks.map((hook) => hook.command));
+    assert.equal(commands.filter((command) => command === "fooks codex-runtime-hook --native-hook").length, 1);
+  }
+  assert.ok(merged.hooks.SessionStart.some((matcher) => matcher.hooks.some((hook) => hook.command === "node /tmp/omx-start.js")));
+  assert.ok(merged.hooks.UserPromptSubmit.some((matcher) => matcher.hooks.some((hook) => hook.command === "node /tmp/omx.js")));
+  assert.ok(merged.hooks.Stop.some((matcher) => matcher.hooks.some((hook) => hook.command === "node /tmp/omx-stop.js")));
+});
+
+test("setup reports partial activation without false ready claims when attach is blocked", () => {
+  const tempDir = makeTempProject("https://github.com/example-org/temp-project.git");
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "example-org",
+    FOOKS_CODEX_HOME: codexHome,
+  });
+
+  assert.equal(result.command, "setup");
+  assert.equal(result.ready, false);
+  assert.equal(result.state, "partial");
+  assert.equal(result.attach.runtimeProof.status, "blocked");
+  assert.ok(result.blockers.some((item) => item.includes("minislively account context not detected")));
+  assert.equal(result.hooks.command, "fooks codex-runtime-hook --native-hook");
+  assert.equal(fs.existsSync(path.join(codexHome, "hooks.json")), true);
+  assert.equal(fs.existsSync(path.join(codexHome, "fooks")), false);
+  assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
+});
+
+test("setup reports partial activation when Codex hooks cannot be parsed", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  fs.writeFileSync(path.join(codexHome, "hooks.json"), "{not-json");
+
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "minislively",
+    FOOKS_CODEX_HOME: codexHome,
+  });
+
+  assert.equal(result.command, "setup");
+  assert.equal(result.ready, false);
+  assert.equal(result.state, "partial");
+  assert.equal(result.attach.runtimeProof.status, "passed");
+  assert.equal(result.hooks, null);
+  assert.ok(result.blockers.some((item) => item.includes("Codex hook preset install failed")));
+  assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
+  assert.equal(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"), "{not-json");
+});
+
+test("setup reports blocked state for projects without React components", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-empty-"));
+  fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify({ name: "empty", repository: { url: "https://github.com/minislively/empty.git" } }, null, 2));
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+
+  const result = run(["setup"], tempDir, { FOOKS_CODEX_HOME: codexHome });
+
+  assert.equal(result.ready, false);
+  assert.equal(result.state, "blocked");
+  assert.equal(result.attach, null);
+  assert.equal(result.hooks, null);
+  assert.ok(result.blockers.some((item) => item.includes("No React/TSX component file found")));
+  assert.ok(result.nextSteps.some((item) => item.includes("Add a React/TSX component")));
+});
+
+test("cli usage advertises setup and package install has no auto hook side effects", () => {
+  let usage = "";
+  try {
+    runText(["unknown-command"]);
+  } catch (error) {
+    usage = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.match(usage, /setup/);
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  assert.equal(pkg.scripts?.postinstall, undefined);
+  assert.equal(pkg.scripts?.preinstall, undefined);
+});
+
 test("install codex-hooks creates a reusable hooks preset", () => {
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
   const result = run(["install", "codex-hooks"], repoRoot, { FOOKS_CODEX_HOME: codexHome });


### PR DESCRIPTION
## Summary
- Add `fooks setup` as the explicit one-time Codex activation path.
- Compose project initialization, Codex attach, hook preset installation, and runtime status reporting into one structured `ready | partial | blocked` response.
- Preserve package-install safety by avoiding `postinstall`/`preinstall` hook mutation and documenting advanced commands separately.
- Harden setup recovery so invalid/unparseable Codex hook files return `ready:false` with blockers instead of crashing.

## User impact
Regular Codex users can now run:

```bash
npm install -g fooks
fooks setup
# then use Codex normally
```

Maintainers still have the lower-level `init`, `attach codex`, and `install codex-hooks` commands for validation/debugging.

## Validation
- `npm run build`
- `node --test test/fooks.test.mjs --test-name-pattern "setup|install codex-hooks|attach codex"` — 53 pass, 0 fail
- `npm run lint`
- `git diff --check`
- `npm test` — 88 pass, 0 fail

## Notes
- Claude runtime parity remains intentionally out of scope for this Codex activation path.
- Real production permission-denied writes to a user's `~/.codex/hooks.json` were not manually simulated; setup now catches hook preset install failures and reports them as structured blockers.
