### PR TITLE
[codex] Simplify public fooks docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,448 +1,112 @@
 # fooks
 
-Product / primary CLI name: `fooks`
-Public npm package name: `oh-my-fooks`
-Local frontend-only context compression engine for React/TSX files.
+Frontend context compression for Codex.
 
-## Validation
+Public npm package: `oh-my-fooks`  
+CLI command: `fooks`
 
-- Agent-neutral terminal CLI validation on current `main` (2026-04-19): [`docs/terminal-cli-validation-2026-04-19.md`](docs/terminal-cli-validation-2026-04-19.md)
-
-## What it does
-
-`fooks` reduces AI read cost before a coding runtime opens full frontend source by returning one of:
-
-- `raw`
-- `compressed`
-- `hybrid`
-
-Phase 1 is intentionally narrow:
-
-- React / TSX / JSX focused
-- same-folder linked `.ts` only (`type` imports, props/interface/type aliases, adjacent util/helper files)
-- local scan / extract / decide / attach flow
-- runtime-agnostic core schema with thin adapters
+`fooks` helps Codex avoid rereading the same React component source over and over. In an attached Codex project, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time.
 
 ## Quick start
 
-Regular Codex users should use the one-time setup path. The public npm package is `oh-my-fooks`, and it installs the `fooks` CLI command:
-
 ```bash
 npm install -g oh-my-fooks
-fooks setup
-# then open Codex in this repo and work normally
-```
-
-From a local checkout, build first and run the same explicit setup step:
-
-```bash
-npm run build
+cd your-react-project
 fooks setup
 ```
 
-`fooks setup` initializes local `.fooks/` state, attaches the current repo to the Codex runtime, merges the fooks Codex hook preset into `~/.codex/hooks.json`, and reports whether the activation is `ready`, `partial`, or `blocked`. The setup command is explicit by design: package installation does **not** silently edit your Codex hooks. For setup output interpretation and troubleshooting, see [`docs/setup.md`](docs/setup.md).
+Then open Codex in that repo and work normally.
 
-The shipping product name and all supported runtime/storage names are `fooks`. The npm package name is `oh-my-fooks` to avoid the already-occupied npm package name `fooks`; users who already have a global `fooks` binary should check for command conflicts before installing. For release-prep checks, see [`docs/release.md`](docs/release.md).
+`fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks.
+
+## What gets optimized
+
+Current automatic optimization is intentionally narrow:
+
+- Runtime: Codex hooks
+- Files: `.tsx` and `.jsx`
+- Pattern: repeated same-file work in one Codex session
+- First mention: record only
+- Later same-file mentions: reuse a compact fooks payload when safe
+
+This is best for iterative frontend component work such as:
+
+```text
+Review src/components/Form.tsx.
+Now update src/components/Form.tsx validation copy.
+One more change in src/components/Form.tsx: add disabled state.
+```
+
+If fooks cannot safely build a payload, it falls back to normal full-source behavior.
 
 ## Everyday commands
 
 ```bash
-fooks setup
-fooks run "<prompt>"
-fooks status codex
-fooks status cache
+fooks setup          # one-time Codex activation for this repo
+fooks status codex   # check Codex attach/hook state
+fooks status cache   # check local fooks cache health
 ```
 
-`fooks run` prepares a shared handoff context file, then leaves execution to the runtime you already use (`codex`, `claude`, `omx`, etc.).
-
-## Advanced / validation commands
-
-These remain available for maintainers, benchmark validation, and debugging, but regular users should not need them for the first-success path:
+For manual inspection:
 
 ```bash
-fooks init
+fooks extract src/components/Button.tsx --model-payload
 fooks scan
-fooks extract <file> --json
-fooks extract <file> --model-payload
-fooks decide <file>
-fooks codex-pre-read <file>
-fooks codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop>
-fooks codex-runtime-hook --native-hook
-fooks install codex-hooks
-fooks install opencode-tool
-fooks attach codex
-fooks attach claude
 ```
 
-Current support boundary:
+## opencode support
 
-- Primary Codex user path today: `fooks setup`, then normal Codex usage through the installed hook preset
-- Shared terminal CLI proof today: `init`, `scan`, `decide`, `extract`, `run` handoff context, `attach codex`, `attach claude`
-- Codex-specific advanced surfaces today: `codex-pre-read`, `codex-runtime-hook`, `install codex-hooks`, `status codex`
-- Claude-specific status today: attach/runtime-manifest proof plus manual/shared handoff only; this repo does not yet ship a Claude-native hook installer, runtime bridge, `status claude`, or Claude runtime-token benchmark proof
-- opencode-specific support today: `install opencode-tool` creates a project-local `.opencode/tools/fooks_extract.ts` custom tool for manual/semi-automatic extraction; this repo does not yet ship opencode read interception, automatic runtime-token savings, or opencode benchmark proof
-
-Claim boundary: Codex can use the in-repo runtime hook path for repeated-prompt context injection. Claude and opencode can consume reduced model-facing artifacts through manual/shared handoff, for example `fooks extract <file> --model-payload` or the generated `fooks_extract` opencode custom tool, but this is **not** a claim that Claude or opencode receives automatic runtime savings.
-
-## opencode custom tool support
-
-opencode support is intentionally manual/semi-automatic in this MVP. Install a project-local custom tool from the project root:
+opencode support is **manual/semi-automatic** today. It does not intercept opencode `read` calls and does not claim automatic runtime-token savings.
 
 ```bash
 fooks install opencode-tool
 ```
 
-This creates `.opencode/tools/fooks_extract.ts`. In opencode, ask the model to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload. The generated tool validates that the requested file stays inside the current opencode project/worktree and calls:
+This creates a project-local custom-tool:
 
-```bash
-fooks extract <file> --model-payload
+```text
+.opencode/tools/fooks_extract.ts
 ```
 
