### PR TITLE
Make Claude handoff readiness inspectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These are Codex-focused benchmark/proxy measurements from a 5-task sample. The t
 fooks setup          # one-time readiness: Codex hooks + Claude handoff + opencode helper
 fooks status          # local estimated context-size telemetry for this repo
 fooks status codex   # check Codex attach/hook state
+fooks status claude  # check Claude manual handoff artifact health
 fooks status cache   # check local fooks cache health
 ```
 
@@ -106,6 +107,7 @@ If setup does not report ready:
 ```bash
 fooks setup
 fooks status codex
+fooks status claude
 fooks status cache
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,6 +45,7 @@ Package install alone does not edit Codex hooks, Claude files, or opencode proje
 ```bash
 fooks status
 fooks status codex
+fooks status claude
 fooks status cache
 ```
 
@@ -52,6 +53,7 @@ Good signs:
 
 - Bare `fooks status` returns `metricTier: "estimated"` and no error. A fresh repo may show zero sessions/events.
 - Codex status is connected/ready-style.
+- Claude status is `handoff-ready` when the local adapter files and Claude attachment manifest are present. This is a manual handoff health check, not an automatic Claude hook claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.

--- a/src/adapters/claude-status.ts
+++ b/src/adapters/claude-status.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import path from "node:path";
+import { adapterDir } from "../core/paths";
+import { runtimeManifestPath } from "./shared";
+
+type ClaudeStatusState = "handoff-ready" | "blocked";
+
+type FileStatus = {
+  path: string;
+  exists: boolean;
+  valid?: boolean;
+  blocker?: string;
+};
+
+type ClaudeManifestStatus = {
+  home: string;
+  path: string;
+  homeExists: boolean;
+  exists: boolean;
+  valid?: boolean;
+  runtimeMatches?: boolean;
+  projectRootMatches?: boolean;
+  blocker?: string;
+};
+
+export type ClaudeRuntimeStatus = {
+  runtime: "claude";
+  state: ClaudeStatusState;
+  mode: "manual-shared-handoff";
+  ready: boolean;
+  blockers: string[];
+  adapter: {
+    installed: boolean;
+    directory: string;
+    adapterJson: FileStatus;
+    contextTemplate: FileStatus;
+  };
+  manifest: ClaudeManifestStatus;
+  nextSteps: string[];
+  notes: string[];
+};
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function adapterJsonStatus(filePath: string): FileStatus {
+  if (!fs.existsSync(filePath)) {
+    return { path: filePath, exists: false, blocker: "Claude adapter metadata is missing" };
+  }
+
+  try {
+    const parsed = readJson(filePath) as { runtime?: unknown };
+    if (parsed.runtime !== "claude") {
+      return { path: filePath, exists: true, valid: false, blocker: "Claude adapter metadata has an unexpected runtime" };
+    }
+    return { path: filePath, exists: true, valid: true };
+  } catch (error) {
+    return {
+      path: filePath,
+      exists: true,
+      valid: false,
+      blocker: `Claude adapter metadata is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function contextTemplateStatus(filePath: string): FileStatus {
+  if (!fs.existsSync(filePath)) {
+    return { path: filePath, exists: false, blocker: "Claude context template is missing" };
+  }
+  return { path: filePath, exists: true, valid: true };
+}
+
+function manifestStatus(cwd: string): ClaudeManifestStatus {
+  const { home, manifestPath } = runtimeManifestPath("claude", cwd);
+  const homeExists = fs.existsSync(home);
+  if (!homeExists) {
+    return {
+      home,
+      path: manifestPath,
+      homeExists,
+      exists: false,
+      blocker: "Claude runtime home not detected",
+    };
+  }
+
+  if (!fs.existsSync(manifestPath)) {
+    return {
+      home,
+      path: manifestPath,
+      homeExists,
+      exists: false,
+      blocker: "Claude runtime manifest is missing",
+    };
+  }
+
+  try {
+    const parsed = readJson(manifestPath) as { runtime?: unknown; projectRoot?: unknown };
+    const runtimeMatches = parsed.runtime === "claude";
+    const projectRootMatches = parsed.projectRoot === cwd;
+    const valid = runtimeMatches && projectRootMatches;
+    return {
+      home,
+      path: manifestPath,
+      homeExists,
+      exists: true,
+      valid,
+      runtimeMatches,
+      projectRootMatches,
+      blocker: valid ? undefined : "Claude runtime manifest does not match this project",
+    };
+  } catch (error) {
+    return {
+      home,
+      path: manifestPath,
+      homeExists,
+      exists: true,
+      valid: false,
+      blocker: `Claude runtime manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function blockersFrom(...items: Array<FileStatus | ClaudeManifestStatus>): string[] {
+  return items.flatMap((item) => (item.blocker ? [item.blocker] : []));
+}
+
+export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatus {
+  const directory = adapterDir("claude", cwd);
+  const adapterJson = adapterJsonStatus(path.join(directory, "adapter.json"));
+  const contextTemplate = contextTemplateStatus(path.join(directory, "context-template.md"));
+  const manifest = manifestStatus(cwd);
+  const blockers = blockersFrom(adapterJson, contextTemplate, manifest);
+  const ready = blockers.length === 0;
+
+  return {
+    runtime: "claude",
+    state: ready ? "handoff-ready" : "blocked",
+    mode: "manual-shared-handoff",
+    ready,
+    blockers,
+    adapter: {
+      installed: adapterJson.valid === true && contextTemplate.valid === true,
+      directory,
+      adapterJson,
+      contextTemplate,
+    },
+    manifest,
+    nextSteps: ready
+      ? [
+          "Use fooks extract <file> --model-payload or the generated Claude handoff artifacts when sharing reduced context with Claude.",
+          "Do not describe this as Claude prompt interception or automatic Claude token savings.",
+        ]
+      : [
+          "Run fooks attach claude or fooks setup after ensuring the Claude runtime home exists.",
+          "Use fooks extract <file> --model-payload for explicit manual handoff until Claude status becomes handoff-ready.",
+        ],
+    notes: [
+      "Claude automatic hooks are not enabled by fooks.",
+      "Claude status is a read-only handoff-artifact health check, not a runtime interception or token-savings claim.",
+    ],
+  };
+}

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -118,7 +118,7 @@ export function writeAdapterFiles(runtime: "codex" | "claude", cwd = process.cwd
   return files;
 }
 
-function runtimeHome(runtime: "codex" | "claude"): string {
+export function runtimeHome(runtime: "codex" | "claude"): string {
   const override = runtime === "codex" ? process.env.FOOKS_CODEX_HOME : process.env.FOOKS_CLAUDE_HOME;
   if (override) {
     return override;
@@ -126,14 +126,21 @@ function runtimeHome(runtime: "codex" | "claude"): string {
   return path.join(os.homedir(), runtime === "codex" ? ".codex" : ".claude");
 }
 
+export function runtimeManifestPath(runtime: "codex" | "claude", cwd = process.cwd()): { home: string; manifestPath: string } {
+  const home = runtimeHome(runtime);
+  const projectName = path.basename(cwd).replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
+  return {
+    home,
+    manifestPath: path.join(home, "fooks", "attachments", `${projectName}.json`),
+  };
+}
+
 export function installRuntimeManifest(
   runtime: "codex" | "claude",
   cwd = process.cwd(),
   metadata: Record<string, unknown> = {},
 ): RuntimeManifestInstallResult {
-  const home = runtimeHome(runtime);
-  const projectName = path.basename(cwd).replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
-  const manifestPath = path.join(home, "fooks", "attachments", `${projectName}.json`);
+  const { home, manifestPath } = runtimeManifestPath(runtime, cwd);
 
   if (!fs.existsSync(home)) {
     return { status: "missing", home, manifestPath };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -388,6 +388,7 @@ Everyday commands:
   ${displayCliName} codex-pre-read <file> [--json]
   ${displayCliName} status
   ${displayCliName} status codex
+  ${displayCliName} status claude
   ${displayCliName} status cache
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
@@ -615,6 +616,11 @@ async function run(): Promise<void> {
         print(readCodexTrustStatus(process.cwd()));
         return;
       }
+      if (arg1 === "claude") {
+        const { readClaudeRuntimeStatus } = await import("../adapters/claude-status.js");
+        print(readClaudeRuntimeStatus(process.cwd()));
+        return;
+      }
       if (arg1 === "cache") {
         const { canonicalProjectDataDir } = await import("../core/paths.js");
         const { CacheMonitor } = await import("../core/cache-monitor.js");
@@ -622,7 +628,7 @@ async function run(): Promise<void> {
         print(monitor.healthReport());
         return;
       }
-      throw new Error("status expects no argument, 'codex', or 'cache'");
+      throw new Error("status expects no argument, 'codex', 'claude', or 'cache'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1409,6 +1409,7 @@ test("setup reports blocked state for projects without React components", () => 
 test("cli help advertises setup and package install has no auto hook side effects", () => {
   const help = runText(["--help"]);
   assert.match(help, /fooks setup/);
+  assert.match(help, /fooks status claude/);
   assert.match(help, /Codex: automatic runtime hook path/);
   assert.match(help, /Claude: manual\/shared handoff artifacts only/);
   assert.match(help, /opencode: manual\/semi-automatic custom tool/);
@@ -1452,6 +1453,67 @@ test("setup runtime summary keeps Claude and opencode claims bounded", () => {
   assert.doesNotMatch(text, /Claude prompt interception is enabled/i);
   assert.doesNotMatch(text, /automatic opencode read interception is enabled/i);
   assert.doesNotMatch(text, /automatic opencode runtime-token savings are enabled/i);
+});
+
+test("status claude reports handoff-ready artifacts without automatic runtime claims", () => {
+  const tempDir = makeTempProject();
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  const env = {
+    FOOKS_ACTIVE_ACCOUNT: "minislively",
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  };
+
+  const setup = run(["setup"], tempDir, env);
+  assert.equal(setup.runtimes.claude.state, "handoff-ready");
+
+  const status = run(["status", "claude"], tempDir, env);
+  assert.equal(status.runtime, "claude");
+  assert.equal(status.state, "handoff-ready");
+  assert.equal(status.ready, true);
+  assert.equal(status.mode, "manual-shared-handoff");
+  assert.deepEqual(status.blockers, []);
+  assert.equal(status.adapter.installed, true);
+  assert.equal(status.adapter.adapterJson.exists, true);
+  assert.equal(status.adapter.adapterJson.valid, true);
+  assert.equal(status.adapter.contextTemplate.exists, true);
+  assert.equal(status.adapter.contextTemplate.valid, true);
+  assert.equal(status.manifest.home, claudeHome);
+  assert.equal(status.manifest.exists, true);
+  assert.equal(status.manifest.valid, true);
+  assert.equal(status.manifest.runtimeMatches, true);
+  assert.equal(status.manifest.projectRootMatches, true);
+  assert.equal(fs.existsSync(status.manifest.path), true);
+
+  const text = collectStrings(status).join("\n");
+  assert.match(text, /manual-shared-handoff/);
+  assert.match(text, /Claude automatic hooks are not enabled by fooks/);
+  assert.match(text, /read-only handoff-artifact health check/);
+  assert.doesNotMatch(text, /Claude prompt interception is enabled/i);
+  assert.doesNotMatch(text, /automatic Claude token savings are enabled/i);
+});
+
+test("status claude reports blocked state without creating artifacts", () => {
+  const tempDir = makeTempProject();
+  const claudeHome = path.join(tempDir, ".missing-claude-home");
+
+  const beforeFooks = fs.existsSync(path.join(tempDir, ".fooks"));
+  const status = run(["status", "claude"], tempDir, { FOOKS_CLAUDE_HOME: claudeHome });
+  const afterFooks = fs.existsSync(path.join(tempDir, ".fooks"));
+
+  assert.equal(status.runtime, "claude");
+  assert.equal(status.state, "blocked");
+  assert.equal(status.ready, false);
+  assert.equal(status.adapter.installed, false);
+  assert.equal(status.adapter.adapterJson.exists, false);
+  assert.equal(status.adapter.contextTemplate.exists, false);
+  assert.equal(status.manifest.homeExists, false);
+  assert.equal(status.manifest.exists, false);
+  assert.ok(status.blockers.some((item) => item.includes("Claude adapter metadata is missing")));
+  assert.ok(status.blockers.some((item) => item.includes("Claude context template is missing")));
+  assert.ok(status.blockers.some((item) => item.includes("Claude runtime home not detected")));
+  assert.equal(afterFooks, beforeFooks);
 });
 
 test("install codex-hooks creates a reusable hooks preset", () => {


### PR DESCRIPTION
## Summary
- add read-only `fooks status claude` for Claude handoff artifact health
- verify local Claude adapter files and Claude attachment manifest without claiming automatic hook parity
- document the new status command in README and setup docs

## Validation
- `npm test` — 107 pass, 0 fail
- `npm run lint`
- `npm run release:smoke`
- `git diff --check`

## Claim boundary
Claude remains manual/shared handoff support only; this PR does not add automatic Claude prompt interception or runtime-token savings claims.