### PR TITLE
Prepare oh-my-fooks public package handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fooks
 
-Product / package / primary CLI name: `fooks`
+Product / primary CLI name: `fooks`
+Public npm package name: `oh-my-fooks`
 Local frontend-only context compression engine for React/TSX files.
 
 ## Validation
@@ -24,10 +25,10 @@ Phase 1 is intentionally narrow:
 
 ## Quick start
 
-Regular Codex users should use the one-time setup path:
+Regular Codex users should use the one-time setup path. The public npm package is `oh-my-fooks`, and it installs the `fooks` CLI command:
 
 ```bash
-npm install -g fooks
+npm install -g oh-my-fooks
 fooks setup
 # then open Codex in this repo and work normally
 ```
@@ -41,7 +42,7 @@ fooks setup
 
 `fooks setup` initializes local `.fooks/` state, attaches the current repo to the Codex runtime, merges the fooks Codex hook preset into `~/.codex/hooks.json`, and reports whether the activation is `ready`, `partial`, or `blocked`. The setup command is explicit by design: package installation does **not** silently edit your Codex hooks. For setup output interpretation and troubleshooting, see [`docs/setup.md`](docs/setup.md).
 
-The shipping product name and all supported runtime/storage names are `fooks`.
+The shipping product name and all supported runtime/storage names are `fooks`. The npm package name is `oh-my-fooks` to avoid the already-occupied npm package name `fooks`; users who already have a global `fooks` binary should check for command conflicts before installing. For release-prep checks, see [`docs/release.md`](docs/release.md).
 
 ## Everyday commands
 
@@ -143,7 +144,7 @@ Current verification snapshot:
     - scan startup sub-buckets (`pathsModuleImportMs`, `scanModuleImportMs`, `ensureProjectDataDirsMs`, `commandDispatchResidualMs`)
     - benchmark-harness overhead (`stdoutParseMsByScenario`, `bareNodeProcessAvgMs`, `cliBootstrapNoCommandAvgMs`, `cliBootstrapResidualAvgMs`, `artifactWriteMs`)
 - current optimization read: unchanged-file rereads are under control, measured `scan` startup work is much smaller than before, and the next remaining startup cost is largely explained by bare Node process launch plus a smaller CLI bootstrap residual
-- optimization follow-up ranking: [`docs/benchmark-phase-2-optimization-candidates.md`](docs/benchmark-phase-2-optimization-candidates.md)
+- optimization follow-up ranking: [`docs/archive/benchmark-phase-2-optimization-candidates.md`](docs/archive/benchmark-phase-2-optimization-candidates.md)
 - adoption guardrail for future launcher/helper work: [`docs/performance-vs-operational-complexity.md`](docs/performance-vs-operational-complexity.md)
 - real-environment validation checklist for launcher/helper decisions: [`docs/real-environment-process-model-validation.md`](docs/real-environment-process-model-validation.md)
 
