### PR TITLE
[docs] Simplify public docs for easier scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd your-react-project
 fooks setup
 ```
 
-Then open Codex in that repo and work normally. The same setup command also prepares bounded Claude handoff artifacts and an opencode helper when their local runtime homes/tool files are available.
+Then open Codex in that repo and work normally.
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks.
 
@@ -45,17 +45,17 @@ Latest published Codex-oriented benchmark snapshot (2026-04-14):
 
 | Metric | Before | With fooks | Result |
 | --- | --- | --- | --- |
-| Prepared-context proxy estimate | ~2.1M | ~450K | **78.2% less** |
+| Estimated token use | ~2.1M | ~450K | **78.2% less** |
 | Average task time | 98.2s | 77.9s | **20.7% faster** |
 | Large component payloads | full source | compressed payload | **7x-15x smaller** |
 | Success rate | 5/5 | 5/5 | no regression in sample |
 
-These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme). Layer 2 real-runtime task execution is still blocked by an external configured Codex gateway 502, so those real-runtime results do not exist yet.
+These numbers are Codex-focused benchmark/proxy measurements, not Claude or opencode runtime-token savings claims. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md).
 
 ## Everyday commands
 
 ```bash
-fooks setup          # one-time readiness: Codex hooks + Claude handoff + opencode helper
+fooks setup          # one-time Codex activation for this repo
 fooks status codex   # check Codex attach/hook state
 fooks status cache   # check local fooks cache health
 ```
@@ -71,40 +71,25 @@ fooks scan
 
 opencode support is **manual/semi-automatic** today. It does not intercept opencode `read` calls and does not claim automatic runtime-token savings.
 
-`fooks setup` installs the project-local opencode bridge when the project has a supported `.tsx` / `.jsx` component. You can also install or repair just that bridge from the project root:
-
 ```bash
 fooks install opencode-tool
 ```
 
-This creates two project-local opencode artifacts:
+This creates a project-local custom-tool:
 
-- `.opencode/tools/fooks_extract.ts` — the custom tool that runs fooks extraction.
-- `.opencode/commands/fooks-extract.md` — a slash command prompt so you can explicitly run `/fooks-extract path/to/File.tsx` instead of relying on model tool-selection heuristics.
+```text
+.opencode/tools/fooks_extract.ts
+```
 
-In opencode, run `/fooks-extract path/to/File.tsx` or ask the model to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload. The generated tool validates that the requested file stays inside the current opencode project/worktree and calls `fooks extract <file> --model-payload`.
-
-This custom tool and slash command do **not** intercept opencode `read` calls, do **not** install a `tool.execute.before` read replacement hook, and do **not** establish an opencode runtime-token benchmark claim. The slash command only reduces the small usability risk that the model might not choose the tool on its own. Automatic opencode context interception is a separate future project that needs its own quality and token measurements.
-
-Keep these three levels separate:
-
-- explicit use: the user runs `/fooks-extract path/to/File.tsx`
-- tool-selection steering: the generated slash command nudges opencode toward `fooks_extract`, but still does not replace normal `read`
-- automatic read interception: a separate bridge would need to substitute fooks output into normal opencode file reads without broad regressions
-
-fooks does **not** currently install a project-local `read` shadow for opencode. opencode's built-in `read` behavior is broader than this repo's current custom tool bridge: it covers directories, line offsets/limits, binary/image/PDF handling, permission checks, and reminder metadata. Replacing that safely is outside the narrow issue-59 scope and would need a dedicated compatibility and measurement project before any automatic savings claim. See [`docs/opencode-read-interception.md`](docs/opencode-read-interception.md).
+Use it when you want opencode to request a fooks payload for a `.tsx` or `.jsx` file.
 
 ## Support boundaries
 
-| Environment | Current support | Runtime-token claim |
-| --- | --- | --- |
-| Codex | Automatic repeated-file hook path through `fooks setup` | Codex-oriented benchmark/proxy evidence only |
-| Claude | Manual/shared handoff of fooks payloads | No automatic runtime-token savings claim |
-| opencode | Manual/semi-automatic project-local tool and slash command | No read interception and no automatic runtime-token savings claim |
-
-Claude and opencode do **not** currently have automatic runtime-token savings claims in this repo.
-
-`fooks` is not a universal file-read interceptor. Non-frontend files usually fall back to normal source reading.
+- Codex: automatic repeated-file hook path is supported.
+- Claude and opencode: can consume fooks payloads through manual/shared handoff paths.
+- Claude and opencode do **not** currently have automatic runtime-token savings claims in this repo.
+- fooks is not a universal file-read interceptor.
+- Non-frontend files usually fall back to normal source reading.
 
 ## Troubleshooting
 
@@ -116,23 +101,12 @@ fooks status codex
 fooks status cache
 ```
 
