### PR TITLE
Prove CI compatibility across Node 20 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         node-version:
           - '20'
+          - '24'
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- Keep Node 20 in the CI validation matrix.
- Add Node 24 to the matrix so the project proves future compatibility without becoming Node 24-only.

## Why
- PR #62 moved official GitHub Actions to v5 to remove deprecated Node 20 action-runtime annotations.
- That action-runtime change is separate from the Node version used to run `npm test`.
- This PR makes that separation explicit by validating the package on both Node 20 and Node 24.

## Verification
- git diff --check
- npm pack --dry-run --json includes README.md and the canonical benchmark harness link
- npm run lint
- npm test (94 pass)
- npm run bench:gate (runId 2026-04-20T08:43:35.817Z, gates passed)

Not-tested: GitHub Actions matrix result before PR creation