@@ -205,7 +206,7 @@ python3 quick-test.py     # 5-10 min single test
 python3 full-benchmark-suite.py  # 30-60 min full suite
 ```
 
-See [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md) for detailed setup and reproduction instructions.
+See [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/README.md) for detailed setup and reproduction instructions.
 
 ## Model-facing payload
 
@@ -318,7 +319,7 @@ This keeps the product UX quiet by default while still exposing the minimum trus
 
 For a real-world feedback loop after installation, use the checklist in [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md).
 
-For the next Phase 2B step — validating remaining trust/refresh/source-of-truth risks in real usage — use [`docs/phase-2b-risk-validation-checklist.md`](docs/phase-2b-risk-validation-checklist.md).
+For the next Phase 2B step — validating remaining trust/refresh/source-of-truth risks in real usage — use the archived checklist in [`docs/archive/phase-2b-risk-validation-checklist.md`](docs/archive/phase-2b-risk-validation-checklist.md).
 
 If you prefer to edit the file manually, add this preset:
 
@@ -418,8 +419,9 @@ See `docs/real-repo-validation.md`.
 
 Canonical runtime/storage naming:
 
-- CLI / package name: `fooks`
+- CLI / runtime/storage name: `fooks`
+- npm package name: `oh-my-fooks`
 - project state dir: `.fooks/`
 - runtime-home manifest dir: `fooks/attachments`
 - supported env names: `FOOKS_*`
-- legacy removal record: [`docs/legacy-removal-checklist.md`](docs/legacy-removal-checklist.md)
+- legacy removal record: [`docs/archive/legacy-removal-checklist.md`](docs/archive/legacy-removal-checklist.md)

--- a/docs/archive/legacy-removal-checklist.md
+++ b/docs/archive/legacy-removal-checklist.md
@@ -1,11 +1,14 @@
 # Naming Canonicalization Record
 
+> Archive note: this document predates the public npm package rename. Current public npm installs use `oh-my-fooks`, while the CLI/runtime/storage name remains `fooks`.
+
+
 The repo now supports only canonical `fooks` naming for CLI, project state,
 runtime manifests, and environment variables.
 
 ## Completed cleanup
 
-- public CLI/package/runtime naming converged on `fooks`
+- public CLI/runtime naming converged on `fooks`; public npm package installs now use `oh-my-fooks`
 - project state naming converged on `.fooks/`
 - environment variable naming converged on `FOOKS_*`
 - tests and docs were updated to canonical names only
@@ -14,6 +17,6 @@ runtime manifests, and environment variables.
 
 Keep future changes aligned to canonical names only:
 
-- CLI / package / hook command: `fooks`
+- CLI / hook command: `fooks`; public npm package: `oh-my-fooks`
 - project state dir: `.fooks/`
 - env names: `FOOKS_*`

--- a/docs/archive/rename-migration-notes.md
+++ b/docs/archive/rename-migration-notes.md
@@ -1,5 +1,8 @@
 # Rename / Migration Notes
 
+> Archive note: this document predates the public npm package rename. Current public npm installs use `oh-my-fooks`, while the CLI/runtime/storage name remains `fooks`.
+
+
 ## Decision
 
 `fooks` does **not** implement rename-aware or migration-aware behavior in PHASE 1.
@@ -62,7 +65,7 @@ Current rule:
 
 - `.fooks` is the only supported internal project-state path
 - `FOOKS_*` is the only supported env prefix
-- `fooks` is the only supported CLI/package/runtime name
+- `fooks` is the historical CLI/runtime/storage name; current public npm package installs use `oh-my-fooks`
 - future rename work should stay on canonical `fooks` naming only
 
 For the completed removal record, see

--- a/docs/cli/auto-mode-implementation-plan.md
+++ b/docs/cli/auto-mode-implementation-plan.md
@@ -127,7 +127,7 @@ compressed → hybrid → raw → error (no native degrade)
 - `docs/setup.md` - detailed setup output interpretation and troubleshooting
 
 **Acceptance Criteria**:
-- [ ] `npm install -g fooks` works
+- [ ] `npm install -g oh-my-fooks` works
 - [ ] README has a concise quick start and links to `docs/setup.md` for detailed setup guidance
 - [ ] `docs/setup.md` covers common setup blockers, verification, safe rerun, and manual rollback guidance
 
@@ -148,7 +148,7 @@ compressed → hybrid → raw → error (no native degrade)
 The current preferred Codex activation path is now:
 
 ```bash
-npm install -g fooks
+npm install -g oh-my-fooks
 fooks setup
 # then use Codex normally
 ```
@@ -157,7 +157,7 @@ fooks setup
 
 ## Summary
 
-**Goal**: `npm install -g fooks && fooks setup` one-time activation, followed by normal Codex usage. The older `fooks init && fooks run "task"` path remains useful as a handoff/validation flow, not the primary automatic activation path.
+**Goal**: `npm install -g oh-my-fooks && fooks setup` one-time activation, followed by normal Codex usage. The older `fooks init && fooks run "task"` path remains useful as a handoff/validation flow, not the primary automatic activation path.
 
 **Key Decisions**:
 - Orchestration-centered: scan → decide → extract → fallback → execute

--- a/docs/cli/default-auto-mode-spec.md
+++ b/docs/cli/default-auto-mode-spec.md
@@ -158,7 +158,7 @@ The current safe activation contract is an explicit one-time setup command, not 
 
 ```bash
 # 1. Install
-npm install -g fooks
+npm install -g oh-my-fooks
 
 # 2. Activate in the project root
 fooks setup
@@ -171,7 +171,7 @@ fooks setup
 ### Historical first-time user flow
 ```bash
 # 1. Install
-npm install -g fooks
+npm install -g oh-my-fooks
 
 # 2. Initialize (in project root)
 fooks init
@@ -180,11 +180,9 @@ fooks init
 fooks run "Add loading spinner to login button"
 ```
 