-This custom tool does **not** intercept opencode `read` calls, does **not** install a `tool.execute.before` read replacement hook, and does **not** establish an opencode runtime-token benchmark claim. Automatic opencode context interception is a separate future project that needs its own quality and token measurements.
+Use it when you want opencode to request a fooks payload for a `.tsx` or `.jsx` file.
 
-See [`docs/terminal-cli-validation-2026-04-19.md`](docs/terminal-cli-validation-2026-04-19.md) for the exact commands and current proof boundary on `main`.
+## Support boundaries
 
-## Account context
+- Codex: automatic repeated-file hook path is supported.
+- Claude and opencode: can consume fooks payloads through manual/shared handoff paths.
+- Claude and opencode do **not** currently have automatic runtime-token savings claims in this repo.
+- fooks is not a universal file-read interceptor.
+- Non-frontend files usually fall back to normal source reading.
 
-Attach commands resolve account context in this order:
+## Troubleshooting
 
-1. `FOOKS_ACTIVE_ACCOUNT`
-2. `.fooks/config.json` `targetAccount`
-3. `git remote get-url origin`
-4. `package.json.repository`
-
-For this project, the expected target account is `minislively`.
-
-## Environment detection proof
-
-Attach uses two proof layers:
-
-- **contract proof**: verifies adapter consumption of the core schema
-- **environment proof**: writes an adapter manifest into a detected config home
-
-Environment overrides for deterministic verification:
-
-- `FOOKS_CODEX_HOME`
-- `FOOKS_CLAUDE_HOME`
-- `FOOKS_TARGET_ACCOUNT`
-- `FOOKS_ACTIVE_ACCOUNT`
-
-If a config home is missing, attach returns an explicit blocker instead of a false success.
-
-**Note**: This is adapter-layer integration (codex/omx hooks), not browser/E2E runtime interception—those remain out of current Layer 2 scope.
-
-## Verification snapshot
-
-Current verification snapshot:
-
-- `npm run typecheck`
-- `npm test`
-- `npm run bench:cache`
-- `npm run bench:extract`
-- `npm run bench:stability`
-- `npm run bench:gate`
-- `npm run bench`
-- TypeScript diagnostics: 0 errors
-- value-proof:
-  - `FormSection.tsx`: 34.59% reduction
-  - `DashboardPanel.tsx`: 46.63% reduction
-- latest benchmark baseline (real-world usage):
-  - **cyberthug-screenclone** (14 components): **warm 226ms**
-  - **shadcn-ui** (2,967 components): **cold 5.45s**
-  - **Token savings rate**: **86.9%** verified (fixture baseline: 53.55ms warm)
-  - **Fixture baseline** (81 files): **cold 312ms / warm 49.5ms** (updated 2026-04-14)
-  - Definitions:
-    - **Cold**: First run (no cache built)
-    - **Warm**: Subsequent runs (cache already built)
-  - scan observability captures:
-    - step timings (`discovery`, `stat`, `fileRead`, `hash`, `cacheRead`, `extract`, `cacheWrite`, `indexWrite`, `total`)
-    - skip/hit/miss structure (`metadataReuseCount`, `fileReadCount`, `reparsedFileCount`)
-    - top slow files per scenario
-    - outside-scan command-path breakdown (`commandDispatchMs`, `resultSerializeMs`, `stdoutWriteMs`, `commandPathUnattributedMs`)
-    - scan startup sub-buckets (`pathsModuleImportMs`, `scanModuleImportMs`, `ensureProjectDataDirsMs`, `commandDispatchResidualMs`)
-    - benchmark-harness overhead (`stdoutParseMsByScenario`, `bareNodeProcessAvgMs`, `cliBootstrapNoCommandAvgMs`, `cliBootstrapResidualAvgMs`, `artifactWriteMs`)
-- current optimization read: unchanged-file rereads are under control, measured `scan` startup work is much smaller than before, and the next remaining startup cost is largely explained by bare Node process launch plus a smaller CLI bootstrap residual
-- optimization follow-up ranking: [`docs/archive/benchmark-phase-2-optimization-candidates.md`](docs/archive/benchmark-phase-2-optimization-candidates.md)
-- adoption guardrail for future launcher/helper work: [`docs/performance-vs-operational-complexity.md`](docs/performance-vs-operational-complexity.md)
-- real-environment validation checklist for launcher/helper decisions: [`docs/real-environment-process-model-validation.md`](docs/real-environment-process-model-validation.md)
-
-## Frontend Benchmark Harness (vs vanilla Codex)
-
-Real-world benchmark comparing **vanilla Codex** vs **fooks-enabled Codex** on frontend tasks.
-
-Claim-safety note: the benchmark numbers below are historical Codex-oriented estimates/proxy measurements unless a row explicitly says it was measured as live runtime tokens. They should not be read as Claude or opencode runtime-token savings, nor as Claude/opencode benchmark wins.
-
-### Latest Results (2026-04-14 Final Rerun)
-
-| Metric | Vanilla | Fooks | Improvement | Note |
-|--------|---------|-------|-------------|------|
-| **Token Reduction** | ~2.1M tokens (est.) | ~450K tokens (est.) | **-78.2%** | Real repos (shadcn-ui, cal.com) |
-| **Execution Time** | 98,216ms (avg) | 77,929ms (avg) | **+20.7% faster** | T1-T5 tasks average |
-| **Tokens Saved** | - | **~1.76M per session** (est.) | - | Estimated from sample runs |
-| **Success Rate** | 100% (5/5) | 100% (5/5) | - | All task levels |
-| **Component Compression** | - | 7x-15x | - | Large components (17KB-42KB) |
-| **Tiny Overhead** | - | ~2x | - | <500B files, acceptable |
-
-**Verified Component-like Files (after all fixes):**
-- EventLimitsTab.tsx (41KB) → 3,115 bytes (**13.5x**)
-- AvailabilitySettings.tsx (29KB) → 1,988 bytes (**14.9x**)
-- shadcn page.tsx (5.7KB) → 421 bytes (**13.8x**)
-
-**Excluded from component benchmark:**
-- icons.tsx (18KB, 154 exports) → data-like
-- story-helpers.tsx (12KB, no componentName) → helper
-
-**Tested on:**
-- shadcn-ui (2,967 TSX files)
-- cal.com (1,691 TSX files)
-- nextjs (28,614 TSX files) - meta-framework extraction (20 files tested)
-- tailwindcss (2,500 TS files) - CSS framework extraction (20 files tested)
-- 5 tasks: Button Relocation → Form Validation (easy → hard)
-
-**Framework Extraction Reference (2026-04-16 Expanded):**
-| Repo | Total Files | Raw Mode | Extract/Hybrid | Reference Compression Ratio | Notes |
-|------|-------------|----------|----------------|----------------------------|-------|
-| nextjs | 20 | 11 (55%) | 9 (45%) | **55.7% smaller (extract mode)** | Small files dominant; reference only, not task parity |
-| tailwindcss | 20 | 5 (25%) | 15 (75%) | **77.8% smaller (extract mode)** | AST parsing heavy; reference only, not task parity |
-
-- Expanded from 5 files to 20 files per repo (size-distributed sampling)
-- Raw mode overhead is expected (JSON metadata wrapper); actual delivery uses `useOriginal: true` for tiny files
-- Framework repos are **extraction-test-reference only** — not comparative gating, not task parity benchmark, and not runtime-token proof for Claude or opencode
-
-**Fixes applied since previous run:**
-- AST-based styleBranching detection (tiny files now raw correctly)
-- componentName requirement for hybrid (helper files excluded)
-- exports <= 20 limit (data-like files excluded)
-
-**Location:** `benchmarks/frontend-harness/`
-
-**Quick reproduction:**
-```bash
-cd benchmarks/frontend-harness/runners
-python3 setup.py          # Check environment
-python3 quick-test.py     # 5-10 min single test
-python3 full-benchmark-suite.py  # 30-60 min full suite
-```
-
-See [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/README.md) for detailed setup and reproduction instructions.
-
-## Model-facing payload
-
-`extract` keeps the canonical extraction output by default. For a leaner LLM-delivery view:
-
-```bash
-fooks extract fixtures/compressed/FormSection.tsx --model-payload
-```
-
-The model-facing payload:
-
-- keeps `mode`, relative `filePath`, `componentName`, `exports`
-- keeps `contract`, `behavior`, `structure`, minimal `style`
-- keeps `snippets` for hybrid outputs
-- for tiny raw files (`raw` mode and source under 500 bytes), sets `useOriginal: true` and returns only the original source payload
-- drops engine metadata such as `fileHash` and `meta.generatedAt`
-
-## Codex pre-read decision seam
-
-The first Codex-specific pre-read seam is exposed as a debug surface:
-
-```bash
-fooks codex-pre-read fixtures/compressed/FormSection.tsx
-```
-
-It is intentionally narrow in v1:
-
-- `.tsx/.jsx` only
-- payload-first, never payload-only
-- falls back to `full-read` for:
-  - `raw-mode` (except tiny raw files under 500 bytes, which reuse the original source as a minimal payload)
-  - `missing-contract`
-  - `missing-behavior`
-  - `missing-structure`
-  - `missing-hybrid-snippets`
-  - `ineligible-extension`
-
-This command proves the decision/debug seam that a future automatic Codex hook can reuse. It is **not** the full runtime-wide interception layer yet.
-
-## Codex adapter hook bridge
-
-`fooks` exposes an adapter hook bridge grounded in Codex CLI hook surfaces:
-
-- `SessionStart`
-- `UserPromptSubmit`
-- `Stop`
-
-The v1 bridge is intentionally narrow:
-
-- `.tsx/.jsx` only
-- Repeated same-file work in one session
-- Quiet by default
-- Advanced full-read override for diagnostics
-- Only active inside repos that already ran `fooks setup` or `fooks attach codex`
-
-**Scope**: This is adapter-layer integration (CLI hooks), not browser/E2E runtime interception—those remain out of current Layer 2 scope.
-
-Example debug flow:
-
-```bash
-fooks codex-runtime-hook --event SessionStart --session-id demo
-fooks codex-runtime-hook --event UserPromptSubmit --session-id demo --prompt "Please update fixtures/compressed/FormSection.tsx"
-fooks codex-runtime-hook --event UserPromptSubmit --session-id demo --prompt "Again, update fixtures/compressed/FormSection.tsx"
-```
-
-Expected behavior:
-
-- first prompt mention records the file quietly
-- second prompt mention can reuse `fooks` pre-read payload and emits a one-line header like `fooks: reused pre-read (<mode>) · file: <path>`
-- advanced override requests force immediate full-read fallback and emit `fooks: full read requested · file: <path> · Read the full source file for this turn.`
-- readiness fallback emits `fooks: fallback (<reason>) · file: <path> · Read the full source file for this turn.`
-
-This is a **prompt/session bridge**, not a claim that Codex already exposes a universal low-level file-read hook.
-
-For Codex native hook wiring, the repo-side bridge can also read the hook payload from stdin:
-
-```bash
-fooks codex-runtime-hook --native-hook
-```
-
-Preferred user setup path (initializes the repo, attaches Codex, and writes or merges the Codex hook preset into `~/.codex/hooks.json`):
+If setup does not report ready:
 
 ```bash
 fooks setup
-```
-
-Advanced direct hook install path:
-
-```bash
-fooks install codex-hooks
-fooks install opencode-tool
-```
-
-The installer is idempotent: it only adds the `fooks codex-runtime-hook --native-hook` command to `SessionStart`, `UserPromptSubmit`, and `Stop` when those entries are missing, and preserves other hooks already present in `~/.codex/hooks.json`.
-
-The opencode tool installer is also explicit and idempotent, but project-local: it creates `.opencode/tools/fooks_extract.ts` for manual/semi-automatic custom-tool use and does not edit Codex hooks or global opencode config.
-
-For lightweight trust/debug surfaces after attach or before first scan, inspect runtime and cache status:
-
-```bash
 fooks status codex
 fooks status cache
 ```
 
