### PR TITLE
Add conservative runtime/source metric foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fooks extract src/components/Button.tsx --model-payload
 fooks scan
 ```
 
-`fooks status` reads local `.fooks/sessions` summaries produced by the Codex hook path. The values are approximate context-size estimates only; the CLI status output omits per-session details and is not provider billing tokens, provider costs, or a `ccusage` replacement.
+`fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider billing tokens, provider costs, or a `ccusage` replacement.
 
 ## opencode support
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,7 +45,7 @@ context-compression mechanics and targeted-file behavior, but must not claim
 stable direct runtime-token/time wins until a future multi-task benchmark class
 proves them.
 
-Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
+Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`, including runtime/source breakdowns for Codex automatic hooks and Claude project-local context hooks. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
 Layer 2 now has two proposal-only R4 paired smokes through the current
 `codex exec` runner. In both pairs, the prompt supplied to Codex dropped from

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -62,7 +62,7 @@ Good signs:
 - Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
-Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
+Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 
 ## What the setup result means
 

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -29,6 +29,36 @@ function parsePackJson(stdout) {
   return parsed[0];
 }
 
+
+function assertNoForbiddenPublicClaims(label, text) {
+  const forbidden = [
+    /provider billing-token reduction/i,
+    /billing-token savings/i,
+    /provider cost savings/i,
+    /Claude Read interception is enabled/i,
+    /Claude runtime-token savings are enabled/i,
+    /automatic Claude runtime-token savings/i,
+  ];
+  for (const pattern of forbidden) {
+    assert(!pattern.test(text), `${label} contains forbidden positive claim ${pattern}`);
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    if (/ccusage replacement/i.test(line)) {
+      assert(/not (?:a )?ccusage replacement|not provider billing tokens, provider costs, or a ccusage replacement/i.test(line), `${label} contains unbounded ccusage replacement wording: ${line}`);
+    }
+    if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
+      assert(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
+    }
+  }
+}
+
+function assertPublicSurfaceClaimBoundaries(surfaces) {
+  for (const [label, text] of Object.entries(surfaces)) {
+    assertNoForbiddenPublicClaims(label, text);
+  }
+}
+
 function assertPackedFiles(packEntry) {
   const paths = new Set(packEntry.files.map((file) => file.path));
   const required = [
@@ -87,6 +117,13 @@ run("npm", ["install", "-g", "--prefix", prefix, tarballPath]);
 const fooksBin = path.join(prefix, "bin", "fooks");
 assert(fs.existsSync(fooksBin), `installed fooks binary not found at ${fooksBin}`);
 
+assertPublicSurfaceClaimBoundaries({
+  "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
+  "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
+  "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "dist/cli/index.js": fs.readFileSync(path.join(repoRoot, "dist", "cli", "index.js"), "utf8"),
+});
+
 const project = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-project-"));
 const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-"));
 const codexHome = path.join(runtimeRoot, "codex");
@@ -122,6 +159,37 @@ assert(setup.runtimes?.claude?.blocksOverall === false, "Claude readiness should
 assert(setup.runtimes?.opencode?.state === "tool-ready", `unexpected opencode setup state ${setup.runtimes?.opencode?.state}`);
 assert(setup.runtimes?.opencode?.blocksOverall === false, "opencode readiness should be non-fatal for overall setup");
 assert(setup.attach?.runtimeProof?.details?.includes("account-source=package-repository"), "setup should derive public repo account context from package metadata");
+
+const statusStdout = execFileSync(fooksBin, ["status"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+const claudeStatusStdout = execFileSync(fooksBin, ["status", "claude"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+assertPublicSurfaceClaimBoundaries({
+  "fooks setup output": setupStdout,
+  "fooks status output": statusStdout,
+  "fooks status claude output": claudeStatusStdout,
+});
+const status = JSON.parse(statusStdout);
+assert(status.claimBoundary?.includes("not provider billing tokens"), "status should keep provider billing boundary");
+assert(status.breakdown && typeof status.breakdown === "object", "status should expose runtime/source breakdown");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");
 assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -4,6 +4,12 @@ import { decideCodexPreRead } from "./codex-pre-read";
 import { initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { resolvePromptFileContext } from "./codex-runtime-prompt";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
+import {
+  estimateFileBytes,
+  estimateTextBytes,
+  initializeSessionMetricSummarySafe,
+  recordFooksSessionMetricEventSafe,
+} from "../core/session-metrics";
 
 export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
 
@@ -65,6 +71,39 @@ function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<t
   ].join("\n"));
 }
 
+function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
+  return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function recordClaudeMetric(
+  cwd: string,
+  sessionKey: string,
+  decision: ClaudeRuntimeHookDecision,
+  options: {
+    originalEstimatedBytes?: number;
+    actualEstimatedBytes?: number;
+    comparableForSavings?: boolean;
+    observedOriginalEstimatedBytes?: number;
+  } = {},
+): void {
+  recordFooksSessionMetricEventSafe(cwd, sessionKey, {
+    runtime: "claude",
+    measurementSource: "project-local-context-hook",
+    eventName: decision.hookEventName,
+    hookEventName: decision.hookEventName,
+    action: decision.action,
+    filePath: decision.filePath,
+    reasons: decision.reasons,
+    contextMode: decision.contextMode,
+    contextModeReason: decision.contextModeReason,
+    fallbackReason: decision.fallback?.reason,
+    originalEstimatedBytes: options.originalEstimatedBytes,
+    actualEstimatedBytes: options.actualEstimatedBytes,
+    comparableForSavings: options.comparableForSavings,
+    observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+  });
+}
+
 function sessionStartContext(): string {
   return clampAdditionalContext([
     "fooks: Claude context hook is active for this project.",
@@ -98,6 +137,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (hookEventName === "SessionStart") {
     const statePath = initializeClaudeRuntimeSession(cwd, sessionKey);
+    initializeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
     return {
       runtime: "claude",
       hookEventName,
@@ -121,19 +161,23 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
   const policy = promptContext.policy;
 
   if (!target) {
-    return noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    const decision = noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const resolvedTarget = path.join(cwd, target);
   if (!fs.existsSync(resolvedTarget)) {
-    return noopDecision(input, ["eligible-file-target-missing"], policy);
+    const decision = noopDecision(input, ["eligible-file-target-missing"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const { statePath, seenCount } = markClaudeRuntimeSeenFile(cwd, sessionKey, target);
   const repeatedFile = seenCount >= 2;
 
   if (!repeatedFile) {
-    return {
+    const decision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "record",
@@ -151,13 +195,18 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    recordClaudeMetric(cwd, sessionKey, decision, {
+      observedOriginalEstimatedBytes: targetEstimatedBytes(cwd, target),
+    });
+    return decision;
   }
 
   let decision: ReturnType<typeof decideCodexPreRead>;
   try {
     decision = decideCodexPreRead(resolvedTarget, cwd);
   } catch (error) {
-    return {
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "fallback",
@@ -180,17 +229,24 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         reason: "payload-build-failed",
       },
     };
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: originalEstimatedBytes,
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    return {
+    const additionalContext = buildPayloadContext(target, decision.payload, contextMode);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "inject",
       filePath: target,
       reasons: ["repeated-file"],
-      additionalContext: buildPayloadContext(target, decision.payload, contextMode),
+      additionalContext,
       statePath,
       contextMode,
       contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
@@ -203,9 +259,17 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: estimateTextBytes(additionalContext),
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
-  return {
+  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const runtimeDecision: ClaudeRuntimeHookDecision = {
     runtime: "claude",
     hookEventName,
     action: "fallback",
@@ -228,4 +292,10 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       reason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
     },
   };
+  recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+    originalEstimatedBytes,
+    actualEstimatedBytes: originalEstimatedBytes,
+    comparableForSavings: originalEstimatedBytes !== undefined,
+  });
+  return runtimeDecision;
 }

--- a/src/core/session-metrics.ts
+++ b/src/core/session-metrics.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { sessionEventsPath, sessionSummaryPath, sessionsSummaryPath, sanitizeDataKey } from "./paths";
-import type { CodexRuntimeHookInput, ContextMode } from "./schema";
+import type { ContextMode } from "./schema";
 
 export const FOOKS_SESSION_METRICS_SCHEMA_VERSION = 1;
 export const FOOKS_SESSION_METRIC_TIER = "estimated" as const;
@@ -9,9 +9,15 @@ export const ESTIMATED_BYTES_PER_TOKEN = 4;
 export const FOOKS_METRIC_CLAIM_BOUNDARY =
   "Estimated local context-size telemetry only; values are not provider billing tokens, provider costs, or a ccusage replacement.";
 
+export type FooksMetricRuntime = "codex" | "claude";
+export type FooksMeasurementSource = "automatic-hook" | "project-local-context-hook" | "manual-handoff" | "local-simulation";
 type MetricTier = typeof FOOKS_SESSION_METRIC_TIER;
-type HookEventName = CodexRuntimeHookInput["hookEventName"];
 export type FooksSessionMetricAction = "inject" | "fallback" | "record" | "noop";
+
+export type FooksMetricIdentityOptions = {
+  runtime?: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+};
 
 export type FooksEstimatedUsage = {
   originalEstimatedBytes: number;
@@ -23,35 +29,7 @@ export type FooksEstimatedUsage = {
   savingsRatio: number;
 };
 
-export type FooksSessionMetricEvent = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  timestamp: string;
-  runtime: "codex";
-  sessionKey: string;
-  hookEventName: HookEventName;
-  action: FooksSessionMetricAction;
-  filePath?: string;
-  reasons: string[];
-  contextMode?: ContextMode;
-  contextModeReason?: string;
-  fallbackReason?: string;
-  metricTier: MetricTier;
-  comparableForSavings: boolean;
-  estimated: FooksEstimatedUsage;
-  observedOpportunity?: {
-    originalEstimatedBytes: number;
-    originalEstimatedTokens: number;
-  };
-};
-
-export type FooksSessionMetricSummary = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  metricTier: MetricTier;
-  sessionKey: string;
-  sanitizedSessionKey: string;
-  startedAt: string;
-  updatedAt: string;
-  stoppedAt?: string;
+export type FooksMetricAggregate = {
   eventCount: number;
   comparableEventCount: number;
   injectCount: number;
@@ -62,11 +40,61 @@ export type FooksSessionMetricSummary = {
   observedOriginalEstimatedBytes: number;
   observedOriginalEstimatedTokens: number;
   totals: FooksEstimatedUsage;
+};
+
+export type FooksMetricBreakdown = {
+  byRuntime: Partial<Record<FooksMetricRuntime, FooksMetricAggregate>>;
+  byMeasurementSource: Partial<Record<FooksMeasurementSource, FooksMetricAggregate>>;
+  byRuntimeAndSource: Record<string, FooksMetricAggregate>;
+};
+
+export type FooksSessionMetricEvent = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  timestamp: string;
+  metricTier: MetricTier;
+  claimBoundary: string;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  eventName: string;
+  hookEventName?: string;
+  action: FooksSessionMetricAction;
+  filePath?: string;
+  reasons: string[];
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  fallbackReason?: string;
+  comparableForSavings: boolean;
+  estimated: FooksEstimatedUsage;
+  observedOpportunity?: {
+    originalEstimatedBytes: number;
+    originalEstimatedTokens: number;
+  };
+};
+
+export type FooksSessionMetricSummary = FooksMetricAggregate & {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  metricTier: MetricTier;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  sanitizedSessionKey: string;
+  startedAt: string;
+  updatedAt: string;
+  stoppedAt?: string;
   claimBoundary: string;
 };
 
 export type FooksSessionMetricContribution = Pick<
   FooksSessionMetricSummary,
+  | "runtime"
+  | "measurementSource"
+  | "rawSessionKey"
+  | "metricSessionKey"
   | "sessionKey"
   | "sanitizedSessionKey"
   | "startedAt"
@@ -84,23 +112,14 @@ export type FooksSessionMetricContribution = Pick<
   | "totals"
 >;
 
-export type FooksProjectMetricSummaryFile = {
+export type FooksProjectMetricSummaryFile = FooksMetricAggregate & {
   schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
   metricTier: MetricTier;
   updatedAt: string;
   sessionCount: number;
-  eventCount: number;
-  comparableEventCount: number;
-  injectCount: number;
-  fallbackCount: number;
-  recordCount: number;
-  noopCount: number;
-  observedOpportunityCount: number;
-  observedOriginalEstimatedBytes: number;
-  observedOriginalEstimatedTokens: number;
-  totals: FooksEstimatedUsage;
   latestSessionKeys: string[];
   sessions: Record<string, FooksSessionMetricContribution>;
+  breakdown: FooksMetricBreakdown;
   claimBoundary: string;
 };
 
@@ -109,8 +128,10 @@ export type FooksProjectMetricStatus = Omit<FooksProjectMetricSummaryFile, "sess
 };
 
 export type RecordFooksSessionMetricInput = {
-  runtime: "codex";
-  hookEventName: HookEventName;
+  runtime: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+  eventName?: string;
+  hookEventName?: string;
   action: FooksSessionMetricAction;
   filePath?: string;
   reasons?: string[];
@@ -123,8 +144,60 @@ export type RecordFooksSessionMetricInput = {
   observedOriginalEstimatedBytes?: number;
 };
 
+type MetricIdentity = {
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+};
+
+const MEASUREMENT_SOURCES: FooksMeasurementSource[] = ["automatic-hook", "project-local-context-hook", "manual-handoff", "local-simulation"];
+const RUNTIMES: FooksMetricRuntime[] = ["codex", "claude"];
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function defaultMeasurementSource(runtime: FooksMetricRuntime): FooksMeasurementSource {
+  return runtime === "claude" ? "project-local-context-hook" : "automatic-hook";
+}
+
+export function metricSessionKey(rawSessionKey: string, options: Required<FooksMetricIdentityOptions>): string {
+  return `${options.runtime}:${options.measurementSource}:${rawSessionKey}`;
+}
+
+function parseMetricSessionKey(value: string): MetricIdentity | null {
+  for (const runtime of RUNTIMES) {
+    for (const measurementSource of MEASUREMENT_SOURCES) {
+      const prefix = `${runtime}:${measurementSource}:`;
+      if (value.startsWith(prefix)) {
+        const rawSessionKey = value.slice(prefix.length) || "default-session";
+        return {
+          runtime,
+          measurementSource,
+          rawSessionKey,
+          metricSessionKey: value,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function resolveMetricIdentity(rawOrMetricSessionKey: string, options: FooksMetricIdentityOptions = {}): MetricIdentity {
+  if (!options.runtime && !options.measurementSource) {
+    const parsed = parseMetricSessionKey(rawOrMetricSessionKey);
+    if (parsed) return parsed;
+  }
+  const runtime = options.runtime ?? "codex";
+  const measurementSource = options.measurementSource ?? defaultMeasurementSource(runtime);
+  const rawSessionKey = rawOrMetricSessionKey || "default-session";
+  return {
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: metricSessionKey(rawSessionKey, { runtime, measurementSource }),
+  };
 }
 
 function nonNegativeInteger(value: number | undefined): number {
@@ -168,6 +241,21 @@ function emptyUsage(): FooksEstimatedUsage {
   };
 }
 
+function emptyAggregate(): FooksMetricAggregate {
+  return {
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: emptyUsage(),
+  };
+}
+
 function usageFromBytes(originalBytes: number, actualBytes: number): FooksEstimatedUsage {
   const originalEstimatedBytes = nonNegativeInteger(originalBytes);
   const actualEstimatedBytes = nonNegativeInteger(actualBytes);
@@ -205,6 +293,40 @@ function addUsage(left: FooksEstimatedUsage, right: FooksEstimatedUsage): FooksE
   });
 }
 
+function addAggregate(left: FooksMetricAggregate, right: FooksMetricAggregate): FooksMetricAggregate {
+  return {
+    eventCount: left.eventCount + right.eventCount,
+    comparableEventCount: left.comparableEventCount + right.comparableEventCount,
+    injectCount: left.injectCount + right.injectCount,
+    fallbackCount: left.fallbackCount + right.fallbackCount,
+    recordCount: left.recordCount + right.recordCount,
+    noopCount: left.noopCount + right.noopCount,
+    observedOpportunityCount: left.observedOpportunityCount + right.observedOpportunityCount,
+    observedOriginalEstimatedBytes: left.observedOriginalEstimatedBytes + right.observedOriginalEstimatedBytes,
+    observedOriginalEstimatedTokens: left.observedOriginalEstimatedTokens + right.observedOriginalEstimatedTokens,
+    totals: addUsage(left.totals, right.totals),
+  };
+}
+
+function aggregateFromContribution(contribution: FooksSessionMetricContribution): FooksMetricAggregate {
+  return {
+    eventCount: nonNegativeInteger(contribution.eventCount),
+    comparableEventCount: nonNegativeInteger(contribution.comparableEventCount),
+    injectCount: nonNegativeInteger(contribution.injectCount),
+    fallbackCount: nonNegativeInteger(contribution.fallbackCount),
+    recordCount: nonNegativeInteger(contribution.recordCount),
+    noopCount: nonNegativeInteger(contribution.noopCount),
+    observedOpportunityCount: nonNegativeInteger(contribution.observedOpportunityCount),
+    observedOriginalEstimatedBytes: nonNegativeInteger(contribution.observedOriginalEstimatedBytes),
+    observedOriginalEstimatedTokens: nonNegativeInteger(contribution.observedOriginalEstimatedTokens),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
+function addBreakdownAggregate<T extends string>(target: Partial<Record<T, FooksMetricAggregate>>, key: T, aggregate: FooksMetricAggregate): void {
+  target[key] = addAggregate(target[key] ?? emptyAggregate(), aggregate);
+}
+
 function truncateString(value: string, maxLength = 240): string {
   return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
 }
@@ -231,25 +353,28 @@ function writeJsonAtomic(file: string, value: unknown): void {
   fs.renameSync(tmp, file);
 }
 
-function emptySessionSummary(sessionKey: string, timestamp = nowIso()): FooksSessionMetricSummary {
+function emptySessionSummary(rawSessionKey: string, identity = resolveMetricIdentity(rawSessionKey), timestamp = nowIso()): FooksSessionMetricSummary {
   return {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     metricTier: FOOKS_SESSION_METRIC_TIER,
-    sessionKey,
-    sanitizedSessionKey: sanitizeDataKey(sessionKey),
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(identity.metricSessionKey),
     startedAt: timestamp,
     updatedAt: timestamp,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+function emptyBreakdown(): FooksMetricBreakdown {
+  return {
+    byRuntime: {},
+    byMeasurementSource: {},
+    byRuntimeAndSource: {},
   };
 }
 
@@ -259,18 +384,10 @@ function emptyProjectSummaryFile(timestamp = nowIso()): FooksProjectMetricSummar
     metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: 0,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     latestSessionKeys: [],
     sessions: {},
+    breakdown: emptyBreakdown(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
@@ -283,14 +400,41 @@ function isProjectSummaryFile(value: FooksProjectMetricSummaryFile | null): valu
   return Boolean(value && value.schemaVersion === FOOKS_SESSION_METRICS_SCHEMA_VERSION && value.metricTier === FOOKS_SESSION_METRIC_TIER && value.sessions);
 }
 
-export function readSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const summary = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  return isSessionSummary(summary) ? summary : emptySessionSummary(sessionKey);
+function normalizeSessionSummary(summary: FooksSessionMetricSummary, identity: MetricIdentity): FooksSessionMetricSummary {
+  const normalizedIdentity = {
+    runtime: summary.runtime ?? identity.runtime,
+    measurementSource: summary.measurementSource ?? identity.measurementSource,
+    rawSessionKey: summary.rawSessionKey ?? identity.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey ?? identity.metricSessionKey,
+  };
+  return {
+    ...emptySessionSummary(normalizedIdentity.rawSessionKey, normalizedIdentity, summary.startedAt),
+    ...summary,
+    runtime: normalizedIdentity.runtime,
+    measurementSource: normalizedIdentity.measurementSource,
+    rawSessionKey: normalizedIdentity.rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+export function readSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const summary =
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey)) ??
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
+  return isSessionSummary(summary) ? normalizeSessionSummary(summary, identity) : emptySessionSummary(identity.rawSessionKey, identity);
 }
 
 function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessionMetricContribution {
   return {
-    sessionKey: summary.sessionKey,
+    runtime: summary.runtime,
+    measurementSource: summary.measurementSource,
+    rawSessionKey: summary.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey,
+    sessionKey: summary.metricSessionKey,
     sanitizedSessionKey: summary.sanitizedSessionKey,
     startedAt: summary.startedAt,
     updatedAt: summary.updatedAt,
@@ -308,38 +452,65 @@ function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessi
   };
 }
 
+function normalizeContribution(contribution: FooksSessionMetricContribution): FooksSessionMetricContribution {
+  const seedKey = contribution.metricSessionKey ?? contribution.sessionKey ?? contribution.rawSessionKey ?? "default-session";
+  const seedIdentity = contribution.metricSessionKey
+    ? (parseMetricSessionKey(contribution.metricSessionKey) ?? resolveMetricIdentity(contribution.metricSessionKey))
+    : resolveMetricIdentity(seedKey, {
+        runtime: contribution.runtime,
+        measurementSource: contribution.measurementSource,
+      });
+  const runtime = contribution.runtime ?? seedIdentity.runtime;
+  const measurementSource = contribution.measurementSource ?? seedIdentity.measurementSource;
+  const rawSessionKey = contribution.rawSessionKey ?? seedIdentity.rawSessionKey;
+  const normalizedIdentity = resolveMetricIdentity(rawSessionKey, { runtime, measurementSource });
+  return {
+    ...contribution,
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
 function readProjectSummaryFile(cwd: string): FooksProjectMetricSummaryFile {
   const summary = readJsonFile<FooksProjectMetricSummaryFile>(sessionsSummaryPath(cwd));
-  return isProjectSummaryFile(summary) ? summary : emptyProjectSummaryFile();
+  return isProjectSummaryFile(summary) ? recomputeProjectSummaryFile(summary) : emptyProjectSummaryFile();
 }
 
 function recomputeProjectSummaryFile(summary: FooksProjectMetricSummaryFile, timestamp = nowIso()): FooksProjectMetricSummaryFile {
-  const contributions = Object.values(summary.sessions).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
-  let totals = emptyUsage();
+  const contributions = Object.values(summary.sessions).map(normalizeContribution).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  let aggregate = emptyAggregate();
+  const breakdown = emptyBreakdown();
   for (const contribution of contributions) {
-    totals = addUsage(totals, contribution.totals);
+    const contributionAggregate = aggregateFromContribution(contribution);
+    aggregate = addAggregate(aggregate, contributionAggregate);
+    addBreakdownAggregate(breakdown.byRuntime, contribution.runtime, contributionAggregate);
+    addBreakdownAggregate(breakdown.byMeasurementSource, contribution.measurementSource, contributionAggregate);
+    breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] = addAggregate(
+      breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] ?? emptyAggregate(),
+      contributionAggregate,
+    );
   }
   return {
     ...summary,
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: contributions.length,
-    eventCount: contributions.reduce((total, contribution) => total + contribution.eventCount, 0),
-    comparableEventCount: contributions.reduce((total, contribution) => total + contribution.comparableEventCount, 0),
-    injectCount: contributions.reduce((total, contribution) => total + contribution.injectCount, 0),
-    fallbackCount: contributions.reduce((total, contribution) => total + contribution.fallbackCount, 0),
-    recordCount: contributions.reduce((total, contribution) => total + contribution.recordCount, 0),
-    noopCount: contributions.reduce((total, contribution) => total + contribution.noopCount, 0),
-    observedOpportunityCount: contributions.reduce((total, contribution) => total + contribution.observedOpportunityCount, 0),
-    observedOriginalEstimatedBytes: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedBytes, 0),
-    observedOriginalEstimatedTokens: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedTokens, 0),
-    totals,
-    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.sessionKey),
+    ...aggregate,
+    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.metricSessionKey),
+    sessions: Object.fromEntries(contributions.map((contribution) => [contribution.sanitizedSessionKey, contribution])),
+    breakdown,
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
 
-export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string): FooksProjectMetricStatus {
-  const sessionSummary = readSessionMetricSummary(cwd, sessionKey);
+export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksProjectMetricStatus {
+  const sessionSummary = readSessionMetricSummary(cwd, sessionKey, options);
   const projectSummary = readProjectSummaryFile(cwd);
   projectSummary.sessions[sessionSummary.sanitizedSessionKey] = contributionFromSession(sessionSummary);
   const updated = recomputeProjectSummaryFile(projectSummary);
@@ -360,36 +531,39 @@ export function readProjectMetricSummary(cwd = process.cwd()): FooksProjectMetri
 }
 
 function writeSessionSummary(cwd: string, summary: FooksSessionMetricSummary): void {
-  writeJsonAtomic(sessionSummaryPath(cwd, summary.sessionKey), summary);
+  writeJsonAtomic(sessionSummaryPath(cwd, summary.metricSessionKey), summary);
 }
 
-function appendSessionEvent(cwd: string, sessionKey: string, event: FooksSessionMetricEvent): void {
-  const file = sessionEventsPath(cwd, sessionKey);
+function appendSessionEvent(cwd: string, metricSessionKeyValue: string, event: FooksSessionMetricEvent): void {
+  const file = sessionEventsPath(cwd, metricSessionKeyValue);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.appendFileSync(file, `${JSON.stringify(event)}\n`);
 }
 
-export function initializeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  const summary = isSessionSummary(existing) ? existing : emptySessionSummary(sessionKey);
+export function initializeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey));
+  const summary = isSessionSummary(existing) ? normalizeSessionSummary(existing, identity) : emptySessionSummary(identity.rawSessionKey, identity);
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
-export function finalizeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+export function finalizeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
   const timestamp = nowIso();
   const summary = {
-    ...readSessionMetricSummary(cwd, sessionKey),
+    ...readSessionMetricSummary(cwd, identity.metricSessionKey),
     updatedAt: timestamp,
     stoppedAt: timestamp,
   } satisfies FooksSessionMetricSummary;
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
 export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, input: RecordFooksSessionMetricInput): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, { runtime: input.runtime, measurementSource: input.measurementSource });
   const timestamp = nowIso();
   const comparableForSavings = Boolean(input.comparableForSavings);
   const originalBytes = comparableForSavings ? nonNegativeInteger(input.originalEstimatedBytes) : 0;
@@ -397,11 +571,18 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
   const eventUsage = comparableForSavings ? usageFromBytes(originalBytes, actualBytes) : emptyUsage();
   const observedOriginalEstimatedBytes = nonNegativeInteger(input.observedOriginalEstimatedBytes ?? input.originalEstimatedBytes);
   const observedOpportunity = !comparableForSavings && observedOriginalEstimatedBytes > 0;
+  const eventName = input.eventName ?? input.hookEventName ?? "unknown";
   const event: FooksSessionMetricEvent = {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     timestamp,
-    runtime: input.runtime,
-    sessionKey,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    eventName,
     hookEventName: input.hookEventName,
     action: input.action,
     filePath: input.filePath,
@@ -409,7 +590,6 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     contextMode: input.contextMode,
     contextModeReason: input.contextModeReason ? truncateString(input.contextModeReason) : undefined,
     fallbackReason: input.fallbackReason ? truncateString(input.fallbackReason) : undefined,
-    metricTier: FOOKS_SESSION_METRIC_TIER,
     comparableForSavings,
     estimated: eventUsage,
     observedOpportunity: observedOpportunity
@@ -420,9 +600,9 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
       : undefined,
   };
 
-  appendSessionEvent(cwd, sessionKey, event);
+  appendSessionEvent(cwd, identity.metricSessionKey, event);
 
-  const summary = readSessionMetricSummary(cwd, sessionKey);
+  const summary = readSessionMetricSummary(cwd, identity.metricSessionKey);
   const updated: FooksSessionMetricSummary = {
     ...summary,
     updatedAt: timestamp,
@@ -440,21 +620,21 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
   writeSessionSummary(cwd, updated);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return updated;
 }
 
-export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    initializeSessionMetricSummary(cwd, sessionKey);
+    initializeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }
 }
 
-export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    finalizeSessionMetricSummary(cwd, sessionKey);
+    finalizeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -37,6 +37,7 @@ const {
 } = require(path.join(repoRoot, "dist", "core", "session-metrics.js"));
 const {
   sessionEventsPath,
+  sessionSummaryPath,
   sessionsSummaryPath,
 } = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
@@ -627,9 +628,69 @@ test("bare status reports fast estimated session savings without exposing sessio
   assert.equal(empty.latestSessionCount, 0);
   assert.equal(empty.eventCount, 0);
   assert.equal(empty.totals.savedEstimatedBytes, 0);
+  assert.deepEqual(empty.breakdown.byRuntime, {});
+  assert.deepEqual(empty.breakdown.byMeasurementSource, {});
+  assert.deepEqual(empty.breakdown.byRuntimeAndSource, {});
   assert.equal("sessions" in empty, false);
   assert.equal("latestSessionKeys" in empty, false);
   assert.match(empty.claimBoundary, /not provider billing tokens/);
+});
+
+test("legacy unqualified metric summaries migrate to codex automatic hook identity", () => {
+  const tempDir = makeTempProject();
+  const legacySessionKey = "legacy-session";
+  const timestamp = "2026-04-21T00:00:00.000Z";
+  const usage = {
+    originalEstimatedBytes: 400,
+    actualEstimatedBytes: 100,
+    savedEstimatedBytes: 300,
+    originalEstimatedTokens: 100,
+    actualEstimatedTokens: 25,
+    savedEstimatedTokens: 75,
+    savingsRatio: 0.75,
+  };
+  fs.mkdirSync(path.dirname(sessionSummaryPath(tempDir, legacySessionKey)), { recursive: true });
+  fs.writeFileSync(
+    sessionSummaryPath(tempDir, legacySessionKey),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        metricTier: "estimated",
+        sessionKey: legacySessionKey,
+        sanitizedSessionKey: legacySessionKey,
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        eventCount: 1,
+        comparableEventCount: 1,
+        injectCount: 1,
+        fallbackCount: 0,
+        recordCount: 0,
+        noopCount: 0,
+        observedOpportunityCount: 0,
+        observedOriginalEstimatedBytes: 0,
+        observedOriginalEstimatedTokens: 0,
+        totals: usage,
+        claimBoundary: "legacy local estimate",
+      },
+      null,
+      2,
+    ),
+  );
+
+  const summary = readSessionMetricSummary(tempDir, legacySessionKey);
+  assert.equal(summary.runtime, "codex");
+  assert.equal(summary.measurementSource, "automatic-hook");
+  assert.equal(summary.rawSessionKey, legacySessionKey);
+  assert.equal(summary.metricSessionKey, `codex:automatic-hook:${legacySessionKey}`);
+  assert.equal(summary.sessionKey, summary.metricSessionKey);
+  assert.equal(summary.totals.savedEstimatedBytes, 300);
+
+  const status = refreshProjectMetricSummaryFromSession(tempDir, legacySessionKey);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.latestSessionCount, 1);
+  assert.equal("sessions" in status, false);
 });
 
 test("runtime hook stores redacted estimated metrics for record, inject, fallback, and stop", () => {
@@ -678,7 +739,12 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
     Math.max(0, sessionSummary.totals.originalEstimatedBytes - sessionSummary.totals.actualEstimatedBytes),
   );
 
-  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionId), "utf8");
+  assert.equal(sessionSummary.runtime, "codex");
+  assert.equal(sessionSummary.measurementSource, "automatic-hook");
+  assert.equal(sessionSummary.rawSessionKey, sessionId);
+  assert.match(sessionSummary.metricSessionKey, /^codex:automatic-hook:/);
+
+  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionSummary.metricSessionKey), "utf8");
   assert.doesNotMatch(eventLog, /Again, update/);
   assert.doesNotMatch(eventLog, /additionalContext/);
   assert.doesNotMatch(eventLog, /rawText/);
@@ -721,11 +787,15 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
   assert.equal(status.fallbackCount, 1);
   assert.equal(status.recordCount, 1);
   assert.equal(status.latestSessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 3);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 3);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 3);
   assert.equal("latestSessionKeys" in status, false);
   assert.equal("sessions" in status, false);
 
   const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
   assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(Object.keys(summaryFile.sessions).every((key) => key.startsWith("codex-automatic-hook-")));
 });
 
 test("runtime metric write failures are non-fatal to hook decisions", () => {
@@ -1696,6 +1766,114 @@ test("claude runtime hook records first eligible prompt, injects repeated same-f
   const linkedTs = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Explain src/components/Button.types.ts" }, tempDir);
   assert.equal(linkedTs.action, "noop");
   const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
+  assert.equal(missing.action, "noop");
+});
+
+test("codex and claude estimated metrics are runtime/source-qualified without session collisions", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "same-session";
+  const target = path.join("src", "components", "FormSection.tsx");
+  const targetBytes = fs.statSync(path.join(tempDir, target)).size;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const claudeStart = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(claudeStart.action, "inject");
+  const claudeStartSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(claudeStartSummary.eventCount, 0);
+  assert.equal(claudeStartSummary.injectCount, 0);
+  assert.equal(claudeStartSummary.comparableEventCount, 0);
+
+  const claudeFirst = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Explain ${target}` }, tempDir);
+  assert.equal(claudeFirst.action, "record");
+  const claudeSecond = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, explain ${target}` }, tempDir);
+  assert.equal(claudeSecond.action, "inject");
+  assert.ok(claudeSecond.additionalContext);
+
+  const codexSummary = readSessionMetricSummary(tempDir, sessionId);
+  const claudeSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(codexSummary.runtime, "codex");
+  assert.equal(codexSummary.measurementSource, "automatic-hook");
+  assert.equal(claudeSummary.runtime, "claude");
+  assert.equal(claudeSummary.measurementSource, "project-local-context-hook");
+  assert.equal(codexSummary.rawSessionKey, sessionId);
+  assert.equal(claudeSummary.rawSessionKey, sessionId);
+  assert.notEqual(codexSummary.metricSessionKey, claudeSummary.metricSessionKey);
+  assert.notEqual(sessionSummaryPath(tempDir, codexSummary.metricSessionKey), sessionSummaryPath(tempDir, claudeSummary.metricSessionKey));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, codexSummary.metricSessionKey)));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, claudeSummary.metricSessionKey)));
+
+  assert.equal(claudeSummary.eventCount, 2);
+  assert.equal(claudeSummary.recordCount, 1);
+  assert.equal(claudeSummary.injectCount, 1);
+  assert.equal(claudeSummary.comparableEventCount, 1);
+  assert.equal(claudeSummary.observedOpportunityCount, 1);
+  assert.equal(claudeSummary.observedOriginalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.originalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.actualEstimatedBytes, Buffer.byteLength(claudeSecond.additionalContext, "utf8"));
+
+  const claudeEvents = fs.readFileSync(sessionEventsPath(tempDir, claudeSummary.metricSessionKey), "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  assert.equal(claudeEvents.length, 2);
+  assert.ok(claudeEvents.every((event) => event.metricTier === "estimated"));
+  assert.ok(claudeEvents.every((event) => event.claimBoundary.includes("not provider billing tokens")));
+  assert.ok(claudeEvents.every((event) => event.runtime === "claude"));
+  assert.ok(claudeEvents.every((event) => event.measurementSource === "project-local-context-hook"));
+  assert.ok(claudeEvents.every((event) => event.rawSessionKey === sessionId));
+  assert.ok(claudeEvents.every((event) => event.metricSessionKey === claudeSummary.metricSessionKey));
+  assert.ok(claudeEvents.every((event) => event.eventName === "UserPromptSubmit"));
+
+  const status = run(["status"], tempDir);
+  assert.equal(status.sessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byRuntime.claude.eventCount, 2);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["project-local-context-hook"].eventCount, 2);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["claude:project-local-context-hook"].eventCount, 2);
+
+  const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
+  assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(summaryFile.sessions[codexSummary.sanitizedSessionKey]);
+  assert.ok(summaryFile.sessions[claudeSummary.sanitizedSessionKey]);
+});
+
+test("claude fallback metrics record zero savings and telemetry failures are non-fatal", () => {
+  const tempDir = makeTempProject();
+  const hugeTarget = path.join("src", "components", "HugeRaw.tsx");
+  fs.writeFileSync(
+    path.join(tempDir, hugeTarget),
+    `export const huge = ${JSON.stringify("x".repeat(5000))};\n`,
+  );
+  const hugeBytes = fs.statSync(path.join(tempDir, hugeTarget)).size;
+  const fallbackSession = "claude-fallback-metrics";
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: fallbackSession }, tempDir);
+  assert.equal(handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Explain ${hugeTarget}` }, tempDir).action, "record");
+  const fallback = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Again, explain ${hugeTarget}` }, tempDir);
+  assert.equal(fallback.action, "fallback");
+  const fallbackSummary = readSessionMetricSummary(tempDir, fallbackSession, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(fallbackSummary.fallbackCount, 1);
+  assert.equal(fallbackSummary.comparableEventCount, 1);
+  assert.equal(fallbackSummary.totals.originalEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.actualEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.savedEstimatedBytes, 0);
+
+  const blockedDir = makeTempProject();
+  fs.mkdirSync(path.join(blockedDir, ".fooks"), { recursive: true });
+  fs.writeFileSync(path.join(blockedDir, ".fooks", "sessions"), "not-a-directory");
+  const target = path.join("src", "components", "FormSection.tsx");
+  const blockedSession = "claude-blocked-metrics";
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: blockedSession }, blockedDir);
+  assert.equal(start.action, "inject");
+  assert.match(start.additionalContext, /context hook is active/);
+  const first = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Explain ${target}` }, blockedDir);
+  assert.equal(first.action, "record");
+  const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Again, explain ${target}` }, blockedDir);
+  assert.equal(second.action, "inject");
+  assert.match(second.additionalContext, /fooks: Claude context hook/);
+  const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain this repo" }, blockedDir);
+  assert.equal(noTarget.action, "noop");
+  const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain src/components/MissingPanel.tsx" }, blockedDir);
   assert.equal(missing.action, "noop");
 });
 

--- a/test/metric-cleanup.mjs
+++ b/test/metric-cleanup.mjs
@@ -12,8 +12,20 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
   }
 
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
-      fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(root, entry.name);
+    const summaryPath = path.join(entryPath, "summary.json");
+    let keys = [entry.name];
+    if (fs.existsSync(summaryPath)) {
+      try {
+        const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+        keys = [entry.name, summary.rawSessionKey, summary.metricSessionKey, summary.sessionKey].filter(Boolean);
+      } catch {
+        // Fall back to the directory name for malformed ignored telemetry.
+      }
+    }
+    if (keys.some((key) => prefixes.some((prefix) => String(key).startsWith(prefix)))) {
+      fs.rmSync(entryPath, { recursive: true, force: true });
     }
   }
 
@@ -29,7 +41,7 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
     }
     try {
       const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
-      refreshProjectMetricSummaryFromSession(repoRoot, summary.sessionKey ?? entry.name);
+      refreshProjectMetricSummaryFromSession(repoRoot, summary.metricSessionKey ?? summary.sessionKey ?? entry.name);
       remainingSessionCount += 1;
     } catch {
       // Test cleanup should not fail the suite when ignored telemetry is malformed.


### PR DESCRIPTION
## Summary
- Adds runtime/source-qualified local estimated metric identity for `.fooks/sessions` so Codex automatic hooks and Claude project-local context hooks cannot collide on the same raw session id.
- Adds Claude context-hook telemetry for first-prompt opportunity, repeated same-file injection, fallback zero-savings cases, and non-fatal metric write failures.
- Adds public claim guards and docs wording so estimated local telemetry remains explicitly not provider billing tokens, provider costs, Claude `Read` interception, or a `ccusage` replacement.

## Evidence
- `npm run lint`
- `npm test` — 117 tests passed
- `npm run release:smoke` — ok, setup summary: `codex:automatic-ready:ready`, `claude:context-hook-ready:ready`, `opencode:tool-ready:ready`
- Ralph architect verification: APPROVED

## Claim boundaries
- Metrics are local estimated context-size telemetry only.
- Claude P0 remains project-local `SessionStart` / `UserPromptSubmit` context hooks; no `Read`/tool interception claim.
- No provider billing-token, provider-cost, or stable runtime-token/time savings claim is introduced.

## Stack
- Base: #96 / `codex/claude-auto-adapter-design`
