### PR TITLE
[fix] Close empty-context dead end in fooks run

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -31,6 +31,41 @@ function shellQuote(value: string): string {
   return JSON.stringify(value);
 }
 
+function printSharedHandoff(executionContext: {
+  contextPath: string;
+  fileCount: number;
+  totalSize: number;
+  contextMode: string;
+  contextModeReason: string;
+  prompt: string;
+}): void {
+  const quotedContextPath = shellQuote(executionContext.contextPath);
+  console.log("\n=== Shared Handoff Context ===");
+  console.log(`Context ready: ${executionContext.contextPath}`);
+  console.log(`Files: ${executionContext.fileCount}, Size: ${(executionContext.totalSize / 1024).toFixed(1)}KB`);
+  console.log(`Context mode: ${executionContext.contextMode} (${executionContext.contextModeReason})`);
+  console.log(`Prompt: "${executionContext.prompt}"`);
+
+  if (executionContext.contextMode === "no-op" && executionContext.fileCount === 0) {
+    console.log("\nNo reusable source context was selected.");
+    console.log("This usually means your prompt targets a new or missing file, so the temp context is metadata-only.");
+    console.log("\nNext steps:");
+    console.log("Use your original prompt directly in codex, claude, omx, or another runtime.");
+    console.log("If you already ran `fooks setup` for Codex, open `codex` in this repo and work normally.");
+    console.log(`Metadata-only context file: ${executionContext.contextPath}`);
+    console.log("======================\n");
+    return;
+  }
+
+  console.log("\nManual next steps:");
+  console.log(`Inspect the shared context: cat ${quotedContextPath}`);
+  console.log(`Codex: start \`codex\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
+  console.log(`Claude: start \`claude\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
+  console.log("\nNext: Open this context with your preferred runtime (codex, claude, omx, etc.)");
+  console.log(`Context file: ${executionContext.contextPath}`);
+  console.log("======================\n");
+}
+
 export async function runTask(options: RunOptions): Promise<RunResult> {
   const startTime = Date.now();
   
@@ -77,19 +112,7 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
     let executionContext;
     if (runner === "codex" || runner === "omx") {
       executionContext = await prepareExecutionContext(options.prompt, processedFiles, cwd, selection.policy);
-      const quotedContextPath = shellQuote(executionContext.contextPath);
-      console.log("\n=== Shared Handoff Context ===");
-      console.log(`Context ready: ${executionContext.contextPath}`);
-      console.log(`Files: ${executionContext.fileCount}, Size: ${(executionContext.totalSize / 1024).toFixed(1)}KB`);
-      console.log(`Context mode: ${executionContext.contextMode} (${executionContext.contextModeReason})`);
-      console.log(`Prompt: "${executionContext.prompt}"`);
-      console.log("\nManual next steps:");
-      console.log(`Inspect the shared context: cat ${quotedContextPath}`);
-      console.log(`Codex: start \`codex\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
-      console.log(`Claude: start \`claude\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
-      console.log("\nNext: Open this context with your preferred runtime (codex, claude, omx, etc.)");
-      console.log(`Context file: ${executionContext.contextPath}`);
-      console.log("======================\n");
+      printSharedHandoff(executionContext);
     }
     
     // 5. Summary

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -500,6 +500,25 @@ test("cli run keeps exact-file prompts to one light context file", () => {
   assert.doesNotMatch(context, /## src\/components\/SimpleButton.tsx/);
 });
 
+test("cli run gives direct no-op guidance for new or missing exact-file targets", () => {
+  const tempDir = makeTempProject();
+  const output = runText(["run", "Please", "update", "src/components/NewPanel.tsx"], tempDir);
+  assert.match(output, /Shared Handoff Context/);
+  assert.match(output, /Context mode: no-op \(exact-file-new-or-missing-target\)/);
+  assert.match(output, /Files: 0, Size: 0\.0KB/);
+  assert.match(output, /No reusable source context was selected\./);
+  assert.match(output, /This usually means your prompt targets a new or missing file, so the temp context is metadata-only\./);
+  assert.match(output, /Use your original prompt directly in codex, claude, omx, or another runtime\./);
+  assert.match(output, /If you already ran `fooks setup` for Codex, open `codex` in this repo and work normally\./);
+  assert.match(output, /Metadata-only context file: .*temp-context\.md/);
+  assert.doesNotMatch(output, /Inspect the shared context: cat /);
+  assert.doesNotMatch(output, /then paste your prompt and the context from/);
+  assert.doesNotMatch(output, /preferred runtime \(codex, claude, omx, etc\.\)/);
+  const context = fs.readFileSync(path.join(tempDir, ".fooks", "temp-context.md"), "utf8");
+  assert.match(context, /"contextMode":"no-op"/);
+  assert.doesNotMatch(context, /## src\/components\/NewPanel\.tsx/);
+});
+
 test("runtime hook reuses payload only on repeated same-file prompts in one session", () => {
   const sessionId = `hook-repeat-${Date.now()}`;
   const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);


### PR DESCRIPTION
Prevents users from hitting a dead end when running fooks with empty context.

- Detects empty context early
- Provides clear guidance message
- Adds test coverage for the noop case

From first-success-path dogfood session.