-`fooks status cache` reports whether the local cache is `empty`, `healthy`, `recovered`, or `corrupted`, plus entry count and backup availability. Fresh repos now report `empty` until the first scan builds `.fooks/index.json`.
+Common causes:
 
-This keeps the product UX quiet by default while still exposing the minimum trust signals we care about in Phase 2B:
+- You are not in a React/TSX/JSX project root.
+- Another global `fooks` binary is earlier in your PATH.
+- `~/.codex/hooks.json` is invalid JSON or not writable.
+- The repo/account context is not allowed for attach.
 
-- connection state
-- lifecycle state (`ready`, `refreshing`, `attach-prepared`, ...)
-- last scan / refresh timestamps
-- current active file when an attach package was prepared
+More setup details: [`docs/setup.md`](docs/setup.md)
 
-For a real-world feedback loop after installation, use the checklist in [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md).
-
-For the next Phase 2B step — validating remaining trust/refresh/source-of-truth risks in real usage — use the archived checklist in [`docs/archive/phase-2b-risk-validation-checklist.md`](docs/archive/phase-2b-risk-validation-checklist.md).
-
-If you prefer to edit the file manually, add this preset:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "fooks codex-runtime-hook --native-hook"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "fooks codex-runtime-hook --native-hook"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "fooks codex-runtime-hook --native-hook"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-When the current cwd is not a Codex-attached `fooks` project, the native hook bridge exits quietly without output.
-
-## Benchmark suite
-
-You can now validate the phase-1 benchmark baseline with:
+## Development
 
 ```bash
+npm install
 npm test
-npm run bench:cache
-npm run bench:extract
-npm run bench:stability
-npm run bench:gate
-npm run bench
 ```
 
