### PR TITLE
[codex] Report bounded setup readiness across runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd your-react-project
 fooks setup
 ```
 
-Then open Codex in that repo and work normally.
+Then open Codex in that repo and work normally. The same setup command also prepares bounded Claude handoff artifacts and an opencode helper when their local runtime homes/tool files are available.
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks.
 
@@ -50,12 +50,12 @@ Latest published Codex-oriented benchmark snapshot (2026-04-14):
 | Large component payloads | full source | compressed payload | **7x-15x smaller** |
 | Success rate | 5/5 | 5/5 | no regression in sample |
 
-These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme). Layer 2 real-runtime task execution is still blocked by an external Codex→layofflabs gateway 502, so those real-runtime results do not exist yet.
+These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme). Layer 2 real-runtime task execution is still blocked by an external configured Codex gateway 502, so those real-runtime results do not exist yet.
 
 ## Everyday commands
 
 ```bash
-fooks setup          # one-time Codex activation for this repo
+fooks setup          # one-time readiness: Codex hooks + Claude handoff + opencode helper
 fooks status codex   # check Codex attach/hook state
 fooks status cache   # check local fooks cache health
 ```
@@ -71,7 +71,7 @@ fooks scan
 
 opencode support is **manual/semi-automatic** today. It does not intercept opencode `read` calls and does not claim automatic runtime-token savings.
 
-Install the project-local opencode bridge from the project root:
+`fooks setup` installs the project-local opencode bridge when the project has a supported `.tsx` / `.jsx` component. You can also install or repair just that bridge from the project root:
 
 ```bash
 fooks install opencode-tool
@@ -124,7 +124,7 @@ Common causes:
 - You are not in a React/TSX/JSX project root.
 - Another global `fooks` binary is earlier in your PATH.
 - `~/.codex/hooks.json` is invalid JSON or not writable.
-- The repo/account context is not allowed for attach.
+- Your Codex runtime home is missing or not writable; use `FOOKS_CODEX_HOME` for an isolated smoke test.
 
 More setup details: [`docs/setup.md`](docs/setup.md)
 

--- a/benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md
+++ b/benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md
@@ -9,13 +9,13 @@
 | 항목 | 상태 | 상세 |
 |------|------|------|
 | **API Key** | ✅ 있음 | `OPENAI_API_KEY`, `ANTHROPIC_AUTH_TOKEN` 환경변수 확인됨 |
-| **API Base URL** | ✅ 설정됨 | `OPENAI_BASE_URL=https://api.layofflabs.com/v1` |
+| **API Base URL** | ✅ 설정됨 | `OPENAI_BASE_URL=<your-api-base-url>` |
 | **Codex CLI** | ✅ 설치됨 | `/mnt/offloading/.nvm/versions/node/v25.1.0/bin/codex` |
 | **Runner 구현** | ✅ 있음 | `runner.js`, `codex-wrapper.js` 구현 완료; 실행은 gateway 502로 blocked |
 | **Validation Hook** | ✅ 스캐폴드 있음 | metric/validation schema와 수집 로직 준비; 실제 Codex 결과는 gateway 502 때문에 미수집 |
 
 **실제 Blocker (현재 canonical):**
-1. **Codex Gateway Stability (502)** - minimal prompt부터 R4 prompt까지 동일하게 `api.layofflabs.com` 502 발생
+1. **Codex Gateway Stability (502)** - minimal prompt부터 R4 prompt까지 동일하게 `<api-base-url>` 502 발생
 2. **Real runtime result 없음** - runner/scaffold는 준비됐지만 외부 gateway blocker 때문에 Layer 2 실행 결과가 없음
 
 ---
@@ -27,7 +27,7 @@
 | **API Key access** | ✅ 이미 있음 | 시스템 환경변수로 설정 완료 |
 | **Codex CLI 설정** | ⚠️ 확인 필요 | `~/.codex/config.json` 또는 환경변수 |
 | **Runner 개발** | ✅ 완료 | `runner.js`, `codex-wrapper.js` 구현됨; gateway 회복 시 실행 가능 |
-| **shadcn-ui repo 접근** | ✅ 있음 | `/home/bellman/Workspace/fooks-test-repos/ui` |
+| **shadcn-ui repo 접근** | ✅ 있음 | `<test-repo-path>/ui` |
 
 **필요한 작업:**
 - Codex CLI auth 상태 확인 (`codex auth status`)
@@ -111,7 +111,7 @@ ls benchmarks/layer2-frontend-task
 |---|---------|--------|-----------|------|
 | 1 | **R4 Runner/Wrapper** | ✅ RESOLVED | runner.js, codex-wrapper.js 구현 완료 | gateway 회복 대기 |
 | 2 | **Metric 수집 파이프라인** | ✅ RESOLVED | 수집 로직 구현 완료 | 실제 결과는 502로 미수집 |
-| 3 | **Codex Gateway Stability (502)** | ⚠️ **CRITICAL** | api.layofflabs.com 502 Bad Gateway | **현재 병목** |
+| 3 | **Codex Gateway Stability (502)** | ⚠️ **CRITICAL** | `<api-base-url>` 502 Bad Gateway | **현재 병목** |
 
 ---
 
@@ -148,7 +148,7 @@ ls benchmarks/layer2-frontend-task
 **현재 (정확):** `Codex gateway stability blocker (502)`
 
 ### 세부 사항
-- **증상:** `api.layofflabs.com/v1/...` 502 Bad Gateway
+- **증상:** `<api-base-url>/v1/...` 502 Bad Gateway
 - **재현:** 모든 prompt 크기에서 동일하게 발생
 - **소요:** ~43초 후 실패 (timeout과 무관)
 - **원인:** 외부 서비스 (Codex/게이트웨이) 안정성
