### PR TITLE
[codex] Reduce opencode tool-selection ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Latest published Codex-oriented benchmark snapshot (2026-04-14):
 | Large component payloads | full source | compressed payload | **7x-15x smaller** |
 | Success rate | 5/5 | 5/5 | no regression in sample |
 
-These are Codex-focused benchmark/proxy measurements, not Claude or opencode runtime-token savings claims. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md).
+These are Codex-focused benchmark/proxy measurements, not Claude or opencode runtime-token savings claims. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme).
 
 ## Everyday commands
 
@@ -71,17 +71,20 @@ fooks scan
 
 opencode support is **manual/semi-automatic** today. It does not intercept opencode `read` calls and does not claim automatic runtime-token savings.
 
+Install the project-local opencode bridge from the project root:
+
 ```bash
 fooks install opencode-tool
 ```
 
-This creates a project-local custom-tool:
+This creates two project-local opencode artifacts:
 
-```text
-.opencode/tools/fooks_extract.ts
-```
+- `.opencode/tools/fooks_extract.ts` — the custom tool that runs fooks extraction.
+- `.opencode/commands/fooks-extract.md` — a slash command prompt so you can explicitly run `/fooks-extract path/to/File.tsx` instead of relying on model tool-selection heuristics.
 
-Use it when you want opencode to request a fooks payload for a `.tsx` or `.jsx` file.
+In opencode, run `/fooks-extract path/to/File.tsx` or ask the model to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload. The generated tool validates that the requested file stays inside the current opencode project/worktree and calls `fooks extract <file> --model-payload`.
+
+This custom tool and slash command do **not** intercept opencode `read` calls, do **not** install a `tool.execute.before` read replacement hook, and do **not** establish an opencode runtime-token benchmark claim. The slash command only reduces the small usability risk that the model might not choose the tool on its own. Automatic opencode context interception is a separate future project that needs its own quality and token measurements.
 
 ## Support boundaries
 
@@ -100,6 +103,17 @@ fooks setup
 fooks status codex
 fooks status cache
 ```
+
+Advanced direct install paths:
+
+```bash
+fooks install codex-hooks
+fooks install opencode-tool
+```
+
+The Codex hook installer is idempotent: it only adds the `fooks codex-runtime-hook --native-hook` command to `SessionStart`, `UserPromptSubmit`, and `Stop` when those entries are missing, and preserves other hooks already present in `~/.codex/hooks.json`.
+
+The opencode tool installer is also explicit and idempotent, but project-local: it creates `.opencode/tools/fooks_extract.ts` and `.opencode/commands/fooks-extract.md` for manual/semi-automatic use and does not edit Codex hooks or global opencode config.
 
 Common causes:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -84,27 +84,34 @@ Setup is idempotent: rerunning it should not duplicate fooks hook entries.
 
 ## opencode custom-tool
 
-opencode support is manual/semi-automatic. It is not automatic read interception and does not claim opencode runtime-token savings.
+opencode support is a manual/semi-automatic custom-tool bridge. It is intentionally separate from the Codex hook setup path and does not make an automatic runtime-token savings claim.
+
+From an opencode project root, run:
 
 ```bash
 fooks install opencode-tool
 ```
 
-This creates:
+This creates two project-local files:
 
-```text
-.opencode/tools/fooks_extract.ts
-```
+- `.opencode/tools/fooks_extract.ts` — the custom tool implementation.
+- `.opencode/commands/fooks-extract.md` — a slash command prompt for explicit `/fooks-extract path/to/File.tsx` use.
 
-The generated tool:
+After restarting or opening opencode for that project, run `/fooks-extract path/to/File.tsx` or ask opencode to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload. The slash command reduces tool-selection ambiguity; it is not automatic read interception.
+
+The generated custom tool:
 
 - calls `fooks extract <file> --model-payload`;
-- accepts `.tsx` and `.jsx` files;
-- validates that the file stays inside the current project/worktree;
+- validates that the requested file stays inside the current opencode project/worktree;
+- supports `.tsx` and `.jsx` files in this MVP;
+- does not edit `~/.config/opencode`;
 - does not edit Codex hooks;
-- does not edit global opencode config.
+- does not edit global opencode config;
+- does not install `tool.execute.before` or any opencode `read` interception hook.
 
-Claude and opencode can use fooks payloads through manual/shared handoff paths, but this repo does not claim automatic runtime-token savings for Claude and opencode.
+The generated slash command follows opencode's project command convention: markdown files under `.opencode/commands/` become `/command-name` entries, and `$ARGUMENTS` passes the text after the command into the prompt.
+
+Treat this as a usability bridge, not as a benchmark result. This setup guide does not claim opencode runtime-token savings unless a future benchmark explicitly measures them.
 
 ## Advanced commands
 
@@ -117,3 +124,13 @@ fooks codex-runtime-hook --native-hook
 fooks scan
 fooks extract <file> --model-payload
 ```