-Phase 1 keeps the suite **local-first**, **JSON-first**, and **dependency-neutral**.
+Useful internal docs:
 
-- `bench:cache` keeps the legacy cache benchmark entrypoint, but now resolves to the dedicated scan/cache suite
-- `bench:extract` records file-type extraction cost and reduction metrics for the v1 fixture corpus
-- `bench:stability` captures repeated-run distributions for scan and extract timings
-- `bench:gate` evaluates lightweight preservation + mode-decision guardrails
-- `bench` runs the full benchmark suite and writes the canonical envelope used for before/after optimization comparisons
-
-Generated result artifacts are written under:
-
-- `benchmarks/results/latest/`
-- `benchmarks/results/history/`
-
-The canonical benchmark envelope includes:
-
-- benchmark version / run id / git SHA / node version / platform
-- scan/cache suite output
-- scan observability for timing splits, skip/hit/miss counters, slow files, and CLI-vs-scan runtime breakdowns
-- extract suite output
-- repeated-run stability output
-- preservation + mode-decision results
-- final gate pass/fail summary
-
-## Real repo testing
-
-After fixture-level verification, validate against an actual React/TSX
-repo using:
-
-- cold/warm/partial scan behavior
-- representative `decide` checks
-- canonical `extract` vs `extract --model-payload`
-- one real edit task against compressed/hybrid outputs
-
-See `docs/real-repo-validation.md`.
-
-## Notes
-
-- Core logic stays adapter-agnostic.
-- Runtime attach remains environment-dependent by design, but now fails honestly with blocker evidence.
-
-
-Canonical runtime/storage naming:
-
-- CLI / runtime/storage name: `fooks`
-- npm package name: `oh-my-fooks`
-- project state dir: `.fooks/`
-- runtime-home manifest dir: `fooks/attachments`
-- supported env names: `FOOKS_*`
-- legacy removal record: [`docs/archive/legacy-removal-checklist.md`](docs/archive/legacy-removal-checklist.md)
+- Runtime bridge contract: [`docs/runtime-bridge-contract.md`](docs/runtime-bridge-contract.md)
+- Live feedback checklist: [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md)
+- Release checklist: [`docs/release.md`](docs/release.md)
+- Benchmark harness: [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md)