@@ -162,7 +162,7 @@ ls benchmarks/layer2-frontend-task
 - 형수님 지시: **보류**
 
 ### 옵션 B: 게이트웨이 안정성 회복 대기 (현재)
-- `api.layofflabs.com` 안정화 또는 대체 경로 확인 필요
+- `<api-base-url>` 안정화 또는 대체 경로 확인 필요
 - **실제 우선순위**
 
 ### 옵션 C: Anthropic Claude 전환 (컷)

--- a/benchmarks/layer2-frontend-task/LAYER2_EXECUTION_PATH_REDESIGN.md
+++ b/benchmarks/layer2-frontend-task/LAYER2_EXECUTION_PATH_REDESIGN.md
@@ -12,12 +12,12 @@
 - **Characteristics:** 
   - No specific gateway dependency
   - Local-compatible
-  - Reproducible without Layofflabs infrastructure
+  - Reproducible without private gateway infrastructure
   - Benchmark results are infrastructure-agnostic
   - Provider can be OpenAI, Anthropic, or other compatible APIs
 
 ### Internal Optional Path (Downgraded)
-- **Method:** Codex CLI via Layofflabs gateway
+- **Method:** Codex CLI via configured gateway
 - **Entry:** `runner-internal.js` (existing `runner.js` repurposed)
 - **Characteristics:**
   - Convenience for internal team
@@ -30,7 +30,7 @@
 
 | Aspect | Public/Default | Internal/Optional |
 |--------|---------------|-----------------|
-| **Execution** | Direct API calls | Codex CLI + Layofflabs |
+| **Execution** | Direct API calls | Codex CLI + configured gateway |
 | **Dependency** | API key only | Gateway stability |
 | **Status Impact** | Primary benchmark source | Internal convenience only |
 | **Reporting** | PUBLIC_REPORT.md | Internal logs only |
@@ -41,12 +41,12 @@
 ## 3. Removal / Downgrade List
 
 ### Downgraded
-- **Layofflabs gateway path:** From "mandatory default" → "internal optional lane"
+- **configured gateway path:** From "mandatory default" → "internal optional lane"
 - **Codex CLI wrapper:** From "primary runner" → "internal convenience tool"
 
 ### Removed from Critical Path
 - **"Layer 2 blocked by 502" narrative:** Remove from public status
-- **Gateway dependency in public harness:** Public benchmark must not depend on Layofflabs
+- **Gateway dependency in public harness:** Public benchmark must not depend on configured gateway
 
 ### Modified
 - **README/STATUS:** Update to show "Layer 2 public path redesigned, direct execution available"
@@ -67,7 +67,7 @@
 
 > **Layer 2 Task Definition/Spec: Complete**
 > **Layer 2 Execution Redesign Proposal: Ready**
-> **Layofflabs Lane: Downgraded to internal optional**
+> **Configured Gateway Lane: Downgraded to internal optional**
 > **New Default/Public Path: Provider-agnostic direct execution (not yet implemented/validated)**
 > **Layer 2 Real Benchmark: Requires implementation of new default path**
 

--- a/benchmarks/layer2-frontend-task/PUBLIC_REPORT_SAMPLE.md
+++ b/benchmarks/layer2-frontend-task/PUBLIC_REPORT_SAMPLE.md
@@ -108,7 +108,7 @@
 - Artifact structure and methodology
 
 ### Internal (Not Detailed Here)
-- Codex/Layofflabs execution lane details
+- Codex/configured gateway execution lane details
 - Gateway stability troubleshooting
 - Internal retry attempts and logs
 

--- a/benchmarks/layer2-frontend-task/PUBLIC_REPORT_TEMPLATE.md
+++ b/benchmarks/layer2-frontend-task/PUBLIC_REPORT_TEMPLATE.md
@@ -85,7 +85,7 @@
 - Artifact links
 
 ### Internal (Not Public-Facing)
-- Execution lane: Codex/Layofflabs
+- Execution lane: Codex/configured gateway
 - Gateway stability management
 - Internal blocker tracking
 

--- a/benchmarks/layer2-frontend-task/REAL_WORLD_BENCHMARK_DESIGN.md
+++ b/benchmarks/layer2-frontend-task/REAL_WORLD_BENCHMARK_DESIGN.md
@@ -47,7 +47,7 @@
 ## Runner 구조 (Real-World)
 
 ### 기본 원칙
-- **실제 Codex CLI 사용** (Layofflabs gateway 의존)
+- **실제 Codex CLI 사용** (configured gateway 의존)
 - **Gateway 502 blocker는 현실로 인정** ⏸️
 - **Blocker 해결 시 즉시 실행 가능한 구조** 유지
 

--- a/benchmarks/layer2-frontend-task/STATUS.md
+++ b/benchmarks/layer2-frontend-task/STATUS.md
@@ -54,7 +54,7 @@
 | **Runner 미구현** | ✅ RESOLVED | runner.js, codex-wrapper.js 구현 완료 |
 | **Metric 파이프라인** | ✅ RESOLVED | 수집 로직 구현 완료 |
 | **Fooks 구현/설계** | ✅ RESOLVED | spec trio 완성, wrapper 동작 확인 |
-| **Codex→layofflabs Gateway (502)** | ⚠️ **ACTIVE** | 외부 인프라 문제, fooks无关 |
+| **Configured Codex Gateway (502)** | ⚠️ **ACTIVE** | 외부 인프라 문제, fooks无关 |
 
 ### 정확한 Blocker 분석 (최종)
 

