### PR TITLE
[codex] Align release support and evidence boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Latest published Codex-oriented benchmark snapshot (2026-04-14):
 
 | Metric | Before | With fooks | Result |
 | --- | --- | --- | --- |
-| Estimated token use | ~2.1M | ~450K | **78.2% less** |
+| Prepared-context proxy estimate | ~2.1M | ~450K | **78.2% less** |
 | Average task time | 98.2s | 77.9s | **20.7% faster** |
 | Large component payloads | full source | compressed payload | **7x-15x smaller** |
 | Success rate | 5/5 | 5/5 | no regression in sample |
 
-These are Codex-focused benchmark/proxy measurements, not Claude or opencode runtime-token savings claims. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme).
+These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme). Layer 2 real-runtime task execution is still blocked by an external Codex→layofflabs gateway 502, so those real-runtime results do not exist yet.
 
 ## Everyday commands
 
@@ -88,11 +88,15 @@ This custom tool and slash command do **not** intercept opencode `read` calls, d
 
 ## Support boundaries
 
-- Codex: automatic repeated-file hook path is supported.
-- Claude and opencode: can consume fooks payloads through manual/shared handoff paths.
-- Claude and opencode do **not** currently have automatic runtime-token savings claims in this repo.
-- fooks is not a universal file-read interceptor.
-- Non-frontend files usually fall back to normal source reading.
+| Environment | Current support | Runtime-token claim |
+| --- | --- | --- |
+| Codex | Automatic repeated-file hook path through `fooks setup` | Codex-oriented benchmark/proxy evidence only |
+| Claude | Manual/shared handoff of fooks payloads | No automatic runtime-token savings claim |
+| opencode | Manual/semi-automatic project-local tool and slash command | No read interception and no automatic runtime-token savings claim |
+
+Claude and opencode do **not** currently have automatic runtime-token savings claims in this repo.
+
+`fooks` is not a universal file-read interceptor. Non-frontend files usually fall back to normal source reading.
 
 ## Troubleshooting
 

--- a/benchmarks/frontend-harness/README.md
+++ b/benchmarks/frontend-harness/README.md
@@ -12,8 +12,8 @@ This benchmark validates AI editing task efficiency + outcome parity through:
 3. **Isolated environment** - Worktree-per-run with isolated `CODEX_HOME`, explicit auth/config sources
 4. **Verifiable output checks** - Modified file count, diff integrity, build/typecheck where applicable
 
-**Out of scope**: Browser runtime, live app execution, E2E verification. This benchmark measures
-code editing efficiency and outcome parity, not browser behavior correctness.
+**Out of scope**: Browser runtime, live app execution, E2E verification, and billing-grade runtime-token accounting. This benchmark measures
+code editing efficiency and outcome parity, plus prepared-context/proxy token estimates, not browser behavior correctness.
 
 ## Latest Results (2026-04-14)
 
@@ -21,8 +21,8 @@ code editing efficiency and outcome parity, not browser behavior correctness.
 |--------|---------|-------|-------------|
 | **Avg Execution Time** | 98,216ms | 77,929ms | **+20.7%** |
 | **Avg Total Time** | - | 82,969ms | **+15.5%** |
-| **Token Reduction** | ~2.1M tokens | ~450K tokens | **-78.2%** |
-| **Tokens Saved** | - | **~1.76M per session** | - |
+| **Prepared Context Reduction** | ~2.1M estimated context tokens | ~450K estimated context tokens | **-78.2%** |
+| **Prepared Context Avoided (proxy est.)** | - | **~1.76M per session** | - |
 | **Success Rate** | 100% (5/5) | 100% (5/5) | - |
 
 ### Tested Tasks
@@ -213,8 +213,8 @@ benchmarks/frontend-harness/
 
 1. **Execution Time**: Time spent in OMX/Codex (excluding fooks scan)
 2. **Total Time**: Including fooks scan for baseline comparison
-3. **Token Reduction**: Estimated via fooks extract compression ratio
-4. **Codex Tokens Used**: Parsed from OMX/Codex output when available
+3. **Prepared Context Reduction**: Estimated via fooks extract compression ratio
+4. **Codex Tokens Used**: Parsed from OMX/Codex output when available; do not treat prepared-context estimates as billing-grade runtime-token savings
 5. **Files Modified**: Number of files changed during task, plus file list
 6. **Success Rate**: Task completion without timeout/error
 