--- a/docs/codex-live-feedback-checklist.md
+++ b/docs/codex-live-feedback-checklist.md
@@ -1,32 +1,26 @@
 # Codex 실사용 피드백 체크리스트
 
-이 문서는 `fooks install codex-hooks` + `fooks attach codex` 이후,
-실제 repo에서 반복 편집이 얼마나 자연스럽게 동작하는지 빠르게 검증하기 위한 체크리스트입니다.
+목표: fooks가 실제 Codex 세션에서 자연스럽게 도움이 되는지만 빠르게 확인합니다.
 
 ## 1. 설치 확인
 
-실제 repo 루트에서:
+repo 루트에서:
 
 ```bash
-fooks init
-fooks attach codex
-fooks install codex-hooks
+fooks setup
+fooks status codex
+fooks status cache
 ```
 
-확인 포인트:
-- `.fooks/` 가 생성되는가
-- `~/.codex/fooks/attachments/<repo>.json` 이 생성되는가
-- `~/.codex/hooks.json` 에 `fooks codex-runtime-hook --native-hook` 가 들어가는가
+확인할 것:
 
-## 2. 첫 세션 smoke
+- `.fooks/`가 생겼는가
+- `fooks status codex`가 connected/ready 계열인가
+- `~/.codex/hooks.json`에 `fooks codex-runtime-hook --native-hook`가 있는가
 
-Codex를 repo 루트에서 시작하고 같은 `.tsx/.jsx` 파일을 3~4턴 연속으로 다룹니다.
+## 2. 같은 프론트 파일을 반복해서 다루기
 
-추천 패턴:
-1. 구조 요약 요청
-2. 같은 파일의 작은 로직 수정 요청
-3. 같은 파일의 두 번째 후속 수정 요청
-4. 필요하면 일반적인 말로 원문 기준 재검토 요청
+Codex에서 같은 `.tsx` / `.jsx` 파일을 3턴 정도 연속으로 다룹니다.
 
 예시:
 
