### PR TITLE
fix: keep .opencode artifacts out of repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs/
 # Runtime state and local tool configuration
 .omx/
 .fooks/
+.opencode/
 .omc/
 .codex
 .clawhip/

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1798,6 +1798,7 @@ test("package release surface keeps internal docs out of the npm tarball", () =>
   assert.match(releaseSmoke, /docs\/internal\//);
   assert.match(releaseSmoke, /packed tarball includes non-public path/);
   assert.match(gitignore, /docs\/internal\//);
+  assert.match(gitignore, /\.opencode\//);
 });
 
 test("docs keep direct runtime benchmark regressions out of public win claims", () => {


### PR DESCRIPTION
Fixes repo root dirtying after fooks setup creates project-local .opencode artifacts.