@@ -227,12 +227,12 @@ benchmarks/frontend-harness/
 5. Clean up worktrees
 6. Aggregate results across tasks/repos
 7. Attach risk levels for sample size, environment parity, cleanup,
-   wall-clock noise, and runtime-token claims
+   wall-clock noise, and runtime-token claims; runtime-token claims require direct runtime evidence, while compression-ratio rows remain prepared-context/proxy estimates
 
 ### Key Insights
 
-1. **Token Efficiency**: Fooks compresses codebase context by ~78%, saving ~1.76M tokens per session
-2. **Speed**: Average 20.7% faster execution on typical tasks
+1. **Prepared Context Efficiency**: Fooks reduced prepared context by ~78% in this sample, a proxy estimate of ~1.76M context tokens avoided per session
+2. **Speed**: Average 20.7% faster execution in the 5-task Codex-oriented sample
 3. **Scalability**: Works effectively on large repos (cal.com: 1,691 TSX files, next.js: 28,000+ files)
 4. **Framework Coverage**: Tests span UI libraries, apps, and frameworks (React, Next.js, TailwindCSS)
 5. **Isolation**: Each benchmark uses isolated `.codex` folders per worktree

--- a/benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md
+++ b/benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md
@@ -9,14 +9,14 @@
 | 항목 | 상태 | 상세 |
 |------|------|------|
 | **API Key** | ✅ 있음 | `OPENAI_API_KEY`, `ANTHROPIC_AUTH_TOKEN` 환경변수 확인됨 |
-| **API Base URL** | ✅ 설정됨 | `OPENAI_BASE_URL=<your-api-base-url>` |
+| **API Base URL** | ✅ 설정됨 | `OPENAI_BASE_URL=https://api.layofflabs.com/v1` |
 | **Codex CLI** | ✅ 설치됨 | `/mnt/offloading/.nvm/versions/node/v25.1.0/bin/codex` |
-| **Runner 구현** | ❌ 없음 | R4 task 자동 실행/측정/기록 스크립트 미구현 |
-| **Validation Hook** | ❌ 없음 | Codex 결과 → 성공/실패 자동 판정 로직 미구현 |
+| **Runner 구현** | ✅ 있음 | `runner.js`, `codex-wrapper.js` 구현 완료; 실행은 gateway 502로 blocked |
+| **Validation Hook** | ✅ 스캐폴드 있음 | metric/validation schema와 수집 로직 준비; 실제 Codex 결과는 gateway 502 때문에 미수집 |
 
-**실제 Blocker:**
-1. **Runner 미구현** - API는 있지만 R4 task를 자동으로 돌리는 runner 없음
-2. **Metric 수집 파이프라인** - token usage, latency, retry 자동 측정 미구현
+**실제 Blocker (현재 canonical):**
+1. **Codex Gateway Stability (502)** - minimal prompt부터 R4 prompt까지 동일하게 `api.layofflabs.com` 502 발생
+2. **Real runtime result 없음** - runner/scaffold는 준비됐지만 외부 gateway blocker 때문에 Layer 2 실행 결과가 없음
 
 ---
 
@@ -26,19 +26,19 @@
 |------|-----------|------|
 | **API Key access** | ✅ 이미 있음 | 시스템 환경변수로 설정 완료 |
 | **Codex CLI 설정** | ⚠️ 확인 필요 | `~/.codex/config.json` 또는 환경변수 |
-| **Runner 개발** | ❌ 필요 | 에르가재 본인 구현 |
-| **shadcn-ui repo 접근** | ✅ 있음 | `<test-repo-path>/ui` |
+| **Runner 개발** | ✅ 완료 | `runner.js`, `codex-wrapper.js` 구현됨; gateway 회복 시 실행 가능 |
+| **shadcn-ui repo 접근** | ✅ 있음 | `/home/bellman/Workspace/fooks-test-repos/ui` |
 
 **필요한 작업:**
 - Codex CLI auth 상태 확인 (`codex auth status`)
-- R4 runner 스크립트 개발 (Python/Node)
-- Metric 수집 파이프라인 구현
+- Gateway 502 회복 확인
+- 준비된 runner/metric 파이프라인으로 R4 vanilla/fooks 실행
 
 ---
 
-## 3. Access 생기면 바로 실행할 절차
+## 3. Gateway 회복 시 바로 실행할 절차
 