@@ -42,98 +36,37 @@ components/QuestionAnswerForm.tsx 구조를 요약해줘.
 같은 파일에서 입력 아래 글자 수 표시를 어디에 넣어야 하는지 설명해줘.
 ```
 
+필요하면 자연어로 원문 기준 재검토를 요청합니다.
+
 ```text
 components/QuestionAnswerForm.tsx 원문 기준으로 다시 봐줘.
 ```
 
-## 3. 꼭 봐야 할 상태 신호
+## 3. 봐야 할 신호
 
-반복 턴에서 아래 문구가 자연스럽게 보이는지 확인합니다.
+반복 작업에서 아래 같은 짧은 상태가 보이면 정상입니다.
 
 - `fooks: reused pre-read (<mode>)`
 - `fooks: fallback (<reason>)`
 - `fooks: full read requested`
 
-핵심은 **매 턴 다 보이는지**가 아니라,
-**재사용/폴백/우회 같은 의미 있는 변화가 있을 때만 짧게 보이는지**입니다.
+매 턴 보일 필요는 없습니다. 의미 있는 재사용/폴백이 있을 때만 짧게 보이면 됩니다.
 
-## 4. 사용자 체감 질문
-
-세션이 끝나면 아래 네 가지만 기록하면 됩니다.
-
-1. repeated-read 체감
-   - 좋음 / 애매함 / 별차이없음
-2. full-read 욕구
-   - 거의 없음 / 좀 있음 / 자주 있음
-3. fallback 빈도
-   - 드묾 / 보통 / 잦음
-4. 이상한 점
-   - 한 줄 메모
-
-## 5. 바로 보고 싶은 로그/증거
-
-피드백을 남길 때 아래 정보가 있으면 가장 좋습니다.
+## 4. 피드백에 남길 것
 
 - repo 이름
 - 파일 경로
-- task 한 줄 설명
-- `decide` 결과 (`raw/compressed/hybrid`, confidence)
-- 실제로 본 상태 신호
-- 원문 기준 재검토 필요 여부
+- 한 줄 작업 설명
+- repeated-read 체감: 좋음 / 애매함 / 별차이없음
+- 원문 재검토 욕구: 거의 없음 / 좀 있음 / 자주 있음
+- fallback 빈도: 드묾 / 보통 / 잦음
 - build/test/lint 결과
+- 이상한 점 한 줄
 
-## 6. 이슈로 남길 때 템플릿
+## 5. 버그로 볼 것
 
-```md
-### Repo
-- <repo>
-
-### File
-- <path>
-
-### Task
-- <one-line edit task>
-
-### Decision
-- mode: <raw|compressed|hybrid>
-- confidence: <high|medium|low>
-
-### Runtime experience
-- repeated-read: <좋음|애매함|별차이없음>
-- full-read desire: <거의 없음|좀 있음|자주 있음>
-- fallback frequency: <드묾|보통|잦음>
-
-### Signals seen
-- <fooks: reused pre-read ...>
-- <fooks: fallback ...>
-- <fooks: full read requested>
-
-### Verification
-- build: <pass|fail|not-tested>
-- lint/test: <pass|fail|not-tested>
-
-### Notes
-- <anything surprising>
-```
-
-## 7. 언제 버그로 본다
-
-아래는 우선적으로 고쳐야 할 버그/회귀로 취급합니다.
-
-- 같은 파일 반복 턴인데도 pre-read 재사용이 거의 안 보임
-- 원문 기준 재검토 요청이 기대대로 full-read 우회를 못 함
-- 짧은 상태 문구가 너무 지저분해 의미 파악이 어려움
-- compressed/hybrid가 edit quality를 반복적으로 깨뜨림
+- 같은 파일 반복 작업인데도 pre-read 재사용이 거의 안 보임
+- 원문 기준 재검토 요청이 제대로 반영되지 않음
+- 상태 문구가 너무 길거나 지저분함
+- compressed/hybrid payload가 반복적으로 수정 품질을 깨뜨림
 - fallback이 늦어서 잘못된 수정이 먼저 나옴
-
-## 8. 현재 Phase 2A 기준
-
-현재 우선순위는 **압축률보다 신뢰성**입니다.
-즉 실사용에서 애매하면:
-- 더 많이 압축하는 쪽보다
-- 더 빨리 raw로 물러나는 쪽
-이 맞습니다.
-
-
-호환성 참고:
-- 이제 신규 사용뿐 아니라 기존 자동화도 `fooks` / `.fooks` / `FOOKS_*` 기준으로만 맞추세요.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,203 +1,119 @@
 # Setup fooks for Codex
 
-This guide is the user-facing setup and recovery reference for enabling `fooks` in a Codex project.
+Use this when you want fooks to work automatically inside a Codex project.
 
-## Normal path
-
-Install the public npm package, then activate the installed `fooks` CLI explicitly in the project root:
+## 1. Install
 
 ```bash
 npm install -g oh-my-fooks
