### PR TITLE
Make public release readiness auditable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+See [`docs/CODE_OF_CONDUCT.md`](docs/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for helping improve `fooks`.
+
+## Local development
+
+```bash
+npm install
+npm run lint
+npm test
+npm run bench:gate
+npm run release:smoke
+```
+
+Run the smaller checks first while iterating (`npm run lint`, then targeted tests). Run `npm run release:smoke` before any release-readiness PR because it verifies the built package contents and a disposable install/setup path.
+
+## Claim and benchmark rules
+
+Keep public wording conservative:
+
+- Prepared-context estimates are not provider billing-token savings.
+- Bare `fooks status` reports local estimated context-size telemetry only; it is not provider billing data, provider cost data, or a `ccusage` replacement.
+- Claude and opencode support are handoff/tool paths unless a future bridge proves otherwise.
+- Do not claim stable runtime-token/time wins or applied-code benchmark wins without a committed benchmark artifact and matching documentation update.
+
+## Package boundary
+
+The npm package is `oh-my-fooks`; the installed CLI command is `fooks`. Do not document `npm install -g fooks` for this project unless package ownership and release planning change.
+
+## Pull request checklist
+
+- [ ] Source changes are tracked; generated `dist/` is ignored and rebuilt by scripts.
+- [ ] Docs match the current claim boundary.
+- [ ] `npm run lint` passes.
+- [ ] `npm test` passes.
+- [ ] `npm run bench:gate` passes when benchmark-affecting code or claims changed.
+- [ ] `npm run release:smoke` passes when package contents or release docs changed.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ Latest published Codex-oriented benchmark snapshot (2026-04-14):
 | Large component payloads | full source | compressed payload | **7x-15x smaller** |
 | Success rate | 5/5 | 5/5 | no regression in sample |
 
-These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. A later direct-Codex Formbricks N=3 follow-up found that runtime-token/time wins are **not stable yet**: across 6 paired runs, fooks used more runtime tokens in 3/6 pairs and median runtime-token reduction was -5.35%. Treat that as a regression signal, not a marketing win. Full benchmark details live in [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md) and [`benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md`](benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md). Layer 2 now has two proposal-only R4 paired smokes through the current `codex exec` runner: in both pairs, the prompt supplied to Codex dropped from 11,365 approx tokens in vanilla mode to 861 in fooks mode (92.4% smaller). Those proposal-only smokes are validated for runner success, output shape, path-sanitization, and claim boundaries. An applied-code acceptance gate now exists and is self-tested, but matched generated vanilla/fooks outputs have not passed it yet; the current evidence is still not provider billing telemetry, an applied-code benchmark win, or a stable runtime-token/time win claim.
+These are Codex-focused benchmark/proxy measurements from a 5-task sample. The token row is a prepared-context estimate from the benchmark harness, not a measured runtime-token billing claim and not a Claude or opencode savings claim. A later direct-Codex Formbricks N=3 follow-up found that runtime-token/time wins are **not stable yet**: across 6 paired runs, fooks used more runtime tokens in 3/6 pairs and median runtime-token reduction was -5.35%. Treat that as a regression signal, not a marketing win. Full benchmark details live in the GitHub benchmark docs: [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/README.md) and [`benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md). Layer 2 now has two proposal-only R4 paired smokes through the current `codex exec` runner: in both pairs, the prompt supplied to Codex dropped from 11,365 approx tokens in vanilla mode to 861 in fooks mode (92.4% smaller). Those proposal-only smokes are validated for runner success, output shape, path-sanitization, and claim boundaries. An applied-code acceptance gate now exists and is self-tested, but matched generated vanilla/fooks outputs have not passed it yet; the current evidence is still not provider billing telemetry, an applied-code benchmark win, or a stable runtime-token/time win claim.
 
 ## Everyday commands
 
 ```bash
 fooks setup          # one-time readiness: Codex hooks + Claude handoff + opencode helper
+fooks status          # local estimated context-size telemetry for this repo
 fooks status codex   # check Codex attach/hook state
 fooks status cache   # check local fooks cache health
 ```
@@ -66,6 +67,8 @@ For manual inspection:
 fooks extract src/components/Button.tsx --model-payload
 fooks scan
 ```
+
+`fooks status` reads local `.fooks/sessions` summaries produced by the Codex hook path. The values are approximate context-size estimates only; the CLI status output omits per-session details and is not provider billing tokens, provider costs, or a `ccusage` replacement.
 
 ## opencode support
 
@@ -127,4 +130,4 @@ Useful internal docs:
 - Runtime bridge contract: [`docs/runtime-bridge-contract.md`](docs/runtime-bridge-contract.md)
 - Live feedback checklist: [`docs/codex-live-feedback-checklist.md`](docs/codex-live-feedback-checklist.md)
 - Release checklist: [`docs/release.md`](docs/release.md)
-- Benchmark harness: [`benchmarks/frontend-harness/README.md`](benchmarks/frontend-harness/README.md)
+- Benchmark harness: [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/README.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+`fooks` is pre-1.0 software. Security fixes are targeted at the latest release on `main` and the latest published npm version of `oh-my-fooks` when a package has been published.
+
+## Reporting a vulnerability
+
+Please do **not** publish exploit details, private tokens, local file contents, or machine-specific paths in a public issue.
+
+Preferred path:
+
+1. Use GitHub's private vulnerability reporting / security advisory flow for this repository when available.
+2. If private reporting is not available, open a minimal public issue that says you need a private maintainer contact for a security report. Do not include sensitive details in that issue.
+
+Useful report details once a private channel exists:
+
+- fooks version or commit SHA
+- operating system
+- command or hook path involved (`fooks setup`, `fooks status`, `fooks codex-runtime-hook`, etc.)
+- whether the issue involves local `.fooks/` state, `~/.codex/hooks.json`, generated `.opencode/` files, or packed npm contents
+- a minimal reproduction that avoids real secrets
+
+## Local state and hook boundary
+
+`fooks setup` can write project-local `.fooks/` state, project-local opencode helper files, and Codex hook configuration. The package install alone should not mutate those files. Treat unexpected mutation outside those documented paths as security-relevant.

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,19 +31,21 @@ aligned with any future change to this boundary.
 
 Benchmark and language evidence for this boundary must be checked against:
 
-- `benchmarks/frontend-harness/README.md` — current frontend harness methodology and prepared-context/proxy estimates.
-- `benchmarks/layer2-frontend-task/STATUS.md` — canonical Layer 2 state.
-- `benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md` — gateway blocker analysis.
+- [`benchmarks/frontend-harness/README.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/README.md) — current frontend harness methodology and prepared-context/proxy estimates.
+- [`benchmarks/layer2-frontend-task/STATUS.md`](https://github.com/minislively/fooks/blob/main/benchmarks/layer2-frontend-task/STATUS.md) — canonical Layer 2 state.
+- [`benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md`](https://github.com/minislively/fooks/blob/main/benchmarks/layer2-frontend-task/API_ACCESS_BLOCKER.md) — gateway blocker analysis.
 - `docs/language-core-strategy.md` — Python harness benchmark-only and native-core non-goal constraints.
 
 Prepared-context or proxy estimates must not be worded as measured runtime-token
 billing savings. The direct-Codex Formbricks N=3 follow-up in
-`benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md` is
+[`benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md`](https://github.com/minislively/fooks/blob/main/benchmarks/frontend-harness/reports/round1-risk-followup-1776327829.md) is
 also not a win claim: fooks used more runtime tokens in 3/6 pairs and median
 runtime-token reduction was -5.35%. Public wording may say fooks has
 context-compression mechanics and targeted-file behavior, but must not claim
 stable direct runtime-token/time wins until a future multi-task benchmark class
 proves them.
+
+Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
 Layer 2 now has two proposal-only R4 paired smokes through the current
 `codex exec` runner. In both pairs, the prompt supplied to Codex dropped from
@@ -72,6 +74,7 @@ npm ls -g --depth=0 | grep -E 'fooks|oh-my-fooks'
 | `npm publish` not run | Keep unresolved until explicit human approval; use `npm run release:smoke` and `npm publish --dry-run` only for proof. | Blocks real publication, not docs/code PR merge. |
 | Layer 2 applied-code / multi-task evidence absent | Runner path plus two repeated proposal-only smokes now exist. The applied acceptance gate is implemented/self-tested, but matched live generated outputs and multi-task evidence do not exist yet. | Blocks only stable Layer 2 runtime-token/time win claims and applied-code benchmark-win wording. |
 | Direct-Codex runtime-token regression | Negative/unstable Formbricks evidence is documented and linked. | Blocks stable runtime-token/time win claims. |
+| Local `fooks status` estimates | Bare status is documented as local context-size telemetry only. | Blocks billing-token, provider-cost, or `ccusage` replacement wording. |
 | Claude/opencode automatic savings | Explicit non-goal unless new runtime bridges are designed and measured. | Keep handoff/tool wording only. |
 
 ## Pre-publish blockers
@@ -84,6 +87,7 @@ Automated local checks now covered by `npm run release:smoke`:
 - [x] possible pre-existing global `fooks` binary conflict is documented.
 - [x] no install, pack, publish, or version lifecycle script mutates user machines or publishes implicitly.
 - [x] packed tarball includes `dist/cli/index.js`, `dist/index.js`, `README.md`, `package.json`, and linked docs.
+- [x] package source and built `dist/` are generated from tracked source before pack/smoke verification.
 - [x] temp-prefix global install smoke test passes.
 - [x] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
 - [x] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -43,14 +43,18 @@ Package install alone does not edit Codex hooks, Claude files, or opencode proje
 ## 3. Check status
 
 ```bash
+fooks status
 fooks status codex
 fooks status cache
 ```
 
 Good signs:
 
+- Bare `fooks status` returns `metricTier: "estimated"` and no error. A fresh repo may show zero sessions/events.
 - Codex status is connected/ready-style.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
+
+Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 
 ## What the setup result means
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,16 @@
   "main": "dist/index.js",
   "files": [
     "dist",
-    "docs"
+    "docs/setup.md",
+    "docs/release.md",
+    "docs/runtime-bridge-contract.md",
+    "docs/codex-live-feedback-checklist.md",
+    "docs/opencode-read-interception.md",
+    "docs/language-core-strategy.md",
+    "docs/CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md"
   ],
   "repository": {
     "type": "git",

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -41,10 +41,18 @@ function assertPackedFiles(packEntry) {
     "dist/adapters/opencode-tool-preset.js",
     "docs/setup.md",
     "docs/release.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
   ];
 
   for (const filePath of required) {
     assert(paths.has(filePath), `packed tarball missing ${filePath}`);
+  }
+
+  for (const file of packEntry.files) {
+    assert(!file.path.startsWith("docs/archive/"), `packed tarball should not include internal archive docs: ${file.path}`);
+    assert(!file.path.startsWith("benchmarks/frontend-harness/reports/"), `packed tarball should not include internal benchmark reports: ${file.path}`);
   }
 }
 

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -10,6 +10,13 @@ import {
   resolveCodexRuntimeSessionKey,
 } from "./codex-runtime-session";
 import type { CodexRuntimeHookDecision, CodexRuntimeHookInput, ContextMode, ModelFacingPayload } from "../core/schema";
+import {
+  estimateFileBytes,
+  estimateTextBytes,
+  finalizeSessionMetricSummarySafe,
+  initializeSessionMetricSummarySafe,
+  recordFooksSessionMetricEventSafe,
+} from "../core/session-metrics";
 
 function payloadContextMode(payload: ModelFacingPayload): ContextMode {
   return payload.useOriginal ? "light-minimal" : "light";
@@ -21,6 +28,37 @@ function buildAdditionalContext(filePath: string, payload: ModelFacingPayload, c
     "",
     JSON.stringify(payload, null, 2),
   ].join("\n");
+}
+
+function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
+  return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function recordRuntimeDecisionMetric(
+  cwd: string,
+  sessionKey: string,
+  decision: CodexRuntimeHookDecision,
+  options: {
+    originalEstimatedBytes?: number;
+    actualEstimatedBytes?: number;
+    comparableForSavings?: boolean;
+    observedOriginalEstimatedBytes?: number;
+  } = {},
+): void {
+  recordFooksSessionMetricEventSafe(cwd, sessionKey, {
+    runtime: "codex",
+    hookEventName: decision.hookEventName,
+    action: decision.action,
+    filePath: decision.filePath,
+    reasons: decision.reasons,
+    contextMode: decision.contextMode,
+    contextModeReason: decision.contextModeReason,
+    fallbackReason: decision.fallback?.reason,
+    originalEstimatedBytes: options.originalEstimatedBytes,
+    actualEstimatedBytes: options.actualEstimatedBytes,
+    comparableForSavings: options.comparableForSavings,
+    observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+  });
 }
 
 function fallbackDecision(
@@ -67,6 +105,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   if (hookEventName === "SessionStart") {
     const statePath = initializeCodexRuntimeSession(cwd, sessionKey);
     markCodexReady(cwd);
+    initializeSessionMetricSummarySafe(cwd, sessionKey);
     return {
       runtime: "codex",
       hookEventName,
@@ -86,6 +125,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   if (hookEventName === "Stop") {
     const statePath = clearCodexRuntimeSession(cwd, sessionKey);
     clearCodexActiveFile(cwd);
+    finalizeSessionMetricSummarySafe(cwd, sessionKey);
     return {
       runtime: "codex",
       hookEventName,
@@ -109,7 +149,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   const escapeHatchUsed = hasFullReadEscapeHatch(prompt);
 
   if (!target) {
-    return {
+    const runtimeDecision: CodexRuntimeHookDecision = {
       runtime: "codex",
       hookEventName,
       action: "noop",
@@ -125,11 +165,14 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         escapeHatchUsed,
       },
     };
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision);
+    return runtimeDecision;
   }
 
   if (escapeHatchUsed) {
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
-    return fallbackDecision(
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision = fallbackDecision(
       hookEventName,
       target,
       undefined,
@@ -140,6 +183,12 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       "escape-hatch-full-read",
       policy,
     );
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: originalEstimatedBytes,
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
   const freshness = ensureFreshCodexContextForTarget(target, cwd);
@@ -148,7 +197,8 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
   if (!repeatedFile) {
     markCodexReady(cwd);
-    return {
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision: CodexRuntimeHookDecision = {
       runtime: "codex",
       hookEventName,
       action: "record",
@@ -166,20 +216,26 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         escapeHatchUsed: false,
       },
     };
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
+      observedOriginalEstimatedBytes: originalEstimatedBytes,
+    });
+    return runtimeDecision;
   }
 
   const decision = decideCodexPreRead(path.join(cwd, target), cwd);
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
+    const additionalContext = buildAdditionalContext(target, decision.payload, contextMode);
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
-    return {
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision: CodexRuntimeHookDecision = {
       runtime: "codex",
       hookEventName,
       action: "inject",
       filePath: target,
       reasons: freshness.refreshed ? ["repeated-file", "refreshed-before-attach"] : ["repeated-file"],
       statePath,
-      additionalContext: buildAdditionalContext(target, decision.payload, contextMode),
+      additionalContext,
       contextMode,
       contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
       contextBudget: policy.contextBudget,
@@ -192,10 +248,17 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         decision,
       },
     };
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: estimateTextBytes(additionalContext),
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
   markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
-  return fallbackDecision(
+  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const runtimeDecision = fallbackDecision(
     hookEventName,
     target,
     statePath,
@@ -207,4 +270,10 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     policy,
     decision,
   );
+  recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
+    originalEstimatedBytes,
+    actualEstimatedBytes: originalEstimatedBytes,
+    comparableForSavings: originalEstimatedBytes !== undefined,
+  });
+  return runtimeDecision;
 }

--- a/src/adapters/codex-runtime-session.ts
+++ b/src/adapters/codex-runtime-session.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeDataKey } from "../core/paths";
 
 type SeenFileState = {
   firstSeenAt: string;
@@ -17,7 +18,7 @@ function stateRoot(cwd: string): string {
 }
 
 function sanitizeKey(sessionKey: string): string {
-  return sessionKey.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
+  return sanitizeDataKey(sessionKey);
 }
 
 export function resolveCodexRuntimeSessionKey(sessionId?: string, threadId?: string): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -386,6 +386,7 @@ Everyday commands:
   ${displayCliName} install codex-hooks
   ${displayCliName} install opencode-tool
   ${displayCliName} codex-pre-read <file> [--json]
+  ${displayCliName} status
   ${displayCliName} status codex
   ${displayCliName} status cache
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -604,6 +605,11 @@ async function run(): Promise<void> {
       throw new Error("install expects 'codex-hooks' or 'opencode-tool'");
     }
     case "status": {
+      if (!arg1) {
+        const { readProjectMetricSummary } = await import("../core/session-metrics.js");
+        print(readProjectMetricSummary(process.cwd()));
+        return;
+      }
       if (arg1 === "codex") {
         const { readCodexTrustStatus } = await import("../adapters/codex-runtime-trust.js");
         print(readCodexTrustStatus(process.cwd()));
@@ -616,7 +622,7 @@ async function run(): Promise<void> {
         print(monitor.healthReport());
         return;
       }
-      throw new Error("status expects 'codex' or 'cache'");
+      throw new Error("status expects no argument, 'codex', or 'cache'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -16,6 +16,10 @@ export function ensureProjectDataDirs(cwd = process.cwd()): void {
   fs.mkdirSync(path.join(canonicalProjectDataDir(cwd), "adapters"), { recursive: true });
 }
 
+export function sanitizeDataKey(key: string): string {
+  return key.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase() || "default-session";
+}
+
 export function configPath(cwd = process.cwd()): string {
   return path.join(canonicalProjectDataDir(cwd), "config.json");
 }
@@ -34,4 +38,24 @@ export function adapterDir(runtime: "codex" | "claude", cwd = process.cwd()): st
 
 export function runtimeStatusPath(runtime: "codex" | "claude", cwd = process.cwd()): string {
   return path.join(adapterDir(runtime, cwd), "status.json");
+}
+
+export function sessionsDir(cwd = process.cwd()): string {
+  return path.join(canonicalProjectDataDir(cwd), "sessions");
+}
+
+export function sessionDir(cwd: string, sessionKey: string): string {
+  return path.join(sessionsDir(cwd), sanitizeDataKey(sessionKey));
+}
+
+export function sessionEventsPath(cwd: string, sessionKey: string): string {
+  return path.join(sessionDir(cwd, sessionKey), "events.jsonl");
+}
+
+export function sessionSummaryPath(cwd: string, sessionKey: string): string {
+  return path.join(sessionDir(cwd, sessionKey), "summary.json");
+}
+
+export function sessionsSummaryPath(cwd = process.cwd()): string {
+  return path.join(sessionsDir(cwd), "summary.json");
 }

--- a/src/core/session-metrics.ts
+++ b/src/core/session-metrics.ts
@@ -1,0 +1,469 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sessionEventsPath, sessionSummaryPath, sessionsSummaryPath, sanitizeDataKey } from "./paths";
+import type { CodexRuntimeHookInput, ContextMode } from "./schema";
+
+export const FOOKS_SESSION_METRICS_SCHEMA_VERSION = 1;
+export const FOOKS_SESSION_METRIC_TIER = "estimated" as const;
+export const ESTIMATED_BYTES_PER_TOKEN = 4;
+export const FOOKS_METRIC_CLAIM_BOUNDARY =
+  "Estimated local context-size telemetry only; values are not provider billing tokens, provider costs, or a ccusage replacement.";
+
+type MetricTier = typeof FOOKS_SESSION_METRIC_TIER;
+type HookEventName = CodexRuntimeHookInput["hookEventName"];
+export type FooksSessionMetricAction = "inject" | "fallback" | "record" | "noop";
+
+export type FooksEstimatedUsage = {
+  originalEstimatedBytes: number;
+  actualEstimatedBytes: number;
+  savedEstimatedBytes: number;
+  originalEstimatedTokens: number;
+  actualEstimatedTokens: number;
+  savedEstimatedTokens: number;
+  savingsRatio: number;
+};
+
+export type FooksSessionMetricEvent = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  timestamp: string;
+  runtime: "codex";
+  sessionKey: string;
+  hookEventName: HookEventName;
+  action: FooksSessionMetricAction;
+  filePath?: string;
+  reasons: string[];
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  fallbackReason?: string;
+  metricTier: MetricTier;
+  comparableForSavings: boolean;
+  estimated: FooksEstimatedUsage;
+  observedOpportunity?: {
+    originalEstimatedBytes: number;
+    originalEstimatedTokens: number;
+  };
+};
+
+export type FooksSessionMetricSummary = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  metricTier: MetricTier;
+  sessionKey: string;
+  sanitizedSessionKey: string;
+  startedAt: string;
+  updatedAt: string;
+  stoppedAt?: string;
+  eventCount: number;
+  comparableEventCount: number;
+  injectCount: number;
+  fallbackCount: number;
+  recordCount: number;
+  noopCount: number;
+  observedOpportunityCount: number;
+  observedOriginalEstimatedBytes: number;
+  observedOriginalEstimatedTokens: number;
+  totals: FooksEstimatedUsage;
+  claimBoundary: string;
+};
+
+export type FooksSessionMetricContribution = Pick<
+  FooksSessionMetricSummary,
+  | "sessionKey"
+  | "sanitizedSessionKey"
+  | "startedAt"
+  | "updatedAt"
+  | "stoppedAt"
+  | "eventCount"
+  | "comparableEventCount"
+  | "injectCount"
+  | "fallbackCount"
+  | "recordCount"
+  | "noopCount"
+  | "observedOpportunityCount"
+  | "observedOriginalEstimatedBytes"
+  | "observedOriginalEstimatedTokens"
+  | "totals"
+>;
+
+export type FooksProjectMetricSummaryFile = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  metricTier: MetricTier;
+  updatedAt: string;
+  sessionCount: number;
+  eventCount: number;
+  comparableEventCount: number;
+  injectCount: number;
+  fallbackCount: number;
+  recordCount: number;
+  noopCount: number;
+  observedOpportunityCount: number;
+  observedOriginalEstimatedBytes: number;
+  observedOriginalEstimatedTokens: number;
+  totals: FooksEstimatedUsage;
+  latestSessionKeys: string[];
+  sessions: Record<string, FooksSessionMetricContribution>;
+  claimBoundary: string;
+};
+
+export type FooksProjectMetricStatus = Omit<FooksProjectMetricSummaryFile, "sessions" | "latestSessionKeys"> & {
+  latestSessionCount: number;
+};
+
+export type RecordFooksSessionMetricInput = {
+  runtime: "codex";
+  hookEventName: HookEventName;
+  action: FooksSessionMetricAction;
+  filePath?: string;
+  reasons?: string[];
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  fallbackReason?: string;
+  originalEstimatedBytes?: number;
+  actualEstimatedBytes?: number;
+  comparableForSavings?: boolean;
+  observedOriginalEstimatedBytes?: number;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function nonNegativeInteger(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.round(value);
+}
+
+export function estimateTextBytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+export function estimateFileBytes(filePath: string): number | undefined {
+  try {
+    const stats = fs.statSync(filePath);
+    return stats.isFile() ? stats.size : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function estimateTokensFromBytes(bytes: number): number {
+  const safeBytes = nonNegativeInteger(bytes);
+  return safeBytes === 0 ? 0 : Math.ceil(safeBytes / ESTIMATED_BYTES_PER_TOKEN);
+}
+
+function roundRatio(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function emptyUsage(): FooksEstimatedUsage {
+  return {
+    originalEstimatedBytes: 0,
+    actualEstimatedBytes: 0,
+    savedEstimatedBytes: 0,
+    originalEstimatedTokens: 0,
+    actualEstimatedTokens: 0,
+    savedEstimatedTokens: 0,
+    savingsRatio: 0,
+  };
+}
+
+function usageFromBytes(originalBytes: number, actualBytes: number): FooksEstimatedUsage {
+  const originalEstimatedBytes = nonNegativeInteger(originalBytes);
+  const actualEstimatedBytes = nonNegativeInteger(actualBytes);
+  const savedEstimatedBytes = Math.max(0, originalEstimatedBytes - actualEstimatedBytes);
+  const originalEstimatedTokens = estimateTokensFromBytes(originalEstimatedBytes);
+  const actualEstimatedTokens = estimateTokensFromBytes(actualEstimatedBytes);
+  const savedEstimatedTokens = Math.max(0, originalEstimatedTokens - actualEstimatedTokens);
+  return {
+    originalEstimatedBytes,
+    actualEstimatedBytes,
+    savedEstimatedBytes,
+    originalEstimatedTokens,
+    actualEstimatedTokens,
+    savedEstimatedTokens,
+    savingsRatio: originalEstimatedBytes === 0 ? 0 : roundRatio(savedEstimatedBytes / originalEstimatedBytes),
+  };
+}
+
+function recomputeUsageRatio(usage: FooksEstimatedUsage): FooksEstimatedUsage {
+  return {
+    ...usage,
+    savingsRatio: usage.originalEstimatedBytes === 0 ? 0 : roundRatio(usage.savedEstimatedBytes / usage.originalEstimatedBytes),
+  };
+}
+
+function addUsage(left: FooksEstimatedUsage, right: FooksEstimatedUsage): FooksEstimatedUsage {
+  return recomputeUsageRatio({
+    originalEstimatedBytes: left.originalEstimatedBytes + right.originalEstimatedBytes,
+    actualEstimatedBytes: left.actualEstimatedBytes + right.actualEstimatedBytes,
+    savedEstimatedBytes: left.savedEstimatedBytes + right.savedEstimatedBytes,
+    originalEstimatedTokens: left.originalEstimatedTokens + right.originalEstimatedTokens,
+    actualEstimatedTokens: left.actualEstimatedTokens + right.actualEstimatedTokens,
+    savedEstimatedTokens: left.savedEstimatedTokens + right.savedEstimatedTokens,
+    savingsRatio: 0,
+  });
+}
+
+function truncateString(value: string, maxLength = 240): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
+}
+
+function sanitizeReasons(reasons: string[] | undefined): string[] {
+  return (reasons ?? []).slice(0, 12).map((reason) => truncateString(reason));
+}
+
+function readJsonFile<T>(file: string): T | null {
+  try {
+    if (!fs.existsSync(file)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonAtomic(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(value, null, 2));
+  fs.renameSync(tmp, file);
+}
+
+function emptySessionSummary(sessionKey: string, timestamp = nowIso()): FooksSessionMetricSummary {
+  return {
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    sessionKey,
+    sanitizedSessionKey: sanitizeDataKey(sessionKey),
+    startedAt: timestamp,
+    updatedAt: timestamp,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: emptyUsage(),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+function emptyProjectSummaryFile(timestamp = nowIso()): FooksProjectMetricSummaryFile {
+  return {
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    updatedAt: timestamp,
+    sessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: emptyUsage(),
+    latestSessionKeys: [],
+    sessions: {},
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+function isSessionSummary(value: FooksSessionMetricSummary | null): value is FooksSessionMetricSummary {
+  return Boolean(value && value.schemaVersion === FOOKS_SESSION_METRICS_SCHEMA_VERSION && value.metricTier === FOOKS_SESSION_METRIC_TIER);
+}
+
+function isProjectSummaryFile(value: FooksProjectMetricSummaryFile | null): value is FooksProjectMetricSummaryFile {
+  return Boolean(value && value.schemaVersion === FOOKS_SESSION_METRICS_SCHEMA_VERSION && value.metricTier === FOOKS_SESSION_METRIC_TIER && value.sessions);
+}
+
+export function readSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+  const summary = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
+  return isSessionSummary(summary) ? summary : emptySessionSummary(sessionKey);
+}
+
+function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessionMetricContribution {
+  return {
+    sessionKey: summary.sessionKey,
+    sanitizedSessionKey: summary.sanitizedSessionKey,
+    startedAt: summary.startedAt,
+    updatedAt: summary.updatedAt,
+    stoppedAt: summary.stoppedAt,
+    eventCount: summary.eventCount,
+    comparableEventCount: summary.comparableEventCount,
+    injectCount: summary.injectCount,
+    fallbackCount: summary.fallbackCount,
+    recordCount: summary.recordCount,
+    noopCount: summary.noopCount,
+    observedOpportunityCount: summary.observedOpportunityCount,
+    observedOriginalEstimatedBytes: summary.observedOriginalEstimatedBytes,
+    observedOriginalEstimatedTokens: summary.observedOriginalEstimatedTokens,
+    totals: summary.totals,
+  };
+}
+
+function readProjectSummaryFile(cwd: string): FooksProjectMetricSummaryFile {
+  const summary = readJsonFile<FooksProjectMetricSummaryFile>(sessionsSummaryPath(cwd));
+  return isProjectSummaryFile(summary) ? summary : emptyProjectSummaryFile();
+}
+
+function recomputeProjectSummaryFile(summary: FooksProjectMetricSummaryFile, timestamp = nowIso()): FooksProjectMetricSummaryFile {
+  const contributions = Object.values(summary.sessions).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  let totals = emptyUsage();
+  for (const contribution of contributions) {
+    totals = addUsage(totals, contribution.totals);
+  }
+  return {
+    ...summary,
+    updatedAt: timestamp,
+    sessionCount: contributions.length,
+    eventCount: contributions.reduce((total, contribution) => total + contribution.eventCount, 0),
+    comparableEventCount: contributions.reduce((total, contribution) => total + contribution.comparableEventCount, 0),
+    injectCount: contributions.reduce((total, contribution) => total + contribution.injectCount, 0),
+    fallbackCount: contributions.reduce((total, contribution) => total + contribution.fallbackCount, 0),
+    recordCount: contributions.reduce((total, contribution) => total + contribution.recordCount, 0),
+    noopCount: contributions.reduce((total, contribution) => total + contribution.noopCount, 0),
+    observedOpportunityCount: contributions.reduce((total, contribution) => total + contribution.observedOpportunityCount, 0),
+    observedOriginalEstimatedBytes: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedBytes, 0),
+    observedOriginalEstimatedTokens: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedTokens, 0),
+    totals,
+    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.sessionKey),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string): FooksProjectMetricStatus {
+  const sessionSummary = readSessionMetricSummary(cwd, sessionKey);
+  const projectSummary = readProjectSummaryFile(cwd);
+  projectSummary.sessions[sessionSummary.sanitizedSessionKey] = contributionFromSession(sessionSummary);
+  const updated = recomputeProjectSummaryFile(projectSummary);
+  writeJsonAtomic(sessionsSummaryPath(cwd), updated);
+  return toProjectMetricStatus(updated);
+}
+
+function toProjectMetricStatus(summary: FooksProjectMetricSummaryFile): FooksProjectMetricStatus {
+  const { sessions: _sessions, latestSessionKeys, ...status } = summary;
+  return {
+    ...status,
+    latestSessionCount: latestSessionKeys.length,
+  };
+}
+
+export function readProjectMetricSummary(cwd = process.cwd()): FooksProjectMetricStatus {
+  return toProjectMetricStatus(readProjectSummaryFile(cwd));
+}
+
+function writeSessionSummary(cwd: string, summary: FooksSessionMetricSummary): void {
+  writeJsonAtomic(sessionSummaryPath(cwd, summary.sessionKey), summary);
+}
+
+function appendSessionEvent(cwd: string, sessionKey: string, event: FooksSessionMetricEvent): void {
+  const file = sessionEventsPath(cwd, sessionKey);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, `${JSON.stringify(event)}\n`);
+}
+
+export function initializeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
+  const summary = isSessionSummary(existing) ? existing : emptySessionSummary(sessionKey);
+  writeSessionSummary(cwd, summary);
+  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  return summary;
+}
+
+export function finalizeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+  const timestamp = nowIso();
+  const summary = {
+    ...readSessionMetricSummary(cwd, sessionKey),
+    updatedAt: timestamp,
+    stoppedAt: timestamp,
+  } satisfies FooksSessionMetricSummary;
+  writeSessionSummary(cwd, summary);
+  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  return summary;
+}
+
+export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, input: RecordFooksSessionMetricInput): FooksSessionMetricSummary {
+  const timestamp = nowIso();
+  const comparableForSavings = Boolean(input.comparableForSavings);
+  const originalBytes = comparableForSavings ? nonNegativeInteger(input.originalEstimatedBytes) : 0;
+  const actualBytes = comparableForSavings ? nonNegativeInteger(input.actualEstimatedBytes) : 0;
+  const eventUsage = comparableForSavings ? usageFromBytes(originalBytes, actualBytes) : emptyUsage();
+  const observedOriginalEstimatedBytes = nonNegativeInteger(input.observedOriginalEstimatedBytes ?? input.originalEstimatedBytes);
+  const observedOpportunity = !comparableForSavings && observedOriginalEstimatedBytes > 0;
+  const event: FooksSessionMetricEvent = {
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    timestamp,
+    runtime: input.runtime,
+    sessionKey,
+    hookEventName: input.hookEventName,
+    action: input.action,
+    filePath: input.filePath,
+    reasons: sanitizeReasons(input.reasons),
+    contextMode: input.contextMode,
+    contextModeReason: input.contextModeReason ? truncateString(input.contextModeReason) : undefined,
+    fallbackReason: input.fallbackReason ? truncateString(input.fallbackReason) : undefined,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    comparableForSavings,
+    estimated: eventUsage,
+    observedOpportunity: observedOpportunity
+      ? {
+          originalEstimatedBytes: observedOriginalEstimatedBytes,
+          originalEstimatedTokens: estimateTokensFromBytes(observedOriginalEstimatedBytes),
+        }
+      : undefined,
+  };
+
+  appendSessionEvent(cwd, sessionKey, event);
+
+  const summary = readSessionMetricSummary(cwd, sessionKey);
+  const updated: FooksSessionMetricSummary = {
+    ...summary,
+    updatedAt: timestamp,
+    eventCount: summary.eventCount + 1,
+    comparableEventCount: summary.comparableEventCount + (comparableForSavings ? 1 : 0),
+    injectCount: summary.injectCount + (input.action === "inject" ? 1 : 0),
+    fallbackCount: summary.fallbackCount + (input.action === "fallback" ? 1 : 0),
+    recordCount: summary.recordCount + (input.action === "record" ? 1 : 0),
+    noopCount: summary.noopCount + (input.action === "noop" ? 1 : 0),
+    observedOpportunityCount: summary.observedOpportunityCount + (observedOpportunity ? 1 : 0),
+    observedOriginalEstimatedBytes: summary.observedOriginalEstimatedBytes + (observedOpportunity ? observedOriginalEstimatedBytes : 0),
+    observedOriginalEstimatedTokens:
+      summary.observedOriginalEstimatedTokens + (observedOpportunity ? estimateTokensFromBytes(observedOriginalEstimatedBytes) : 0),
+    totals: addUsage(summary.totals, eventUsage),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+  writeSessionSummary(cwd, updated);
+  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  return updated;
+}
+
+export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+  try {
+    initializeSessionMetricSummary(cwd, sessionKey);
+  } catch {
+    // Metrics are observational only; hook behavior must not depend on telemetry writes.
+  }
+}
+
+export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+  try {
+    finalizeSessionMetricSummary(cwd, sessionKey);
+  } catch {
+    // Metrics are observational only; hook behavior must not depend on telemetry writes.
+  }
+}
+
+export function recordFooksSessionMetricEventSafe(cwd: string, sessionKey: string, input: RecordFooksSessionMetricInput): void {
+  try {
+    recordFooksSessionMetricEvent(cwd, sessionKey, input);
+  } catch {
+    // Metrics are observational only; hook behavior must not depend on telemetry writes.
+  }
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -12,6 +12,7 @@ import os from "node:os";
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import { cleanupMetricSessions } from "./metric-cleanup.mjs";
 
 const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
@@ -29,12 +30,24 @@ const {
   codexRuntimeSessionPath,
 } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-session.js"));
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  readProjectMetricSummary,
+  readSessionMetricSummary,
+  refreshProjectMetricSummaryFromSession,
+} = require(path.join(repoRoot, "dist", "core", "session-metrics.js"));
+const {
+  sessionEventsPath,
+  sessionsSummaryPath,
+} = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
 const { prepareExecutionContext } = require(path.join(repoRoot, "dist", "adapters", "codex.js"));
 const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude.js"));
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 const ts = require("typescript");
+
+const repoMetricTestSessionPrefixes = ["hook-", "cli-hook-", "bridge-contract-"];
+test.after(() => cleanupMetricSessions(repoRoot, repoMetricTestSessionPrefixes));
 
 function run(args, cwd = repoRoot, envOverrides = {}) {
   return JSON.parse(execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } }));
@@ -586,6 +599,137 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.additionalContext.includes("#fooks-full-read"), false);
   assert.equal(second.additionalContext.includes("#fooks-disable-pre-read"), false);
   assert.equal(second.debug.repeatedFile, true);
+});
+
+test("bare status reports fast estimated session savings without exposing session contribution internals", () => {
+  const tempDir = makeTempProject();
+  const empty = run(["status"], tempDir);
+  assert.equal(empty.schemaVersion, 1);
+  assert.equal(empty.metricTier, "estimated");
+  assert.equal(empty.sessionCount, 0);
+  assert.equal(empty.latestSessionCount, 0);
+  assert.equal(empty.eventCount, 0);
+  assert.equal(empty.totals.savedEstimatedBytes, 0);
+  assert.equal("sessions" in empty, false);
+  assert.equal("latestSessionKeys" in empty, false);
+  assert.match(empty.claimBoundary, /not provider billing tokens/);
+});
+
+test("runtime hook stores redacted estimated metrics for record, inject, fallback, and stop", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `metrics-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  const targetBytes = fs.statSync(path.join(tempDir, target)).size;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const started = run(["status"], tempDir);
+  assert.equal(started.sessionCount, 1);
+  assert.equal(started.eventCount, 0);
+
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please update ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, update ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(second.action, "inject");
+  assert.ok(second.additionalContext);
+
+  const sessionSummary = readSessionMetricSummary(tempDir, sessionId);
+  assert.equal(sessionSummary.eventCount, 2);
+  assert.equal(sessionSummary.recordCount, 1);
+  assert.equal(sessionSummary.injectCount, 1);
+  assert.equal(sessionSummary.comparableEventCount, 1);
+  assert.equal(sessionSummary.observedOpportunityCount, 1);
+  assert.equal(sessionSummary.observedOriginalEstimatedBytes, targetBytes);
+  assert.equal(sessionSummary.totals.originalEstimatedBytes, targetBytes);
+  assert.equal(sessionSummary.totals.actualEstimatedBytes, Buffer.byteLength(second.additionalContext, "utf8"));
+  assert.equal(
+    sessionSummary.totals.savedEstimatedBytes,
+    Math.max(0, sessionSummary.totals.originalEstimatedBytes - sessionSummary.totals.actualEstimatedBytes),
+  );
+
+  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionId), "utf8");
+  assert.doesNotMatch(eventLog, /Again, update/);
+  assert.doesNotMatch(eventLog, /additionalContext/);
+  assert.doesNotMatch(eventLog, /rawText/);
+  assert.doesNotMatch(eventLog, /"debug"/);
+  assert.doesNotMatch(eventLog, /"decision"/);
+
+  const fallbackSession = `${sessionId}-fallback`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: fallbackSession }, tempDir);
+  const fallback = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: fallbackSession,
+      prompt: `Need exact source ${target} #fooks-full-read`,
+    },
+    tempDir,
+  );
+  assert.equal(fallback.action, "fallback");
+  const fallbackSummary = readSessionMetricSummary(tempDir, fallbackSession);
+  assert.equal(fallbackSummary.fallbackCount, 1);
+  assert.equal(fallbackSummary.comparableEventCount, 1);
+  assert.equal(fallbackSummary.totals.originalEstimatedBytes, targetBytes);
+  assert.equal(fallbackSummary.totals.actualEstimatedBytes, targetBytes);
+  assert.equal(fallbackSummary.totals.savedEstimatedBytes, 0);
+
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  const stopped = readSessionMetricSummary(tempDir, sessionId);
+  assert.ok(stopped.stoppedAt);
+
+  const beforeRefresh = readProjectMetricSummary(tempDir);
+  refreshProjectMetricSummaryFromSession(tempDir, sessionId);
+  refreshProjectMetricSummaryFromSession(tempDir, sessionId);
+  const afterRefresh = readProjectMetricSummary(tempDir);
+  assert.equal(afterRefresh.eventCount, beforeRefresh.eventCount);
+  assert.deepEqual(afterRefresh.totals, beforeRefresh.totals);
+
+  const status = run(["status"], tempDir);
+  assert.equal(status.sessionCount, 2);
+  assert.equal(status.eventCount, 3);
+  assert.equal(status.injectCount, 1);
+  assert.equal(status.fallbackCount, 1);
+  assert.equal(status.recordCount, 1);
+  assert.equal(status.latestSessionCount, 2);
+  assert.equal("latestSessionKeys" in status, false);
+  assert.equal("sessions" in status, false);
+
+  const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
+  assert.equal(Object.keys(summaryFile.sessions).length, 2);
+});
+
+test("runtime metric write failures are non-fatal to hook decisions", () => {
+  const tempDir = makeTempProject();
+  fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, ".fooks", "sessions"), "not-a-directory");
+
+  const sessionId = `metrics-blocked-${Date.now()}`;
+  const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(start.action, "noop");
+
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Please update src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+  assert.equal(first.filePath, path.join("src", "components", "FormSection.tsx"));
 });
 
 test("runtime hook injects tiny raw originals and still honors escape hatch fallbacks", () => {

--- a/test/metric-cleanup.mjs
+++ b/test/metric-cleanup.mjs
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export async function cleanupMetricSessions(repoRoot, prefixes) {
+  const [{ refreshProjectMetricSummaryFromSession }, { sessionsDir, sessionsSummaryPath }] = await Promise.all([
+    import(path.join(repoRoot, "dist", "core", "session-metrics.js")),
+    import(path.join(repoRoot, "dist", "core", "paths.js")),
+  ]);
+  const root = sessionsDir(repoRoot);
+  if (!fs.existsSync(root)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
+      fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+    }
+  }
+
+  fs.rmSync(sessionsSummaryPath(repoRoot), { force: true });
+  let remainingSessionCount = 0;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const summaryPath = path.join(root, entry.name, "summary.json");
+    if (!fs.existsSync(summaryPath)) {
+      continue;
+    }
+    try {
+      const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+      refreshProjectMetricSummaryFromSession(repoRoot, summary.sessionKey ?? entry.name);
+      remainingSessionCount += 1;
+    } catch {
+      // Test cleanup should not fail the suite when ignored telemetry is malformed.
+    }
+  }
+
+  if (remainingSessionCount === 0) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -2,11 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanupMetricSessions } from "./metric-cleanup.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+test.after(() => cleanupMetricSessions(repoRoot, ["bridge-contract-"]));
 
 test("runtime bridge contract keeps repeated-read inject and fallback semantics stable", () => {
   const injectSession = `bridge-contract-inject-${Date.now()}`;


### PR DESCRIPTION
## Summary

- tracks the local Codex session-metrics source and exposes bare `fooks status` as redacted estimated context-size telemetry
- keeps public/docs claim boundaries explicit: no provider billing-token, provider-cost, ccusage, stable runtime-token/time, or applied-code benchmark-win claims
- fixes npm README benchmark evidence links by pointing them to GitHub, narrows package docs, and strengthens `release:smoke` tarball assertions
- adds root `SECURITY.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` for open-source readiness

## Verification

- `npm run lint`
- `npm test`
- `npm run bench:gate`
- `npm run bench:layer2:applied:selftest`
- `npm run release:smoke`
- `git diff --check`
- `npm pack --dry-run --json`
- `npm view oh-my-fooks version dist-tags --json` currently returns E404/not found as of 2026-04-21T02:12Z, so package name/state must be rechecked before any publish

## Claim boundary

This PR makes release readiness more auditable, but it still does **not** claim provider billing-token savings, provider cost savings, stable runtime-token/time wins, or applied-code benchmark wins. Real `npm publish` remains authority-gated and was not run.