-### npx Path (no install)
-```bash
-npx fooks init
-npx fooks run "Fix form validation"
-```
+### No bare npx path
+
+Do not use a bare npx invocation targeting the occupied `fooks` package in public docs. The unscoped npm package name `fooks` is occupied by another owner, so public no-install examples must be package-qualified and separately verified before they are documented.
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,80 @@
+# Public release checklist
+
+This checklist prepares `fooks` for public npm distribution without publishing it by accident.
+
+## Package and CLI boundary
+
+- npm package name: `oh-my-fooks`
+- installed CLI command: `fooks`
+- install command: `npm install -g oh-my-fooks`
+- first setup command: `fooks setup`
+
+The npm package name intentionally differs from the CLI command because the unscoped npm package `fooks` is already occupied by another owner. Public docs must not tell users to globally install the occupied `fooks` npm package unless that ownership situation changes and a new release plan is approved.
+
+A user who already has another global `fooks` binary may see command conflicts. Ask them to inspect their global npm binaries before installing or reinstall into a clean prefix when debugging:
+
+```bash
+which fooks
+npm prefix -g
+npm ls -g --depth=0 | grep -E 'fooks|oh-my-fooks'
+```
+
+## Pre-publish blockers
+
+Do not run `npm publish` without explicit approval after this checklist is reviewed.
+
+Before any real publish, confirm:
+
+- [ ] `npm view oh-my-fooks` still confirms the name/state expected for release.
+- [ ] `npm whoami` shows the intended publishing account.
+- [ ] package version and Git tag strategy are decided.
+- [ ] license decision is explicit and reflected in package metadata if required.
+- [ ] package/CLI boundary is documented: `oh-my-fooks` installs `fooks`.
+- [ ] possible pre-existing global `fooks` binary conflict is documented.
+- [ ] no install, pack, publish, or version lifecycle script mutates user machines or publishes implicitly.
+- [ ] packed tarball includes `dist/cli/index.js`, `dist/index.js`, `README.md`, `package.json`, and linked docs.
+- [ ] temp-prefix global install smoke test passes.
+- [ ] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
+
+## Verification commands
+
+Run these before discussing publication:
+
+```bash
+npm run lint
+npm test
+npm pack --dry-run --json > /tmp/oh-my-fooks-pack.json
+rm -rf /tmp/fooks-pack
+mkdir -p /tmp/fooks-pack
+npm pack --pack-destination /tmp/fooks-pack
+```
+
+Then install the produced tarball into a temporary global prefix and verify the packed CLI path:
+
+```bash
+TMP_PREFIX=$(mktemp -d)
+TARBALL=$(ls /tmp/fooks-pack/oh-my-fooks-*.tgz | tail -n 1)
+npm install -g --prefix "$TMP_PREFIX" "$TARBALL"
+"$TMP_PREFIX/bin/fooks" status cache
+```
+
+Finally, verify setup command routing from a disposable React/TSX-style project with isolated runtime homes:
+
+```bash
+TMP_HOME=$(mktemp -d)
+TMP_PROJECT=$(mktemp -d)
+mkdir -p "$TMP_HOME/codex" "$TMP_PROJECT/src"
+printf '{"scripts":{}}\n' > "$TMP_PROJECT/package.json"
+printf 'export function App(){ return <main>Hello</main>; }\n' > "$TMP_PROJECT/src/App.tsx"
+(
+  cd "$TMP_PROJECT"
+  HOME="$TMP_HOME/home" \
+  XDG_CONFIG_HOME="$TMP_HOME/config" \
+  FOOKS_CODEX_HOME="$TMP_HOME/codex" \
+  FOOKS_ACTIVE_ACCOUNT=minislively \
+  FOOKS_TARGET_ACCOUNT=minislively \
+  "$TMP_PREFIX/bin/fooks" setup
+)
+```
+
+The release-prep PR must state that `npm publish` was not run.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,10 +4,10 @@ This guide is the user-facing setup and recovery reference for enabling `fooks` 
 
 ## Normal path
 
-Install the CLI, then activate it explicitly in the project root:
+Install the public npm package, then activate the installed `fooks` CLI explicitly in the project root:
 
 ```bash
-npm install -g fooks
+npm install -g oh-my-fooks
 fooks setup
 # then open Codex in this repo and work normally
 ```