-fooks setup
-# then open Codex in this repo and work normally
 ```
 
-From a local checkout, build first:
+The package is named `oh-my-fooks`; it installs the `fooks` command.
+
+If setup seems to run the wrong binary, check:
 
 ```bash
-npm run build
+which fooks
+```
+
+## 2. Activate a repo
+
+Run this from your React project root:
+
+```bash
 fooks setup
 ```
 
-`npm install -g oh-my-fooks` installs the `fooks` CLI only. It does not silently edit or mutate `~/.codex/hooks.json`; the Codex hook wiring happens only when you explicitly run `fooks setup`. The package name is `oh-my-fooks` because the unscoped npm package name `fooks` is already occupied by another owner.
+`fooks setup` does three things:
 
-## Package name vs CLI command
+1. creates local `.fooks/` state;
+2. attaches the repo to the Codex runtime;
+3. merges the fooks hook command into `~/.codex/hooks.json`.
 
-The package and command names intentionally differ:
-
-- install package: `oh-my-fooks`
-- run command: `fooks`
-
-If another tool already installed a global `fooks` binary, your shell may resolve that command first. Check `which fooks` and your global npm prefix if setup appears to run an unexpected binary.
-
-## What `fooks setup` changes
-
-`fooks setup` composes the lower-level setup steps so normal users do not need to run them manually:
-
-- creates or reuses project-local `.fooks/` state;
-- finds a supported React/TSX/JSX component in the current project;
-- attaches the current repo to the Codex runtime;
-- explicitly merges the fooks Codex hook preset into `~/.codex/hooks.json`;
-- preserves unrelated Codex hooks when merging;
-- reports a structured result with `ready`, `state`, `blockers`, and `nextSteps`.
-
-The hook command installed for Codex is:
+The hook command is:
 
 ```bash
 fooks codex-runtime-hook --native-hook
 ```
 
-## Understand setup output
+Package install alone does not edit Codex hooks. Activation only happens when you run `fooks setup`.
 
-`fooks setup` prints JSON. The most important fields are:
-
-| Field | Meaning |
-| --- | --- |
-| `ready` | `true` only when attach, hook install, and Codex runtime status all look ready. |
-| `state` | One of `ready`, `partial`, or `blocked`. |
-| `blockers` | Human-readable reasons setup could not fully complete. |
-| `nextSteps` | Recovery guidance for the next command or manual check. |
-| `hooks` | Hook install/merge result, or `null` if hook setup failed. |
-| `status` | Current Codex runtime trust/status snapshot. |
-
-### `ready`
-
-`ready: true` and `state: "ready"` means setup completed. Open Codex in the repo and work normally.
-
-### `partial`
-
-`ready: false` and `state: "partial"` means some setup work succeeded, but one or more blockers remain. Common examples:
-
-- the project attached, but Codex hook installation could not parse or write `~/.codex/hooks.json`;
-- the hook preset was installed, but account/runtime proof is blocked;
-- the active account does not match the expected `minislively` context for this repository.
-
-Read `blockers`, follow `nextSteps`, fix the issue, then rerun:
-
-```bash
-fooks setup
-```
-
-### `blocked`
-
-`ready: false` and `state: "blocked"` means setup could not proceed far enough to activate Codex. The most common case is that no supported React/TSX/JSX component was found.
-
-For React projects, add or restore a supported component and rerun:
-
-```bash
-fooks setup
-```
-
-For non-React projects, the automatic Codex activation path may not apply. Use lower-level `fooks extract` or `fooks scan` only when you know the files are supported.
-
-## Verify setup
-
-After setup, inspect Codex status:
+## 3. Check status
 
 ```bash
 fooks status codex
-```
-
-Optional cache status check:
-
-```bash
 fooks status cache
 ```
 
-For a successful setup, `fooks status codex` should show a connected/ready-style Codex state. If not, use the latest `fooks setup` output and its `blockers` / `nextSteps` fields as the source of truth.
+Good signs:
 
-## Common blockers
+- Codex status is connected/ready-style.
+- Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
-### No React/TSX component found
+## What the setup result means
 
-`fooks setup` is designed for frontend React/TSX/JSX projects. If setup reports no component file was found, run it from the project root and confirm the project has a supported component file.
+| State | Meaning |
+| --- | --- |
+| `ready` | Attach and hook setup completed. Open Codex and work normally. |
+| `partial` | Some setup work succeeded, but a blocker remains. Read `blockers` / `nextSteps`, fix, then rerun `fooks setup`. |
+| `blocked` | fooks could not activate this repo, usually because no supported React component was found. |
 
-### Account context mismatch
+## Common fixes
 
-Attach checks account context to avoid claiming a false activation. For this repository, the expected target account is `minislively`.
+### No React component found
 
-Useful environment overrides for deterministic checks:
+Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files.
+
+### Account mismatch
+
+If the repo account is ambiguous, set the target explicitly:
 
 ```bash