-Advanced direct install paths:
-
-```bash
-fooks install codex-hooks
-fooks install opencode-tool
-```
-
-The Codex hook installer is idempotent: it only adds the `fooks codex-runtime-hook --native-hook` command to `SessionStart`, `UserPromptSubmit`, and `Stop` when those entries are missing, and preserves other hooks already present in `~/.codex/hooks.json`.
-
-The opencode tool installer is also explicit and idempotent, but project-local: it creates `.opencode/tools/fooks_extract.ts` and `.opencode/commands/fooks-extract.md` for manual/semi-automatic use and does not edit Codex hooks or global opencode config.
-
 Common causes:
 
 - You are not in a React/TSX/JSX project root.
 - Another global `fooks` binary is earlier in your PATH.
 - `~/.codex/hooks.json` is invalid JSON or not writable.
-- Your Codex runtime home is missing or not writable; use `FOOKS_CODEX_HOME` for an isolated smoke test.
+- The repo/account context is not allowed for attach.
 
 More setup details: [`docs/setup.md`](docs/setup.md)
 
@@ -143,17 +117,9 @@ npm install
 npm test
 ```
 
-Repository layout:
-
-- `src/**/*.ts` is the source of truth for product code.
-- `dist/` is generated JavaScript, declarations, and source maps from `npm run build`.
-- `test/*.mjs` and benchmark `.mjs` files are small Node runners that exercise the built `dist` package.
-- Keep this split unless a TypeScript-runner refactor has a clear payoff; avoiding extra test/runtime tooling is intentional.
-
 Useful internal docs:
 
 - Runtime bridge contract: [`docs/runtime-bridge-contract.md`](docs/runtime-bridge-contract.md)
 - Live feedback checklist: [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md)
 - Release checklist: [`docs/release.md`](docs/release.md)
-- Benchmark harness: [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/tree/main/benchmarks/frontend-harness#readme)
-- Language/core strategy: [`docs/language-core-strategy.md`](docs/language-core-strategy.md)
+- Benchmark harness: [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
-# Setup fooks
+# Setup fooks for Codex
 
-Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex is the only automatic hook path today; Claude and opencode setup results are bounded handoff/tool readiness summaries.
+Use this when you want fooks to work automatically inside a Codex project.
 
 ## 1. Install
 
@@ -24,13 +24,11 @@ Run this from your React project root:
 fooks setup
 ```
 
-`fooks setup` does five things:
+`fooks setup` does three things:
 
 1. creates local `.fooks/` state;
 2. attaches the repo to the Codex runtime;
-3. merges the fooks hook command into `~/.codex/hooks.json`;
-4. prepares Claude manual/shared handoff artifacts when a Claude home is available;
-5. installs the project-local opencode custom tool and slash command when a supported component exists.
+3. merges the fooks hook command into `~/.codex/hooks.json`.
 
 The hook command is:
 
@@ -38,7 +36,7 @@ The hook command is:
 fooks codex-runtime-hook --native-hook
 ```
 
-Package install alone does not edit Codex hooks, Claude files, or opencode project files. Activation only happens when you run `fooks setup`. Benchmark harness commands are not required for normal use; they are only for maintainers measuring fooks behavior.
+Package install alone does not edit Codex hooks. Activation only happens when you run `fooks setup`.
 
 ## 3. Check status
 
@@ -60,29 +58,18 @@ Good signs:
 | `partial` | Some setup work succeeded, but a blocker remains. Read `blockers` / `nextSteps`, fix, then rerun `fooks setup`. |
 | `blocked` | fooks could not activate this repo, usually because no supported React component was found. |
 
-`fooks setup` also returns a `runtimes` object:
-
-| Runtime field | Ready state | Meaning |
-| --- | --- | --- |
-| `runtimes.codex.state` | `automatic-ready` | Codex attach, trust status, and hook preset are ready. This is the only automatic runtime hook path in the setup command. |
-| `runtimes.claude.state` | `handoff-ready` or `blocked` | Claude manual/shared handoff artifacts were prepared, or a non-fatal Claude blocker was reported. This does not mean Claude prompt interception is enabled. |
-| `runtimes.opencode.state` | `tool-ready`, `manual-step-required`, or `blocked` | The project-local opencode helper is installed, needs an explicit/manual step, or hit a non-fatal blocker. This does not mean opencode read interception or automatic runtime-token savings are enabled. |
-| `blocksOverall` | `true` only for Codex today | Claude/opencode blockers should not make Codex setup look failed when Codex itself is ready. |
-
 ## Common fixes
 
 ### No React component found
 
-Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files. The activation path is intentionally frontend-focused: repos without supported React component candidates should remain `blocked` instead of installing hooks for unrelated file types.
+Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files.
 
-### Account context
+### Account mismatch
 
-Public repos should not need an account override. fooks derives account context from `FOOKS_ACTIVE_ACCOUNT`, `.fooks/config.json`, GitHub remote metadata, or `package.json` repository metadata. The default placeholder created by `fooks setup` is ignored so a fresh user is not blocked by `<your-github-org>`.
-
-If you still need to force a value for local validation, set the target explicitly:
+If the repo account is ambiguous, set the target explicitly:
 
 ```bash
-FOOKS_TARGET_ACCOUNT=<your-github-org> fooks setup
+FOOKS_TARGET_ACCOUNT=minislively fooks setup
 ```
 
 ### Bad Codex hooks file
@@ -97,42 +84,27 @@ Setup is idempotent: rerunning it should not duplicate fooks hook entries.
 
 ## opencode custom-tool
 
-opencode support is a manual/semi-automatic custom-tool bridge. `fooks setup` prepares this bridge when it can prove a supported component exists, and `fooks install opencode-tool` remains the direct repair/debug command. It is intentionally separate from the Codex hook setup path and does not make an automatic runtime-token savings claim.
-
-From an opencode project root, run:
+opencode support is manual/semi-automatic. It is not automatic read interception and does not claim opencode runtime-token savings.
 
 ```bash
 fooks install opencode-tool
 ```
 
-This creates two project-local files:
+This creates:
 
-- `.opencode/tools/fooks_extract.ts` — the custom tool implementation.
-- `.opencode/commands/fooks-extract.md` — a slash command prompt for explicit `/fooks-extract path/to/File.tsx` use.
+```text
+.opencode/tools/fooks_extract.ts
+```
 
-After restarting or opening opencode for that project, run `/fooks-extract path/to/File.tsx` or ask opencode to call `fooks_extract` for a `.tsx` or `.jsx` file when you want a fooks model-facing payload. The slash command reduces tool-selection ambiguity; it is not automatic read interception.
-
-The generated custom tool:
+The generated tool:
 
 - calls `fooks extract <file> --model-payload`;
-- validates that the requested file stays inside the current opencode project/worktree;
-- supports `.tsx` and `.jsx` files in this MVP;
-- does not edit `~/.config/opencode`;
+- accepts `.tsx` and `.jsx` files;
+- validates that the file stays inside the current project/worktree;
 - does not edit Codex hooks;
-- does not edit global opencode config;
-- does not install `tool.execute.before` or any opencode `read` interception hook.
+- does not edit global opencode config.
 
-The generated slash command follows opencode's project command convention: markdown files under `.opencode/commands/` become `/command-name` entries, and `$ARGUMENTS` passes the text after the command into the prompt.
-
-Treat this as a usability bridge, not as a benchmark result. This setup guide does not claim opencode runtime-token savings unless a future benchmark explicitly measures them.
-
-Keep these distinct:
-
-- explicit `/fooks-extract ...` usage;
-- tool-selection steering toward `fooks_extract`;
-- true automatic `read` interception.
-
-Today, `fooks install opencode-tool` only covers the first two. It does not install a project-local `read` override. That omission is intentional: opencode's native `read` surface is broader than the current bridge and includes directory reads, `offset`/`limit` handling, binary/image/PDF behavior, permission gates, and reminder metadata. Shipping a generated `read` shadow without reproducing that contract would be a broader and riskier change than this MVP supports. See [`docs/opencode-read-interception.md`](opencode-read-interception.md).
+Claude and opencode can use fooks payloads through manual/shared handoff paths, but this repo does not claim automatic runtime-token savings for Claude and opencode.
 
 ## Advanced commands
 
@@ -145,14 +117,3 @@ fooks codex-runtime-hook --native-hook
 fooks scan
 fooks extract <file> --model-payload
 ```
-
-Use them only when you are debugging a setup blocker or validating an adapter path directly.
-
-## Support boundaries
-
-- The primary supported automatic activation path today is Codex hook activation through `fooks setup`.
-- Package installation alone does not edit Codex hooks.
-- Claude support remains manual/shared handoff oriented unless a separate Claude-native hook installer is introduced in the future.
-- opencode support is manual/semi-automatic custom-tool and slash-command oriented unless a separate opencode read-interception bridge is introduced and measured in the future.
-- This setup guide does not make benchmark or marketing claims; it only explains installation, activation, verification, and recovery.
-- Benchmark harnesses, Python runners, and Layer 2 task-execution scaffolds are maintainer measurement tools, not required setup steps.


### PR DESCRIPTION
Makes public documentation easier to scan and read.

- Simplified README structure
- Streamlined setup guide
- Removed redundant sections