### PR TITLE
Keep setup actionable when runtime manifest writes fail

### DIFF
--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -7,19 +7,36 @@ export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachRes
   const account = detectAccountContext(cwd);
   const attemptedAt = new Date().toISOString();
   const runtimeProof = (() => {
-    const manifestPath = installRuntimeManifest("claude", cwd);
-    if (manifestPath) {
+    const manifest = installRuntimeManifest("claude", cwd);
+    if (manifest.status === "passed") {
       return {
         status: "passed" as const,
         attemptedAt,
-        artifactPath: manifestPath,
-        details: [`account-context=${account.account}`, `account-source=${account.source}`, `runtime-manifest=${manifestPath}`, "claude adapter artifacts created"],
+        artifactPath: manifest.manifestPath,
+        details: [`account-context=${account.account}`, `account-source=${account.source}`, `runtime-manifest=${manifest.manifestPath}`, "claude adapter artifacts created"],
+      };
+    }
+
+    if (manifest.status === "blocked") {
+      return {
+        status: "blocked" as const,
+        attemptedAt,
+        artifactPath: manifest.manifestPath,
+        details: [
+          "claude adapter artifacts created",
+          `account-source=${account.source}`,
+          `runtime-manifest=${manifest.manifestPath}`,
+          "runtime-manifest-write-attempted=true",
+          `runtime-manifest-error=${manifest.errorMessage}`,
+        ],
+        blocker: `Claude runtime manifest install failed: ${manifest.errorMessage}`,
       };
     }
 
     return {
       status: "blocked" as const,
       attemptedAt,
+      artifactPath: manifest.manifestPath,
       details: ["claude adapter artifacts created", `account-source=${account.source}`, "runtime-manifest-write-attempted=false"],
       blocker: "Claude runtime home not detected",
     };

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -16,7 +16,7 @@ export function attachCodex(sampleFile: string, cwd = process.cwd(), runtimeBrid
   const account = detectAccountContext(cwd);
   const attemptedAt = new Date().toISOString();
   const runtimeProof = (() => {
-    const manifestPath = installRuntimeManifest("codex", cwd, {
+    const manifest = installRuntimeManifest("codex", cwd, {
       runtimeBridge: {
         command: runtimeBridgeCommand,
         supportedHookEvents: ["SessionStart", "UserPromptSubmit", "Stop"],
@@ -27,20 +27,38 @@ export function attachCodex(sampleFile: string, cwd = process.cwd(), runtimeBrid
         escapeHatches: [...codexRuntimeEscapeHatches()],
       },
     });
-    if (!manifestPath) {
+
+    if (manifest.status === "passed") {
+      return {
+        status: "passed" as const,
+        attemptedAt,
+        artifactPath: manifest.manifestPath,
+        details: [`account-context=${account.account}`, `account-source=${account.source}`, `runtime-manifest=${manifest.manifestPath}`, "codex adapter artifacts created"],
+      };
+    }
+
+    if (manifest.status === "blocked") {
       return {
         status: "blocked" as const,
         attemptedAt,
-        details: ["codex adapter artifacts created", `account-source=${account.source}`, "runtime-manifest-write-attempted=false"],
-        blocker: "Codex runtime home not detected",
+        artifactPath: manifest.manifestPath,
+        details: [
+          "codex adapter artifacts created",
+          `account-source=${account.source}`,
+          `runtime-manifest=${manifest.manifestPath}`,
+          "runtime-manifest-write-attempted=true",
+          `runtime-manifest-error=${manifest.errorMessage}`,
+        ],
+        blocker: `Codex runtime manifest install failed: ${manifest.errorMessage}`,
       };
     }
 
     return {
-      status: "passed" as const,
+      status: "blocked" as const,
       attemptedAt,
-      artifactPath: manifestPath,
-      details: [`account-context=${account.account}`, `account-source=${account.source}`, `runtime-manifest=${manifestPath}`, "codex adapter artifacts created"],
+      artifactPath: manifest.manifestPath,
+      details: ["codex adapter artifacts created", `account-source=${account.source}`, "runtime-manifest-write-attempted=false"],
+      blocker: "Codex runtime home not detected",
     };
   })();
   return finalizeAttach("codex", sample, runtimeProof, cwd, trustStatus);

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -10,6 +10,24 @@ type AccountDetection = {
   source: "env" | "config" | "git-remote" | "package-repository" | "unknown";
 };
 
+export type RuntimeManifestInstallResult =
+  | {
+      status: "missing";
+      home: string;
+      manifestPath: string;
+    }
+  | {
+      status: "blocked";
+      home: string;
+      manifestPath: string;
+      errorMessage: string;
+    }
+  | {
+      status: "passed";
+      home: string;
+      manifestPath: string;
+    };
+
 function extractGithubOwner(value: string | undefined): string | null {
   if (!value) return null;
   const normalized = value.trim();
@@ -108,29 +126,42 @@ function runtimeHome(runtime: "codex" | "claude"): string {
   return path.join(os.homedir(), runtime === "codex" ? ".codex" : ".claude");
 }
 
-export function installRuntimeManifest(runtime: "codex" | "claude", cwd = process.cwd(), metadata: Record<string, unknown> = {}): string | null {
+export function installRuntimeManifest(
+  runtime: "codex" | "claude",
+  cwd = process.cwd(),
+  metadata: Record<string, unknown> = {},
+): RuntimeManifestInstallResult {
   const home = runtimeHome(runtime);
-  if (!fs.existsSync(home)) {
-    return null;
-  }
-
   const projectName = path.basename(cwd).replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
   const manifestPath = path.join(home, "fooks", "attachments", `${projectName}.json`);
-  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
-  fs.writeFileSync(
-    manifestPath,
-    JSON.stringify(
-      {
-        runtime,
-        projectRoot: cwd,
-        installedAt: new Date().toISOString(),
-        ...metadata,
-      },
-      null,
-      2,
-    ),
+
+  if (!fs.existsSync(home)) {
+    return { status: "missing", home, manifestPath };
+  }
+
+  const manifestBody = JSON.stringify(
+    {
+      runtime,
+      projectRoot: cwd,
+      installedAt: new Date().toISOString(),
+      ...metadata,
+    },
+    null,
+    2,
   );
-  return manifestPath;
+
+  try {
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, manifestBody);
+    return { status: "passed", home, manifestPath };
+  } catch (error) {
+    return {
+      status: "blocked",
+      home,
+      manifestPath,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 export function finalizeAttach(

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1357,6 +1357,33 @@ test("setup reports partial activation when Codex hooks cannot be parsed", () =>
   assert.equal(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"), "{not-json");
 });
 
+test("setup reports partial activation when the Codex runtime manifest path cannot be written", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  const blockedAttachmentsPath = path.join(codexHome, "fooks", "attachments");
+  fs.mkdirSync(path.dirname(blockedAttachmentsPath), { recursive: true });
+  fs.writeFileSync(blockedAttachmentsPath, "blocked");
+
+  const result = run(["setup"], tempDir, {
+    FOOKS_ACTIVE_ACCOUNT: "minislively",
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  });
+
+  assert.equal(result.ready, false);
+  assert.equal(result.state, "partial");
+  assert.equal(result.attach.runtimeProof.status, "blocked");
+  assert.equal(result.runtimes.codex.state, "partial");
+  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.ok(result.attach.runtimeProof.blocker.includes("Codex runtime manifest install failed"));
+  assert.ok(result.attach.runtimeProof.blocker.match(/EEXIST|ENOTDIR/));
+  assert.ok(result.blockers.some((item) => item.includes("Codex runtime manifest install failed")));
+  assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
+  assert.ok(result.attach.runtimeProof.details.some((item) => item.includes("runtime-manifest-write-attempted=true")));
+  assert.ok(result.attach.runtimeProof.details.some((item) => item.includes("runtime-manifest-error=")));
+});
+
 test("setup reports blocked state for projects without React components", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-empty-"));
   fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify({ name: "empty", repository: { url: "https://github.com/minislively/empty.git" } }, null, 2));


### PR DESCRIPTION
## Summary
- Normalize runtime manifest install outcomes into missing/blocked/passed results.
- Map manifest write failures into existing Codex/Claude blocked runtimeProof surfaces instead of throwing.
- Add a setup regression for an unwritable Codex manifest path so fooks setup returns partial JSON with blockers.

## Verification
- npm test passed: 104 tests.
- Manual repro: node dist/cli/index.js setup now returns structured partial JSON with Codex runtime manifest install failed: EROFS... instead of crashing.