-### Runner 구현 후 실행 순서
+### Runner 실행 순서
 
 ```bash
 # 1. R4 Runner 실행 (Vanilla)
@@ -78,7 +78,7 @@ benchmarks/layer2-frontend-task/results/
 
 ## 4. 지금 당장 가능한 사전점검
 
-**API Key 없이도 가능:**
+**Gateway 회복 전에도 가능:**
 - ✅ R4 spec trio 검증 (runner-spec, validation-checklist, metric-schema)
 - ✅ Target file 존재 확인 (`combobox-example.tsx`)
 - ✅ Fooks extraction 동작 확인 (payload 생성)
@@ -89,7 +89,7 @@ benchmarks/layer2-frontend-task/results/
 - Layer 1: nextjs 4 + tailwindcss 5, Avg Savings 85.3%, real benchmark ✅
 - Layer 2: R4 Feature Module Split spec/scaffold ✅
 - API: Key 있음, Codex CLI 있음 ✅
-- Runner: 미구현 ❌
+- Runner: 구현됨 ✅, 실제 실행은 gateway 502 blocked ⏸️
 
 **즉시 가능한 작업:**
 ```bash
@@ -99,8 +99,8 @@ codex auth status
 # Fooks extraction 테스트
 node -e "const fooks = require('./dist/index.js'); console.log(fooks.extractFile('./fooks-test-repos/ui/apps/v4/registry/bases/radix/examples/combobox-example.tsx'))"
 
-# R4 runner 스캐폴드 생성
-# (에르가재 본인 구현)
+# R4 runner/scaffold 확인
+ls benchmarks/layer2-frontend-task
 ```
 
 ---
@@ -109,9 +109,9 @@ node -e "const fooks = require('./dist/index.js'); console.log(fooks.extractFile
 
 | # | Blocker | 심각도 | 해결 방법 | 상태 |
 |---|---------|--------|-----------|------|
-| 1 | **R4 Runner 미구현** | ⏸️ PARTIAL | runner.js, codex-wrapper.js 구현됐으나 실행은 502 blocked | 미해결 |
-| 2 | **Metric 수집 파이프라인 없음** | ⏸️ PARTIAL | 수집 로직 구현됐으나 실행 불가 | 미해결 |
-| 3 | **Codex Gateway Stability (502)** | ⚠️ **CRITICAL** | <api-base-url> 502 Bad Gateway | **현재 병목** |
+| 1 | **R4 Runner/Wrapper** | ✅ RESOLVED | runner.js, codex-wrapper.js 구현 완료 | gateway 회복 대기 |
+| 2 | **Metric 수집 파이프라인** | ✅ RESOLVED | 수집 로직 구현 완료 | 실제 결과는 502로 미수집 |
+| 3 | **Codex Gateway Stability (502)** | ⚠️ **CRITICAL** | api.layofflabs.com 502 Bad Gateway | **현재 병목** |
 
 ---
 
@@ -148,7 +148,7 @@ node -e "const fooks = require('./dist/index.js'); console.log(fooks.extractFile
 **현재 (정확):** `Codex gateway stability blocker (502)`
 
 ### 세부 사항
-- **증상:** `<api-base-url>/v1/...` 502 Bad Gateway
+- **증상:** `api.layofflabs.com/v1/...` 502 Bad Gateway
 - **재현:** 모든 prompt 크기에서 동일하게 발생
 - **소요:** ~43초 후 실패 (timeout과 무관)
 - **원인:** 외부 서비스 (Codex/게이트웨이) 안정성
@@ -162,7 +162,7 @@ node -e "const fooks = require('./dist/index.js'); console.log(fooks.extractFile
 - 형수님 지시: **보류**
 
 ### 옵션 B: 게이트웨이 안정성 회복 대기 (현재)
-- `<api-base-url>` 안정화 또는 대체 경로 확인 필요
+- `api.layofflabs.com` 안정화 또는 대체 경로 확인 필요
 - **실제 우선순위**
 
 ### 옵션 C: Anthropic Claude 전환 (컷)

--- a/docs/language-core-strategy.md
+++ b/docs/language-core-strategy.md
@@ -51,6 +51,11 @@ Poor first candidates:
 - runtime trust/status checks;
 - docs, release, or package glue.
 
+## Release-readiness invariant
+
+Public release docs may cite this file as the boundary for language/runtime claims:
+Python runners are benchmark-only tooling, not product runtime, and native-core work stays out of scope unless the native-core reopen gate below is satisfied.
+
 ## Python benchmark harness direction
 
 The Python benchmark harness is not part of the `fooks` product runtime. It is a

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,25 @@ This checklist prepares `fooks` for public npm distribution without publishing i
 
 The npm package name intentionally differs from the CLI command because the unscoped npm package `fooks` is already occupied by another owner. Public docs must not tell users to globally install the occupied `fooks` npm package unless that ownership situation changes and a new release plan is approved.
 
+## Public support and evidence boundary
+
+Before a public release, keep the public claim surface aligned to this matrix:
+
+| Environment | Release-ready wording | Do not claim |
+| --- | --- | --- |
+| Codex | Automatic repeated-file hook path through `fooks setup` | Universal file-read interception |
+| Claude | Manual/shared handoff unless a Claude-native installer exists | Automatic runtime-token savings |
+| opencode | Manual/semi-automatic custom tool and slash command | Read interception or automatic runtime-token savings |
+
+Benchmark and language evidence for this boundary must be checked against:
+
+- `benchmarks/frontend-harness/README.md` — current frontend harness methodology and prepared-context/proxy estimates.
+- `benchmarks/layer2-frontend-task/STATUS.md` — canonical Layer 2 state.
+- `benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md` — gateway blocker analysis.
+- `docs/language-core-strategy.md` — Python harness benchmark-only and native-core non-goal constraints.
+
+Prepared-context or proxy estimates must not be worded as measured runtime-token billing savings. Layer 2 real-runtime benchmark results do not exist while the external Codex→layofflabs gateway 502 blocker remains active.
+
 A user who already has another global `fooks` binary may see command conflicts. Ask them to inspect their global npm binaries before installing or reinstall into a clean prefix when debugging:
 
 ```bash
