### PR TITLE
[codex] Restore concise README benchmark snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ One more change in src/components/Form.tsx: add disabled state.
 
 If fooks cannot safely build a payload, it falls back to normal full-source behavior.
 
+## Benchmark snapshot
+
+Latest published Codex-oriented benchmark snapshot (2026-04-14):
+
+| Metric | Before | With fooks | Result |
+| --- | --- | --- | --- |
+| Estimated token use | ~2.1M | ~450K | **78.2% less** |
+| Average task time | 98.2s | 77.9s | **20.7% faster** |
+| Large component payloads | full source | compressed payload | **7x-15x smaller** |
+| Success rate | 5/5 | 5/5 | no regression in sample |
+
+These are Codex-focused benchmark/proxy measurements, not Claude or opencode runtime-token savings claims. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md).
+
 ## Everyday commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Restore a short README benchmark snapshot after the docs simplification.
- Keep the intuitive headline numbers: estimated token reduction, average task time, large component compression, and sample success rate.
- Keep claim-safety wording so the numbers are scoped to Codex-oriented benchmark/proxy measurements, not Claude/opencode runtime-token claims.

## Why

The simplified docs are easier to read, but removing all benchmark context makes it harder for new users to quickly understand the value. This keeps the README concise while preserving the “how much does it reduce?” answer.

## Validation

- `npm test` — 94 tests passing in `/tmp/fooks-benchmark-docs`.
