### PR TITLE
Add MIT license for public package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 minislively
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "oh-my-fooks",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "typescript": "^5.9.2"
       },

--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   "homepage": "https://github.com/minislively/fooks#readme",
   "dependencies": {
     "typescript": "^5.9.2"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary

- adds an MIT `LICENSE` file with `Copyright (c) 2026 minislively`
- adds `"license": "MIT"` to `package.json`
- updates `package-lock.json` root metadata to include the MIT license

## Why

The package is now prepared for public npm testing as `oh-my-fooks`, but it should not remain license-ambiguous for public users. MIT keeps installation/reuse friction low for early public feedback.

## Verification

- `npm whoami` → `minislively`
- `npm run lint` — PASS
- `npm test` — PASS, 88 tests
- license static check — PASS
  - `package.json.license === "MIT"`
  - `package-lock.json.packages[""].license === "MIT"`
  - `LICENSE` includes `Copyright (c) 2026 minislively`
- `npm pack --dry-run --json` — PASS
  - pack name `oh-my-fooks`
  - includes `LICENSE`
  - total files: 111
- `npm view oh-my-fooks` — E404/unavailable; recheck before actual publish

## Release boundary

`npm publish` was **not** run.
