### PR TITLE
Keep packaged README benchmark link navigable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ Useful internal docs:
 - Runtime bridge contract: [`docs/runtime-bridge-contract.md`](docs/runtime-bridge-contract.md)
 - Live feedback checklist: [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md)
 - Release checklist: [`docs/release.md`](docs/release.md)
-- Benchmark harness: [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md)
+- Benchmark harness: [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme)


### PR DESCRIPTION
## Summary
- Point the README benchmark harness link at the canonical GitHub README URL so it remains navigable when the README is rendered outside the repository tree.
- Keep the public benchmark details discoverable without changing product code.

## Verification
- git diff --check
- npm run lint
- npm test (94 pass)
- npm run bench:gate (runId 2026-04-20T08:06:10.724Z, gates passed)

## Notes
- This branch is based on latest origin/main.
- The earlier runtime JavaScript/source split README note is already present on main as of origin/main ba11195.

Not-tested: npm registry renderer preview