@@ -38,11 +57,19 @@ Before any real publish, confirm:
 
 ## Verification commands
 
-Run these before discussing publication:
+Use the current `package.json` scripts as the source of truth. For a release-readiness docs PR, run the normal local gates first:
 
 ```bash
 npm run lint
 npm test
+npm run bench:gate
+```
+
+`bench:gate` is a local benchmark gate; it is not the blocked external Layer 2 live benchmark.
+
+For an actual package publication review, also run the pack/install checks below before discussing publication:
+
+```bash
 npm pack --dry-run --json > /tmp/oh-my-fooks-pack.json
 rm -rf /tmp/fooks-pack
 mkdir -p /tmp/fooks-pack

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,7 +36,7 @@ The hook command is:
 fooks codex-runtime-hook --native-hook
 ```
 
-Package install alone does not edit Codex hooks. Activation only happens when you run `fooks setup`.
+Package install alone does not edit Codex hooks. Activation only happens when you run `fooks setup`. Benchmark harness commands are not required for normal use; they are only for maintainers measuring fooks behavior.
 
 ## 3. Check status
 
@@ -62,7 +62,7 @@ Good signs:
 
 ### No React component found
 
-Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files.
+Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files. The activation path is intentionally frontend-focused: repos without supported React component candidates should remain `blocked` instead of installing hooks for unrelated file types.
 
 ### Account mismatch
 
@@ -134,3 +134,4 @@ Use them only when you are debugging a setup blocker or validating an adapter pa
 - Claude support remains manual/shared handoff oriented unless a separate Claude-native hook installer is introduced in the future.
 - opencode support is manual/semi-automatic custom-tool and slash-command oriented unless a separate opencode read-interception bridge is introduced and measured in the future.
 - This setup guide does not make benchmark or marketing claims; it only explains installation, activation, verification, and recovery.
+- Benchmark harnesses, Python runners, and Layer 2 task-execution scaffolds are maintainer measurement tools, not required setup steps.


### PR DESCRIPTION
## Summary

- Tighten README and benchmark wording so the published snapshot is described as prepared-context/proxy evidence, not billing-grade runtime-token savings.
- Add release checklist boundaries for Codex, Claude, and opencode support claims.
- Update Layer 2 blocker notes to reflect that runner/scaffold work exists, while external Codex→layofflabs gateway 502 still blocks real runtime results.
- Reaffirm language/runtime scope: Python remains benchmark tooling, and native-core work stays gated behind measured hot-path evidence.

## Why

This keeps release-readiness documentation aligned with what fooks can currently prove: Codex-oriented proxy/benchmark evidence, Claude/opencode manual handoff/tool paths, and no unsupported automatic savings claims outside Codex.

## Validation

- `npm run lint`
- `npm test` — 94 tests passed
- `npm run bench:gate`
- `npm pack --dry-run --json`
- Packed tarball temp-prefix install + `fooks setup` smoke in a temporary React TSX project

## Not tested

- External Layer 2 live benchmark execution; it remains blocked by the documented layofflabs gateway 502.
