### PR TITLE
sanitize: remove absolute paths for public release

### DIFF
--- a/docs/terminal-cli-validation-2026-04-19.md
+++ b/docs/terminal-cli-validation-2026-04-19.md
@@ -34,7 +34,7 @@ claude --version
 
 ## Validation performed
 
-All commands below were run on 2026-04-19 from `/home/bellman/Workspace/fooks` after `npm run build`.
+All commands below were run on 2026-04-19 from `<repository-root>` after `npm run build`.
 
 ### 1. Codex attach path
 

--- a/test/benchmark-v2-large-mixed.test.mjs
+++ b/test/benchmark-v2-large-mixed.test.mjs
@@ -6,7 +6,7 @@ import { createRequire } from "node:module";
 import ts from "typescript";
 
 const repoRoot = process.cwd();
-const samplePath = "/home/bellman/Workspace/fooks-test-repos/cal.com/packages/app-store/hitpay/components/EventTypeAppSettingsInterface.tsx";
+const samplePath = path.join(repoRoot, "test/fixtures/cal.com/packages/app-store/hitpay/components/EventTypeAppSettingsInterface.tsx");
 const require = createRequire(import.meta.url);
 
 function loadTsModule(filePath, cache = new Map()) {


### PR DESCRIPTION
## Summary
Sanitize absolute paths for public package release.

## Changes
- docs/terminal-cli-validation-2026-04-19.md:  → 
- test/benchmark-v2-large-mixed.test.mjs: hardcoded absolute path → 

## Refs
Public package sanitization requirements