### PR TITLE
Avoid deprecated GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
## Summary
- Bump official GitHub Actions from `actions/checkout@v4` and `actions/setup-node@v4` to v5.
- Keep the package validation matrix on Node 20 while avoiding GitHub's deprecated Node 20 JavaScript action-runtime annotation.

## Verification
- git diff --check
- npm pack --dry-run --json includes README.md and the canonical benchmark harness link
- npm run lint
- npm test (94 pass)
- npm run bench:gate (runId 2026-04-20T08:11:48.275Z, gates passed)
- GitHub CI `Validate (Node 20)` passed on PR #62

## Context
- PR #61 already merged the README benchmark harness link fix.
- This PR resolves the remaining CI annotation risk separately.
