### PR TITLE
[codex] Document language core strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ Useful internal docs:
 - Live feedback checklist: [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md)
 - Release checklist: [`docs/release.md`](docs/release.md)
 - Benchmark harness: [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme)
+- Language/core strategy: [`docs/language-core-strategy.md`](docs/language-core-strategy.md)

--- a/benchmarks/frontend-harness/README.md
+++ b/benchmarks/frontend-harness/README.md
@@ -52,6 +52,14 @@ code editing efficiency and outcome parity, not browser behavior correctness.
 
 **Results file:** `benchmarks/results/latest/nextjs-tailwindcss-expanded.json`
 
+## Harness language note
+
+The current real-repo harness is Python-based, but Python is not part of the
+`fooks` product runtime. Keep these scripts working while they are the proven
+benchmark path; when reducing Python dependency, prefer porting active runners to
+Node/MJS before adding a Rust toolchain. See
+[`../../docs/language-core-strategy.md`](../../docs/language-core-strategy.md).
+
 ## Quick Start (Local Reproduction)
 
 ### Prerequisites

--- a/docs/language-core-strategy.md
+++ b/docs/language-core-strategy.md
@@ -1,0 +1,77 @@
+# Language and core strategy
+
+Keep `fooks` easy to install and easy to debug first. Do not rewrite the project
+for language aesthetics alone.
+
+## Stable direction
+
+`fooks` should keep its public shell in TypeScript/Node and only move measured,
+contract-stable hot paths to a native core when benchmarks prove the payoff.
+
+| Area | Current language | Direction |
+| --- | --- | --- |
+| npm package, CLI, setup, status, install flows | TypeScript compiled to JavaScript | Keep in TypeScript |
+| Codex, Claude, and opencode adapter glue | TypeScript | Keep in TypeScript |
+| extraction, scan, cache, hash, and payload decisions | TypeScript | Candidate native core later, only with evidence |
+| benchmark orchestration scripts under `benchmarks/scripts/` | Node/MJS | Keep as the low-friction benchmark path |
+| real-repo benchmark runners under `benchmarks/frontend-harness/runners/` | Python | Keep while proven; port active paths to Node/MJS before Rust |
+
+## Why not rewrite everything in Rust or Go now
+
+A full rewrite would change the riskiest parts all at once: package install,
+Codex hook activation, generated payload contracts, cache layout, and benchmark
+interpretation. That would make `fooks` harder to trust even if some internal
+operations became faster.
+
+The better boundary is:
+
+> TypeScript owns the product shell. A future native core may own small,
+> measured, pure functions behind stable JSON contracts.
+
+## Native-core reopen gate
+
+Only reopen Rust/Go/native-core work when all of these are true:
+
+1. A benchmark identifies a specific hot path, not a general feeling that TS is slow.
+2. The native implementation preserves extraction and model-payload contracts.
+3. The product path gets faster, not only a standalone helper microbenchmark.
+4. Fallback and rollback are clear if the native path fails.
+5. npm install, `fooks setup`, and hook debugging do not become harder for users.
+
+Good first candidates, if evidence appears:
+
+- file hashing and cache-index reads;
+- pure `extractSource`-style parsing/extraction functions;
+- scan/index helpers, but only if process-model benchmarks prove a persistent helper wins.
+
+Poor first candidates:
+
+- CLI argument parsing;
+- hook installation;
+- runtime trust/status checks;
+- docs, release, or package glue.
+
+## Python benchmark harness direction
+
+The Python benchmark harness is not part of the `fooks` product runtime. It is a
+real-repo validation tool. Keep it working while it remains the proven benchmark
+path, but do not expand Python into the product architecture.
+
+Recommended sequence:
+
+1. Keep the current Python real-repo harness until equivalent coverage exists elsewhere.
+2. Delete or archive unused setup/quick scripts before porting active runners.
+3. Port active benchmark orchestration to Node/MJS first because this repo already ships through npm.
+4. Keep benchmark result schemas stable so old and new runner outputs remain comparable.
+5. Consider Rust only for a measured product hot path, not for benchmark orchestration.
+
+## Decision rule
+
+Default to:
+
+- **TypeScript shell + TypeScript core** for the current product;
+- **Node/MJS cleanup** for benchmark harness simplification;
+- **Rust/Go/native core later** only after measured bottlenecks and stable contracts.
+
+This keeps `fooks` understandable now while leaving a clean upgrade path for the
+small parts that may eventually deserve a lower-level implementation.

--- a/docs/performance-vs-operational-complexity.md
+++ b/docs/performance-vs-operational-complexity.md
@@ -116,3 +116,11 @@
 > **one-shot CLI를 안정적인 기본선으로 유지하면서, thinner launcher/helper를 엄격한 reopen 기준 아래 두는 단계**
 
 로 보는 것이 맞습니다.
+---
+
+## Related language strategy
+
+For language-boundary decisions, use the same conservatism: keep the TypeScript
+CLI/hook shell stable, reduce Python benchmark harness friction through MJS first,
+and consider Rust/Go only for measured core hot paths. See
+[`docs/language-core-strategy.md`](./language-core-strategy.md).


### PR DESCRIPTION
## Summary

- Add `docs/language-core-strategy.md` to define the TypeScript shell / measured native-core boundary.
- Clarify that Python benchmark runners are validation tooling, not product runtime, and should be reduced through Node/MJS before any Rust toolchain.
- Link the strategy from the README, benchmark harness docs, and the performance-vs-operational-complexity note.

## Why

This preserves the current low-friction npm/TypeScript product path while leaving a clear reopen gate for Rust/Go/native core work if benchmarks later identify a real hot path.

## Validation

- `npm test` — 94 tests passed.

## Not tested

- Runtime behavior changes; this is docs-only.
