### PR TITLE
[codex] Document fooks setup onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run build
 fooks setup
 ```
 
-`fooks setup` initializes local `.fooks/` state, attaches the current repo to the Codex runtime, merges the fooks Codex hook preset into `~/.codex/hooks.json`, and reports whether the activation is `ready`, `partial`, or `blocked`. The setup command is explicit by design: package installation does **not** silently edit your Codex hooks.
+`fooks setup` initializes local `.fooks/` state, attaches the current repo to the Codex runtime, merges the fooks Codex hook preset into `~/.codex/hooks.json`, and reports whether the activation is `ready`, `partial`, or `blocked`. The setup command is explicit by design: package installation does **not** silently edit your Codex hooks. For setup output interpretation and troubleshooting, see [`docs/setup.md`](docs/setup.md).
 
 The shipping product name and all supported runtime/storage names are `fooks`.
 
@@ -79,7 +79,7 @@ Current support boundary:
 - Codex-specific advanced surfaces today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
 - Claude-specific status today: attach/runtime-manifest proof plus manual/shared handoff only; this repo does not yet ship a Claude-native hook installer, runtime bridge, `status claude`, or Claude runtime-token benchmark proof
 
-Claim boundary: Codex can use the in-repo runtime hook path for repeated-prompt context injection. Claude can consume reduced model-facing artifacts through manual/shared handoff, for example `fooks extract <file> --model-payload`, but this is **not** a claim of automatic Claude runtime token reduction.
+Claim boundary: Codex can use the in-repo runtime hook path for repeated-prompt context injection. Claude can consume reduced model-facing artifacts through manual/shared handoff, for example `fooks extract <file> --model-payload`, but this is **not** a claim that Claude receives automatic runtime savings.
 
 See [`docs/terminal-cli-validation-2026-04-19.md`](docs/terminal-cli-validation-2026-04-19.md) for the exact commands and current proof boundary on `main`.
 

--- a/docs/cli/auto-mode-implementation-plan.md
+++ b/docs/cli/auto-mode-implementation-plan.md
@@ -123,12 +123,13 @@ compressed → hybrid → raw → error (no native degrade)
 
 **Touched Files**:
 - `package.json` - Metadata, bin entry, dependencies
-- `README.md` - 3-step quick start, troubleshooting
+- `README.md` - concise first-success quick start
+- `docs/setup.md` - detailed setup output interpretation and troubleshooting
 
 **Acceptance Criteria**:
 - [ ] `npm install -g fooks` works
-- [ ] README has 3-step quick start without external docs
-- [ ] Troubleshooting covers common issues
+- [ ] README has a concise quick start and links to `docs/setup.md` for detailed setup guidance
+- [ ] `docs/setup.md` covers common setup blockers, verification, safe rerun, and manual rollback guidance
 
 **Risk**: Low
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,169 @@
+# Setup fooks for Codex
+
+This guide is the user-facing setup and recovery reference for enabling `fooks` in a Codex project.
+
+## Normal path
+
+Install the CLI, then activate it explicitly in the project root:
+
+```bash
+npm install -g fooks
+fooks setup
+# then open Codex in this repo and work normally
+```
+
+From a local checkout, build first:
+
+```bash
+npm run build
+fooks setup
+```
+
+`npm install -g fooks` installs the CLI only. It does not silently edit or mutate `~/.codex/hooks.json`; the Codex hook wiring happens only when you explicitly run `fooks setup`.
+
+## What `fooks setup` changes
+
+`fooks setup` composes the lower-level setup steps so normal users do not need to run them manually:
+
+- creates or reuses project-local `.fooks/` state;
+- finds a supported React/TSX/JSX component in the current project;
+- attaches the current repo to the Codex runtime;
+- explicitly merges the fooks Codex hook preset into `~/.codex/hooks.json`;
+- preserves unrelated Codex hooks when merging;
+- reports a structured result with `ready`, `state`, `blockers`, and `nextSteps`.
+
+The hook command installed for Codex is:
+
+```bash
+fooks codex-runtime-hook --native-hook
+```
+
+## Understand setup output
+
+`fooks setup` prints JSON. The most important fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `ready` | `true` only when attach, hook install, and Codex runtime status all look ready. |
+| `state` | One of `ready`, `partial`, or `blocked`. |
+| `blockers` | Human-readable reasons setup could not fully complete. |
+| `nextSteps` | Recovery guidance for the next command or manual check. |
+| `hooks` | Hook install/merge result, or `null` if hook setup failed. |
+| `status` | Current Codex runtime trust/status snapshot. |
+
+### `ready`
+
+`ready: true` and `state: "ready"` means setup completed. Open Codex in the repo and work normally.
+
+### `partial`
+
+`ready: false` and `state: "partial"` means some setup work succeeded, but one or more blockers remain. Common examples:
+
+- the project attached, but Codex hook installation could not parse or write `~/.codex/hooks.json`;
+- the hook preset was installed, but account/runtime proof is blocked;
+- the active account does not match the expected `minislively` context for this repository.
+
+Read `blockers`, follow `nextSteps`, fix the issue, then rerun:
+
+```bash
+fooks setup
+```
+
+### `blocked`
+
+`ready: false` and `state: "blocked"` means setup could not proceed far enough to activate Codex. The most common case is that no supported React/TSX/JSX component was found.
+
+For React projects, add or restore a supported component and rerun:
+
+```bash
+fooks setup
+```
+
+For non-React projects, the automatic Codex activation path may not apply. Use lower-level `fooks extract` or `fooks scan` only when you know the files are supported.
+
+## Verify setup
+
+After setup, inspect Codex status:
+
+```bash
+fooks status codex
+```
+
+Optional cache status check:
+
+```bash
+fooks status cache
+```
+
+For a successful setup, `fooks status codex` should show a connected/ready-style Codex state. If not, use the latest `fooks setup` output and its `blockers` / `nextSteps` fields as the source of truth.
+
+## Common blockers
+
+### No React/TSX component found
+
+`fooks setup` is designed for frontend React/TSX/JSX projects. If setup reports no component file was found, run it from the project root and confirm the project has a supported component file.
+
+### Account context mismatch
+
+Attach checks account context to avoid claiming a false activation. For this repository, the expected target account is `minislively`.
+
+Useful environment overrides for deterministic checks:
+
+```bash
+FOOKS_ACTIVE_ACCOUNT=minislively fooks setup
+FOOKS_TARGET_ACCOUNT=minislively fooks setup
+```
+
+### Codex runtime home is missing
+
+Codex hook installation uses the Codex home directory, normally `~/.codex`. Tests may override it with `FOOKS_CODEX_HOME`, but normal users usually should not need that.
+
+If the runtime home is missing or unavailable, open/configure Codex first, then rerun:
+
+```bash
+fooks setup
+```
+
+### `hooks.json` cannot be parsed or written
+
+If `~/.codex/hooks.json` is invalid JSON or cannot be written, setup reports `state: "partial"`, `hooks: null`, and a blocker such as `Codex hook preset install failed`.
+
+Fix or restore the hooks file, then rerun:
+
+```bash
+fooks setup
+```
+
+## Re-run and rollback safely
+
+`fooks setup` is intended to be safe to rerun:
+
+- existing fooks hook entries are skipped instead of duplicated;
+- unrelated Codex hooks are preserved;
+- if an existing hook file is modified, setup can report a `backupPath` for the previous file.
+
+Use rerun plus manual rollback for setup recovery; setup does not provide a separate CLI reset path. If you need to roll back hook changes, inspect the `backupPath` from setup output and manually restore or edit `~/.codex/hooks.json`.
+
+Project-local state lives under `.fooks/`. Treat it as local activation/cache state for this project, not as source code.
+
+## Advanced commands
+
+Normal users should start with `fooks setup`. These lower-level commands remain available for maintainers, debugging, and validation:
+
+```bash
+fooks attach codex
+fooks install codex-hooks
+fooks codex-runtime-hook --native-hook
+fooks init
+fooks scan
+fooks extract <file> --model-payload
+```
+
+Use them only when you are debugging a setup blocker or validating an adapter path directly.
+
+## Support boundaries
+
+- The primary supported automatic activation path today is Codex hook activation through `fooks setup`.
+- Package installation alone does not edit Codex hooks.
+- Claude support remains manual/shared handoff oriented unless a separate Claude-native hook installer is introduced in the future.
+- This setup guide does not make benchmark or marketing claims; it only explains installation, activation, verification, and recovery.


### PR DESCRIPTION
## Summary
- Add `docs/setup.md` as the canonical user-facing guide for `fooks setup`.
- Link the guide from the README Quick start so normal users can find output interpretation and troubleshooting without README bloat.
- Reconcile the older README-only troubleshooting note in `docs/cli/auto-mode-implementation-plan.md`.

## Context
PR #45 already merged the `fooks setup` activation UX. This follow-up keeps the docs aligned with that product path.

## User impact
Users now have a single guide for:
- `npm install -g fooks`
- `fooks setup`
- `ready` / `partial` / `blocked`
- `blockers` / `nextSteps`
- `fooks status codex`
- common blockers
- safe re-run and manual rollback via `backupPath`
- advanced command boundaries

## Validation
- `git diff --check`
- docs-specific required/forbidden grep checks from `.omx/plans/test-spec-docs-setup-ux.md`
- `npm run lint`
- `npm test` — 88 pass, 0 fail

## Notes
- Docs-only follow-up; no code behavior changes.
- Does not document or imply a `fooks reset` command.
- Does not claim Claude automatic runtime-token reduction.
