### PR TITLE
Clarify setup install scope boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Then open Codex in that repo and work normally. The same setup command also prep
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files.
 
+### Install/setup scope at a glance
+
+| Step | Scope | What can change |
+| --- | --- | --- |
+| `npm install -g oh-my-fooks` | global CLI install | Makes the `fooks` command available in the npm global prefix / PATH. It does not activate a project. |
+| `fooks setup` | current project + runtime homes | Creates project-local `.fooks/` state, may add project-local `.opencode/` helper files, and may update runtime-home files such as Codex hooks/manifests or Claude handoff manifests. |
+| `fooks status` | current project inspection | Reads local fooks telemetry/status; it is not a package installer or billing-token report. |
+
+The `fooks setup` JSON includes a `scope` object so support/debug logs can show which paths are project-local and which are user-runtime/home scoped.
+
 ## What gets optimized
 
 Current automatic optimization is intentionally narrow:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@ Use this when you want one explicit command to prepare fooks for a supported fro
 npm install -g oh-my-fooks
 ```
 
-The package is named `oh-my-fooks`; it installs the `fooks` command.
+The package is named `oh-my-fooks`; it installs the `fooks` command. This is a **global CLI install** step: it changes which command is available from your npm global prefix/PATH, but it does not activate any repository by itself.
 
 If setup seems to run the wrong binary, check:
 
@@ -40,6 +40,18 @@ fooks codex-runtime-hook --native-hook
 
 Package install alone does not edit Codex hooks, Claude files, or opencode project files. Activation only happens when you run `fooks setup`.
 
+### Scope boundaries
+
+`fooks setup` is intentionally a one-command activation flow, but its writes have different scopes:
+
+| Scope | Examples | Notes |
+| --- | --- | --- |
+| Global CLI install | `npm install -g oh-my-fooks`, `fooks` on PATH | This happens before setup. `fooks setup` does not install or update the npm package. |
+| Project-local | `.fooks/config.json`, `.fooks/cache/`, `.opencode/tools/fooks_extract.ts`, `.opencode/commands/fooks-extract.md` | These apply to the current project root where you run `fooks setup`. |
+| User runtime/home | `~/.codex/hooks.json`, Codex attachment manifests, Claude handoff manifests | These are runtime integration files. Tests and smoke checks can isolate them with `FOOKS_CODEX_HOME` and `FOOKS_CLAUDE_HOME`. |
+
+The setup JSON includes an additive `scope` object with `packageInstall`, `projectLocal`, `userRuntime`, and `nonGoals` sections so issue reports can show exactly which paths were considered. There is no separate `--scope` option today, and setup does not ask interactive scope questions.
+
 ## 3. Check status
 
 ```bash
@@ -65,6 +77,8 @@ Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summarie
 | `ready` | Attach and hook setup completed. Open Codex and work normally. |
 | `partial` | Some setup work succeeded, but a blocker remains. Read `blockers` / `nextSteps`, fix, then rerun `fooks setup`. |
 | `blocked` | fooks could not activate this repo, usually because no supported React component was found. |
