### PR TITLE
[opencode] Preserve manual boundary - reject automatic read interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ In opencode, run `/fooks-extract path/to/File.tsx` or ask the model to call `foo
 
 This custom tool and slash command do **not** intercept opencode `read` calls, do **not** install a `tool.execute.before` read replacement hook, and do **not** establish an opencode runtime-token benchmark claim. The slash command only reduces the small usability risk that the model might not choose the tool on its own. Automatic opencode context interception is a separate future project that needs its own quality and token measurements.
 
+Keep these three levels separate:
+
+- explicit use: the user runs `/fooks-extract path/to/File.tsx`
+- tool-selection steering: the generated slash command nudges opencode toward `fooks_extract`, but still does not replace normal `read`
+- automatic read interception: a separate bridge would need to substitute fooks output into normal opencode file reads without broad regressions
+
+fooks does **not** currently install a project-local `read` shadow for opencode. opencode's built-in `read` behavior is broader than this repo's current custom tool bridge: it covers directories, line offsets/limits, binary/image/PDF handling, permission checks, and reminder metadata. Replacing that safely is outside the narrow issue-59 scope and would need a dedicated compatibility and measurement project before any automatic savings claim. See [`docs/opencode-read-interception.md`](docs/opencode-read-interception.md).
+
 ## Support boundaries
 
 | Environment | Current support | Runtime-token claim |

--- a/docs/opencode-read-interception.md
+++ b/docs/opencode-read-interception.md
@@ -1,0 +1,70 @@
+# opencode read interception boundary
+
+Issue #59 asks whether fooks can move from explicit `/fooks-extract` usage to automatic opencode token-saving through normal `read` interception.
+
+## Current safe conclusion
+
+Not in this repo's current product-safe scope.
+
+The strongest supported opencode path we ship today remains:
+
+- a project-local `fooks_extract` custom tool
+- a project-local `/fooks-extract` slash command
+- manual or semi-automatic use inside the current worktree
+
+That is **not** the same as automatic read interception, and it is **not** sufficient for an automatic runtime-token savings claim.
+
+## Why this is a no-go for the narrow issue-59 patch
+
+The relevant official opencode surfaces point in two directions:
+
+1. Plugins can observe tool execution through `tool.execute.before` and `tool.execute.after`.
+2. Custom tools can shadow built-in tools by name, including `read`.
+
+Those surfaces are real, but neither gives fooks a narrow, low-risk automatic bridge today.
+
+### Hooks are not enough evidence for a claim
+
+The official hook docs show that opencode plugins can inspect upcoming tool calls and adjust arguments. That is useful for policy and steering, but it is not the same as a documented, product-safe substitution of the built-in `read` result with a fooks payload before model context is formed.
+
+Without that stronger guarantee, a "automatic read interception" claim would overstate what this repo can prove.
+
+### Shadowing `read` is broader than it looks
+
+The official upstream `read` tool contract is broader than the current `fooks_extract` bridge. Native `read` behavior includes:
+
+- file and directory reads
+- `offset` / `limit` line slicing
+- binary-file rejection
+- image and PDF attachment handling
+- permission checks
+- external-directory validation
+- reminder metadata appended to output
+
+Generating a project-local `.opencode/tools/read.ts` file would replace the built-in tool. Doing that safely would require either:
+
+- a documented way to delegate back to the original built-in `read`, or
+- a careful reimplementation of the native `read` contract.
+
+We do not have a narrow, low-risk version of either in this repo today.
+
+## Product-safe fallback
+
+Keep opencode explicitly in the manual/semi-automatic lane:
+
+- explicit use: `/fooks-extract path/to/File.tsx`
+- tool-selection steering: the slash command nudges opencode toward `fooks_extract`
+- no automatic interception claim
+- no automatic token-savings claim
+
+If a future opencode-specific project wants automatic interception, it should be treated as a separate compatibility and measurement effort with its own acceptance criteria.
+
+## Evidence required before revisiting
+
+Any future automatic-interception effort should prove all of the following:
+
+- a supported interception path that preserves normal non-TSX/JSX `read` behavior
+- correct fallback for unsupported files and directories
+- compatibility with `offset` / `limit` semantics or an explicitly documented replacement
+- live opencode runtime measurements, not proxy wording alone
+- task-quality checks showing the fooks payload does not regress outcomes

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,6 +21,14 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Claude | Manual/shared handoff unless a Claude-native installer exists | Automatic runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command | Read interception or automatic runtime-token savings |
 
+The opencode boundary is intentional. The current bridge may steer users toward
+`fooks_extract`, but it must not be described as automatic `read` interception.
+A future project-local `read` shadow would need to preserve opencode's native
+read behavior for directories, offset/limit ranges, binary/image/PDF handling,
+permissions, and metadata before it could support an automatic savings claim.
+Keep [`docs/opencode-read-interception.md`](opencode-read-interception.md)
+aligned with any future change to this boundary.
+
 Benchmark and language evidence for this boundary must be checked against:
 
 - `benchmarks/frontend-harness/README.md` — current frontend harness methodology and prepared-context/proxy estimates.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -113,6 +113,14 @@ The generated slash command follows opencode's project command convention: markd
 
 Treat this as a usability bridge, not as a benchmark result. This setup guide does not claim opencode runtime-token savings unless a future benchmark explicitly measures them.
 
+Keep these distinct:
+
+- explicit `/fooks-extract ...` usage;
+- tool-selection steering toward `fooks_extract`;
+- true automatic `read` interception.
+
+Today, `fooks install opencode-tool` only covers the first two. It does not install a project-local `read` override. That omission is intentional: opencode's native `read` surface is broader than the current bridge and includes directory reads, `offset`/`limit` handling, binary/image/PDF behavior, permission gates, and reminder metadata. Shipping a generated `read` shadow without reproducing that contract would be a broader and riskier change than this MVP supports. See [`docs/opencode-read-interception.md`](opencode-read-interception.md).
+
 ## Advanced commands
 
 Mostly for debugging:

--- a/src/adapters/opencode-tool-preset.ts
+++ b/src/adapters/opencode-tool-preset.ts
@@ -103,14 +103,14 @@ export default tool({
 
 function renderOpenCodeCommand(): string {
   return `---
