### PR TITLE
[benchmark] Preserve Formbricks N=3 evidence data

### DIFF
--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../account/components/DeleteAccountModal/index.tsx   | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch
@@ -1,0 +1,53 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..041f823 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,19 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const isEmailFormatValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inputValue);
++  const isConfirmationEmailValid = isEmailFormatValid && inputValue === user.email;
++  const showConfirmationEmailError = inputValue.length > 0 && !isConfirmationEmailValid;
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +74,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +118,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={showConfirmationEmailError}
+           />
++          {showConfirmationEmailError && (
++            <p className="mt-2 text-sm text-red-500">
++              {isEmailFormatValid
++                ? t("environments.actions.does_not_exactly_match")
++                : t("auth.verification-requested.invalid_email_address")}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 30 ++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch
@@ -1,0 +1,70 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..aa5569b 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,28 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasInputValue = inputValue.length > 0;
++  const isInputValueValidEmail = isValidEmail(inputValue);
++  const isConfirmationEmailMalformed = hasInputValue && !isInputValueValidEmail;
++  const isConfirmationEmailMismatch =
++    hasInputValue && !isConfirmationEmailMalformed && inputValue !== user.email;
++  const confirmationEmailError = isConfirmationEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : isConfirmationEmailMismatch
++      ? t("auth.invite.email_does_not_match")
++      : "";
++  const isConfirmationEmailValid = isInputValueValidEmail && inputValue === user.email;
++  const isDeleteDisabled = !isConfirmationEmailValid || deleting;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isDeleteDisabled) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +85,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isDeleteDisabled}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +129,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={!!confirmationEmailError}
++            aria-describedby={confirmationEmailError ? "deleteAccountConfirmation-error" : undefined}
++            aria-invalid={!!confirmationEmailError}
+           />
++          {confirmationEmailError && (
++            <p id="deleteAccountConfirmation-error" className="mt-1 text-sm text-red-500">
++              {confirmationEmailError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch
@@ -1,0 +1,64 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..b7cbf2a 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,19 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const isConfirmationEmailMalformed = inputValue.length > 0 && !isValidEmail(inputValue);
++  const isConfirmationEmailValid = isValidEmail(inputValue) && inputValue === user.email;
++  const showConfirmationEmailError = inputValue.length > 0 && !isConfirmationEmailValid;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +76,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +120,21 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={showConfirmationEmailError}
++            aria-describedby={showConfirmationEmailError ? "deleteAccountConfirmationError" : undefined}
+           />
++          {showConfirmationEmailError && (
++            <p id="deleteAccountConfirmationError" className="mt-2 text-sm text-red-600">
++              {isConfirmationEmailMalformed
++                ? t("auth.verification-requested.invalid_email_address")
++                : t("environments.settings.profile.please_enter_email_to_confirm_account_deletion", {
++                    email: user.email,
++                  })}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 28 +++++++++++++++++++---
+ 1 file changed, 25 insertions(+), 3 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch
@@ -1,0 +1,61 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..045ba0f 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,24 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const [isEmailMalformed, setIsEmailMalformed] = useState(false);
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++
++  const isConfirmationEmailValid = inputValue === user.email && !isEmailMalformed;
++  const showInputError = inputValue.length > 0 && !isConfirmationEmailValid;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+-    setInputValue(e.target.value);
++    const value = e.target.value;
++
++    setInputValue(value);
++    setIsEmailMalformed(value.length > 0 && !e.target.validity.valid);
+   };
+ 
+   const deleteAccount = async () => {
++    if (!isConfirmationEmailValid || deleting) {
++      return;
++    }
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +79,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={!isConfirmationEmailValid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +123,20 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            isInvalid={showInputError}
++            aria-invalid={showInputError}
++            aria-describedby={showInputError ? "deleteAccountConfirmation-error" : undefined}
+           />
++          {showInputError && (
++            <p className="mt-1 text-sm text-red-500" id="deleteAccountConfirmation-error">
++              {isEmailMalformed
++                ? t("auth.verification-requested.invalid_email_address")
++                : t("environments.actions.does_not_exactly_match")}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch
@@ -1,0 +1,64 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..56aa35d 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
+ import { Trans, useTranslation } from "react-i18next";
+ import { TOrganization } from "@formbricks/types/organizations";
+ import { TUser } from "@formbricks/types/user";
++import { isValidEmail } from "@/lib/utils/email";
+ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
+ import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+ import { Input } from "@/modules/ui/components/input";
+@@ -29,11 +30,22 @@ export const DeleteAccountModal = ({
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasConfirmationEmail = inputValue.length > 0;
++  const isConfirmationEmailMalformed = hasConfirmationEmail && !isValidEmail(inputValue);
++  const isConfirmationEmailInvalid = isConfirmationEmailMalformed || inputValue !== user.email;
++  const confirmationEmailError = isConfirmationEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : hasConfirmationEmail && isConfirmationEmailInvalid
++      ? t("environments.actions.does_not_exactly_match")
++      : undefined;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isConfirmationEmailInvalid || deleting) return;
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +79,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isConfirmationEmailInvalid || deleting}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -111,10 +123,18 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={!!confirmationEmailError}
++            aria-describedby={confirmationEmailError ? "deleteAccountConfirmation-error" : undefined}
++            isInvalid={!!confirmationEmailError}
+           />
++          {confirmationEmailError && (
++            <p id="deleteAccountConfirmation-error" className="mt-1 text-xs text-red-500">
++              {confirmationEmailError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat
@@ -1,0 +1,2 @@
+ .../components/DeleteAccountModal/index.tsx        | 25 ++++++++++++++++++++--
+ 1 file changed, 23 insertions(+), 2 deletions(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch
@@ -1,0 +1,66 @@
+diff --git a/apps/web/modules/account/components/DeleteAccountModal/index.tsx b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+index 2ac1335..d095bf3 100644
+--- a/apps/web/modules/account/components/DeleteAccountModal/index.tsx
++++ b/apps/web/modules/account/components/DeleteAccountModal/index.tsx
+@@ -28,12 +28,25 @@ export const DeleteAccountModal = ({
+   const { t } = useTranslation();
+   const [deleting, setDeleting] = useState(false);
+   const [inputValue, setInputValue] = useState("");
++  const [isEmailMalformed, setIsEmailMalformed] = useState(false);
+   const { signOut: signOutWithAudit } = useSignOut({ id: user.id, email: user.email });
++  const hasInputValue = inputValue.length > 0;
++  const isEmailMismatch = hasInputValue && !isEmailMalformed && inputValue !== user.email;
++  const emailConfirmationError = isEmailMalformed
++    ? t("auth.verification-requested.invalid_email_address")
++    : isEmailMismatch
++      ? t("auth.invite.email_does_not_match")
++      : undefined;
++  const isDeleteDisabled = deleting || inputValue !== user.email || isEmailMalformed;
++
+   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+     setInputValue(e.target.value);
++    setIsEmailMalformed(e.target.validity.typeMismatch);
+   };
+ 
+   const deleteAccount = async () => {
++    if (isDeleteDisabled) return;
++
+     try {
+       setDeleting(true);
+       await deleteUserAction();
+@@ -67,7 +80,7 @@ export const DeleteAccountModal = ({
+       onDelete={() => deleteAccount()}
+       text={t("environments.settings.profile.account_deletion_consequences_warning")}
+       isDeleting={deleting}
+-      disabled={inputValue !== user.email}>
++      disabled={isDeleteDisabled}>
+       <div className="py-5">
+         <ul className="list-disc pb-6 pl-6">
+           <li>
+@@ -96,6 +109,7 @@ export const DeleteAccountModal = ({
+         </ul>
+         <form
+           data-testid="deleteAccountForm"
++          noValidate
+           onSubmit={async (e) => {
+             e.preventDefault();
+             await deleteAccount();
+@@ -111,10 +125,17 @@ export const DeleteAccountModal = ({
+             onChange={handleInputChange}
+             placeholder={user.email}
+             className="mt-5"
+-            type="text"
++            type="email"
+             id="deleteAccountConfirmation"
+             name="deleteAccountConfirmation"
++            aria-invalid={!!emailConfirmationError}
++            aria-describedby={emailConfirmationError ? "deleteAccountConfirmationError" : undefined}
+           />
++          {emailConfirmationError && (
++            <p className="mt-1 text-sm text-red-500" id="deleteAccountConfirmationError">
++              {emailConfirmationError}
++            </p>
++          )}
+         </form>
+       </div>
+     </DeleteDialog>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch
@@ -1,0 +1,38 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..2250f32 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -147,6 +147,11 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
++
++  const handlePasswordKeyEvent = (event: React.KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +243,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => {
++                              field.onBlur();
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch
@@ -1,0 +1,47 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..5bcd4f0 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,18 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => {
++                              field.onBlur();
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p role="alert" aria-live="polite" className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_warning", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat
@@ -1,0 +1,2 @@
+ .../web/modules/auth/login/components/login-form.tsx | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch
@@ -1,0 +1,46 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..ebdc383 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -5,6 +5,7 @@ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+ import { useEffect, useMemo, useRef, useState } from "react";
++import type { KeyboardEvent } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -147,6 +148,11 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
++
++  const updateCapsLockState = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +244,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={updateCapsLockState}
++                            onKeyUp={updateCapsLockState}
++                            onBlur={() => {
++                              setIsCapsLockOn(false);
++                              field.onBlur();
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs font-medium text-red-600">
++                              {t("auth.login.caps_lock_warning", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch
@@ -1,0 +1,34 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..1759680 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -147,6 +147,7 @@ export const LoginForm = ({
+   const [totpBackup, setTotpBackup] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+ 
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+@@ -238,7 +239,21 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={(event) => {
++                              setIsCapsLockOn(event.getModifierState("CapsLock"));
++                            }}
++                            onKeyUp={(event) => {
++                              setIsCapsLockOn(event.getModifierState("CapsLock"));
++                            }}
++                            onBlur={() => {
++                              setIsCapsLockOn(false);
++                            }}
+                           />
++                          {isCapsLockOn && (
++                            <p role="status" aria-live="polite" className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch
@@ -1,0 +1,46 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..4e5f5a2 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,17 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              role="status"
++                              aria-live="polite"
++                              className="mt-1 text-left text-xs text-red-600">
++                              {t("auth.login.caps_lock_is_on", { defaultValue: "Caps Lock is on" })}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat
@@ -1,0 +1,2 @@
+ apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)

--- a/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch
+++ b/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch
@@ -1,0 +1,47 @@
+diff --git a/apps/web/modules/auth/login/components/login-form.tsx b/apps/web/modules/auth/login/components/login-form.tsx
+index ca7fe44..8a09a68 100644
+--- a/apps/web/modules/auth/login/components/login-form.tsx
++++ b/apps/web/modules/auth/login/components/login-form.tsx
+@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
+ import { signIn } from "next-auth/react";
+ import Link from "next/link";
+ import { useRouter } from "next/navigation";
+-import { useEffect, useMemo, useRef, useState } from "react";
++import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+ import { toast } from "react-hot-toast";
+ import { useTranslation } from "react-i18next";
+@@ -145,9 +145,14 @@ export const LoginForm = ({
+   const [showLogin, setShowLogin] = useState(false);
+   const [totpLogin, setTotpLogin] = useState(false);
+   const [totpBackup, setTotpBackup] = useState(false);
++  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+   const formRef = useRef<HTMLFormElement>(null);
+   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
+ 
++  const handlePasswordKeyEvent = (event: KeyboardEvent<HTMLInputElement>) => {
++    setIsCapsLockOn(event.getModifierState("CapsLock"));
++  };
++
+   useEffect(() => {
+     if (typeof window !== "undefined") {
+       setLastLoggedInWith(localStorage.getItem(FORMBRICKS_LOGGED_IN_WITH_LS) || "");
+@@ -238,7 +243,18 @@ export const LoginForm = ({
+                             className="block w-full rounded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm"
+                             value={field.value}
+                             onChange={(password) => field.onChange(password)}
++                            onKeyDown={handlePasswordKeyEvent}
++                            onKeyUp={handlePasswordKeyEvent}
++                            onBlur={() => setIsCapsLockOn(false)}
+                           />
++                          {isCapsLockOn && (
++                            <p
++                              className="mt-1 text-left text-xs font-medium text-red-600"
++                              role="status"
++                              aria-live="polite">
++                              {t("auth.login.caps_lock_is_on", "Caps Lock is on")}
++                            </p>
++                          )}
+                           {error?.message && <FormError className="text-left">{error.message}</FormError>}
+                         </div>
+                       </FormControl>

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776176597.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776176597.json
@@ -1,0 +1,182 @@
+{
+  "timestamp": "2026-04-14T14:23:17.907018",
+  "summary": {
+    "total_benchmarks": 5,
+    "vanilla_success": 5,
+    "fooks_success": 5,
+    "avg_token_reduction": 78.22790189366704,
+    "avg_tokens_saved": 1761296.2
+  },
+  "results": [
+    {
+      "task": "T1",
+      "task_name": "Button Relocation",
+      "repo": "shadcn-ui",
+      "difficulty": "easy",
+      "timestamp": "2026-04-14T14:06:44.553157",
+      "tokens": {
+        "total_files": 2967,
+        "raw_bytes": 10061195.9,
+        "compressed_bytes": 1811155.7000000002,
+        "raw_tokens": 2515298.0,
+        "compressed_tokens": 452788.0,
+        "tokens_saved": 2062510.0,
+        "reduction_pct": 81.99860416195654
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 140415,
+        "files": 1,
+        "error": null
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 73890,
+        "scan_time": 5770,
+        "total_time": 79660,
+        "files": 1,
+        "error": null
+      },
+      "improvement": {
+        "exec": 47.37741694263433,
+        "total": 43.26816935512588
+      }
+    },
+    {
+      "task": "T2",
+      "task_name": "Style Modification",
+      "repo": "shadcn-ui",
+      "difficulty": "easy",
+      "timestamp": "2026-04-14T14:10:40.759856",
+      "tokens": {
+        "total_files": 2967,
+        "raw_bytes": 7938307.4,
+        "compressed_bytes": 1852397.0,
+        "raw_tokens": 1984576.0,
+        "compressed_tokens": 463099.0,
+        "tokens_saved": 1521477.0,
+        "reduction_pct": 76.66508858046994
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 75477,
+        "files": 1,
+        "error": null
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 71062,
+        "scan_time": 5863,
+        "total_time": 76925,
+        "files": 1,
+        "error": null
+      },
+      "improvement": {
+        "exec": 5.84946407514872,
+        "total": -1.9184652278177456
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "shadcn-ui",
+      "difficulty": "hard",
+      "timestamp": "2026-04-14T14:13:29.773721",
+      "tokens": {
+        "total_files": 2967,
+        "raw_bytes": 10885428.5,
+        "compressed_bytes": 2230788.4,
+        "raw_tokens": 2721357.0,
+        "compressed_tokens": 557697.0,
+        "tokens_saved": 2163660.0,
+        "reduction_pct": 79.50665515831554
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 80332,
+        "files": 1,
+        "error": null
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 35344,
+        "scan_time": 5856,
+        "total_time": 41200,
+        "files": 1,
+        "error": null
+      },
+      "improvement": {
+        "exec": 56.00258925459344,
+        "total": 48.7128417069163
+      }
+    },
+    {
+      "task": "T1",
+      "task_name": "Button Relocation",
+      "repo": "cal.com",
+      "difficulty": "easy",
+      "timestamp": "2026-04-14T14:15:47.690211",
+      "tokens": {
+        "total_files": 1691,
+        "raw_bytes": 7587347.9,
+        "compressed_bytes": 1645568.4666666668,
+        "raw_tokens": 1896836.0,
+        "compressed_tokens": 411392.0,
+        "tokens_saved": 1485444.0,
+        "reduction_pct": 78.31167769878238
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 92182,
+        "files": 1,
+        "error": null
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 75897,
+        "scan_time": 3835,
+        "total_time": 79732,
+        "files": 1,
+        "error": null
+      },
+      "improvement": {
+        "exec": 17.666138725564647,
+        "total": 13.505890520925995
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "cal.com",
+      "difficulty": "hard",
+      "timestamp": "2026-04-14T14:18:59.130891",
+      "tokens": {
+        "total_files": 1691,
+        "raw_bytes": 8429916.833333334,
+        "compressed_bytes": 2136353.033333333,
+        "raw_tokens": 2107479.0,
+        "compressed_tokens": 534088.0,
+        "tokens_saved": 1573390.0,
+        "reduction_pct": 74.65748386881081
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 102676,
+        "files": 1,
+        "error": null
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 133454,
+        "scan_time": 3873,
+        "total_time": 137327,
+        "files": 1,
+        "error": null
+      },
+      "improvement": {
+        "exec": -29.97584635163037,
+        "total": -33.74790603451635
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776310675.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776310675.json
@@ -1,0 +1,137 @@
+{
+  "timestamp": "2026-04-16T12:37:55.486869",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 66.46864989258164,
+    "avg_tokens_saved": 639001.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "omx exec --full-auto",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan before the same OMX command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, runner=omx exec --full-auto",
+        "interpretation": "Both variants use OMX exec with isolated CODEX_HOME; fooks additionally prepares .fooks context."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used fewer runtime tokens in 1/1 pair (39% less: 57705 -> 34978).",
+        "interpretation": "Runtime token reduction observed, but N=1 sample. Repeat N>=3 before claiming stable runtime token savings. Keep proxy compression and actual tokens separate in reporting."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-16T12:31:48.040927",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3845431.8,
+        "compressed_bytes": 1289425.2,
+        "raw_tokens": 961357.0,
+        "compressed_tokens": 322356.0,
+        "tokens_saved": 639001.0,
+        "reduction_pct": 66.46864989258164,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 176575,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 57705,
+        "command": {
+          "runner": "omx exec --full-auto",
+          "omx_bin": "/opt/homebrew/bin/omx",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776310315",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776310315/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60"
+        },
+        "stdout_tail": "Implemented the requested one-file change.\n\nModified file:\n- `apps/web/modules/account/components/DeleteAccountModal/index.tsx`\n\nChanges made:\n- Changed the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback under the input after typing a malformed or non-matching email.\n- Marked the input invalid visually/accessibly when showing the error.\n- Kept the delete action disabled while the confirmation email is invalid or deletion is already running.\n- Added guards so submit/delete won\u2019t proceed while invalid or already deleting.\n\nValidation:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` could not run because `prettier` was not found in the current environment.\n",
+        "stderr_tail": "?? .codex/logs_2.sqlite-shm\n?? .codex/logs_2.sqlite-wal\n?? .codex/models_cache.json\n?? .codex/plugins/\n?? .codex/sessions/\n?? .codex/shell_snapshots/\n?? .codex/skills/\n?? .codex/state_5.sqlite\n?? .codex/state_5.sqlite-shm\n?? .codex/state_5.sqlite-wal\n?? .codex/tmp/\n\ncodex\nImplemented the requested one-file change.\n\nModified file:\n- `apps/web/modules/account/components/DeleteAccountModal/index.tsx`\n\nChanges made:\n- Changed the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback under the input after typing a malformed or non-matching email.\n- Marked the input invalid visually/accessibly when showing the error.\n- Kept the delete action disabled while the confirmation email is invalid or deletion is already running.\n- Added guards so submit/delete won\u2019t proceed while invalid or already deleting.\n\nValidation:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` could not run because `prettier` was not found in the current environment.\ntokens used\n57,705\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 168468,
+        "scan_time": 2816,
+        "total_time": 171284,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 34978,
+        "command": {
+          "runner": "omx exec --full-auto",
+          "omx_bin": "/opt/homebrew/bin/omx",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776310497",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776310497/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60"
+        },
+        "stdout_tail": "Implemented the account deletion email confirmation improvements.\n\nModified file:\n- `apps/web/modules/account/components/DeleteAccountModal/index.tsx`\n\nChanges made:\n- Changed confirmation input to `type=\"email\"`.\n- Added inline red error text under the input after the user types an invalid confirmation.\n- Distinguishes malformed email from non-matching email using existing translation keys.\n- Keeps delete action disabled while:\n  - the confirmation email is malformed,\n  - the confirmation does not exactly match `user.email`,\n  - or deletion is already running.\n- Guarded both delete button flow and form submit flow from running while invalid/disabled.\n\nVerification:\n- Confirmed only this tracked file is modified via `git diff --name-only`.\n- Tried `pnpm exec prettier --check apps/web/modules/account/components/DeleteAccountModal/index.tsx`, but `prettier` was not available in the workspace environment.\n",
+        "stderr_tail": "   await deleteAccount();\n+            await handleDeleteAccount();\n           }}>\n           <label htmlFor=\"deleteAccountConfirmation\">\n             {t(\"environments.settings.profile.please_enter_email_to_confirm_account_deletion\", {\n@@ -111,10 +126,19 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={showEmailConfirmationError}\n+            aria-describedby={\n+              showEmailConfirmationError ? \"deleteAccountConfirmationError\" : undefined\n+            }\n           />\n+          {showEmailConfirmationError && (\n+            <p id=\"deleteAccountConfirmationError\" className=\"mt-2 text-sm text-red-500\">\n+              {emailConfirmationErrorMessage}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n34,978\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 4.591250176978621,
+        "total": 2.9964604275803484
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776311809.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776311809.json
@@ -1,0 +1,173 @@
+{
+  "timestamp": "2026-04-16T12:56:49.499448",
+  "summary": {
+    "total_benchmarks": 1,
+    "vanilla_success": 1,
+    "fooks_success": 1,
+    "avg_token_reduction": 67.5924542398207,
+    "avg_tokens_saved": 531978.0
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "high",
+        "evidence": "1 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "medium",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "medium",
+        "evidence": "Actual OMX/Codex tokens available; fooks used fewer runtime tokens in 1/1 pair (29% less: 63435 -> 44970).",
+        "interpretation": "Runtime token reduction observed, but N=1 sample. Repeat N>=3 before claiming stable runtime token savings. Keep proxy compression and actual tokens separate in reporting."
+      }
+    ]
+  },
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "timestamp": "2026-04-16T12:49:10.585889",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3148152.0,
+        "compressed_bytes": 1020238.7999999999,
+        "raw_tokens": 787038.0,
+        "compressed_tokens": 255059.0,
+        "tokens_saved": 531978.0,
+        "reduction_pct": 67.5924542398207,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 230072,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 63435,
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776311358",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776311358/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776311358/apps/web/modules/account/components/DeleteAccountModal/index.tsx:32).\n\nChanges made:\n- Changed the confirmation input to `type=\"email\"`.\n- Added inline red validation text after the user starts typing:\n  - malformed email: existing `auth.verification-requested.invalid_email_address`\n  - non-matching email: existing `environments.actions.does_not_exactly_match`\n- Added invalid input styling and ARIA wiring.\n- Kept deletion disabled while the email is invalid or deletion is already running.\n- Added a guard in `deleteAccount()` so form submission cannot bypass the disabled state.\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec eslint ...` and `pnpm exec prettier ...` could not run because those binaries are not installed in this checkout (`Command \"eslint\" not found`, `Command \"prettier\" not found`).\n",
+        "stderr_tail": "led}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +117,22 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={showEmailError}\n+            aria-invalid={showEmailError}\n+            aria-describedby={showEmailError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {showEmailError && (\n+            <p id=\"deleteAccountConfirmationError\" className=\"mt-2 text-sm text-red-500\">\n+              {t(\n+                isEmailMalformed\n+                  ? \"auth.verification-requested.invalid_email_address\"\n+                  : \"environments.actions.does_not_exactly_match\"\n+              )}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n63,435\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 204761,
+        "scan_time": 3684,
+        "total_time": 208445,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 44970,
+        "prepare": {
+          "success": true,
+          "duration_ms": 3684,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 94,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 3049,
+              "stdout_tail": ": 782,\n      \"importResolveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 916.46\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 154.75\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/styling-view.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 85.7\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 85.63\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 79.58\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 541,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T03:53:17.616Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/.codex/fooks/attachments/bm-t5-fooks-1776311592.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/.codex/fooks/attachments/bm-t5-fooks-1776311592.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T03:53:17.604Z\",\"attachedAt\":\"2026-04-16T03:53:17.601Z\",\"lastScanAt\":\"2026-04-16T03:53:17.601Z\",\"lastRefreshAt\":\"2026-04-16T03:53:17.601Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776311592/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation text under the input after the user types a malformed or non-matching email.\n- Reused existing translation keys.\n- Kept deletion disabled when the email is invalid or deletion is already running.\n- Added a guard so `deleteAccount()` returns early if invoked while invalid/disabled.\n\nVerification:\n- `git diff --check` passed.\n- Targeted `prettier`/`eslint` commands could not run because those binaries are not available in this checkout via `pnpm exec`.\n",
+        "stderr_tail": "ences_warning\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={isDeleteDisabled}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +123,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={Boolean(confirmationEmailError)}\n+            aria-invalid={Boolean(confirmationEmailError)}\n+            aria-describedby={confirmationEmailError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {confirmationEmailError && (\n+            <p id=\"deleteAccountConfirmationError\" className=\"mt-2 text-sm text-red-500\">\n+              {confirmationEmailError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n44,970\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 11.001338711359923,
+        "total": 9.40010083799854
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776325941.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776325941.json
@@ -1,0 +1,1042 @@
+{
+  "timestamp": "2026-04-16T17:15:59.221237",
+  "summary": {
+    "total_benchmarks": 3,
+    "successful_pairs": 3,
+    "vanilla_success": 3,
+    "fooks_success": 3,
+    "same_file_pairs": 3,
+    "avg_token_reduction": 69.01720464251308,
+    "avg_tokens_saved": 714642.3333333334,
+    "median_exec_improvement": -13.695065740563733,
+    "median_total_improvement": -15.784638586206166,
+    "median_runtime_token_reduction": 3.8182079781302827,
+    "runtime_token_reductions": [
+      14.861176103571985,
+      3.8182079781302827,
+      -14.514797576183366
+    ],
+    "acceptance_pairs": [
+      {
+        "iteration": 1,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 8,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": false
+            },
+            {
+              "name": "aria_describedby",
+              "passed": false
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 2,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 3,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "input_type_email",
+              "passed": true
+            },
+            {
+              "name": "inline_red_error",
+              "passed": true
+            },
+            {
+              "name": "invalid_email_state",
+              "passed": true
+            },
+            {
+              "name": "non_matching_email_state",
+              "passed": true
+            },
+            {
+              "name": "disabled_condition_updated",
+              "passed": true
+            },
+            {
+              "name": "submit_guard",
+              "passed": true
+            },
+            {
+              "name": "aria_invalid",
+              "passed": true
+            },
+            {
+              "name": "aria_describedby",
+              "passed": true
+            },
+            {
+              "name": "existing_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    },
+    "artifactCapture": {
+      "scope": "git diff patch, git diff --stat, git diff --check, changed file list, task-specific acceptance score when available.",
+      "purpose": "Separate output parity and quality evidence from runtime/token measurements."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "medium",
+        "evidence": "3 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "artifact_quality",
+        "level": "high",
+        "evidence": "acceptance_scored_pairs=3, fooks_lower_score_pairs=1",
+        "interpretation": "Output parity matters as much as time/token deltas; inspect captured patches when fooks scores lower."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "low",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "high",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 1/3 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941",
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 1,
+      "timestamp": "2026-04-16T16:52:21.976758",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3403197.0,
+        "compressed_bytes": 1134281.4,
+        "raw_tokens": 850799.0,
+        "compressed_tokens": 283570.0,
+        "tokens_saved": 567228.0,
+        "reduction_pct": 66.67012224093992,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 276417,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 76932,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-vanilla.diffstat",
+          "patch_bytes": 3175,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 30 ++++++++++++++++++++--\n 1 file changed, 28 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776325949/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation text after the user types a malformed email or a valid-but-nonmatching email.\n- Kept existing translation keys and deletion flow.\n- Disabled and guarded deletion unless the confirmation email is both valid and exactly matches `user.email`, or while deletion is already running.\n\nValidation:\n- `git diff --check` passed.\n- Could not run prettier/eslint/typecheck because this checkout does not have the local toolchain installed (`eslint`, `prettier`, and `tsc` are missing from `node_modules`).\n",
+        "stderr_tail": "tion_consequences_warning\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={isDeleteDisabled}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +129,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={!!confirmationEmailError}\n+            aria-describedby={confirmationEmailError ? \"deleteAccountConfirmation-error\" : undefined}\n+            aria-invalid={!!confirmationEmailError}\n           />\n+          {confirmationEmailError && (\n+            <p id=\"deleteAccountConfirmation-error\" className=\"mt-1 text-sm text-red-500\">\n+              {confirmationEmailError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n76,932\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 216978,
+        "scan_time": 3157,
+        "total_time": 220135,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 65499,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter1-fooks.diffstat",
+          "patch_bytes": 2299,
+          "diffstat": " .../account/components/DeleteAccountModal/index.tsx   | 19 +++++++++++++++++--\n 1 file changed, 17 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 8,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": false
+              },
+              {
+                "name": "aria_describedby",
+                "passed": false
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3157,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 95,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2593,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 836.17\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 145.69\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 80.14\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 72.4\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 62.65\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 468,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T07:57:16.701Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex/fooks/attachments/bm-t5-fooks-1776326232.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex/fooks/attachments/bm-t5-fooks-1776326232.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T07:57:16.691Z\",\"attachedAt\":\"2026-04-16T07:57:16.689Z\",\"lastScanAt\":\"2026-04-16T07:57:16.689Z\",\"lastRefreshAt\":\"2026-04-16T07:57:16.689Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326232/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation text under the input after the user types an invalid or non-matching email.\n- Kept deletion disabled while the confirmation email is invalid or deletion is already running.\n- Added a guard inside `deleteAccount` so submitting the form with Enter cannot bypass validation.\n- Reused existing translation keys; no translation files changed.\n\nVerification:\n- `git diff --check` passed.\n- `prettier` and `eslint` could not be run because neither binary is installed in this workspace\u2019s `node_modules`.\n",
+        "stderr_tail": "ettings.profile.account_deletion_consequences_warning\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={!isConfirmationEmailValid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +118,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={showConfirmationEmailError}\n           />\n+          {showConfirmationEmailError && (\n+            <p className=\"mt-2 text-sm text-red-500\">\n+              {isEmailFormatValid\n+                ? t(\"environments.actions.does_not_exactly_match\")\n+                : t(\"auth.verification-requested.invalid_email_address\")}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n65,499\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 21.503380761675295,
+        "total": 20.361265768747945
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 2,
+      "timestamp": "2026-04-16T17:01:01.135052",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 5015375.399999999,
+        "compressed_bytes": 1152685.8,
+        "raw_tokens": 1253843.0,
+        "compressed_tokens": 288171.0,
+        "tokens_saved": 965672.0,
+        "reduction_pct": 77.0169586906695,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 188433,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 55602,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-vanilla.diffstat",
+          "patch_bytes": 2566,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 28 +++++++++++++++++++---\n 1 file changed, 25 insertions(+), 3 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326468/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user types an invalid or non-matching value.\n- Reused existing translation keys for the validation messages.\n- Kept deletion disabled while the email confirmation is invalid or deletion is already running.\n- Added a guard inside `deleteAccount()` so form submission via Enter cannot bypass the disabled button state.\n\nVerification:\n- `git diff --check` passed.\n- Could not run `prettier`, `eslint`, or `tsc` because those binaries are not available in the current checkout\u2019s executable path.\n",
+        "stderr_tail": "isConfirmationEmailValid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +123,20 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            isInvalid={showInputError}\n+            aria-invalid={showInputError}\n+            aria-describedby={showInputError ? \"deleteAccountConfirmation-error\" : undefined}\n           />\n+          {showInputError && (\n+            <p className=\"mt-1 text-sm text-red-500\" id=\"deleteAccountConfirmation-error\">\n+              {isEmailMalformed\n+                ? t(\"auth.verification-requested.invalid_email_address\")\n+                : t(\"environments.actions.does_not_exactly_match\")}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n55,602\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 255035,
+        "scan_time": 3174,
+        "total_time": 258209,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 53479,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter2-fooks.diffstat",
+          "patch_bytes": 3006,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--\n 1 file changed, 22 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3174,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 88,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2636,
+              "stdout_tail": "solveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 906.54\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 148.1\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 86.89\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 76.62\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 65.77\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 449,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:04:27.022Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex/fooks/attachments/bm-t5-fooks-1776326663.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex/fooks/attachments/bm-t5-fooks-1776326663.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:04:27.011Z\",\"attachedAt\":\"2026-04-16T08:04:27.009Z\",\"lastScanAt\":\"2026-04-16T08:04:27.009Z\",\"lastRefreshAt\":\"2026-04-16T08:04:27.009Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion email confirmation update in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776326663/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user enters a malformed or non-matching email.\n- Kept deletion disabled while the confirmation email is invalid or deletion is running.\n- Added a guard in `deleteAccount()` so form submit/Enter cannot bypass the disabled delete button.\n- Reused existing translations; no locale files were changed.\n\nValidation:\n- `git diff --check -- apps/web/modules/account/components/DeleteAccountModal/index.tsx` passed.\n- Could not run Prettier/ESLint/TypeScript because local `node_modules` tooling is missing in this worktree (`prettier`, `eslint`, and `tsc` are not available).\n",
+        "stderr_tail": "pb-6 pl-6\">\n           <li>\n@@ -111,10 +120,21 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={showConfirmationEmailError}\n+            aria-describedby={showConfirmationEmailError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {showConfirmationEmailError && (\n+            <p id=\"deleteAccountConfirmationError\" className=\"mt-2 text-sm text-red-600\">\n+              {isConfirmationEmailMalformed\n+                ? t(\"auth.verification-requested.invalid_email_address\")\n+                : t(\"environments.settings.profile.please_enter_email_to_confirm_account_deletion\", {\n+                    email: user.email,\n+                  })}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n53,479\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -35.34518900617196,
+        "total": -37.02960734054014
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 3,
+      "timestamp": "2026-04-16T17:08:50.554909",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 3857221.1999999997,
+        "compressed_bytes": 1413111.0,
+        "raw_tokens": 964305.0,
+        "compressed_tokens": 353277.0,
+        "tokens_saved": 611027.0,
+        "reduction_pct": 63.364532995929814,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 188316,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 56935,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-vanilla.diffstat",
+          "patch_bytes": 2800,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 25 ++++++++++++++++++++--\n 1 file changed, 23 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the account deletion confirmation validation in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776326938/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nChanges made:\n- Switched the confirmation input to `type=\"email\"`.\n- Added inline red validation feedback after the user types a malformed email or a non-matching email.\n- Kept existing translation usage by reusing existing `t()` keys.\n- Disabled deletion while the email is invalid or deletion is already running.\n- Added a guard in `deleteAccount()` so form submission cannot bypass the disabled delete button.\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `node_modules` is missing and the commands are not installed in this workspace.\n",
+        "stderr_tail": ">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -96,6 +109,7 @@\n         </ul>\n         <form\n           data-testid=\"deleteAccountForm\"\n+          noValidate\n           onSubmit={async (e) => {\n             e.preventDefault();\n             await deleteAccount();\n@@ -111,10 +125,17 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={!!emailConfirmationError}\n+            aria-describedby={emailConfirmationError ? \"deleteAccountConfirmationError\" : undefined}\n           />\n+          {emailConfirmationError && (\n+            <p className=\"mt-1 text-sm text-red-500\" id=\"deleteAccountConfirmationError\">\n+              {emailConfirmationError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n56,935\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 214106,
+        "scan_time": 3935,
+        "total_time": 218041,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/account/components/DeleteAccountModal/index.tsx"
+        ],
+        "tokens_used": 65199,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776325941/formbricks-T5-iter3-fooks.diffstat",
+          "patch_bytes": 3020,
+          "diffstat": " .../components/DeleteAccountModal/index.tsx        | 24 ++++++++++++++++++++--\n 1 file changed, 22 insertions(+), 2 deletions(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "input_type_email",
+                "passed": true
+              },
+              {
+                "name": "inline_red_error",
+                "passed": true
+              },
+              {
+                "name": "invalid_email_state",
+                "passed": true
+              },
+              {
+                "name": "non_matching_email_state",
+                "passed": true
+              },
+              {
+                "name": "disabled_condition_updated",
+                "passed": true
+              },
+              {
+                "name": "submit_guard",
+                "passed": true
+              },
+              {
+                "name": "aria_invalid",
+                "passed": true
+              },
+              {
+                "name": "aria_describedby",
+                "passed": true
+              },
+              {
+                "name": "existing_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3935,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 107,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 3349,
+              "stdout_tail": "lveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 1015.49\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 157.96\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 102.3\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 99.27\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 69.99\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 477,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:12:17.626Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex/fooks/attachments/bm-t5-fooks-1776327132.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex/fooks/attachments/bm-t5-fooks-1776327132.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:12:17.616Z\",\"attachedAt\":\"2026-04-16T08:12:17.614Z\",\"lastScanAt\":\"2026-04-16T08:12:17.614Z\",\"lastRefreshAt\":\"2026-04-16T08:12:17.614Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/.codex",
+          "prompt_sha256": "920cc272ab8728825be4a2f4f96d868cb9a85bca7c59b0481da1bf2fa0b52a60",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the form validation change in [apps/web/modules/account/components/DeleteAccountModal/index.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776327132/apps/web/modules/account/components/DeleteAccountModal/index.tsx).\n\nWhat changed:\n- Switched the confirmation input to `type=\"email\"`.\n- Added an inline red validation message after the user types an invalid or non-matching email.\n- Reused existing translation keys for the error messages.\n- Kept deletion disabled while the email is invalid or deletion is already running.\n- Added a guard in `deleteAccount()` so Enter-submit cannot bypass the disabled delete button.\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `prettier` and `eslint` executables are not available in this checkout.\n",
+        "stderr_tail": "ing\")}\n       isDeleting={deleting}\n-      disabled={inputValue !== user.email}>\n+      disabled={isConfirmationEmailInvalid || deleting}>\n       <div className=\"py-5\">\n         <ul className=\"list-disc pb-6 pl-6\">\n           <li>\n@@ -111,10 +123,18 @@\n             onChange={handleInputChange}\n             placeholder={user.email}\n             className=\"mt-5\"\n-            type=\"text\"\n+            type=\"email\"\n             id=\"deleteAccountConfirmation\"\n             name=\"deleteAccountConfirmation\"\n+            aria-invalid={!!confirmationEmailError}\n+            aria-describedby={confirmationEmailError ? \"deleteAccountConfirmation-error\" : undefined}\n+            isInvalid={!!confirmationEmailError}\n           />\n+          {confirmationEmailError && (\n+            <p id=\"deleteAccountConfirmation-error\" className=\"mt-1 text-xs text-red-500\">\n+              {confirmationEmailError}\n+            </p>\n+          )}\n         </form>\n       </div>\n     </DeleteDialog>\n\ntokens used\n65,199\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -13.695065740563733,
+        "total": -15.784638586206166
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/benchmark-full-1776327829.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776327829.json
@@ -1,0 +1,1042 @@
+{
+  "timestamp": "2026-04-16T17:45:30.437381",
+  "summary": {
+    "total_benchmarks": 3,
+    "successful_pairs": 3,
+    "vanilla_success": 3,
+    "fooks_success": 3,
+    "same_file_pairs": 3,
+    "avg_token_reduction": 69.85156645128036,
+    "avg_tokens_saved": 718148.3333333334,
+    "median_exec_improvement": -18.17825989711474,
+    "median_total_improvement": -19.907179601878774,
+    "median_runtime_token_reduction": -49.74528921998247,
+    "runtime_token_reductions": [
+      4.11093257653221,
+      -49.74528921998247,
+      -169.0504768347773
+    ],
+    "acceptance_pairs": [
+      {
+        "iteration": 1,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 2,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      },
+      {
+        "iteration": 3,
+        "vanilla": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        },
+        "fooks": {
+          "available": true,
+          "score": 10,
+          "max_score": 10,
+          "checks": [
+            {
+              "name": "target_file_only",
+              "passed": true
+            },
+            {
+              "name": "caps_lock_state",
+              "passed": true
+            },
+            {
+              "name": "get_modifier_state",
+              "passed": true
+            },
+            {
+              "name": "password_input_handlers",
+              "passed": true
+            },
+            {
+              "name": "inline_warning_text",
+              "passed": true
+            },
+            {
+              "name": "red_tailwind_warning",
+              "passed": true
+            },
+            {
+              "name": "accessible_announcement",
+              "passed": true
+            },
+            {
+              "name": "password_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "two_factor_flow_preserved",
+              "passed": true
+            },
+            {
+              "name": "email_signin_flow_preserved",
+              "passed": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "notes": {
+    "tokenEstimate": {
+      "scope": "tsx-only proxy",
+      "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+    },
+    "environmentParity": {
+      "runner": "Selected with --runner; vanilla and fooks variants use the same runner.",
+      "prompt": "Identical task text for vanilla and fooks variants.",
+      "codexHome": "Each variant uses an isolated CODEX_HOME with auth.json and config.toml symlinked from the same host account.",
+      "variantDifference": "The fooks variant runs fooks init/scan/attach before the same agent command; vanilla does not."
+    },
+    "artifactCapture": {
+      "scope": "git diff patch, git diff --stat, git diff --check, changed file list, task-specific acceptance score when available.",
+      "purpose": "Separate output parity and quality evidence from runtime/token measurements."
+    }
+  },
+  "riskAssessment": {
+    "overall": "high",
+    "scale": {
+      "low": "Safe to cite with caveat.",
+      "medium": "Useful but should be repeated.",
+      "high": "Round-1 directional evidence only.",
+      "critical": "Do not cite without fixing measurement."
+    },
+    "risks": [
+      {
+        "name": "sample_size",
+        "level": "medium",
+        "evidence": "3 successful paired benchmark(s).",
+        "interpretation": "Use as round-1 proof only; repeat N>=3 before claiming stable performance."
+      },
+      {
+        "name": "environment_parity",
+        "level": "low",
+        "evidence": "same_prompt=True, same_files=True, same_runner=True, runner=codex exec --full-auto",
+        "interpretation": "Both variants use the same selected runner with isolated CODEX_HOME; fooks additionally prepares native fooks context."
+      },
+      {
+        "name": "orchestration_overhead",
+        "level": "low",
+        "evidence": "runner=codex exec --full-auto",
+        "interpretation": "Direct Codex is the cleaner product benchmark; OMX runner includes orchestration overhead and policy surface."
+      },
+      {
+        "name": "cleanup_reproducibility",
+        "level": "low",
+        "evidence": "cleanup_removed=True",
+        "interpretation": "Worktree residue can contaminate reruns if cleanup fails."
+      },
+      {
+        "name": "artifact_quality",
+        "level": "low",
+        "evidence": "acceptance_scored_pairs=3, fooks_lower_score_pairs=0",
+        "interpretation": "Output parity matters as much as time/token deltas; inspect captured patches when fooks scores lower."
+      },
+      {
+        "name": "wall_clock_noise",
+        "level": "low",
+        "evidence": "Single-run wall-clock timing includes model/service variability.",
+        "interpretation": "Prefer median and p95 over repeated identical tasks."
+      },
+      {
+        "name": "runtime_token_claim",
+        "level": "high",
+        "evidence": "Actual OMX/Codex tokens available; fooks used more runtime tokens in 2/3 pair(s).",
+        "interpretation": "Do not claim runtime token reduction from this run; keep proxy compression and actual tokens separate."
+      }
+    ]
+  },
+  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829",
+  "results": [
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 1,
+      "timestamp": "2026-04-16T17:23:49.979260",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 5308052.399999999,
+        "compressed_bytes": 1318296.0,
+        "raw_tokens": 1327013.0,
+        "compressed_tokens": 329574.0,
+        "tokens_saved": 997439.0,
+        "reduction_pct": 75.16422407585878,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 232586,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 47921,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-vanilla.diffstat",
+          "patch_bytes": 2630,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-\n 1 file changed, 17 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776327838/apps/web/modules/auth/login/components/login-form.tsx:148).\n\nWhat changed:\n- Added React state for Caps Lock status.\n- Updated the password field to detect Caps Lock on `onKeyDown` and `onKeyUp`.\n- Resets the warning on password field blur.\n- Renders a small red inline warning under the password field with `role=\"alert\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Left email sign-in, password reset, and two-factor flows untouched.\n\nModified file:\n- `apps/web/modules/auth/login/components/login-form.tsx`\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- `pnpm exec prettier` and `pnpm exec eslint` could not run because those binaries are not installed in this checkout.\n",
+        "stderr_tail": "sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => {\n+                              field.onBlur();\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p role=\"alert\" aria-live=\"polite\" className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n47,921\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 196514,
+        "scan_time": 3213,
+        "total_time": 199727,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 45951,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter1-fooks.diffstat",
+          "patch_bytes": 2033,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 19 +++++++++++++++++++\n 1 file changed, 19 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3213,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 93,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2638,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 881.77\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 149.23\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 84.18\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 74.14\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 63.75\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 482,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:28:00.778Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex/fooks/attachments/bm-t5-fooks-1776328076.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex/fooks/attachments/bm-t5-fooks-1776328076.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:28:00.768Z\",\"attachedAt\":\"2026-04-16T08:28:00.765Z\",\"lastScanAt\":\"2026-04-16T08:28:00.765Z\",\"lastRefreshAt\":\"2026-04-16T08:28:00.765Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328076/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added React state for Caps Lock detection.\n- Updated the password input to track `CapsLock` via keyboard events.\n- Added a small red inline warning under the password field with `role=\"status\"` and `aria-live=\"polite\"`.\n- Kept the existing email sign-in, password reset, and two-factor flows unchanged.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Could not run ESLint/Prettier because `pnpm exec eslint` and `pnpm exec prettier` are unavailable in this checkout (`Command \"eslint\"/\"prettier\" not found`).\n",
+        "stderr_tail": "Change={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => {\n+                              field.onBlur();\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n45,951\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": 15.509102009579253,
+        "total": 14.127677504234992
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 2,
+      "timestamp": "2026-04-16T17:31:24.829390",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 4348113.0,
+        "compressed_bytes": 1238945.4,
+        "raw_tokens": 1087028.0,
+        "compressed_tokens": 309736.0,
+        "tokens_saved": 777291.0,
+        "reduction_pct": 71.5061361100781,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 178840,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 36512,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-vanilla.diffstat",
+          "patch_bytes": 1950,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 15 +++++++++++++++\n 1 file changed, 15 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the inline Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328293/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added `isCapsLockOn` React state.\n- Updated the password field to detect Caps Lock via `event.getModifierState(\"CapsLock\")` on key down/up.\n- Rendered a small red Tailwind warning under the password field with `role=\"status\"` and `aria-live=\"polite\"`.\n- Left email sign-in, password reset, and two-factor flows untouched.\n\nVerification:\n- `git diff --check` passed.\n- I could not run Prettier or ESLint because this checkout has no `node_modules`, and `pnpm exec prettier` / `pnpm --filter @formbricks/web exec eslint` reported the commands were unavailable.\n",
+        "stderr_tail": "       onKeyDown={(event) => {\n+                              setIsCapsLockOn(event.getModifierState(\"CapsLock\"));\n+                            }}\n+                            onKeyUp={(event) => {\n+                              setIsCapsLockOn(event.getModifierState(\"CapsLock\"));\n+                            }}\n+                            onBlur={() => {\n+                              setIsCapsLockOn(false);\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p role=\"status\" aria-live=\"polite\" className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n36,512\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 211350,
+        "scan_time": 3092,
+        "total_time": 214442,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 54675,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter2-fooks.diffstat",
+          "patch_bytes": 2439,
+          "diffstat": " .../web/modules/auth/login/components/login-form.tsx | 20 ++++++++++++++++++++\n 1 file changed, 20 insertions(+)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3092,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 107,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2546,
+              "stdout_tail": "olveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 853.45\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 140.41\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 80.94\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 73.56\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 61.02\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 438,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:34:42.059Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex/fooks/attachments/bm-t5-fooks-1776328477.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex/fooks/attachments/bm-t5-fooks-1776328477.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:34:42.049Z\",\"attachedAt\":\"2026-04-16T08:34:42.047Z\",\"lastScanAt\":\"2026-04-16T08:34:42.047Z\",\"lastRefreshAt\":\"2026-04-16T08:34:42.047Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328477/apps/web/modules/auth/login/components/login-form.tsx:151).\n\nChanged only:\n`apps/web/modules/auth/login/components/login-form.tsx`\n\nWhat changed:\n- Added `isCapsLockOn` React state.\n- Detects Caps Lock from password field `onKeyDown` / `onKeyUp` via `event.getModifierState(\"CapsLock\")`.\n- Clears the warning on password field blur while preserving `field.onBlur()`.\n- Renders a small red Tailwind warning under the password input with `role=\"status\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Used `t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })` so the string remains i18n-compatible without modifying locale files.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Targeted ESLint could not run because this checkout does not have an installed `eslint` binary in `node_modules`.\n",
+        "stderr_tail": "(password) => field.onChange(password)}\n+                            onKeyDown={updateCapsLockState}\n+                            onKeyUp={updateCapsLockState}\n+                            onBlur={() => {\n+                              setIsCapsLockOn(false);\n+                              field.onBlur();\n+                            }}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs font-medium text-red-600\">\n+                              {t(\"auth.login.caps_lock_warning\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n54,675\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -18.17825989711474,
+        "total": -19.907179601878774
+      }
+    },
+    {
+      "task": "T5",
+      "task_name": "Form Validation",
+      "repo": "formbricks",
+      "difficulty": "hard",
+      "iteration": 3,
+      "timestamp": "2026-04-16T17:38:21.290986",
+      "tokens": {
+        "total_files": 882,
+        "raw_bytes": 2415327.6,
+        "compressed_bytes": 896464.7999999999,
+        "raw_tokens": 603831.0,
+        "compressed_tokens": 224116.0,
+        "tokens_saved": 379715.0,
+        "reduction_pct": 62.88433916790419,
+        "scope": "tsx-only proxy",
+        "method": "Sample TSX files, run `fooks extract --model-payload`, scale sampled bytes to repo-level proxy."
+      },
+      "vanilla": {
+        "success": true,
+        "duration_ms": 172430,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 45823,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-vanilla.diffstat",
+          "patch_bytes": 2604,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 18 +++++++++++++++++-\n 1 file changed, 17 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-vanilla-1776328708/apps/web/modules/auth/login/components/login-form.tsx).\n\nWhat changed:\n- Added React state for Caps Lock status.\n- Detects Caps Lock via password field `onKeyDown` / `onKeyUp`.\n- Clears the warning on password field blur.\n- Renders a small red Tailwind warning under the password field only while Caps Lock is on.\n- Uses `role=\"status\"` and `aria-live=\"polite\"` for accessible announcement.\n- Kept the existing login, reset-password link, and two-factor flow structure unchanged.\n\nVerification:\n- `git diff --check -- apps/web/modules/auth/login/components/login-form.tsx` passed.\n- Targeted ESLint could not run because `eslint` is not installed/available in this worktree via `pnpm`.\n- Modified file: `apps/web/modules/auth/login/components/login-form.tsx`.\n",
+        "stderr_tail": "ark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n+                            onBlur={() => setIsCapsLockOn(false)}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              className=\"mt-1 text-left text-xs font-medium text-red-600\"\n+                              role=\"status\"\n+                              aria-live=\"polite\">\n+                              {t(\"auth.login.caps_lock_is_on\", \"Caps Lock is on\")}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n45,823\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "fooks": {
+        "success": true,
+        "duration_ms": 233158,
+        "scan_time": 3105,
+        "total_time": 236263,
+        "files": 1,
+        "files_list": [
+          "apps/web/modules/auth/login/components/login-form.tsx"
+        ],
+        "tokens_used": 123287,
+        "artifact": {
+          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.patch",
+          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776327829/formbricks-T5-iter3-fooks.diffstat",
+          "patch_bytes": 2543,
+          "diffstat": " apps/web/modules/auth/login/components/login-form.tsx | 17 ++++++++++++++++-\n 1 file changed, 16 insertions(+), 1 deletion(-)\n",
+          "diff_check": {
+            "success": true,
+            "stdout": "",
+            "stderr": ""
+          },
+          "acceptance": {
+            "available": true,
+            "score": 10,
+            "max_score": 10,
+            "checks": [
+              {
+                "name": "target_file_only",
+                "passed": true
+              },
+              {
+                "name": "caps_lock_state",
+                "passed": true
+              },
+              {
+                "name": "get_modifier_state",
+                "passed": true
+              },
+              {
+                "name": "password_input_handlers",
+                "passed": true
+              },
+              {
+                "name": "inline_warning_text",
+                "passed": true
+              },
+              {
+                "name": "red_tailwind_warning",
+                "passed": true
+              },
+              {
+                "name": "accessible_announcement",
+                "passed": true
+              },
+              {
+                "name": "password_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "two_factor_flow_preserved",
+                "passed": true
+              },
+              {
+                "name": "email_signin_flow_preserved",
+                "passed": true
+              }
+            ]
+          }
+        },
+        "prepare": {
+          "success": true,
+          "duration_ms": 3105,
+          "steps": [
+            {
+              "name": "init",
+              "success": true,
+              "duration_ms": 85,
+              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.fooks/cache\"}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "scan",
+              "success": true,
+              "duration_ms": 2573,
+              "stdout_tail": "tResolveCacheHits\": 165\n    },\n    \"slowFiles\": [\n      {\n        \"filePath\": \"apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 849.34\n      },\n      {\n        \"filePath\": \"apps/storybook/src/App.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 146.37\n      },\n      {\n        \"filePath\": \"apps/web/modules/survey/editor/components/block-card.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 84.3\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/view-permission-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 77\n      },\n      {\n        \"filePath\": \"apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx\",\n        \"kind\": \"component\",\n        \"action\": \"refreshed\",\n        \"totalMs\": 65.56\n      }\n    ]\n  }\n}\n",
+              "stderr_tail": ""
+            },
+            {
+              "name": "attach-codex",
+              "success": true,
+              "duration_ms": 447,
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-16T08:41:31.227Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex/fooks/attachments/bm-t5-fooks-1776328887.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex/fooks/attachments/bm-t5-fooks-1776328887.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-16T08:41:31.217Z\",\"attachedAt\":\"2026-04-16T08:41:31.214Z\",\"lastScanAt\":\"2026-04-16T08:41:31.214Z\",\"lastRefreshAt\":\"2026-04-16T08:41:31.214Z\"}}\n",
+              "stderr_tail": ""
+            }
+          ],
+          "error": null
+        },
+        "command": {
+          "runner": "codex exec --full-auto",
+          "runner_key": "codex",
+          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887",
+          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/.codex",
+          "prompt_sha256": "b5975512706d6bd11e3c5a2c8b26f0ff399359720ebe52d940fcbf09c6b19747",
+          "codex_bin": "/opt/homebrew/bin/codex"
+        },
+        "stdout_tail": "Implemented the Caps Lock warning in [login-form.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T5-fooks-1776328887/apps/web/modules/auth/login/components/login-form.tsx:148).\n\nChanged only `apps/web/modules/auth/login/components/login-form.tsx`:\n- Added React state for Caps Lock detection.\n- Updated the password field with `onKeyDown` / `onKeyUp` handlers using `getModifierState(\"CapsLock\")`.\n- Rendered a small red Tailwind warning under the password input with `role=\"status\"` and `aria-live=\"polite\"` only when Caps Lock is on.\n- Left the existing email sign-in, password reset link, and two-factor branches unchanged.\n\nValidation:\n- `git diff --check` passed.\n- Targeted ESLint could not run because dependencies are not installed in this workspace: `Command \"eslint\" not found`.\n",
+        "stderr_tail": "nded-md border-slate-300 pr-8 shadow-sm focus:border-brand-dark focus:ring-brand-dark sm:text-sm\"\n                             value={field.value}\n                             onChange={(password) => field.onChange(password)}\n+                            onKeyDown={handlePasswordKeyEvent}\n+                            onKeyUp={handlePasswordKeyEvent}\n                           />\n+                          {isCapsLockOn && (\n+                            <p\n+                              role=\"status\"\n+                              aria-live=\"polite\"\n+                              className=\"mt-1 text-left text-xs text-red-600\">\n+                              {t(\"auth.login.caps_lock_is_on\", { defaultValue: \"Caps Lock is on\" })}\n+                            </p>\n+                          )}\n                           {error?.message && <FormError className=\"text-left\">{error.message}</FormError>}\n                         </div>\n                       </FormControl>\n\ntokens used\n123,287\n",
+        "error": null,
+        "cleanup": {
+          "removed": true,
+          "branch_deleted": true,
+          "error": null
+        }
+      },
+      "improvement": {
+        "exec": -35.21892942063446,
+        "total": -37.019660151945715
+      }
+    }
+  ]
+}

--- a/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md
+++ b/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md
@@ -1,0 +1,61 @@
+# Round-one risk follow-up: direct Codex Formbricks repeats
+
+Date: 2026-04-16
+Runner: direct `codex exec --full-auto`
+Repo: `formbricks/formbricks`
+Framework surface: Next.js app components with Tailwind classes
+Variant contract: vanilla and fooks use the same prompt, same runner, isolated `CODEX_HOME`; fooks additionally runs `fooks init` / `fooks scan` / `fooks attach codex`.
+
+## Why this follow-up exists
+
+The first direct-Codex Formbricks N=1 run showed a promising fooks result, but the risk assessment still had three important gaps:
+
+1. Sample size was too small.
+2. The task mix only covered one feature type.
+3. Runtime-token regressions needed to be separated from proxy compression claims.
+
+This follow-up adds a second N=3 task and preserves patch artifacts so output quality can be checked alongside time and token deltas.
+
+## Included evidence
+
+| Report | Task | Pairs | Same target file | Acceptance result | Median total-time improvement | Median runtime-token reduction |
+| --- | --- | ---: | ---: | --- | ---: | ---: |
+| `benchmark-full-1776325941.json` | Delete account email confirmation validation | 3 | 3/3 | fooks lower in 1/3 | -15.78% | +3.82% |
+| `benchmark-full-1776327829.json` | Login password Caps Lock warning | 3 | 3/3 | parity in 3/3 | -19.91% | -49.75% |
+
+Rollup across both direct-Codex N=3 runs:
+
+- Successful paired runs: 6/6
+- Same-file pairs: 6/6
+- Fooks lower acceptance score: 1/6
+- Median total-time improvement: -17.85%
+- Median runtime-token reduction: -5.35%
+- Fooks used more runtime tokens in 3/6 pairs
+
+## Interpretation
+
+This evidence does **not** support a stable direct-Codex speed or runtime-token reduction claim yet. The honest current read is:
+
+- fooks reliably kept the agent on the intended file in these targeted Formbricks tasks.
+- fooks proxy compression remains positive, but proxy compression is not the same as actual Codex runtime token usage.
+- On explicit single-file tasks, fooks preparation can add context without reducing the agent's reasoning path enough to offset it.
+- More runtime tokens on the fooks side is a negative result, not a marketing win; it should be treated as a regression signal until a task class shows repeated savings.
+
+## Token regression note
+
+The Caps Lock task is the clearest warning sign. Patch sizes were comparable across variants, but fooks runtime tokens were higher in 2/3 pairs and much higher in iteration 3. That means the extra token use is unlikely to be explained by a larger output patch alone. The likely causes to investigate next are:
+
+1. fooks-injected context is helpful for navigation but too heavy for explicitly targeted single-file prompts.
+2. The current attach/runtime-hook path may add context even when the prompt already names the exact file.
+3. Codex hidden reasoning/service variability can amplify small prompt/context differences, so N>=5 and multiple task classes are needed before making claims.
+
+## Next recommended benchmark class
+
+Do not repeat only explicit single-file tasks. The next run should target cases where fooks should theoretically help:
+
+- ambiguous file discovery across a feature folder,
+- multi-file refactor where imports/types matter,
+- migration that requires preserving existing patterns across related components,
+- large TSX component extraction without naming the exact file.
+
+Until those pass, public wording should say: fooks has promising context-compression mechanics and file-targeting behavior, but direct runtime token/time wins are not yet stable in the current Formbricks evidence.


### PR DESCRIPTION
Preserves raw benchmark reports and patch artifacts from Formbricks N=3 runs.

- 5 full benchmark JSON reports
- 24 patch/diffstat artifact files
- Includes round1-risk-followup documentation

Supersedes #68 (branch had diverged from main).