### PR TITLE
[codex] Clarify TypeScript source and runtime JS split

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ npm install
 npm test
 ```
 
+Repository layout:
+
+- `src/**/*.ts` is the source of truth for product code.
+- `dist/` is generated JavaScript, declarations, and source maps from `npm run build`.
+- `test/*.mjs` and benchmark `.mjs` files are small Node runners that exercise the built `dist` package.
+- Keep this split unless a TypeScript-runner refactor has a clear payoff; avoiding extra test/runtime tooling is intentional.
+
 Useful internal docs:
 
 - Runtime bridge contract: [`docs/runtime-bridge-contract.md`](docs/runtime-bridge-contract.md)


### PR DESCRIPTION
## Summary
- document that product source lives in `src/**/*.ts`
- clarify that `dist/` is generated JS/declaration/map output
- explain that `.mjs` test/benchmark files are lightweight Node runners for built package coverage

## Why
This keeps the repo approachable without converting test/benchmark runners to TypeScript solely for aesthetic consistency.

## Verification
- npm test

Not-tested: No runtime behavior changed; docs-only PR.