-description: Use fooks_extract to get a fooks payload for a React TSX/JSX file
+description: Explicitly steer opencode to fooks_extract for a React TSX/JSX file
 ---
 
 Call the \`fooks_extract\` custom tool with \`filePath\` set to \`$ARGUMENTS\`.
 
 Use this when the user wants a fooks model-facing payload for a project-relative \`.tsx\` or \`.jsx\` file. If \`$ARGUMENTS\` is empty, ask for a project-relative TSX/JSX file path before calling the tool.
 
-After the tool returns, summarize the payload and continue from that reduced context. Do not claim automatic opencode read interception or runtime-token savings. If the tool reports that the file is unsupported or outside the project, explain the error and ask for a supported in-project file.
+After the tool returns, summarize the payload and continue from that reduced context. This command is explicit tool-selection steering, not automatic opencode \`read\` interception. Do not claim automatic opencode read interception or runtime-token savings. If the tool reports that the file is unsupported or outside the project, explain the error and ask for a supported in-project file.
 `;
 }
 
@@ -153,7 +153,7 @@ export function installOpenCodeToolPreset(
     mode: "manual/semi-automatic",
     nextSteps: [
       "Open opencode in this project and run /fooks-extract path/to/File.tsx when you want a fooks model-facing payload.",
-      "The /fooks-extract command tells opencode to call fooks_extract, reducing tool-selection ambiguity without intercepting read calls.",
+      "The /fooks-extract command is explicit tool-selection steering toward fooks_extract; it does not replace normal read behavior.",
       "This custom tool and command are manual/semi-automatic; they do not prove automatic opencode runtime token savings.",
     ],
   };

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1230,9 +1230,10 @@ test("install opencode-tool creates project-local fooks_extract tool and slash c
   assert.doesNotMatch(artifact, /exec\(/);
 
   const command = fs.readFileSync(result.commandPath, "utf8");
-  assert.match(command, /description: Use fooks_extract/);
+  assert.match(command, /description: Explicitly steer opencode to fooks_extract/);
   assert.match(command, /\$ARGUMENTS/);
   assert.match(command, /Call the `fooks_extract` custom tool/);
+  assert.match(command, /explicit tool-selection steering/);
   assert.match(command, /Do not claim automatic opencode read interception or runtime-token savings/);
 });
 
@@ -1339,13 +1340,17 @@ test("install rejects unknown targets with all supported install options", () =>
 test("docs describe opencode as manual custom-tool support without runtime savings claims", () => {
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
   const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
-  const combined = `${readme}\n${setup}`;
+  const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
+  const interception = fs.readFileSync(path.join(repoRoot, "docs", "opencode-read-interception.md"), "utf8");
+  const combined = `${readme}\n${setup}\n${release}\n${interception}`;
 
   assert.match(combined, /fooks install opencode-tool/);
   assert.match(combined, /\/fooks-extract/);
   assert.match(combined, /manual\/semi-automatic/);
   assert.match(combined, /custom-tool/);
+  assert.match(combined, /tool-selection steering/);
   assert.match(combined, /read interception|intercept opencode `read` calls/);
+  assert.match(combined, /project-local `read` shadow|project-local `read` override/);
   assert.match(combined, /runtime-token savings|runtime-token benchmark claim/);
   assert.match(combined, /Claude and opencode/);
 });


### PR DESCRIPTION
Resolves #59 investigation on opencode automatic token-saving.

**Conclusion**: Preserve the manual  boundary.

**Investigation Summary**:
- Explored hooks, custom-tool shadowing, and read interception options
- Rejected: Full read tool shadow (compatibility risk with directories, offsets, binary files)
- Rejected: Hook-based automatic interception (no proven narrow substitution path)
- Accepted: Explicit  command remains the safe, supported path

**Changes**:
- Add  (70 lines) documenting the decision rationale
- Update README.md, docs/release.md, docs/setup.md with manual boundary claims
- Adjust src/adapters/opencode-tool-preset.ts implementation
- Update test assertions for explicit command behavior

**Risk**: Narrow (opencode-only, no Codex/Claude claims broadened)

Closes #59