### PR TITLE
Preserve tiny-raw payload reuse for validated small-file floor

### DIFF
--- a/test/cache-resilience.test.mjs
+++ b/test/cache-resilience.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { CacheResilience } from "../dist/core/cache-resilience.js";
+
+function makeTempCacheDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "fooks-cache-test-"));
+}
+
+test("CacheResilience: read empty cache returns null", () => {
+  const cacheDir = makeTempCacheDir();
+  const resilience = new CacheResilience(cacheDir);
+  
+  const result = resilience.readIndexSafe();
+  
+  assert.strictEqual(result, null, "Should return null for non-existent cache");
+  
+  fs.rmSync(cacheDir, { recursive: true });
+});
+
+test("CacheResilience: write and read valid cache", () => {
+  const cacheDir = makeTempCacheDir();
+  const resilience = new CacheResilience(cacheDir);
+  
+  const validIndex = {
+    version: "1.0.0",
+    entries: {
+      "file1.ts": { hash: "abc123", timestamp: Date.now(), path: "/test/file1.ts" }
+    }
+  };
+  
+  resilience.writeIndexSafe(validIndex);
+  const result = resilience.readIndexSafe();
+  
+  assert.notStrictEqual(result, null, "Should read valid cache");
+  assert.strictEqual(result.version, "1.0.0");
+  assert.strictEqual(Object.keys(result.entries).length, 1);
+  
+  fs.rmSync(cacheDir, { recursive: true });
+});
+
+test("CacheResilience: corrupted cache returns null and regenerates", () => {
+  const cacheDir = makeTempCacheDir();
+  
+  // Create corrupted cache
+  fs.writeFileSync(path.join(cacheDir, "index.json"), "{ invalid json");
+  
+  const resilience = new CacheResilience(cacheDir);
+  const result = resilience.readIndexSafe();
+  
+  // Should return null (graceful fallback)
+  assert.strictEqual(result, null, "Should return null for corrupted cache");
+  
+  fs.rmSync(cacheDir, { recursive: true });
+});
+
+test("CacheResilience: atomic write prevents partial writes", () => {
+  const cacheDir = makeTempCacheDir();
+  const resilience = new CacheResilience(cacheDir);
+  
+  const validIndex = {
+    version: "1.0.0",
+    entries: { "test.ts": { hash: "xyz", timestamp: 12345, path: "/test.ts" } }
+  };
+  
+  resilience.writeIndexSafe(validIndex);
+  
+  // Verify no temp file left behind
+  const tempExists = fs.existsSync(path.join(cacheDir, "index.json.tmp"));
+  assert.strictEqual(tempExists, false, "Should not leave temp file after atomic write");
+  
+  // Verify actual file exists
+  const indexExists = fs.existsSync(path.join(cacheDir, "index.json"));
+  assert.strictEqual(indexExists, true, "Should have written index.json");
+  
+  fs.rmSync(cacheDir, { recursive: true });
+});

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -16,6 +16,7 @@ const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
 const require = createRequire(import.meta.url);
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { RAW_ORIGINAL_SIZE_THRESHOLD_BYTES } = require(path.join(repoRoot, "dist", "core", "decide.js"));
 const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 const { assessPayloadReadiness } = require(path.join(repoRoot, "dist", "core", "payload", "readiness.js"));
 const { decideCodexPreRead } = require(path.join(repoRoot, "dist", "adapters", "codex-pre-read.js"));
@@ -272,6 +273,30 @@ test("codex pre-read falls back for larger raw files past the original-source th
   assert.equal(result.decision, "fallback");
   assert.ok(result.reasons.includes("raw-mode"));
   assert.equal(result.fallback.reason, "raw-mode");
+});
+
+test("codex pre-read keeps original payloads for small raw files below the validated floor", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-small-raw-"));
+  const rawPath = path.join(tempDir, "SmallRawButton.tsx");
+  const baseSource = fs.readFileSync(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), "utf8").trimEnd();
+  let extracted;
+  for (let extraBytes = 1; extraBytes < 220; extraBytes += 1) {
+    fs.writeFileSync(rawPath, `${baseSource}\n/* ${"x".repeat(extraBytes)} */\n`);
+    extracted = extractFile(rawPath);
+    if (extracted.meta.rawSizeBytes > 200 && extracted.meta.rawSizeBytes < RAW_ORIGINAL_SIZE_THRESHOLD_BYTES) {
+      break;
+    }
+  }
+
+  assert.ok(extracted);
+  assert.equal(extracted.mode, "raw");
+  assert.ok(extracted.meta.rawSizeBytes > 200);
+  assert.ok(extracted.meta.rawSizeBytes < RAW_ORIGINAL_SIZE_THRESHOLD_BYTES);
+
+  const result = decideCodexPreRead(rawPath, tempDir);
+  assert.equal(result.decision, "payload");
+  assert.equal(result.payload.useOriginal, true);
+  assert.equal(result.payload.rawText, extracted.rawText);
 });
 
 test("cli codex-pre-read reuses the same decision seam and advertises the command", () => {


### PR DESCRIPTION
Adds cache resilience test coverage and preserves tiny-raw payload reuse for the validated small-file floor.