@@ -19,7 +19,16 @@ npm run build
 fooks setup
 ```
 
-`npm install -g fooks` installs the CLI only. It does not silently edit or mutate `~/.codex/hooks.json`; the Codex hook wiring happens only when you explicitly run `fooks setup`.
+`npm install -g oh-my-fooks` installs the `fooks` CLI only. It does not silently edit or mutate `~/.codex/hooks.json`; the Codex hook wiring happens only when you explicitly run `fooks setup`. The package name is `oh-my-fooks` because the unscoped npm package name `fooks` is already occupied by another owner.
+
+## Package name vs CLI command
+
+The package and command names intentionally differ:
+
+- install package: `oh-my-fooks`
+- run command: `fooks`
+
+If another tool already installed a global `fooks` binary, your shell may resolve that command first. Check `which fooks` and your global npm prefix if setup appears to run an unexpected binary.
 
 ## What `fooks setup` changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "fooks",
+  "name": "oh-my-fooks",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fooks",
+      "name": "oh-my-fooks",
       "version": "0.1.0",
+      "dependencies": {
+        "typescript": "^5.9.2"
+      },
       "bin": {
         "fooks": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@types/node": "^24.5.2",
-        "typescript": "^5.9.2"
+        "@types/node": "^24.5.2"
       }
     },
     "node_modules/@types/node": {
@@ -29,7 +31,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "fooks",
+  "name": "oh-my-fooks",
   "version": "0.1.0",
-  "private": true,
   "type": "commonjs",
   "bin": {
     "fooks": "dist/cli/index.js"
@@ -22,13 +21,13 @@
     "lint": "npm run typecheck -- --pretty false"
   },
   "devDependencies": {
-    "@types/node": "^24.5.2",
-    "typescript": "^5.9.2"
+    "@types/node": "^24.5.2"
   },
-  "description": "fooks repository containing the frontend context compression engine for React/TSX.",
+  "description": "Frontend context compression CLI for React/TSX projects; npm package oh-my-fooks installs the fooks command.",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "docs"
   ],
   "repository": {
     "type": "git",
@@ -37,5 +36,8 @@
   "bugs": {
     "url": "https://github.com/minislively/fooks/issues"
   },
-  "homepage": "https://github.com/minislively/fooks#readme"
+  "homepage": "https://github.com/minislively/fooks#readme",
+  "dependencies": {
+    "typescript": "^5.9.2"
+  }
 }


### PR DESCRIPTION
## Summary

- prepares the public npm package name as `oh-my-fooks` while preserving the installed `fooks` CLI command
- updates setup/public docs to use `npm install -g oh-my-fooks` and documents package/CLI boundary plus global `fooks` binary conflict risk
- adds `docs/release.md` with publish blockers and smoke-test checklist
- moves `typescript` to production dependencies because packed `fooks setup` imports the extraction path at runtime
- packs `docs` and repairs README relative links / stale archived naming notes

## Release boundary

This PR is release preparation only.

- `npm publish` was **not** run.
- GitHub Release/tag creation was **not** run.
- npm login/account changes were **not** run.
- License selection remains a publish blocker pending explicit approval.

## Verification

- `npm run lint` — PASS
- `npm test` — PASS, 88 tests
- static package/docs checks — PASS
  - `package.json.name === "oh-my-fooks"`
  - `bin.fooks === "dist/cli/index.js"`
  - no install/pack/publish/version lifecycle hooks
  - no stale `npm install -g fooks`, `npx fooks`, or `npm exec fooks` public surfaces
- `npm pack --dry-run --json` — PASS
  - pack name `oh-my-fooks`
  - includes `dist/index.js`, `dist/cli/index.js`, `README.md`, `docs/setup.md`, `docs/release.md`
  - README relative links are packed or absolute
- temp-prefix tarball install — PASS
- packed `fooks status cache` — PASS
- isolated temp `HOME`/`CODEX_HOME` `fooks setup` — PASS, `ready: true`, `blockers: []`
- `npm view oh-my-fooks` — E404/unavailable, expected pre-publish/name-availability signal but must be rechecked before actual publish
- `npm whoami` — ENEEDAUTH, recorded publish blocker

## Notes

Architect review initially requested iteration for stale bare `npx fooks` docs and untracked `docs/release.md`; both were fixed and re-reviewed as APPROVE.