+
+`fooks setup` also returns a `scope` object that summarizes global CLI install boundaries, current-project paths, and user-runtime/home paths. The `scope.packageInstall.mutatedBySetup` flag is `false` because `setup` does not run `npm install`; project-local paths are under the current repo, while runtime-home paths identify files such as Codex hooks/manifests.
 
 `fooks setup` also returns a `runtimes` object:
 

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -122,6 +122,16 @@ assert(setup.runtimes?.claude?.blocksOverall === false, "Claude readiness should
 assert(setup.runtimes?.opencode?.state === "tool-ready", `unexpected opencode setup state ${setup.runtimes?.opencode?.state}`);
 assert(setup.runtimes?.opencode?.blocksOverall === false, "opencode readiness should be non-fatal for overall setup");
 assert(setup.attach?.runtimeProof?.details?.includes("account-source=package-repository"), "setup should derive public repo account context from package metadata");
+assert(setup.scope?.schemaVersion === 1, "setup should report scope summary schema");
+assert(setup.scope?.packageInstall?.scope === "global-cli", "setup scope should distinguish global CLI package install");
+assert(setup.scope?.packageInstall?.mutatedBySetup === false, "setup must not imply npm package install mutation");
+const setupProjectRoot = fs.realpathSync(project);
+assert(setup.scope?.projectLocal?.root === setupProjectRoot, "setup scope should identify the current project root");
+assert(setup.scope?.projectLocal?.paths?.includes(path.join(setupProjectRoot, ".fooks", "config.json")), "setup scope should include project-local .fooks config");
+assert(setup.scope?.projectLocal?.paths?.includes(path.join(setupProjectRoot, ".opencode", "tools", "fooks_extract.ts")), "setup scope should include project-local opencode tool");
+assert(setup.scope?.userRuntime?.paths?.includes(path.join(codexHome, "hooks.json")), "setup scope should include isolated Codex hooks path");
+assert(setup.scope?.userRuntime?.paths?.some((item) => item.startsWith(path.join(codexHome, "fooks", "attachments"))), "setup scope should include isolated Codex runtime manifest path");
+assert(setup.scope?.nonGoals?.some((item) => item.includes("No --scope option")), "setup scope should document that no new scope option is required");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 assert(fs.existsSync(path.join(project, ".opencode", "tools", "fooks_extract.ts")), "opencode helper should be installed project-locally");
 assert(fs.existsSync(path.join(project, ".opencode", "commands", "fooks-extract.md")), "opencode slash command should be installed project-locally");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -118,6 +118,122 @@ type RuntimeReadiness = {
   notes: string[];
 };
 
+
+type SetupScopeSummary = {
+  schemaVersion: 1;
+  command: "setup";
+  projectRoot: string;
+  packageInstall: {
+    scope: "global-cli";
+    command: "npm install -g oh-my-fooks";
+    installsCommand: string;
+    mutatedBySetup: false;
+    note: string;
+  };
+  projectLocal: {
+    scope: "project-local";
+    root: string;
+    paths: string[];
+    note: string;
+  };
+  userRuntime: {
+    scope: "user-home-runtime";
+    paths: string[];
+    note: string;
+  };
+  nonGoals: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function stringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const property = value[key];
+  return typeof property === "string" ? property : undefined;
+}
+
+function objectProperty(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const property = value[key];
+  return isRecord(property) ? property : undefined;
+}
+
+function addUniquePath(paths: string[], maybePath: string | undefined): void {
+  if (maybePath && !paths.includes(maybePath)) {
+    paths.push(maybePath);
+  }
+}
+
+function runtimeInstallPaths(runtimeReadiness: RuntimeReadiness | undefined): string[] {
+  const paths: string[] = [];
+  const details = objectProperty(runtimeReadiness, "details");
+  const install = objectProperty(details, "install");
+  addUniquePath(paths, stringProperty(install, "artifactPath"));
+  addUniquePath(paths, stringProperty(install, "commandPath"));
+  return paths;
+}
+
+function runtimeManifestPathFromAttach(attach: unknown): string | undefined {
+  return stringProperty(objectProperty(attach, "runtimeProof"), "artifactPath");
+}
+
+function runtimeManifestPathFromReadiness(runtimeReadiness: RuntimeReadiness | undefined): string | undefined {
+  const details = objectProperty(runtimeReadiness, "details");
+  const attach = objectProperty(details, "attach");
+  return runtimeManifestPathFromAttach(attach);
+}
+
+function buildSetupScopeSummary(options: {
+  cwd: string;
+  displayCliName: string;
+  initialized: { config: string; cacheDir: string };
+  attach?: unknown;
+  hooks?: unknown;
+  claude?: RuntimeReadiness;
+  opencode?: RuntimeReadiness;
+}): SetupScopeSummary {
+  const projectLocalPaths = [options.initialized.config, options.initialized.cacheDir];
+  for (const opencodePath of runtimeInstallPaths(options.opencode)) {
+    addUniquePath(projectLocalPaths, opencodePath);
+  }
+
+  const userRuntimePaths: string[] = [];
+  addUniquePath(userRuntimePaths, stringProperty(options.hooks, "hooksPath"));
+  addUniquePath(userRuntimePaths, runtimeManifestPathFromAttach(options.attach));
+  addUniquePath(userRuntimePaths, runtimeManifestPathFromReadiness(options.claude));
+
+  return {
+    schemaVersion: 1,
+    command: "setup",
+    projectRoot: options.cwd,
+    packageInstall: {
+      scope: "global-cli",
+      command: "npm install -g oh-my-fooks",
+      installsCommand: options.displayCliName,
+      mutatedBySetup: false,
+      note: "The npm package install makes the fooks command available globally; fooks setup does not install or update the npm package.",
+    },
+    projectLocal: {
+      scope: "project-local",
+      root: options.cwd,
+      paths: projectLocalPaths,
+      note: "fooks setup is run from one project root and may create or update only this project's .fooks/.opencode artifacts for project-local state.",
+    },
+    userRuntime: {
+      scope: "user-home-runtime",
+      paths: userRuntimePaths,
+      note: "fooks setup may create or update runtime-home files such as Codex hooks/manifests and Claude handoff manifests; tests can isolate these homes with FOOKS_CODEX_HOME/FOOKS_CLAUDE_HOME.",
+    },
+    nonGoals: [
+      "No --scope option is required for setup.",
+      "No interactive setup prompt is required.",
+      "Setup behavior is unchanged; this object only documents where the existing setup flow writes.",
+    ],
+  };
+}
+
 function setupClaimBoundaries(): string[] {
   return [
     "Codex setup installs the automatic fooks hook path when Codex trust checks pass.",
@@ -278,6 +394,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
       hooks: null,
       status,
       runtimes,
+      scope: buildSetupScopeSummary({ cwd, displayCliName, initialized, attach: null, hooks: null, claude: runtimes.claude, opencode: runtimes.opencode }),
       summary: setupSummary(runtimes),
       claimBoundaries: setupClaimBoundaries(),
       blockers,
@@ -354,6 +471,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
     hooks,
     status,
     runtimes,
+    scope: buildSetupScopeSummary({ cwd, displayCliName, initialized, attach, hooks, claude, opencode }),
     summary: setupSummary(runtimes),
     claimBoundaries: setupClaimBoundaries(),
     blockers,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1237,6 +1237,22 @@ test("setup prepares explicit one-time Codex activation", () => {
   assert.equal(result.runtimes.claude.blocksOverall, false);
   assert.equal(result.runtimes.opencode.state, "tool-ready");
   assert.equal(result.runtimes.opencode.blocksOverall, false);
+  assert.equal(result.scope.schemaVersion, 1);
+  assert.equal(result.scope.packageInstall.scope, "global-cli");
+  assert.equal(result.scope.packageInstall.command, "npm install -g oh-my-fooks");
+  assert.equal(result.scope.packageInstall.mutatedBySetup, false);
+  const setupProjectRoot = fs.realpathSync(tempDir);
+  assert.equal(result.scope.projectLocal.scope, "project-local");
+  assert.equal(result.scope.projectLocal.root, setupProjectRoot);
+  assert.ok(result.scope.projectLocal.paths.includes(path.join(setupProjectRoot, ".fooks", "config.json")));
+  assert.ok(result.scope.projectLocal.paths.includes(path.join(setupProjectRoot, ".fooks", "cache")));
+  assert.ok(result.scope.projectLocal.paths.includes(path.join(setupProjectRoot, ".opencode", "tools", "fooks_extract.ts")));
+  assert.ok(result.scope.projectLocal.paths.includes(path.join(setupProjectRoot, ".opencode", "commands", "fooks-extract.md")));
+  assert.equal(result.scope.userRuntime.scope, "user-home-runtime");
+  assert.ok(result.scope.userRuntime.paths.includes(path.join(codexHome, "hooks.json")));
+  assert.ok(result.scope.userRuntime.paths.includes(runtimeManifestPath(result.attach)));
+  assert.ok(result.scope.userRuntime.paths.includes(runtimeManifestPath(result.runtimes.claude.details.attach)));
+  assert.ok(result.scope.nonGoals.some((item) => item.includes("No --scope option")));
   assert.deepEqual(result.summary, ["codex:automatic-ready:ready", "claude:handoff-ready:ready", "opencode:tool-ready:ready"]);
   assert.ok(result.claimBoundaries.some((item) => item.includes("Claude setup prepares manual/shared handoff artifacts only")));
   assert.ok(result.nextSteps.some((item) => item.includes("Codex")));
@@ -1402,6 +1418,12 @@ test("setup reports blocked state for projects without React components", () => 
   assert.equal(result.runtimes.opencode.state, "manual-step-required");
   assert.equal(result.runtimes.opencode.blocksOverall, false);
   assert.equal(fs.existsSync(path.join(tempDir, ".opencode")), false);
+  const setupProjectRoot = fs.realpathSync(tempDir);
+  assert.equal(result.scope.projectRoot, setupProjectRoot);
+  assert.equal(result.scope.packageInstall.mutatedBySetup, false);
+  assert.ok(result.scope.projectLocal.paths.includes(path.join(setupProjectRoot, ".fooks", "config.json")));
+  assert.deepEqual(result.scope.userRuntime.paths, []);
+  assert.ok(result.scope.nonGoals.some((item) => item.includes("No interactive setup prompt")));
   assert.ok(result.blockers.some((item) => item.includes("No React/TSX component file found")));
   assert.ok(result.nextSteps.some((item) => item.includes("Add a React/TSX component")));
 });
@@ -1413,6 +1435,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /Codex: automatic runtime hook path/);
   assert.match(help, /Claude: manual\/shared handoff artifacts only/);
   assert.match(help, /opencode: manual\/semi-automatic custom tool/);
+  assert.doesNotMatch(help, /--scope/);
   assert.doesNotMatch(help, /Unknown command/);
 
   let usage = "";


### PR DESCRIPTION
## Summary

Closes #90.

This PR makes the install/setup scope boundary explicit without changing setup behavior:

- adds an additive `scope` object to `fooks setup` JSON output
- separates global CLI install context, project-local artifacts, and user runtime-home writes
- documents the boundary in README and setup docs
- pins the contract in unit tests and release smoke

## Scope model added to `fooks setup`

The new `scope` object includes:

- `packageInstall`: global CLI install (`npm install -g oh-my-fooks`) and `mutatedBySetup: false`
- `projectLocal`: current project root and `.fooks` / `.opencode` paths
- `userRuntime`: runtime-home paths such as Codex hooks/manifests and Claude handoff manifests
- `nonGoals`: no new `--scope` option, no interactive prompt, no behavior change

## Verification

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run release:smoke`
- [x] `git diff --check`

## Notes

- No new dependencies.
- No setup/install behavior changes.
- No `fooks status` schema changes required for this issue.