--- a/benchmarks/layer2-frontend-task/direct-executor.js
+++ b/benchmarks/layer2-frontend-task/direct-executor.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Direct API Executor - Layofflabs-independent
+ * Direct API Executor - gateway-independent
  * Executes CASE-1 via direct OpenAI API
  */
 

--- a/benchmarks/layer2-frontend-task/layoff-executor.js
+++ b/benchmarks/layer2-frontend-task/layoff-executor.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Layofflabs Direct Executor - Uses current API key with correct endpoint
+ * Layer 2 Direct Executor - Uses current API key with configured endpoint
  */
 
 const https = require('https');
@@ -8,15 +8,15 @@ const fs = require('fs');
 const path = require('path');
 
 const API_KEY = process.env.OPENAI_API_KEY;
-const BASE_URL = 'api.layofflabs.com';
+const BASE_URL = (process.env.OPENAI_BASE_URL || '<api-base-url>').replace(/^https?:\/\//, '').replace(/\/.*$/, '');
 
 if (!API_KEY) {
-  console.error('[Layoff Executor] ERROR: OPENAI_API_KEY not set');
+  console.error('[Layer2 Executor] ERROR: OPENAI_API_KEY not set');
   process.exit(1);
 }
 
-console.log(`[Layoff Executor] Using endpoint: ${BASE_URL}`);
-console.log(`[Layoff Executor] Key format: ${API_KEY.substring(0, 10)}...`);
+console.log(`[Layer2 Executor] Using endpoint: ${BASE_URL}`);
+console.log(`[Layer2 Executor] Key format: ${API_KEY.substring(0, 10)}...`);
 
 // Test connection first
 const testReq = https.request({
@@ -25,14 +25,14 @@ const testReq = https.request({
   method: 'GET',
   headers: { 'Authorization': `Bearer ${API_KEY}` }
 }, (res) => {
-  console.log(`[Layoff Executor] Connection test: ${res.statusCode}`);
+  console.log(`[Layer2 Executor] Connection test: ${res.statusCode}`);
   
   if (res.statusCode === 200) {
-    console.log('[Layoff Executor] ✅ Connection valid, ready for CASE-1 execution');
+    console.log('[Layer2 Executor] ✅ Connection valid, ready for CASE-1 execution');
   } else {
-    console.error('[Layoff Executor] ❌ Connection failed');
+    console.error('[Layer2 Executor] ❌ Connection failed');
   }
 });
 
-testReq.on('error', (e) => console.error(`[Layoff Executor] Error: ${e.message}`));
+testReq.on('error', (e) => console.error(`[Layer2 Executor] Error: ${e.message}`));
 testReq.end();

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,8 +18,8 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Environment | Release-ready wording | Do not claim |
 | --- | --- | --- |
 | Codex | Automatic repeated-file hook path through `fooks setup` | Universal file-read interception |
-| Claude | Manual/shared handoff unless a Claude-native installer exists | Automatic runtime-token savings |
-| opencode | Manual/semi-automatic custom tool and slash command | Read interception or automatic runtime-token savings |
+| Claude | Manual/shared handoff prepared by `fooks setup` when possible | Automatic hooks, prompt interception, or runtime-token savings |
+| opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
 Benchmark and language evidence for this boundary must be checked against:
 
@@ -28,7 +28,7 @@ Benchmark and language evidence for this boundary must be checked against:
 - `benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md` — gateway blocker analysis.
 - `docs/language-core-strategy.md` — Python harness benchmark-only and native-core non-goal constraints.
 
-Prepared-context or proxy estimates must not be worded as measured runtime-token billing savings. Layer 2 real-runtime benchmark results do not exist while the external Codex→layofflabs gateway 502 blocker remains active.
+Prepared-context or proxy estimates must not be worded as measured runtime-token billing savings. Layer 2 real-runtime benchmark results do not exist while the external configured Codex gateway 502 blocker remains active.
 
 A user who already has another global `fooks` binary may see command conflicts. Ask them to inspect their global npm binaries before installing or reinstall into a clean prefix when debugging:
 
@@ -54,6 +54,7 @@ Before any real publish, confirm:
 - [ ] packed tarball includes `dist/cli/index.js`, `dist/index.js`, `README.md`, `package.json`, and linked docs.
 - [ ] temp-prefix global install smoke test passes.
 - [ ] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
+- [ ] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.
 
 ## Verification commands
 
@@ -90,7 +91,7 @@ Finally, verify setup command routing from a disposable React/TSX-style project 
 ```bash
 TMP_HOME=$(mktemp -d)
 TMP_PROJECT=$(mktemp -d)
-mkdir -p "$TMP_HOME/codex" "$TMP_PROJECT/src"
+mkdir -p "$TMP_HOME/codex" "$TMP_HOME/claude" "$TMP_PROJECT/src"
 printf '{"scripts":{}}\n' > "$TMP_PROJECT/package.json"
 printf 'export function App(){ return <main>Hello</main>; }\n' > "$TMP_PROJECT/src/App.tsx"
 (
@@ -98,10 +99,13 @@ printf 'export function App(){ return <main>Hello</main>; }\n' > "$TMP_PROJECT/s
   HOME="$TMP_HOME/home" \
   XDG_CONFIG_HOME="$TMP_HOME/config" \
   FOOKS_CODEX_HOME="$TMP_HOME/codex" \
-  FOOKS_ACTIVE_ACCOUNT=<your-github-org> \
-  FOOKS_TARGET_ACCOUNT=<your-github-org> \
+  FOOKS_CLAUDE_HOME="$TMP_HOME/claude" \
+  FOOKS_ACTIVE_ACCOUNT= \
+  FOOKS_TARGET_ACCOUNT= \
   "$TMP_PREFIX/bin/fooks" setup
 )
 ```
+
+Expected shape: top-level `ready: true`, `runtimes.codex.state: "automatic-ready"`, `runtimes.claude.state: "handoff-ready"` when the Claude home exists, and `runtimes.opencode.state: "tool-ready"`. Claude/opencode blockers are non-fatal and must remain bounded to handoff/tool readiness wording.
 
 The release-prep PR must state that `npm publish` was not run.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
-# Setup fooks for Codex
+# Setup fooks
 
-Use this when you want fooks to work automatically inside a Codex project.
+Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex is the only automatic hook path today; Claude and opencode setup results are bounded handoff/tool readiness summaries.
 
 ## 1. Install
 
@@ -24,11 +24,13 @@ Run this from your React project root:
 fooks setup
 ```
 
-`fooks setup` does three things:
+`fooks setup` does five things:
 
 1. creates local `.fooks/` state;
 2. attaches the repo to the Codex runtime;
-3. merges the fooks hook command into `~/.codex/hooks.json`.
+3. merges the fooks hook command into `~/.codex/hooks.json`;
+4. prepares Claude manual/shared handoff artifacts when a Claude home is available;
+5. installs the project-local opencode custom tool and slash command when a supported component exists.
 
 The hook command is:
 
@@ -36,7 +38,7 @@ The hook command is:
 fooks codex-runtime-hook --native-hook
 ```
 
-Package install alone does not edit Codex hooks. Activation only happens when you run `fooks setup`. Benchmark harness commands are not required for normal use; they are only for maintainers measuring fooks behavior.
+Package install alone does not edit Codex hooks, Claude files, or opencode project files. Activation only happens when you run `fooks setup`. Benchmark harness commands are not required for normal use; they are only for maintainers measuring fooks behavior.
 
 ## 3. Check status
 
@@ -58,15 +60,26 @@ Good signs:
 | `partial` | Some setup work succeeded, but a blocker remains. Read `blockers` / `nextSteps`, fix, then rerun `fooks setup`. |
 | `blocked` | fooks could not activate this repo, usually because no supported React component was found. |
 
+`fooks setup` also returns a `runtimes` object:
+
+| Runtime field | Ready state | Meaning |
+| --- | --- | --- |
+| `runtimes.codex.state` | `automatic-ready` | Codex attach, trust status, and hook preset are ready. This is the only automatic runtime hook path in the setup command. |
+| `runtimes.claude.state` | `handoff-ready` or `blocked` | Claude manual/shared handoff artifacts were prepared, or a non-fatal Claude blocker was reported. This does not mean Claude prompt interception is enabled. |
+| `runtimes.opencode.state` | `tool-ready`, `manual-step-required`, or `blocked` | The project-local opencode helper is installed, needs an explicit/manual step, or hit a non-fatal blocker. This does not mean opencode read interception or automatic runtime-token savings are enabled. |
+| `blocksOverall` | `true` only for Codex today | Claude/opencode blockers should not make Codex setup look failed when Codex itself is ready. |
+
 ## Common fixes
 
 ### No React component found
 
 Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files. The activation path is intentionally frontend-focused: repos without supported React component candidates should remain `blocked` instead of installing hooks for unrelated file types.
 
-### Account mismatch
+### Account context
 
-If the repo account is ambiguous, set the target explicitly:
+Public repos should not need an account override. fooks derives account context from `FOOKS_ACTIVE_ACCOUNT`, `.fooks/config.json`, GitHub remote metadata, or `package.json` repository metadata. The default placeholder created by `fooks setup` is ignored so a fresh user is not blocked by `<your-github-org>`.
+
+If you still need to force a value for local validation, set the target explicitly:
 
 ```bash
 FOOKS_TARGET_ACCOUNT=<your-github-org> fooks setup
@@ -84,7 +97,7 @@ Setup is idempotent: rerunning it should not duplicate fooks hook entries.
 
 ## opencode custom-tool
 
-opencode support is a manual/semi-automatic custom-tool bridge. It is intentionally separate from the Codex hook setup path and does not make an automatic runtime-token savings claim.
+opencode support is a manual/semi-automatic custom-tool bridge. `fooks setup` prepares this bridge when it can prove a supported component exists, and `fooks install opencode-tool` remains the direct repair/debug command. It is intentionally separate from the Codex hook setup path and does not make an automatic runtime-token savings claim.
 
 From an opencode project root, run:
 

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -52,7 +52,7 @@ export function detectAccountContext(cwd = process.cwd()): AccountDetection {
   }
 
   const configuredAccount = configAccount(cwd);
-  if (configuredAccount) {
+  if (configuredAccount && !isPlaceholderAccount(configuredAccount)) {
     return { account: configuredAccount, source: "config" };
   }
 
@@ -67,6 +67,10 @@ export function detectAccountContext(cwd = process.cwd()): AccountDetection {
   }
 
   return { account: "unknown", source: "unknown" };
+}
+
+export function isPlaceholderAccount(account: string): boolean {
+  return account === "expected-account-placeholder" || account === "<your-github-org>";
 }
 
 export function accountContext(cwd = process.cwd()): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -103,6 +103,150 @@ async function initializeProject(cwd = process.cwd()): Promise<{ config: string;
 }
 
 type SetupState = "ready" | "partial" | "blocked";
+type RuntimeName = "codex" | "claude" | "opencode";
+type RuntimeSetupState = "automatic-ready" | "handoff-ready" | "tool-ready" | "manual-step-required" | "partial" | "blocked";
+
+type RuntimeReadiness = {
+  runtime: RuntimeName;
+  state: RuntimeSetupState;
+  mode: string;
+  ready: boolean;
+  blocksOverall: boolean;
+  details: unknown;
+  blockers: string[];
+  nextSteps: string[];
+  notes: string[];
+};
+
+function setupClaimBoundaries(): string[] {
+  return [
+    "Codex setup installs the automatic fooks hook path when Codex trust checks pass.",
+    "Claude setup prepares manual/shared handoff artifacts only; it does not enable automatic hooks or prompt interception.",
+    "opencode setup prepares a manual/semi-automatic custom tool and slash command only; it does not intercept read calls or prove runtime-token savings.",
+    "Projects without supported React .tsx/.jsx component candidates stay blocked for automatic setup instead of pretending unrelated files are ready.",
+  ];
+}
+
+function setupSummary(runtimes: Record<RuntimeName, RuntimeReadiness>): string[] {
+  return [
+    `codex:${runtimes.codex.state}${runtimes.codex.ready ? ":ready" : ":not-ready"}`,
+    `claude:${runtimes.claude.state}${runtimes.claude.ready ? ":ready" : ":not-ready"}`,
+    `opencode:${runtimes.opencode.state}${runtimes.opencode.ready ? ":ready" : ":not-ready"}`,
+  ];
+}
+
+function codexRuntimeReadiness(
+  state: SetupState,
+  ready: boolean,
+  attach: unknown,
+  hooks: unknown,
+  status: unknown,
+  blockers: string[],
+): RuntimeReadiness {
+  return {
+    runtime: "codex",
+    state: ready ? "automatic-ready" : state === "ready" ? "partial" : state,
+    mode: "automatic-runtime-hook",
+    ready,
+    blocksOverall: true,
+    details: { attach, hooks, status },
+    blockers,
+    nextSteps: ready
+      ? [
+          "Open Codex in this repo and work normally; fooks will run through the installed Codex hooks.",
+          "Use fooks status codex if you want to inspect the runtime trust state.",
+        ]
+      : [
+          "Fix Codex setup blockers, then run fooks setup again.",
+          "Use fooks status codex for current runtime state and inspect runtimes.codex.blockers above.",
+        ],
+    notes: ["Codex is the only runtime in this setup command with an automatic hook path today."],
+  };
+}
+
+function blockedClaudeReadiness(blockers: string[], details: unknown = null): RuntimeReadiness {
+  return {
+    runtime: "claude",
+    state: "blocked",
+    mode: "manual-shared-handoff",
+    ready: false,
+    blocksOverall: false,
+    details,
+    blockers,
+    nextSteps: [
+      "Fix the Claude handoff blocker if you want Claude-ready artifacts, then run fooks setup again.",
+      "Until then, use fooks extract <file> --model-payload for explicit manual handoff.",
+    ],
+    notes: [
+      "Claude automatic hooks are not enabled by fooks setup.",
+      "Claude support remains manual/shared handoff oriented; this is non-fatal for Codex readiness.",
+    ],
+  };
+}
+
+function claudeRuntimeReadiness(attach: { runtimeProof?: { status?: string; blocker?: string } }): RuntimeReadiness {
+  if (attach.runtimeProof?.status === "passed") {
+    return {
+      runtime: "claude",
+      state: "handoff-ready",
+      mode: "manual-shared-handoff",
+      ready: true,
+      blocksOverall: false,
+      details: { attach },
+      blockers: [],
+      nextSteps: [
+        "Use fooks extract <file> --model-payload or the generated Claude handoff artifacts when sharing reduced context with Claude.",
+        "Do not describe this as Claude prompt interception or automatic Claude token savings.",
+      ],
+      notes: [
+        "Claude automatic hooks are not enabled by fooks setup.",
+        "Claude readiness means manual/shared handoff artifacts were prepared successfully.",
+      ],
+    };
+  }
+
+  return blockedClaudeReadiness([attach.runtimeProof?.blocker ?? "Claude handoff proof blocked"], { attach });
+}
+
+function opencodeRuntimeReadiness(installResult: unknown): RuntimeReadiness {
+  return {
+    runtime: "opencode",
+    state: "tool-ready",
+    mode: "manual/semi-automatic-custom-tool",
+    ready: true,
+    blocksOverall: false,
+    details: { install: installResult },
+    blockers: [],
+    nextSteps: [
+      "Open opencode in this project and run /fooks-extract path/to/File.tsx when you want a fooks model-facing payload.",
+      "Use fooks install opencode-tool explicitly if you need to repair or refresh the opencode helper artifacts.",
+    ],
+    notes: [
+      "opencode setup does not intercept read calls.",
+      "opencode setup does not prove automatic runtime-token savings.",
+    ],
+  };
+}
+
+function manualOpenCodeReadiness(blockers: string[], details: unknown = null): RuntimeReadiness {
+  return {
+    runtime: "opencode",
+    state: "manual-step-required",
+    mode: "manual/semi-automatic-custom-tool",
+    ready: false,
+    blocksOverall: false,
+    details,
+    blockers,
+    nextSteps: [
+      "Add a supported React .tsx/.jsx component, then run fooks setup again or fooks install opencode-tool explicitly.",
+      "Use fooks extract <file> --model-payload manually for supported files if you do not want project-local opencode helper artifacts.",
+    ],
+    notes: [
+      "opencode setup does not intercept read calls.",
+      "opencode setup does not prove automatic runtime-token savings.",
+    ],
+  };
+}
 
 async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Record<string, unknown>> {
   const initialized = await initializeProject(cwd);
@@ -117,6 +261,13 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 
   if (!sampleFile) {
     const { readCodexTrustStatus } = await import("../adapters/codex-runtime-trust.js");
+    const status = readCodexTrustStatus(cwd);
+    const runtimes: Record<RuntimeName, RuntimeReadiness> = {
+      codex: codexRuntimeReadiness("blocked", false, null, null, status, blockers),
+      claude: blockedClaudeReadiness(["No React/TSX component file found for Claude handoff proof"]),
+      opencode: manualOpenCodeReadiness(["No React/TSX component file found for opencode helper proof"]),
+    };
+
     return {
       command: "setup",
       runtime: "codex",
@@ -125,7 +276,10 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
       initialized,
       attach: null,
       hooks: null,
-      status: readCodexTrustStatus(cwd),
+      status,
+      runtimes,
+      summary: setupSummary(runtimes),
+      claimBoundaries: setupClaimBoundaries(),
       blockers,
       nextSteps: [
         "Add a React/TSX component to this project, then run fooks setup again.",
@@ -134,9 +288,17 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
     };
   }
 
-  const [{ attachCodex }, { installCodexHookPreset }, { readCodexTrustStatus }] = await Promise.all([
+  const [
+    { attachCodex },
+    { attachClaude },
+    { installCodexHookPreset },
+    { installOpenCodeToolPreset },
+    { readCodexTrustStatus },
+  ] = await Promise.all([
     import("../adapters/codex.js"),
+    import("../adapters/claude.js"),
     import("../adapters/codex-hook-preset.js"),
+    import("../adapters/opencode-tool-preset.js"),
     import("../adapters/codex-runtime-trust.js"),
   ]);
 
@@ -162,6 +324,26 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
     status.lifecycleState === "ready";
   const state: SetupState = ready ? "ready" : "partial";
 
+  let claude: RuntimeReadiness;
+  try {
+    claude = claudeRuntimeReadiness(attachClaude(sampleFile, cwd));
+  } catch (error) {
+    claude = blockedClaudeReadiness([`Claude handoff setup failed: ${error instanceof Error ? error.message : String(error)}`]);
+  }
+
+  let opencode: RuntimeReadiness;
+  try {
+    opencode = opencodeRuntimeReadiness(installOpenCodeToolPreset(cwd, displayCliName));
+  } catch (error) {
+    opencode = manualOpenCodeReadiness([`opencode helper setup failed: ${error instanceof Error ? error.message : String(error)}`]);
+  }
+
+  const runtimes: Record<RuntimeName, RuntimeReadiness> = {
+    codex: codexRuntimeReadiness(state, ready, attach, hooks, status, blockers),
+    claude,
+    opencode,
+  };
+
   return {
     command: "setup",
     runtime: "codex",
@@ -171,17 +353,46 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
     attach,
     hooks,
     status,
+    runtimes,
+    summary: setupSummary(runtimes),
+    claimBoundaries: setupClaimBoundaries(),
     blockers,
     nextSteps: ready
       ? [
           "Open Codex in this repo and work normally; fooks will run through the installed Codex hooks.",
           "Use fooks status codex if you want to inspect the runtime trust state.",
+          "Claude and opencode entries under runtimes are non-fatal handoff/tool readiness summaries, not automatic hook claims.",
         ]
       : [
           "Fix setup blockers, then run fooks setup again.",
           "Use fooks status codex for current runtime state and inspect the blockers field above.",
+          "Claude and opencode entries under runtimes are non-fatal handoff/tool readiness summaries, not automatic hook claims.",
         ],
   };
+}
+
+function printHelp(displayCliName: string): void {
+  console.log(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>
+
+Everyday commands:
+  ${displayCliName} setup
+      Prepare one-command readiness for supported runtimes:
+      - Codex: automatic runtime hook path when trust checks pass.
+      - Claude: manual/shared handoff artifacts only; no automatic hooks or prompt interception.
+      - opencode: manual/semi-automatic custom tool and slash command; no read interception or runtime-token claim.
+
+  ${displayCliName} run <prompt>
+  ${displayCliName} extract <file> [--model-payload] [--json]
+  ${displayCliName} install codex-hooks
+  ${displayCliName} install opencode-tool
+  ${displayCliName} codex-pre-read <file> [--json]
+  ${displayCliName} status codex
+  ${displayCliName} status cache
+  ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
+  ${displayCliName} codex-runtime-hook --native-hook
+
+Install: npm install -g oh-my-fooks
+CLI command: ${displayCliName}`);
 }
 
 function parseExtractArgs(args: string[]): { filePath: string; modelPayload: boolean } {
@@ -284,6 +495,11 @@ async function run(): Promise<void> {
   const invokedName = path.basename(process.argv[1] ?? "fooks");
   const cliName = isRecognizedCliName(invokedName) ? invokedName : "fooks";
   const displayCliName = cliName;
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    printHelp(displayCliName);
+    return;
+  }
+
   const commandStartedAt = performance.now();
 
   switch (command) {
@@ -435,18 +651,8 @@ async function run(): Promise<void> {
       return;
     }
     default:
-      console.error(`Unknown command: ${command ?? "<none>"}`);
-      console.error(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>`);
-      console.error(`       ${displayCliName} setup`);
-      console.error(`       ${displayCliName} run <prompt>`);
-      console.error(`       ${displayCliName} extract <file> [--model-payload] [--json]`);
-      console.error(`       ${displayCliName} install codex-hooks`);
-      console.error(`       ${displayCliName} install opencode-tool`);
-      console.error(`       ${displayCliName} codex-pre-read <file> [--json]`);
-      console.error(`       ${displayCliName} status codex
-       ${displayCliName} status cache`);
-      console.error(`       ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]`);
-      console.error(`       ${displayCliName} codex-runtime-hook --native-hook`);
+      console.error(`Unknown command: ${command}`);
+      printHelp(displayCliName);
       process.exitCode = 1;
   }
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -53,6 +53,25 @@ function runTextWithInput(args, input, cwd = repoRoot, envOverrides = {}) {
   });
 }
 
+function collectStrings(value) {
+  const strings = [];
+  const visit = (item) => {
+    if (typeof item === "string") {
+      strings.push(item);
+      return;
+    }
+    if (Array.isArray(item)) {
+      for (const child of item) visit(child);
+      return;
+    }
+    if (item && typeof item === "object") {
+      for (const child of Object.values(item)) visit(child);
+    }
+  };
+  visit(value);
+  return strings;
+}
+
 function makeTempProject(repositoryUrl = "https://github.com/minislively/temp-project.git") {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-"));
   fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
@@ -1001,10 +1020,12 @@ test("model-facing payload trim hits >=15% reduction on at least two compressed/
 test("setup prepares explicit one-time Codex activation", () => {
   const tempDir = makeTempProject();
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
 
   const result = run(["setup"], tempDir, {
     FOOKS_ACTIVE_ACCOUNT: "minislively",
     FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
   });
 
   assert.equal(result.command, "setup");
@@ -1019,7 +1040,17 @@ test("setup prepares explicit one-time Codex activation", () => {
   assert.deepEqual(result.hooks.installedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
   assert.equal(result.status.connectionState, "connected");
   assert.equal(result.status.lifecycleState, "ready");
+  assert.equal(result.runtimes.codex.state, "automatic-ready");
+  assert.equal(result.runtimes.codex.blocksOverall, true);
+  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.claude.blocksOverall, false);
+  assert.equal(result.runtimes.opencode.state, "tool-ready");
+  assert.equal(result.runtimes.opencode.blocksOverall, false);
+  assert.deepEqual(result.summary, ["codex:automatic-ready:ready", "claude:handoff-ready:ready", "opencode:tool-ready:ready"]);
+  assert.ok(result.claimBoundaries.some((item) => item.includes("Claude setup prepares manual/shared handoff artifacts only")));
   assert.ok(result.nextSteps.some((item) => item.includes("Codex")));
+  assert.ok(fs.existsSync(path.join(tempDir, ".opencode", "tools", "fooks_extract.ts")));
+  assert.ok(fs.existsSync(path.join(tempDir, ".opencode", "commands", "fooks-extract.md")));
 
   const hooks = JSON.parse(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"));
   assert.equal(hooks.hooks.SessionStart[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
@@ -1027,9 +1058,31 @@ test("setup prepares explicit one-time Codex activation", () => {
   assert.equal(hooks.hooks.Stop[0].hooks[0].command, "fooks codex-runtime-hook --native-hook");
 });
 
+test("setup can become ready for a public repo without an active account override", () => {
+  const tempDir = makeTempProject("https://github.com/example-org/temp-project.git");
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "",
+    FOOKS_TARGET_ACCOUNT: "",
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  });
+
+  assert.equal(result.ready, true);
+  assert.equal(result.state, "ready");
+  assert.equal(result.runtimes.codex.state, "automatic-ready");
+  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.opencode.state, "tool-ready");
+  assert.ok(result.attach.runtimeProof.details.includes("account-source=package-repository"));
+  assert.ok(result.attach.runtimeProof.details.includes("account-context=example-org"));
+});
+
 test("setup is idempotent and preserves unrelated Codex hooks", () => {
   const tempDir = makeTempProject();
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
   const hooksPath = path.join(codexHome, "hooks.json");
   fs.writeFileSync(hooksPath, JSON.stringify({
     hooks: {
@@ -1039,14 +1092,16 @@ test("setup is idempotent and preserves unrelated Codex hooks", () => {
     },
   }, null, 2));
 
-  const env = { FOOKS_ACTIVE_ACCOUNT: "minislively", FOOKS_CODEX_HOME: codexHome };
+  const env = { FOOKS_ACTIVE_ACCOUNT: "minislively", FOOKS_CODEX_HOME: codexHome, FOOKS_CLAUDE_HOME: claudeHome };
   const first = run(["setup"], tempDir, env);
   assert.equal(first.ready, true);
+  assert.equal(first.runtimes.opencode.state, "tool-ready");
   assert.equal(first.hooks.modified, true);
   assert.ok(first.hooks.backupPath);
 
   const second = run(["setup"], tempDir, env);
   assert.equal(second.ready, true);
+  assert.equal(second.runtimes.opencode.state, "tool-ready");
   assert.equal(second.hooks.modified, false);
   assert.deepEqual(second.hooks.skippedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
 
@@ -1067,12 +1122,19 @@ test("setup reports partial activation without false ready claims when attach is
 
   const result = run(["setup"], tempDir, {
     FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: path.join(tempDir, ".missing-claude-home"),
   });
 
   assert.equal(result.command, "setup");
   assert.equal(result.ready, false);
   assert.equal(result.state, "partial");
   assert.equal(result.attach.runtimeProof.status, "blocked");
+  assert.equal(result.runtimes.codex.state, "partial");
+  assert.equal(result.runtimes.codex.blocksOverall, true);
+  assert.equal(result.runtimes.claude.state, "blocked");
+  assert.equal(result.runtimes.claude.blocksOverall, false);
+  assert.equal(result.runtimes.opencode.state, "tool-ready");
+  assert.equal(result.runtimes.opencode.blocksOverall, false);
   assert.ok(result.blockers.some((item) => item.includes("Codex runtime home not detected")));
   assert.equal(fs.existsSync(path.join(codexHome, "fooks")), false);
   assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
@@ -1081,11 +1143,13 @@ test("setup reports partial activation without false ready claims when attach is
 test("setup reports partial activation when Codex hooks cannot be parsed", () => {
   const tempDir = makeTempProject();
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
   fs.writeFileSync(path.join(codexHome, "hooks.json"), "{not-json");
 
   const result = run(["setup"], tempDir, {
     FOOKS_ACTIVE_ACCOUNT: "minislively",
     FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
   });
 
   assert.equal(result.command, "setup");
@@ -1093,6 +1157,10 @@ test("setup reports partial activation when Codex hooks cannot be parsed", () =>
   assert.equal(result.state, "partial");
   assert.equal(result.attach.runtimeProof.status, "passed");
   assert.equal(result.hooks, null);
+  assert.equal(result.runtimes.codex.state, "partial");
+  assert.equal(result.runtimes.codex.blocksOverall, true);
+  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.opencode.state, "tool-ready");
   assert.ok(result.blockers.some((item) => item.includes("Codex hook preset install failed")));
   assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
   assert.equal(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"), "{not-json");
@@ -1109,22 +1177,61 @@ test("setup reports blocked state for projects without React components", () => 
   assert.equal(result.state, "blocked");
   assert.equal(result.attach, null);
   assert.equal(result.hooks, null);
+  assert.equal(result.runtimes.codex.state, "blocked");
+  assert.equal(result.runtimes.codex.blocksOverall, true);
+  assert.equal(result.runtimes.claude.state, "blocked");
+  assert.equal(result.runtimes.claude.blocksOverall, false);
+  assert.equal(result.runtimes.opencode.state, "manual-step-required");
+  assert.equal(result.runtimes.opencode.blocksOverall, false);
+  assert.equal(fs.existsSync(path.join(tempDir, ".opencode")), false);
   assert.ok(result.blockers.some((item) => item.includes("No React/TSX component file found")));
   assert.ok(result.nextSteps.some((item) => item.includes("Add a React/TSX component")));
 });
 
-test("cli usage advertises setup and package install has no auto hook side effects", () => {
+test("cli help advertises setup and package install has no auto hook side effects", () => {
+  const help = runText(["--help"]);
+  assert.match(help, /fooks setup/);
+  assert.match(help, /Codex: automatic runtime hook path/);
+  assert.match(help, /Claude: manual\/shared handoff artifacts only/);
+  assert.match(help, /opencode: manual\/semi-automatic custom tool/);
+  assert.doesNotMatch(help, /Unknown command/);
+
   let usage = "";
   try {
     runText(["unknown-command"]);
   } catch (error) {
     usage = `${error.stdout ?? ""}${error.stderr ?? ""}`;
   }
-  assert.match(usage, /setup/);
+  assert.match(usage, /Unknown command: unknown-command/);
+  assert.match(usage, /fooks setup/);
 
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   assert.equal(pkg.scripts?.postinstall, undefined);
   assert.equal(pkg.scripts?.preinstall, undefined);
+  assert.equal(pkg.scripts?.prepare, undefined);
+});
+
+
+test("setup runtime summary keeps Claude and opencode claims bounded", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "minislively",
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  });
+  const text = collectStrings(result).join("\n");
+
+  assert.equal(result.runtimes.claude.blocksOverall, false);
+  assert.equal(result.runtimes.opencode.blocksOverall, false);
+  assert.match(text, /Claude automatic hooks are not enabled by fooks setup/);
+  assert.match(text, /opencode setup does not intercept read calls/);
+  assert.match(text, /opencode setup does not prove automatic runtime-token savings/);
+  assert.doesNotMatch(text, /Claude automatic hooks are enabled/i);
+  assert.doesNotMatch(text, /Claude prompt interception is enabled/i);
+  assert.doesNotMatch(text, /automatic opencode read interception is enabled/i);
+  assert.doesNotMatch(text, /automatic opencode runtime-token savings are enabled/i);
 });
 
 test("install codex-hooks creates a reusable hooks preset", () => {


### PR DESCRIPTION
## Summary

- Extend `fooks setup` so the JSON output reports bounded readiness for Codex, Claude, and opencode separately.
- Keep Codex as the only automatic hook path; Claude is reported as manual/shared handoff readiness and opencode as manual/semi-automatic custom-tool readiness.
- Preserve public-release safety by ignoring the default placeholder account for detection while avoiding account-based gating.
- Tighten README/setup/release docs and Layer 2 benchmark notes so claims do not imply unmeasured runtime-token savings or internal gateway details.

## Why

PR #67 merged the docs-only support/evidence boundary. This follow-up makes the product output match that boundary: users can run one explicit `fooks setup` command and see what is actually ready per runtime without mistaking Claude/opencode helper artifacts for automatic prompt interception or measured token savings.

## Validation

- `npm run lint`
- `npm test` — 94 tests passed
- `npm run bench:gate` — preservation and mode-decision gates passed; latest gate reductions include FormSection 31.99% and DashboardPanel 45.72%
- `npm pack --dry-run --json` — `oh-my-fooks-0.1.0.tgz`, 109 entries
- Packed tarball temp-prefix install smoke:
  - `fooks status cache` returned healthy
  - isolated React TSX project `fooks setup` returned `ready: true`
  - `runtimes.codex.state: "automatic-ready"`
  - `runtimes.claude.state: "handoff-ready"`
  - `runtimes.opencode.state: "tool-ready"`

## Not tested

- `npm publish` was not run.
- External Layer 2 live benchmark execution remains blocked by the documented configured Codex gateway 502.
- Claude/opencode automatic runtime-token interception is intentionally not claimed or tested; current support is bounded to handoff/tool readiness.