+
+Use them only when you are debugging a setup blocker or validating an adapter path directly.
+
+## Support boundaries
+
+- The primary supported automatic activation path today is Codex hook activation through `fooks setup`.
+- Package installation alone does not edit Codex hooks.
+- Claude support remains manual/shared handoff oriented unless a separate Claude-native hook installer is introduced in the future.
+- opencode support is manual/semi-automatic custom-tool and slash-command oriented unless a separate opencode read-interception bridge is introduced and measured in the future.
+- This setup guide does not make benchmark or marketing claims; it only explains installation, activation, verification, and recovery.

--- a/src/adapters/opencode-tool-preset.ts
+++ b/src/adapters/opencode-tool-preset.ts
@@ -2,16 +2,24 @@ import fs from "node:fs";
 import path from "node:path";
 
 const TOOL_RELATIVE_PATH = path.join(".opencode", "tools", "fooks_extract.ts");
+const COMMAND_RELATIVE_PATH = path.join(".opencode", "commands", "fooks-extract.md");
 const TOOL_NAME = "fooks_extract";
+const COMMAND_NAME = "fooks-extract";
 
 export interface OpenCodeToolPresetResult {
   command: "install opencode-tool";
   runtime: "opencode";
   artifactKind: "custom-tool";
   artifactPath: string;
+  commandPath: string;
   created: boolean;
   modified: boolean;
+  toolCreated: boolean;
+  toolModified: boolean;
+  commandCreated: boolean;
+  commandModified: boolean;
   toolName: typeof TOOL_NAME;
+  commandName: typeof COMMAND_NAME;
   mode: "manual/semi-automatic";
   nextSteps: string[];
 }