-FOOKS_ACTIVE_ACCOUNT=minislively fooks setup
 FOOKS_TARGET_ACCOUNT=minislively fooks setup
 ```
 
-### Codex runtime home is missing
+### Bad Codex hooks file
 
-Codex hook installation uses the Codex home directory, normally `~/.codex`. Tests may override it with `FOOKS_CODEX_HOME`, but normal users usually should not need that.
-
-If the runtime home is missing or unavailable, open/configure Codex first, then rerun:
+If `~/.codex/hooks.json` cannot be parsed or written, fix that file and rerun:
 
 ```bash
 fooks setup
 ```
 
-### `hooks.json` cannot be parsed or written
+Setup is idempotent: rerunning it should not duplicate fooks hook entries.
 
-If `~/.codex/hooks.json` is invalid JSON or cannot be written, setup reports `state: "partial"`, `hooks: null`, and a blocker such as `Codex hook preset install failed`.
+## opencode custom-tool
 
-Fix or restore the hooks file, then rerun:
+opencode support is manual/semi-automatic. It is not automatic read interception and does not claim opencode runtime-token savings.
 
 ```bash
-fooks setup
+fooks install opencode-tool
 ```
 
-## Re-run and rollback safely
+This creates:
 
-`fooks setup` is intended to be safe to rerun:
+```text
+.opencode/tools/fooks_extract.ts
+```
 
-- existing fooks hook entries are skipped instead of duplicated;
-- unrelated Codex hooks are preserved;
-- if an existing hook file is modified, setup can report a `backupPath` for the previous file.
+The generated tool:
 
-Use rerun plus manual rollback for setup recovery; setup does not provide a separate CLI reset path. If you need to roll back hook changes, inspect the `backupPath` from setup output and manually restore or edit `~/.codex/hooks.json`.
+- calls `fooks extract <file> --model-payload`;
+- accepts `.tsx` and `.jsx` files;
+- validates that the file stays inside the current project/worktree;
+- does not edit Codex hooks;
+- does not edit global opencode config.
 
-Project-local state lives under `.fooks/`. Treat it as local activation/cache state for this project, not as source code.
+Claude and opencode can use fooks payloads through manual/shared handoff paths, but this repo does not claim automatic runtime-token savings for Claude and opencode.
 
 ## Advanced commands
 
-Normal users should start with `fooks setup`. These lower-level commands remain available for maintainers, debugging, and validation:
+Mostly for debugging:
 
 ```bash
 fooks attach codex
 fooks install codex-hooks
-fooks install opencode-tool
 fooks codex-runtime-hook --native-hook
-fooks init
 fooks scan
 fooks extract <file> --model-payload
 ```
-
-Use them only when you are debugging a setup blocker or validating an adapter path directly.
-
-## opencode custom tool support
-
-opencode support is a manual/semi-automatic custom-tool bridge. It is intentionally separate from the Codex hook setup path and does not make an automatic runtime-token savings claim.
-
-From an opencode project root, run:
-
-```bash
-fooks install opencode-tool
-```
-
-This creates a project-local `.opencode/tools/fooks_extract.ts` file. After restarting or opening opencode for that project, ask opencode to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload.
-
-The generated custom tool:
-
-- calls `fooks extract <file> --model-payload`;
-- validates that the requested file stays inside the current opencode project/worktree;
-- supports `.tsx` and `.jsx` files in this MVP;
-- does not edit `~/.config/opencode`;
-- does not edit Codex hooks;
-- does not install `tool.execute.before` or any opencode `read` interception hook.
-
-Treat this as a usability bridge, not as a benchmark result. This setup guide does not claim opencode runtime-token savings unless a future benchmark explicitly measures them.
-
-## Support boundaries
-
-- The primary supported automatic activation path today is Codex hook activation through `fooks setup`.
-- Package installation alone does not edit Codex hooks.
-- Claude support remains manual/shared handoff oriented unless a separate Claude-native hook installer is introduced in the future.
-- opencode support is manual/semi-automatic custom-tool oriented unless a separate opencode read-interception bridge is introduced and measured in the future.
-- This setup guide does not make benchmark or marketing claims; it only explains installation, activation, verification, and recovery.


### PR DESCRIPTION
## Summary

- Reduce the README from a long mixed reference into a short install/use/limits guide.
- Shorten `docs/setup.md` to the core Codex activation path, status checks, common fixes, and opencode boundary.
- Trim the live feedback checklist to the smallest practical smoke-test flow and bug criteria.

## Why

The public docs had too much benchmark, validation, and internal-contract detail on the first read. Users mainly need to know what fooks does, how to set it up, when token savings apply, and where the support boundaries are.

## Validation

- `npm test` — 94 tests passing in isolated worktree `/tmp/fooks-docs-simplify`.

## Notes

Internal reference docs remain linked for maintainers, but the default path is now intentionally concise.