@@ -93,34 +101,60 @@ export default tool({
 `;
 }
 
+function renderOpenCodeCommand(): string {
+  return `---
+description: Use fooks_extract to get a fooks payload for a React TSX/JSX file
+---
+
+Call the \`fooks_extract\` custom tool with \`filePath\` set to \`$ARGUMENTS\`.
+
+Use this when the user wants a fooks model-facing payload for a project-relative \`.tsx\` or \`.jsx\` file. If \`$ARGUMENTS\` is empty, ask for a project-relative TSX/JSX file path before calling the tool.
+
+After the tool returns, summarize the payload and continue from that reduced context. Do not claim automatic opencode read interception or runtime-token savings. If the tool reports that the file is unsupported or outside the project, explain the error and ask for a supported in-project file.
+`;
+}
+
+function writeGeneratedArtifact(filePath: string, content: string): { created: boolean; modified: boolean } {
+  const created = !fs.existsSync(filePath);
+  const previous = created ? null : fs.readFileSync(filePath, "utf8");
+  const modified = previous !== content;
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (modified) {
+    fs.writeFileSync(filePath, content, "utf8");
+  }
+
+  return { created, modified };
+}
+
 export function installOpenCodeToolPreset(
   cwd = process.cwd(),
   displayCliName = "fooks",
 ): OpenCodeToolPresetResult {
   const artifactPath = path.join(cwd, TOOL_RELATIVE_PATH);
-  const artifactDir = path.dirname(artifactPath);
-  const content = renderOpenCodeTool(displayCliName);
-  const created = !fs.existsSync(artifactPath);
-  const previous = created ? null : fs.readFileSync(artifactPath, "utf8");
-  const modified = previous !== content;
-
-  fs.mkdirSync(artifactDir, { recursive: true });
-  if (modified) {
-    fs.writeFileSync(artifactPath, content, "utf8");
-  }
+  const commandPath = path.join(cwd, COMMAND_RELATIVE_PATH);
+  const toolArtifact = writeGeneratedArtifact(artifactPath, renderOpenCodeTool(displayCliName));
+  const commandArtifact = writeGeneratedArtifact(commandPath, renderOpenCodeCommand());
 
   return {
     command: "install opencode-tool",
     runtime: "opencode",
     artifactKind: "custom-tool",
     artifactPath,
-    created,
-    modified,
+    commandPath,
+    created: toolArtifact.created || commandArtifact.created,
+    modified: toolArtifact.modified || commandArtifact.modified,
+    toolCreated: toolArtifact.created,
+    toolModified: toolArtifact.modified,
+    commandCreated: commandArtifact.created,
+    commandModified: commandArtifact.modified,
     toolName: TOOL_NAME,
+    commandName: COMMAND_NAME,
     mode: "manual/semi-automatic",
     nextSteps: [
-      "Open opencode in this project and ask it to call fooks_extract for a .tsx/.jsx file when you want a fooks model-facing payload.",
-      "This custom tool is manual/semi-automatic; it does not intercept opencode read calls or prove automatic runtime token savings.",
+      "Open opencode in this project and run /fooks-extract path/to/File.tsx when you want a fooks model-facing payload.",
+      "The /fooks-extract command tells opencode to call fooks_extract, reducing tool-selection ambiguity without intercepting read calls.",
+      "This custom tool and command are manual/semi-automatic; they do not prove automatic opencode runtime token savings.",
     ],
   };
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1195,7 +1195,7 @@ test("install codex-hooks normalizes bridge commands to the canonical fooks comm
   assert.equal(normalized.hooks.Stop[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
 });
 
-test("install opencode-tool creates a project-local fooks_extract custom tool", () => {
+test("install opencode-tool creates project-local fooks_extract tool and slash command", () => {
   const tempDir = makeTempProject();
   const result = run(["install", "opencode-tool"], tempDir);
 
@@ -1203,10 +1203,16 @@ test("install opencode-tool creates a project-local fooks_extract custom tool", 
   assert.equal(result.runtime, "opencode");
   assert.equal(result.artifactKind, "custom-tool");
   assert.equal(result.toolName, "fooks_extract");
+  assert.equal(result.commandName, "fooks-extract");
   assert.equal(result.mode, "manual/semi-automatic");
   assert.equal(result.created, true);
   assert.equal(result.modified, true);
+  assert.equal(result.toolCreated, true);
+  assert.equal(result.toolModified, true);
+  assert.equal(result.commandCreated, true);
+  assert.equal(result.commandModified, true);
   assert.ok(result.artifactPath.endsWith(path.join(".opencode", "tools", "fooks_extract.ts")));
+  assert.ok(result.commandPath.endsWith(path.join(".opencode", "commands", "fooks-extract.md")));
 
   const artifact = fs.readFileSync(result.artifactPath, "utf8");
   assert.match(artifact, /export default tool\(/);
@@ -1224,19 +1230,35 @@ test("install opencode-tool creates a project-local fooks_extract custom tool", 
   assert.doesNotMatch(artifact, /tool\.execute\.before/);
   assert.doesNotMatch(artifact, /input\.tool\s*===\s*["']read["']/);
   assert.doesNotMatch(artifact, /exec\(/);
+
+  const command = fs.readFileSync(result.commandPath, "utf8");
+  assert.match(command, /description: Use fooks_extract/);
+  assert.match(command, /\$ARGUMENTS/);
+  assert.match(command, /Call the `fooks_extract` custom tool/);
+  assert.match(command, /Do not claim automatic opencode read interception or runtime-token savings/);
 });
 
 test("install opencode-tool is idempotent", () => {
   const tempDir = makeTempProject();
   const first = run(["install", "opencode-tool"], tempDir);
   const firstContent = fs.readFileSync(first.artifactPath, "utf8");
+  const firstCommandContent = fs.readFileSync(first.commandPath, "utf8");
   const second = run(["install", "opencode-tool"], tempDir);
 
   assert.equal(first.created, true);
   assert.equal(first.modified, true);
+  assert.equal(first.toolCreated, true);
+  assert.equal(first.toolModified, true);
+  assert.equal(first.commandCreated, true);
+  assert.equal(first.commandModified, true);
   assert.equal(second.created, false);
   assert.equal(second.modified, false);
+  assert.equal(second.toolCreated, false);
+  assert.equal(second.toolModified, false);
+  assert.equal(second.commandCreated, false);
+  assert.equal(second.commandModified, false);
   assert.equal(fs.readFileSync(second.artifactPath, "utf8"), firstContent);
+  assert.equal(fs.readFileSync(second.commandPath, "utf8"), firstCommandContent);
 });
 
 test("generated opencode tool executes fooks extract through a runtime-shaped harness", async () => {
@@ -1322,6 +1344,7 @@ test("docs describe opencode as manual custom-tool support without runtime savin
   const combined = `${readme}\n${setup}`;
 
   assert.match(combined, /fooks install opencode-tool/);
+  assert.match(combined, /\/fooks-extract/);
   assert.match(combined, /manual\/semi-automatic/);
   assert.match(combined, /custom-tool/);
   assert.match(combined, /read interception|intercept opencode `read` calls/);


### PR DESCRIPTION
## Summary
- Adds a project-local `.opencode/commands/fooks-extract.md` slash command alongside the generated `fooks_extract` custom tool.
- Keeps the installer project-local and idempotent, now reporting per-artifact created/modified flags for the tool and command.
- Updates README/setup docs and tests to make the opencode path explicit without claiming read interception or runtime-token savings.

## Why
The remaining small opencode risk was usability: the model may not reliably choose the generated custom tool on its own. A slash command gives users an explicit `/fooks-extract path/to/File.tsx` path that instructs opencode to call `fooks_extract`, reducing tool-selection ambiguity while staying inside the current manual/semi-automatic support boundary.

## Validation
- `npm run lint`
- `npm test`
- `git diff --check`
- Temp-project smoke: `fooks install opencode-tool` creates `.opencode/tools/fooks_extract.ts` and `.opencode/commands/fooks-extract.md`, then `fooks extract src/components/SimpleButton.tsx --model-payload` returns a SimpleButton payload.
- `npm pack --dry-run --json` includes `dist/adapters/opencode-tool-preset.js`, `dist/adapters/opencode-tool-preset.d.ts`, `README.md`, and `docs/setup.md`.

## Claim boundary
This does not add opencode read interception and does not prove opencode runtime-token savings. It is a manual/semi-automatic usability bridge only.
