### PR TITLE
Add conservative runtime source metric foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fooks extract src/components/Button.tsx --model-payload
 fooks scan
 ```
 
-`fooks status` reads local `.fooks/sessions` summaries produced by the Codex hook path. The values are approximate context-size estimates only; the CLI status output omits per-session details and is not provider billing tokens, provider costs, or a `ccusage` replacement.
+`fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider billing tokens, provider costs, or a `ccusage` replacement.
 
 ## opencode support
 

--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -119,6 +119,13 @@ Expected observations:
 - The script creates a disposable frontend project and installs the packed local `fooks` CLI.
 - `fooks setup` must report Codex `automatic-ready` and Claude `context-hook-ready`.
 - Codex normally reports `providerCompleted: true`, `lastMessageExists: true`, and `hookEvidenceObserved: true`.
-- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true` and `providerErrors` records the provider-side failure.
+- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true`, `providerFailureKind` classifies the failure, and `providerErrors` records the provider-side failure.
+- `authStatus.loggedIn: true` only proves the local Claude Code auth file/session is present. It does not guarantee the upstream provider will complete the model call; `providerCompleted` is the provider completion signal.
 - Provider-backed CLI invocations must leave `fooks status` at `metricTier: "estimated"` with the provider-billing boundary intact.
 - Any captured evidence remains hook activation / local status evidence only; it is still not provider billing-token or provider-cost proof.
+
+Provider failure triage:
+
+- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command.
+- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun.
+- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`.

--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -105,16 +105,20 @@ FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-prov
 
 The first command is safe and only reports installed CLI versions plus the exact opt-in command. The second command may use the local Codex / Claude Code account and can spend provider tokens, so run it only when that is intentional.
 
-Optional flags:
+Optional flags and timeout knobs:
 
 ```bash
 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex
 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-claude
+FOOKS_LIVE_CODEX_TIMEOUT_MS=120000 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-claude
+FOOKS_LIVE_CLAUDE_TIMEOUT_MS=120000 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex
 ```
 
 Expected observations:
 
 - The script creates a disposable frontend project and installs the packed local `fooks` CLI.
 - `fooks setup` must report Codex `automatic-ready` and Claude `context-hook-ready`.
+- Codex normally reports `providerCompleted: true`, `lastMessageExists: true`, and `hookEvidenceObserved: true`.
+- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true` and `providerErrors` records the provider-side failure.
 - Provider-backed CLI invocations must leave `fooks status` at `metricTier: "estimated"` with the provider-billing boundary intact.
 - Any captured evidence remains hook activation / local status evidence only; it is still not provider billing-token or provider-cost proof.

--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -105,6 +105,8 @@ FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-prov
 
 The first command is safe and only reports installed CLI versions plus the exact opt-in command. The second command may use the local Codex / Claude Code account and can spend provider tokens, so run it only when that is intentional.
 
+Execution-context boundary: a Codex-hosted shell can exercise the installed `claude` CLI and prove project-local hook activation, but final Claude provider completion should be rerun from the actual Claude Code environment/account that users will operate. If the Codex-hosted smoke reports `hookEvidenceObserved: true` and `providerCompleted: false`, treat that as a provider/account-context diagnostic rather than a fooks hook failure, then rerun the Claude-only command from Claude Code.
+
 Optional flags and timeout knobs:
 
 ```bash
@@ -126,6 +128,6 @@ Expected observations:
 
 Provider failure triage:
 
-- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command.
-- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun.
-- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`.
+- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command from the real Claude Code environment.
+- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun from Claude Code.
+- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`; for final provider-completion evidence, rerun from Claude Code rather than interpreting a Codex-hosted shell failure as a fooks runtime failure.

--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -93,3 +93,28 @@ Use sanitized excerpts only:
 - `fooks status` fields showing `metricTier`, `claimBoundary`, and runtime/source keys.
 - Confirmation that provider billing-token/cost proof remains deferred.
 - Confirmation that `ccusage` replacement remains out of scope.
+
+## Opt-in provider-backed live smoke
+
+The deterministic release smoke is the default proof gate. If a maintainer wants to reduce the remaining interactive-runtime risk with real installed CLI invocations, run the opt-in provider smoke:
+
+```bash
+node scripts/live-provider-hook-smoke.mjs
+FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider
+```
+
+The first command is safe and only reports installed CLI versions plus the exact opt-in command. The second command may use the local Codex / Claude Code account and can spend provider tokens, so run it only when that is intentional.
+
+Optional flags:
+
+```bash
+FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex
+FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-claude
+```
+
+Expected observations:
+
+- The script creates a disposable frontend project and installs the packed local `fooks` CLI.
+- `fooks setup` must report Codex `automatic-ready` and Claude `context-hook-ready`.
+- Provider-backed CLI invocations must leave `fooks status` at `metricTier: "estimated"` with the provider-billing boundary intact.
+- Any captured evidence remains hook activation / local status evidence only; it is still not provider billing-token or provider-cost proof.

--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -1,0 +1,95 @@
+# Internal live hook-smoke checklist
+
+This checklist is for maintainers who want to confirm the same fooks-owned hook and status paths in real Codex / Claude Code sessions after the deterministic release smoke passes.
+
+## Claim boundary
+
+- Treat this as hook-smoke evidence plus local estimated context-size telemetry only.
+- Do not describe it as reducing provider billing tokens or provider costs, replacing `ccusage`, intercepting Claude `Read`, or enabling automatic Claude token reductions.
+- Product evidence must come from `.fooks` artifacts and `fooks status`. `.omx` is an internal planning/development harness only, not fooks product runtime state.
+
+## Automated preflight
+
+Run this from a branch that contains the Claude project-local context hook path and runtime/source metric foundation:
+
+```bash
+npm run build
+npm run release:smoke
+```
+
+Expected observations:
+
+- `fooks setup` reports Codex `automatic-ready` when Codex hook prerequisites pass.
+- `fooks setup` reports Claude `context-hook-ready` when a Claude home exists and project-local hooks can be installed.
+- The smoke drives Codex and Claude `SessionStart` / `UserPromptSubmit` hook payloads against a frontend `.tsx` fixture.
+- Bare `fooks status` reports `metricTier: "estimated"`, runtime/source breakdown entries, and the provider-billing boundary.
+
+## Manual Codex check
+
+1. In a disposable React/TSX project, run:
+
+   ```bash
+   fooks setup
+   fooks status codex
+   ```
+
+2. Open Codex in that project.
+3. Prompt once about an existing `.tsx` / `.jsx` component, for example:
+
+   ```text
+   Explain src/components/Card.tsx
+   ```
+
+4. Prompt again about the same file in the same session:
+
+   ```text
+   Again, explain src/components/Card.tsx
+   ```
+
+5. Run:
+
+   ```bash
+   fooks status
+   ```
+
+Expected observations:
+
+- Codex hook state remains attached/ready.
+- Repeated same-file behavior is reflected through local `.fooks/sessions` estimated telemetry.
+- `fooks status` includes a Codex `automatic-hook` runtime/source breakdown.
+
+## Manual Claude Code check
+
+1. In a disposable React/TSX project with Claude Code available, run:
+
+   ```bash
+   fooks setup
+   fooks status claude
+   cat .claude/settings.local.json
+   ```
+
+2. Confirm `.claude/settings.local.json` contains only fooks `SessionStart` and `UserPromptSubmit` hook commands. It must not install Claude `Read`, `PreToolUse`, or `PostToolUse` interception.
+3. Open Claude Code in that project.
+4. Prompt once about an existing `.tsx` / `.jsx` component.
+5. Prompt again about the same file in the same session.
+6. Run:
+
+   ```bash
+   fooks status
+   ```
+
+Expected observations:
+
+- Claude status is `context-hook-ready`.
+- The first eligible frontend-file prompt is record/preparation only.
+- The repeated same-file prompt may receive bounded `additionalContext` through `UserPromptSubmit`.
+- `fooks status` includes a Claude `project-local-context-hook` runtime/source breakdown.
+
+## Evidence to attach to a PR
+
+Use sanitized excerpts only:
+
+- `npm run release:smoke` success summary.
+- `fooks status` fields showing `metricTier`, `claimBoundary`, and runtime/source keys.
+- Confirmation that provider billing-token/cost proof remains deferred.
+- Confirmation that `ccusage` replacement remains out of scope.

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,7 +45,7 @@ context-compression mechanics and targeted-file behavior, but must not claim
 stable direct runtime-token/time wins until a future multi-task benchmark class
 proves them.
 
-Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
+Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`, including runtime/source breakdowns for Codex automatic hooks and Claude project-local context hooks. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
 Layer 2 now has two proposal-only R4 paired smokes through the current
 `codex exec` runner. In both pairs, the prompt supplied to Codex dropped from

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -62,7 +62,7 @@ Good signs:
 - Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
-Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
+Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 
 ## What the setup result means
 

--- a/scripts/live-provider-hook-smoke.mjs
+++ b/scripts/live-provider-hook-smoke.mjs
@@ -29,6 +29,9 @@ function runResult(command, args, options = {}) {
       status: typeof error?.status === "number" ? error.status : 1,
       stdout: String(error?.stdout ?? error?.output?.[1] ?? ""),
       stderr: String(error?.stderr ?? error?.output?.[2] ?? ""),
+      signal: error?.signal ?? null,
+      code: error?.code ?? null,
+      killed: Boolean(error?.killed),
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -136,6 +139,50 @@ function summarizeProviderErrors(events, stderr) {
   return eventErrors;
 }
 
+function classifyProviderFailure(result, events, providerOutput) {
+  if (result.status === 0) return null;
+  const text = [
+    providerOutput,
+    result.stderr,
+    result.error,
+    result.signal,
+    result.code,
+    ...events.map((event) => JSON.stringify(event)),
+  ].filter(Boolean).join("\n");
+  if (/PERMISSION_DENIED|service has been disabled|disabled in this account|violation of Terms of Service|\b403\b/i.test(text)) {
+    return "auth-denied";
+  }
+  if (/auth_unavailable|no auth available|Failed to authenticate/i.test(text)) {
+    return "auth-unavailable";
+  }
+  if (/rate_limit|\b429\b/i.test(text)) {
+    return "rate-limited";
+  }
+  if (/server_error|\b503\b/i.test(text)) {
+    return "server-error";
+  }
+  if (/ETIMEDOUT|SIGTERM|timeout|timed out/i.test(text)) {
+    return "timeout";
+  }
+  return "provider-error";
+}
+
+function commandJsonResult(command, args, options = {}) {
+  const result = runResult(command, args, options);
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      exitCode: result.status,
+      error: result.stderr || result.error || result.stdout,
+    };
+  }
+  try {
+    return { ok: true, value: JSON.parse(result.stdout) };
+  } catch {
+    return { ok: true, value: result.stdout.trim() };
+  }
+}
+
 function runCodexProviderSmoke(project, env) {
   const outputPath = path.join(project, ".fooks", "live-codex-last-message.txt");
   const result = runResult("codex", [
@@ -153,6 +200,7 @@ function runCodexProviderSmoke(project, env) {
   const providerOutput = `${result.stdout}\n${result.stderr}`;
   const providerErrors = summarizeProviderErrors(events, result.stderr);
   const hookEvidenceObserved = hookEventHints.length > 0 || /hook|fooks/i.test(providerOutput);
+  const providerFailureKind = classifyProviderFailure(result, events, providerOutput);
   if (result.status !== 0 && !hookEvidenceObserved) {
     throw new Error(`Codex provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
   }
@@ -163,6 +211,7 @@ function runCodexProviderSmoke(project, env) {
     outputPath,
     lastMessageExists: fs.existsSync(outputPath),
     hookEvidenceObserved,
+    providerFailureKind,
     hookEventHints,
     providerErrors,
   };
@@ -184,6 +233,8 @@ function runClaudeProviderSmoke(project, env) {
   const providerOutput = `${result.stdout}\n${result.stderr}`;
   const providerErrors = summarizeProviderErrors(events, result.stderr);
   const hookEvidenceObserved = /fooks: Claude context hook|UserPromptSubmit|SessionStart/i.test(providerOutput);
+  const providerFailureKind = classifyProviderFailure(result, events, providerOutput);
+  const authStatus = commandJsonResult("claude", ["auth", "status"], { cwd: project, env, timeout: 10000 });
   if (result.status !== 0 && !hookEvidenceObserved) {
     throw new Error(`Claude provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
   }
@@ -192,6 +243,8 @@ function runClaudeProviderSmoke(project, env) {
     exitCode: result.status,
     providerCompleted: result.status === 0,
     hookEvidenceObserved,
+    providerFailureKind,
+    authStatus,
     hookEventHints,
     providerErrors,
     eventCount: events.length,

--- a/scripts/live-provider-hook-smoke.mjs
+++ b/scripts/live-provider-hook-smoke.mjs
@@ -17,7 +17,21 @@ function run(command, args, options = {}) {
     input: options.input,
     stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...(options.env ?? {}) },
+    timeout: options.timeout,
   });
+}
+
+function runResult(command, args, options = {}) {
+  try {
+    return { status: 0, stdout: run(command, args, options), stderr: "" };
+  } catch (error) {
+    return {
+      status: typeof error?.status === "number" ? error.status : 1,
+      stdout: String(error?.stdout ?? error?.output?.[1] ?? ""),
+      stderr: String(error?.stderr ?? error?.output?.[2] ?? ""),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function commandVersion(command, args = ["--version"]) {
@@ -111,40 +125,75 @@ function summarizeHookEvents(events) {
   });
 }
 
+function summarizeProviderErrors(events, stderr) {
+  const eventErrors = events.filter((event) => (
+    event?.type === "result" && event?.is_error
+  ) || event?.subtype === "api_retry" || event?.error || event?.api_error_status).slice(-5).map((event) => {
+    const text = JSON.stringify(event);
+    return text.length > 600 ? `${text.slice(0, 600)}…` : text;
+  });
+  if (stderr) eventErrors.push(stderr.length > 600 ? `${stderr.slice(0, 600)}…` : stderr);
+  return eventErrors;
+}
+
 function runCodexProviderSmoke(project, env) {
   const outputPath = path.join(project, ".fooks", "live-codex-last-message.txt");
-  const stdout = run("codex", [
+  const result = runResult("codex", [
     "exec",
+    "--skip-git-repo-check",
     "--cd", project,
     "--sandbox", "read-only",
     "--ephemeral",
     "--json",
     "--output-last-message", outputPath,
     "Reply with exactly FOOKS_CODEX_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
-  ], { cwd: project, env });
-  const events = parseJsonLines(stdout);
+  ], { cwd: project, env, timeout: Number(process.env.FOOKS_LIVE_CODEX_TIMEOUT_MS ?? "60000") });
+  const events = parseJsonLines(result.stdout);
+  const hookEventHints = summarizeHookEvents(events);
+  const providerOutput = `${result.stdout}\n${result.stderr}`;
+  const providerErrors = summarizeProviderErrors(events, result.stderr);
+  const hookEvidenceObserved = hookEventHints.length > 0 || /hook|fooks/i.test(providerOutput);
+  if (result.status !== 0 && !hookEvidenceObserved) {
+    throw new Error(`Codex provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
+  }
   return {
-    command: "codex exec --json --ephemeral",
+    command: "codex exec --skip-git-repo-check --json --ephemeral",
+    exitCode: result.status,
+    providerCompleted: result.status === 0,
     outputPath,
     lastMessageExists: fs.existsSync(outputPath),
-    hookEventHints: summarizeHookEvents(events),
+    hookEvidenceObserved,
+    hookEventHints,
+    providerErrors,
   };
 }
 
 function runClaudeProviderSmoke(project, env) {
-  const stdout = run("claude", [
+  const result = runResult("claude", [
     "--print",
+    "--verbose",
     "--output-format=stream-json",
     "--include-hook-events",
     "--max-budget-usd", process.env.FOOKS_LIVE_CLAUDE_MAX_BUDGET_USD ?? "0.05",
     "--tools", "",
     "--no-session-persistence",
     "Reply with exactly FOOKS_CLAUDE_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
-  ], { cwd: project, env });
-  const events = parseJsonLines(stdout);
+  ], { cwd: project, env, timeout: Number(process.env.FOOKS_LIVE_CLAUDE_TIMEOUT_MS ?? "60000") });
+  const events = parseJsonLines(result.stdout);
+  const hookEventHints = summarizeHookEvents(events);
+  const providerOutput = `${result.stdout}\n${result.stderr}`;
+  const providerErrors = summarizeProviderErrors(events, result.stderr);
+  const hookEvidenceObserved = /fooks: Claude context hook|UserPromptSubmit|SessionStart/i.test(providerOutput);
+  if (result.status !== 0 && !hookEvidenceObserved) {
+    throw new Error(`Claude provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
+  }
   return {
-    command: "claude --print --output-format=stream-json --include-hook-events",
-    hookEventHints: summarizeHookEvents(events),
+    command: "claude --print --verbose --output-format=stream-json --include-hook-events",
+    exitCode: result.status,
+    providerCompleted: result.status === 0,
+    hookEvidenceObserved,
+    hookEventHints,
+    providerErrors,
     eventCount: events.length,
   };
 }

--- a/scripts/live-provider-hook-smoke.mjs
+++ b/scripts/live-provider-hook-smoke.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const runProvider = process.argv.includes("--run-provider") && process.env.FOOKS_LIVE_PROVIDER_SMOKE === "1";
+const runCodex = !process.argv.includes("--skip-codex");
+const runClaude = !process.argv.includes("--skip-claude");
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    input: options.input,
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(options.env ?? {}) },
+  });
+}
+
+function commandVersion(command, args = ["--version"]) {
+  try {
+    return run(command, args).trim();
+  } catch (error) {
+    return `unavailable: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseJson(stdout, label) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} did not emit JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function parseJsonLines(stdout) {
+  return stdout.split(/\r?\n/).filter(Boolean).map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      return { type: "non_json_line", line };
+    }
+  });
+}
+
+function copyIfExists(source, target) {
+  if (!fs.existsSync(source)) return false;
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.copyFileSync(source, target);
+  return true;
+}
+
+function restoreBackup(backupPath, targetPath, existed) {
+  if (existed) {
+    fs.copyFileSync(backupPath, targetPath);
+  } else if (fs.existsSync(targetPath)) {
+    fs.rmSync(targetPath, { force: true });
+  }
+}
+
+function installPackedFooks() {
+  run("npm", ["run", "build"]);
+  const packDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-live-pack-"));
+  const tarballName = run("npm", ["pack", "--pack-destination", packDir]).trim().split(/\r?\n/).at(-1);
+  const tarballPath = path.join(packDir, tarballName);
+  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-live-prefix-"));
+  run("npm", ["install", "-g", "--prefix", prefix, tarballPath]);
+  return {
+    tarballPath,
+    prefix,
+    fooksBin: path.join(prefix, "bin", "fooks"),
+    pathEnv: `${path.join(prefix, "bin")}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+}
+
+function createFixtureProject() {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-live-provider-"));
+  fs.mkdirSync(path.join(project, "src", "components"), { recursive: true });
+  fs.writeFileSync(path.join(project, "package.json"), `${JSON.stringify({
+    name: "fooks-live-provider-smoke",
+    repository: { url: "https://github.com/example-org/fooks-live-provider-smoke.git" },
+  }, null, 2)}\n`);
+  fs.writeFileSync(path.join(project, "src", "components", "Card.tsx"), [
+    "export function Card() {",
+    "  return (",
+    "    <section>",
+    "      <h2>fooks live provider smoke</h2>",
+    "      <p>This component verifies project-local hook activation.</p>",
+    "    </section>",
+    "  );",
+    "}",
+    "",
+  ].join("\n"));
+  return project;
+}
+
+function summarizeHookEvents(events) {
+  return events.filter((event) => {
+    const text = JSON.stringify(event);
+    return /hook|SessionStart|UserPromptSubmit|additionalContext|fooks/i.test(text);
+  }).slice(0, 20).map((event) => {
+    const text = JSON.stringify(event);
+    return text.length > 600 ? `${text.slice(0, 600)}…` : text;
+  });
+}
+
+function runCodexProviderSmoke(project, env) {
+  const outputPath = path.join(project, ".fooks", "live-codex-last-message.txt");
+  const stdout = run("codex", [
+    "exec",
+    "--cd", project,
+    "--sandbox", "read-only",
+    "--ephemeral",
+    "--json",
+    "--output-last-message", outputPath,
+    "Reply with exactly FOOKS_CODEX_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
+  ], { cwd: project, env });
+  const events = parseJsonLines(stdout);
+  return {
+    command: "codex exec --json --ephemeral",
+    outputPath,
+    lastMessageExists: fs.existsSync(outputPath),
+    hookEventHints: summarizeHookEvents(events),
+  };
+}
+
+function runClaudeProviderSmoke(project, env) {
+  const stdout = run("claude", [
+    "--print",
+    "--output-format=stream-json",
+    "--include-hook-events",
+    "--max-budget-usd", process.env.FOOKS_LIVE_CLAUDE_MAX_BUDGET_USD ?? "0.05",
+    "--tools", "",
+    "--no-session-persistence",
+    "Reply with exactly FOOKS_CLAUDE_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
+  ], { cwd: project, env });
+  const events = parseJsonLines(stdout);
+  return {
+    command: "claude --print --output-format=stream-json --include-hook-events",
+    hookEventHints: summarizeHookEvents(events),
+    eventCount: events.length,
+  };
+}
+
+const cliVersions = {
+  codex: commandVersion("codex"),
+  claude: commandVersion("claude"),
+};
+
+if (!runProvider) {
+  console.log(JSON.stringify({
+    ok: true,
+    skippedProviderCalls: true,
+    reason: "Provider-backed live smoke is opt-in to avoid accidental token/account spend.",
+    cliVersions,
+    runCommand: "FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider",
+    optionalFlags: ["--skip-codex", "--skip-claude"],
+    claimBoundary: "This script can gather live CLI hook evidence, but it is not provider billing-token or provider-cost proof.",
+  }, null, 2));
+  process.exit(0);
+}
+
+const { fooksBin, pathEnv, tarballPath } = installPackedFooks();
+const project = createFixtureProject();
+const codexHome = process.env.FOOKS_LIVE_CODEX_HOME ?? process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex");
+const claudeHome = process.env.FOOKS_LIVE_CLAUDE_HOME ?? path.join(os.homedir(), ".claude");
+const env = {
+  PATH: pathEnv,
+  FOOKS_CODEX_HOME: codexHome,
+  FOOKS_CLAUDE_HOME: claudeHome,
+};
+
+const codexHooksPath = path.join(codexHome, "hooks.json");
+const codexHooksBackup = path.join(project, ".fooks", "codex-hooks.backup.json");
+const codexHooksExisted = copyIfExists(codexHooksPath, codexHooksBackup);
+
+try {
+  const setup = parseJson(run(fooksBin, ["setup"], { cwd: project, env }), "fooks setup");
+  assert(setup.runtimes?.codex?.state === "automatic-ready", `Codex setup was not automatic-ready: ${setup.runtimes?.codex?.state}`);
+  assert(setup.runtimes?.claude?.state === "context-hook-ready", `Claude setup was not context-hook-ready: ${setup.runtimes?.claude?.state}`);
+
+  const provider = {};
+  if (runCodex) provider.codex = runCodexProviderSmoke(project, env);
+  if (runClaude) provider.claude = runClaudeProviderSmoke(project, env);
+
+  const status = parseJson(run(fooksBin, ["status"], { cwd: project, env }), "fooks status");
+  assert(status.metricTier === "estimated", `status metricTier should be estimated, got ${status.metricTier}`);
+  assert(status.claimBoundary?.includes("not provider billing tokens"), "status should preserve provider billing-token boundary");
+
+  console.log(JSON.stringify({
+    ok: true,
+    project,
+    tarballPath,
+    cliVersions,
+    setupSummary: setup.summary,
+    provider,
+    status: {
+      metricTier: status.metricTier,
+      latestSessionCount: status.latestSessionCount,
+      runtimeSources: Object.keys(status.breakdown?.byRuntimeAndSource ?? {}).sort(),
+      claimBoundary: status.claimBoundary,
+    },
+    claimBoundary: "Live CLI smoke proves installed CLI hook activation and local estimated status evidence only; it is not provider billing-token or provider-cost proof.",
+  }, null, 2));
+} finally {
+  restoreBackup(codexHooksBackup, codexHooksPath, codexHooksExisted);
+}

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -59,6 +59,57 @@ function assertPublicSurfaceClaimBoundaries(surfaces) {
   }
 }
 
+function runInstalledFooks(fooksBin, args, options = {}) {
+  return execFileSync(fooksBin, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    input: options.input,
+    env: {
+      ...process.env,
+      ...(options.env ?? {}),
+    },
+  });
+}
+
+function parseOptionalJson(stdout, label) {
+  if (!stdout.trim()) return null;
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} should emit JSON when non-empty: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function runNativeHook(fooksBin, runtime, projectRoot, env, payload, label) {
+  return parseOptionalJson(
+    runInstalledFooks(fooksBin, [`${runtime}-runtime-hook`, "--native-hook"], {
+      cwd: projectRoot,
+      input: JSON.stringify(payload),
+      env,
+    }),
+    label,
+  );
+}
+
+function sanitizeDataKey(key) {
+  return key.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase() || "default-session";
+}
+
+function readMetricEvents(projectRoot) {
+  const sessionsDir = path.join(projectRoot, ".fooks", "sessions");
+  if (!fs.existsSync(sessionsDir)) return [];
+  return fs.readdirSync(sessionsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const eventsPath = path.join(sessionsDir, entry.name, "events.jsonl");
+      if (!fs.existsSync(eventsPath)) return [];
+      return fs.readFileSync(eventsPath, "utf8")
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+    });
+}
+
 function assertPackedFiles(packEntry) {
   const paths = new Set(packEntry.files.map((file) => file.path));
   const required = [
@@ -121,6 +172,9 @@ assertPublicSurfaceClaimBoundaries({
   "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
   "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
   "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "docs/internal/live-hook-smoke-checklist.md": fs.existsSync(path.join(repoRoot, "docs", "internal", "live-hook-smoke-checklist.md"))
+    ? fs.readFileSync(path.join(repoRoot, "docs", "internal", "live-hook-smoke-checklist.md"), "utf8")
+    : "",
   "dist/cli/index.js": fs.readFileSync(path.join(repoRoot, "dist", "cli", "index.js"), "utf8"),
 });
 
@@ -188,8 +242,10 @@ assertPublicSurfaceClaimBoundaries({
   "fooks status claude output": claudeStatusStdout,
 });
 const status = JSON.parse(statusStdout);
+assert(status.metricTier === "estimated", `status should expose estimated metric tier, got ${status.metricTier}`);
 assert(status.claimBoundary?.includes("not provider billing tokens"), "status should keep provider billing boundary");
 assert(status.breakdown && typeof status.breakdown === "object", "status should expose runtime/source breakdown");
+assert(!Object.prototype.hasOwnProperty.call(status, "sessions"), "CLI status should omit per-session contribution details");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");
 assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");
@@ -206,36 +262,76 @@ assert(
   claudeSettings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
   "Claude UserPromptSubmit smoke hook should use the canonical fooks command",
 );
-const claudeNativeEnv = {
+const hookEnv = {
   ...process.env,
   HOME: path.join(runtimeRoot, "home"),
   XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
   FOOKS_CODEX_HOME: codexHome,
   FOOKS_CLAUDE_HOME: claudeHome,
 };
-const firstClaudePrompt = execFileSync(fooksBin, ["claude-runtime-hook", "--native-hook"], {
+const codexSessionId = "release-smoke-codex";
+const codexStart = runNativeHook(fooksBin, "codex", project, hookEnv, {
+  hook_event_name: "SessionStart",
   cwd: project,
-  encoding: "utf8",
-  input: JSON.stringify({
-    hook_event_name: "UserPromptSubmit",
-    cwd: project,
-    session_id: "release-smoke-claude",
-    prompt: "Explain src/App.tsx",
-  }),
-  env: claudeNativeEnv,
-});
-assert(firstClaudePrompt === "", "Claude first eligible native prompt should record without emitting context");
-const secondClaudePrompt = JSON.parse(execFileSync(fooksBin, ["claude-runtime-hook", "--native-hook"], {
+  session_id: codexSessionId,
+}, "Codex SessionStart");
+assert(codexStart === null, "Codex native SessionStart should initialize without emitting context");
+const firstCodexPrompt = runNativeHook(fooksBin, "codex", project, hookEnv, {
+  hook_event_name: "UserPromptSubmit",
   cwd: project,
-  encoding: "utf8",
-  input: JSON.stringify({
-    hook_event_name: "UserPromptSubmit",
-    cwd: project,
-    session_id: "release-smoke-claude",
-    prompt: "Again, explain src/App.tsx",
-  }),
-  env: claudeNativeEnv,
-}));
+  session_id: codexSessionId,
+  prompt: "Explain src/App.tsx",
+}, "Codex first prompt");
+assert(firstCodexPrompt === null, "Codex first eligible native prompt should record without emitting context");
+const secondCodexPrompt = runNativeHook(fooksBin, "codex", project, hookEnv, {
+  hook_event_name: "UserPromptSubmit",
+  cwd: project,
+  session_id: codexSessionId,
+  prompt: "Again, explain src/App.tsx",
+}, "Codex repeated prompt");
+assert(
+  secondCodexPrompt.hookSpecificOutput?.hookEventName === "UserPromptSubmit",
+  "Codex repeated same-file native prompt should emit UserPromptSubmit context",
+);
+assert(
+  secondCodexPrompt.hookSpecificOutput?.additionalContext?.includes("src/App.tsx"),
+  "Codex repeated same-file native context should reference the target file",
+);
+
+const codexFallbackSessionId = "release-smoke-codex-fallback";
+const codexFallback = runNativeHook(fooksBin, "codex", project, hookEnv, {
+  hook_event_name: "UserPromptSubmit",
+  cwd: project,
+  session_id: codexFallbackSessionId,
+  prompt: "Need exact source src/App.tsx #fooks-full-read",
+}, "Codex fallback prompt");
+assert(
+  codexFallback?.hookSpecificOutput?.additionalContext === "fooks: full read requested · file: src/App.tsx · Read the full source file for this turn.",
+  "Codex fallback hook should use bounded full-read status vocabulary",
+);
+
+const claudeStart = runNativeHook(fooksBin, "claude", project, hookEnv, {
+  hook_event_name: "SessionStart",
+  cwd: project,
+  session_id: "release-smoke-claude",
+}, "Claude SessionStart");
+assert(
+  claudeStart.hookSpecificOutput?.additionalContext?.includes("context hook is active"),
+  "Claude native SessionStart should emit bounded readiness context",
+);
+const firstClaudePrompt = runNativeHook(fooksBin, "claude", project, hookEnv, {
+  hook_event_name: "UserPromptSubmit",
+  cwd: project,
+  session_id: "release-smoke-claude",
+  prompt: "Explain src/App.tsx",
+}, "Claude first prompt");
+assert(firstClaudePrompt === null, "Claude first eligible native prompt should record without emitting context");
+const secondClaudePrompt = runNativeHook(fooksBin, "claude", project, hookEnv, {
+  hook_event_name: "UserPromptSubmit",
+  cwd: project,
+  session_id: "release-smoke-claude",
+  prompt: "Again, explain src/App.tsx",
+}, "Claude repeated prompt");
 assert(
   secondClaudePrompt.hookSpecificOutput?.hookEventName === "UserPromptSubmit",
   "Claude repeated same-file native prompt should emit UserPromptSubmit context",
@@ -244,6 +340,41 @@ assert(
   secondClaudePrompt.hookSpecificOutput?.additionalContext?.includes("src/App.tsx"),
   "Claude repeated same-file native context should reference the target file",
 );
+
+const postHookStatusStdout = runInstalledFooks(fooksBin, ["status"], {
+  cwd: project,
+  env: hookEnv,
+});
+assertPublicSurfaceClaimBoundaries({
+  "post-hook fooks status output": postHookStatusStdout,
+});
+const postHookStatus = JSON.parse(postHookStatusStdout);
+assert(postHookStatus.metricTier === "estimated", `post-hook status should expose estimated metric tier, got ${postHookStatus.metricTier}`);
+assert(postHookStatus.claimBoundary?.includes("not provider billing tokens"), "post-hook status should keep provider billing boundary");
+assert(!Object.prototype.hasOwnProperty.call(postHookStatus, "sessions"), "post-hook CLI status should omit per-session contribution details");
+assert(postHookStatus.breakdown?.byRuntime?.codex?.eventCount >= 2, "post-hook status should include Codex hook metric events");
+assert(postHookStatus.breakdown?.byRuntime?.claude?.eventCount >= 2, "post-hook status should include Claude hook metric events");
+assert(postHookStatus.breakdown?.byMeasurementSource?.["automatic-hook"]?.eventCount >= 2, "post-hook status should include automatic-hook source metrics");
+assert(postHookStatus.breakdown?.byMeasurementSource?.["project-local-context-hook"]?.eventCount >= 2, "post-hook status should include Claude project-local context-hook source metrics");
+assert(postHookStatus.breakdown?.byRuntimeAndSource?.["codex:automatic-hook"]?.injectCount >= 1, "post-hook status should include Codex repeated-file inject evidence");
+assert(postHookStatus.breakdown?.byRuntimeAndSource?.["claude:project-local-context-hook"]?.injectCount >= 1, "post-hook status should include Claude repeated-file inject evidence");
+
+const metricEvents = readMetricEvents(project);
+const codexFallbackMetricKey = `codex:automatic-hook:${codexFallbackSessionId}`;
+const fallbackEvent = metricEvents.find((event) => event.metricSessionKey === codexFallbackMetricKey && event.action === "fallback");
+assert(fallbackEvent, "Codex fallback smoke should record a fallback metric event");
+assert(fallbackEvent.estimated?.savedEstimatedBytes === 0, "fallback metric should not produce positive estimated byte savings");
+assert(fallbackEvent.estimated?.savedEstimatedTokens === 0, "fallback metric should not produce positive estimated token savings");
+const recordEvents = metricEvents.filter((event) => event.action === "record");
+assert(recordEvents.length >= 2, "Codex and Claude hook smokes should record first eligible prompts");
+assert(
+  recordEvents.every((event) => event.estimated?.savedEstimatedBytes === 0 && event.estimated?.savedEstimatedTokens === 0),
+  "record-only hook metrics should not produce positive estimated savings",
+);
+const codexSummaryDir = path.join(project, ".fooks", "sessions", sanitizeDataKey(`codex:automatic-hook:${codexSessionId}`));
+const claudeSummaryDir = path.join(project, ".fooks", "sessions", sanitizeDataKey("claude:project-local-context-hook:release-smoke-claude"));
+assert(fs.existsSync(path.join(codexSummaryDir, "summary.json")), "Codex hook-smoke session summary should be persisted");
+assert(fs.existsSync(path.join(claudeSummaryDir, "summary.json")), "Claude hook-smoke session summary should be persisted");
 assert(fs.existsSync(path.join(project, ".opencode", "tools", "fooks_extract.ts")), "opencode helper should be installed project-locally");
 assert(fs.existsSync(path.join(project, ".opencode", "commands", "fooks-extract.md")), "opencode slash command should be installed project-locally");
 
@@ -253,5 +384,24 @@ console.log(JSON.stringify({
   tarball: tarballPath,
   installedBinary: fooksBin,
   setupSummary: setup.summary,
+  hookSmokeEvidence: {
+    codex: {
+      sessionStart: "recorded",
+      firstPrompt: "record-only",
+      repeatedPrompt: secondCodexPrompt.hookSpecificOutput.hookEventName,
+      fallbackSavingsGuard: "zero-savings",
+    },
+    claude: {
+      sessionStart: claudeStart.hookSpecificOutput.hookEventName,
+      firstPrompt: "record-only",
+      repeatedPrompt: secondClaudePrompt.hookSpecificOutput.hookEventName,
+    },
+    status: {
+      metricTier: postHookStatus.metricTier,
+      latestSessionCount: postHookStatus.latestSessionCount,
+      runtimeSources: Object.keys(postHookStatus.breakdown.byRuntimeAndSource ?? {}).sort(),
+      claimBoundary: postHookStatus.claimBoundary,
+    },
+  },
   accountDetails: setup.attach.runtimeProof.details.filter((detail) => detail.startsWith("account-")),
 }, null, 2));

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -29,6 +29,36 @@ function parsePackJson(stdout) {
   return parsed[0];
 }
 
+
+function assertNoForbiddenPublicClaims(label, text) {
+  const forbidden = [
+    /provider billing-token reduction/i,
+    /billing-token savings/i,
+    /provider cost savings/i,
+    /Claude Read interception is enabled/i,
+    /Claude runtime-token savings are enabled/i,
+    /automatic Claude runtime-token savings/i,
+  ];
+  for (const pattern of forbidden) {
+    assert(!pattern.test(text), `${label} contains forbidden positive claim ${pattern}`);
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    if (/ccusage replacement/i.test(line)) {
+      assert(/not (?:a )?ccusage replacement|not provider billing tokens, provider costs, or a ccusage replacement/i.test(line), `${label} contains unbounded ccusage replacement wording: ${line}`);
+    }
+    if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
+      assert(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
+    }
+  }
+}
+
+function assertPublicSurfaceClaimBoundaries(surfaces) {
+  for (const [label, text] of Object.entries(surfaces)) {
+    assertNoForbiddenPublicClaims(label, text);
+  }
+}
+
 function assertPackedFiles(packEntry) {
   const paths = new Set(packEntry.files.map((file) => file.path));
   const required = [
@@ -87,6 +117,13 @@ run("npm", ["install", "-g", "--prefix", prefix, tarballPath]);
 const fooksBin = path.join(prefix, "bin", "fooks");
 assert(fs.existsSync(fooksBin), `installed fooks binary not found at ${fooksBin}`);
 
+assertPublicSurfaceClaimBoundaries({
+  "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
+  "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
+  "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "dist/cli/index.js": fs.readFileSync(path.join(repoRoot, "dist", "cli", "index.js"), "utf8"),
+});
+
 const project = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-project-"));
 const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-"));
 const codexHome = path.join(runtimeRoot, "codex");
@@ -122,6 +159,37 @@ assert(setup.runtimes?.claude?.blocksOverall === false, "Claude readiness should
 assert(setup.runtimes?.opencode?.state === "tool-ready", `unexpected opencode setup state ${setup.runtimes?.opencode?.state}`);
 assert(setup.runtimes?.opencode?.blocksOverall === false, "opencode readiness should be non-fatal for overall setup");
 assert(setup.attach?.runtimeProof?.details?.includes("account-source=package-repository"), "setup should derive public repo account context from package metadata");
+
+const statusStdout = execFileSync(fooksBin, ["status"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+const claudeStatusStdout = execFileSync(fooksBin, ["status", "claude"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+assertPublicSurfaceClaimBoundaries({
+  "fooks setup output": setupStdout,
+  "fooks status output": statusStdout,
+  "fooks status claude output": claudeStatusStdout,
+});
+const status = JSON.parse(statusStdout);
+assert(status.claimBoundary?.includes("not provider billing tokens"), "status should keep provider billing boundary");
+assert(status.breakdown && typeof status.breakdown === "object", "status should expose runtime/source breakdown");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");
 assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -4,6 +4,12 @@ import { decideCodexPreRead } from "./codex-pre-read";
 import { initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { resolvePromptFileContext } from "./codex-runtime-prompt";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
+import {
+  estimateFileBytes,
+  estimateTextBytes,
+  initializeSessionMetricSummarySafe,
+  recordFooksSessionMetricEventSafe,
+} from "../core/session-metrics";
 
 export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
 
@@ -65,6 +71,39 @@ function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<t
   ].join("\n"));
 }
 
+function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
+  return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function recordClaudeMetric(
+  cwd: string,
+  sessionKey: string,
+  decision: ClaudeRuntimeHookDecision,
+  options: {
+    originalEstimatedBytes?: number;
+    actualEstimatedBytes?: number;
+    comparableForSavings?: boolean;
+    observedOriginalEstimatedBytes?: number;
+  } = {},
+): void {
+  recordFooksSessionMetricEventSafe(cwd, sessionKey, {
+    runtime: "claude",
+    measurementSource: "project-local-context-hook",
+    eventName: decision.hookEventName,
+    hookEventName: decision.hookEventName,
+    action: decision.action,
+    filePath: decision.filePath,
+    reasons: decision.reasons,
+    contextMode: decision.contextMode,
+    contextModeReason: decision.contextModeReason,
+    fallbackReason: decision.fallback?.reason,
+    originalEstimatedBytes: options.originalEstimatedBytes,
+    actualEstimatedBytes: options.actualEstimatedBytes,
+    comparableForSavings: options.comparableForSavings,
+    observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+  });
+}
+
 function sessionStartContext(): string {
   return clampAdditionalContext([
     "fooks: Claude context hook is active for this project.",
@@ -98,6 +137,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (hookEventName === "SessionStart") {
     const statePath = initializeClaudeRuntimeSession(cwd, sessionKey);
+    initializeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
     return {
       runtime: "claude",
       hookEventName,
@@ -121,19 +161,23 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
   const policy = promptContext.policy;
 
   if (!target) {
-    return noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    const decision = noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const resolvedTarget = path.join(cwd, target);
   if (!fs.existsSync(resolvedTarget)) {
-    return noopDecision(input, ["eligible-file-target-missing"], policy);
+    const decision = noopDecision(input, ["eligible-file-target-missing"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const { statePath, seenCount } = markClaudeRuntimeSeenFile(cwd, sessionKey, target);
   const repeatedFile = seenCount >= 2;
 
   if (!repeatedFile) {
-    return {
+    const decision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "record",
@@ -151,13 +195,18 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    recordClaudeMetric(cwd, sessionKey, decision, {
+      observedOriginalEstimatedBytes: targetEstimatedBytes(cwd, target),
+    });
+    return decision;
   }
 
   let decision: ReturnType<typeof decideCodexPreRead>;
   try {
     decision = decideCodexPreRead(resolvedTarget, cwd);
   } catch (error) {
-    return {
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "fallback",
@@ -180,17 +229,24 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         reason: "payload-build-failed",
       },
     };
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: originalEstimatedBytes,
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    return {
+    const additionalContext = buildPayloadContext(target, decision.payload, contextMode);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "inject",
       filePath: target,
       reasons: ["repeated-file"],
-      additionalContext: buildPayloadContext(target, decision.payload, contextMode),
+      additionalContext,
       statePath,
       contextMode,
       contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
@@ -203,9 +259,17 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: estimateTextBytes(additionalContext),
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
-  return {
+  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const runtimeDecision: ClaudeRuntimeHookDecision = {
     runtime: "claude",
     hookEventName,
     action: "fallback",
@@ -228,4 +292,10 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       reason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
     },
   };
+  recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+    originalEstimatedBytes,
+    actualEstimatedBytes: originalEstimatedBytes,
+    comparableForSavings: originalEstimatedBytes !== undefined,
+  });
+  return runtimeDecision;
 }

--- a/src/core/session-metrics.ts
+++ b/src/core/session-metrics.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { sessionEventsPath, sessionSummaryPath, sessionsSummaryPath, sanitizeDataKey } from "./paths";
-import type { CodexRuntimeHookInput, ContextMode } from "./schema";
+import type { ContextMode } from "./schema";
 
 export const FOOKS_SESSION_METRICS_SCHEMA_VERSION = 1;
 export const FOOKS_SESSION_METRIC_TIER = "estimated" as const;
@@ -9,9 +9,15 @@ export const ESTIMATED_BYTES_PER_TOKEN = 4;
 export const FOOKS_METRIC_CLAIM_BOUNDARY =
   "Estimated local context-size telemetry only; values are not provider billing tokens, provider costs, or a ccusage replacement.";
 
+export type FooksMetricRuntime = "codex" | "claude";
+export type FooksMeasurementSource = "automatic-hook" | "project-local-context-hook" | "manual-handoff" | "local-simulation";
 type MetricTier = typeof FOOKS_SESSION_METRIC_TIER;
-type HookEventName = CodexRuntimeHookInput["hookEventName"];
 export type FooksSessionMetricAction = "inject" | "fallback" | "record" | "noop";
+
+export type FooksMetricIdentityOptions = {
+  runtime?: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+};
 
 export type FooksEstimatedUsage = {
   originalEstimatedBytes: number;
@@ -23,35 +29,7 @@ export type FooksEstimatedUsage = {
   savingsRatio: number;
 };
 
-export type FooksSessionMetricEvent = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  timestamp: string;
-  runtime: "codex";
-  sessionKey: string;
-  hookEventName: HookEventName;
-  action: FooksSessionMetricAction;
-  filePath?: string;
-  reasons: string[];
-  contextMode?: ContextMode;
-  contextModeReason?: string;
-  fallbackReason?: string;
-  metricTier: MetricTier;
-  comparableForSavings: boolean;
-  estimated: FooksEstimatedUsage;
-  observedOpportunity?: {
-    originalEstimatedBytes: number;
-    originalEstimatedTokens: number;
-  };
-};
-
-export type FooksSessionMetricSummary = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  metricTier: MetricTier;
-  sessionKey: string;
-  sanitizedSessionKey: string;
-  startedAt: string;
-  updatedAt: string;
-  stoppedAt?: string;
+export type FooksMetricAggregate = {
   eventCount: number;
   comparableEventCount: number;
   injectCount: number;
@@ -62,11 +40,61 @@ export type FooksSessionMetricSummary = {
   observedOriginalEstimatedBytes: number;
   observedOriginalEstimatedTokens: number;
   totals: FooksEstimatedUsage;
+};
+
+export type FooksMetricBreakdown = {
+  byRuntime: Partial<Record<FooksMetricRuntime, FooksMetricAggregate>>;
+  byMeasurementSource: Partial<Record<FooksMeasurementSource, FooksMetricAggregate>>;
+  byRuntimeAndSource: Record<string, FooksMetricAggregate>;
+};
+
+export type FooksSessionMetricEvent = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  timestamp: string;
+  metricTier: MetricTier;
+  claimBoundary: string;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  eventName: string;
+  hookEventName?: string;
+  action: FooksSessionMetricAction;
+  filePath?: string;
+  reasons: string[];
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  fallbackReason?: string;
+  comparableForSavings: boolean;
+  estimated: FooksEstimatedUsage;
+  observedOpportunity?: {
+    originalEstimatedBytes: number;
+    originalEstimatedTokens: number;
+  };
+};
+
+export type FooksSessionMetricSummary = FooksMetricAggregate & {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  metricTier: MetricTier;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  sanitizedSessionKey: string;
+  startedAt: string;
+  updatedAt: string;
+  stoppedAt?: string;
   claimBoundary: string;
 };
 
 export type FooksSessionMetricContribution = Pick<
   FooksSessionMetricSummary,
+  | "runtime"
+  | "measurementSource"
+  | "rawSessionKey"
+  | "metricSessionKey"
   | "sessionKey"
   | "sanitizedSessionKey"
   | "startedAt"
@@ -84,23 +112,14 @@ export type FooksSessionMetricContribution = Pick<
   | "totals"
 >;
 
-export type FooksProjectMetricSummaryFile = {
+export type FooksProjectMetricSummaryFile = FooksMetricAggregate & {
   schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
   metricTier: MetricTier;
   updatedAt: string;
   sessionCount: number;
-  eventCount: number;
-  comparableEventCount: number;
-  injectCount: number;
-  fallbackCount: number;
-  recordCount: number;
-  noopCount: number;
-  observedOpportunityCount: number;
-  observedOriginalEstimatedBytes: number;
-  observedOriginalEstimatedTokens: number;
-  totals: FooksEstimatedUsage;
   latestSessionKeys: string[];
   sessions: Record<string, FooksSessionMetricContribution>;
+  breakdown: FooksMetricBreakdown;
   claimBoundary: string;
 };
 
@@ -109,8 +128,10 @@ export type FooksProjectMetricStatus = Omit<FooksProjectMetricSummaryFile, "sess
 };
 
 export type RecordFooksSessionMetricInput = {
-  runtime: "codex";
-  hookEventName: HookEventName;
+  runtime: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+  eventName?: string;
+  hookEventName?: string;
   action: FooksSessionMetricAction;
   filePath?: string;
   reasons?: string[];
@@ -123,8 +144,60 @@ export type RecordFooksSessionMetricInput = {
   observedOriginalEstimatedBytes?: number;
 };
 
+type MetricIdentity = {
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+};
+
+const MEASUREMENT_SOURCES: FooksMeasurementSource[] = ["automatic-hook", "project-local-context-hook", "manual-handoff", "local-simulation"];
+const RUNTIMES: FooksMetricRuntime[] = ["codex", "claude"];
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function defaultMeasurementSource(runtime: FooksMetricRuntime): FooksMeasurementSource {
+  return runtime === "claude" ? "project-local-context-hook" : "automatic-hook";
+}
+
+export function metricSessionKey(rawSessionKey: string, options: Required<FooksMetricIdentityOptions>): string {
+  return `${options.runtime}:${options.measurementSource}:${rawSessionKey}`;
+}
+
+function parseMetricSessionKey(value: string): MetricIdentity | null {
+  for (const runtime of RUNTIMES) {
+    for (const measurementSource of MEASUREMENT_SOURCES) {
+      const prefix = `${runtime}:${measurementSource}:`;
+      if (value.startsWith(prefix)) {
+        const rawSessionKey = value.slice(prefix.length) || "default-session";
+        return {
+          runtime,
+          measurementSource,
+          rawSessionKey,
+          metricSessionKey: value,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function resolveMetricIdentity(rawOrMetricSessionKey: string, options: FooksMetricIdentityOptions = {}): MetricIdentity {
+  if (!options.runtime && !options.measurementSource) {
+    const parsed = parseMetricSessionKey(rawOrMetricSessionKey);
+    if (parsed) return parsed;
+  }
+  const runtime = options.runtime ?? "codex";
+  const measurementSource = options.measurementSource ?? defaultMeasurementSource(runtime);
+  const rawSessionKey = rawOrMetricSessionKey || "default-session";
+  return {
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: metricSessionKey(rawSessionKey, { runtime, measurementSource }),
+  };
 }
 
 function nonNegativeInteger(value: number | undefined): number {
@@ -168,6 +241,21 @@ function emptyUsage(): FooksEstimatedUsage {
   };
 }
 
+function emptyAggregate(): FooksMetricAggregate {
+  return {
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: emptyUsage(),
+  };
+}
+
 function usageFromBytes(originalBytes: number, actualBytes: number): FooksEstimatedUsage {
   const originalEstimatedBytes = nonNegativeInteger(originalBytes);
   const actualEstimatedBytes = nonNegativeInteger(actualBytes);
@@ -205,6 +293,40 @@ function addUsage(left: FooksEstimatedUsage, right: FooksEstimatedUsage): FooksE
   });
 }
 
+function addAggregate(left: FooksMetricAggregate, right: FooksMetricAggregate): FooksMetricAggregate {
+  return {
+    eventCount: left.eventCount + right.eventCount,
+    comparableEventCount: left.comparableEventCount + right.comparableEventCount,
+    injectCount: left.injectCount + right.injectCount,
+    fallbackCount: left.fallbackCount + right.fallbackCount,
+    recordCount: left.recordCount + right.recordCount,
+    noopCount: left.noopCount + right.noopCount,
+    observedOpportunityCount: left.observedOpportunityCount + right.observedOpportunityCount,
+    observedOriginalEstimatedBytes: left.observedOriginalEstimatedBytes + right.observedOriginalEstimatedBytes,
+    observedOriginalEstimatedTokens: left.observedOriginalEstimatedTokens + right.observedOriginalEstimatedTokens,
+    totals: addUsage(left.totals, right.totals),
+  };
+}
+
+function aggregateFromContribution(contribution: FooksSessionMetricContribution): FooksMetricAggregate {
+  return {
+    eventCount: nonNegativeInteger(contribution.eventCount),
+    comparableEventCount: nonNegativeInteger(contribution.comparableEventCount),
+    injectCount: nonNegativeInteger(contribution.injectCount),
+    fallbackCount: nonNegativeInteger(contribution.fallbackCount),
+    recordCount: nonNegativeInteger(contribution.recordCount),
+    noopCount: nonNegativeInteger(contribution.noopCount),
+    observedOpportunityCount: nonNegativeInteger(contribution.observedOpportunityCount),
+    observedOriginalEstimatedBytes: nonNegativeInteger(contribution.observedOriginalEstimatedBytes),
+    observedOriginalEstimatedTokens: nonNegativeInteger(contribution.observedOriginalEstimatedTokens),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
+function addBreakdownAggregate<T extends string>(target: Partial<Record<T, FooksMetricAggregate>>, key: T, aggregate: FooksMetricAggregate): void {
+  target[key] = addAggregate(target[key] ?? emptyAggregate(), aggregate);
+}
+
 function truncateString(value: string, maxLength = 240): string {
   return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
 }
@@ -231,25 +353,28 @@ function writeJsonAtomic(file: string, value: unknown): void {
   fs.renameSync(tmp, file);
 }
 
-function emptySessionSummary(sessionKey: string, timestamp = nowIso()): FooksSessionMetricSummary {
+function emptySessionSummary(rawSessionKey: string, identity = resolveMetricIdentity(rawSessionKey), timestamp = nowIso()): FooksSessionMetricSummary {
   return {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     metricTier: FOOKS_SESSION_METRIC_TIER,
-    sessionKey,
-    sanitizedSessionKey: sanitizeDataKey(sessionKey),
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(identity.metricSessionKey),
     startedAt: timestamp,
     updatedAt: timestamp,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+function emptyBreakdown(): FooksMetricBreakdown {
+  return {
+    byRuntime: {},
+    byMeasurementSource: {},
+    byRuntimeAndSource: {},
   };
 }
 
@@ -259,18 +384,10 @@ function emptyProjectSummaryFile(timestamp = nowIso()): FooksProjectMetricSummar
     metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: 0,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     latestSessionKeys: [],
     sessions: {},
+    breakdown: emptyBreakdown(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
@@ -283,14 +400,41 @@ function isProjectSummaryFile(value: FooksProjectMetricSummaryFile | null): valu
   return Boolean(value && value.schemaVersion === FOOKS_SESSION_METRICS_SCHEMA_VERSION && value.metricTier === FOOKS_SESSION_METRIC_TIER && value.sessions);
 }
 
-export function readSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const summary = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  return isSessionSummary(summary) ? summary : emptySessionSummary(sessionKey);
+function normalizeSessionSummary(summary: FooksSessionMetricSummary, identity: MetricIdentity): FooksSessionMetricSummary {
+  const normalizedIdentity = {
+    runtime: summary.runtime ?? identity.runtime,
+    measurementSource: summary.measurementSource ?? identity.measurementSource,
+    rawSessionKey: summary.rawSessionKey ?? identity.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey ?? identity.metricSessionKey,
+  };
+  return {
+    ...emptySessionSummary(normalizedIdentity.rawSessionKey, normalizedIdentity, summary.startedAt),
+    ...summary,
+    runtime: normalizedIdentity.runtime,
+    measurementSource: normalizedIdentity.measurementSource,
+    rawSessionKey: normalizedIdentity.rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+export function readSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const summary =
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey)) ??
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
+  return isSessionSummary(summary) ? normalizeSessionSummary(summary, identity) : emptySessionSummary(identity.rawSessionKey, identity);
 }
 
 function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessionMetricContribution {
   return {
-    sessionKey: summary.sessionKey,
+    runtime: summary.runtime,
+    measurementSource: summary.measurementSource,
+    rawSessionKey: summary.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey,
+    sessionKey: summary.metricSessionKey,
     sanitizedSessionKey: summary.sanitizedSessionKey,
     startedAt: summary.startedAt,
     updatedAt: summary.updatedAt,
@@ -308,38 +452,65 @@ function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessi
   };
 }
 
+function normalizeContribution(contribution: FooksSessionMetricContribution): FooksSessionMetricContribution {
+  const seedKey = contribution.metricSessionKey ?? contribution.sessionKey ?? contribution.rawSessionKey ?? "default-session";
+  const seedIdentity = contribution.metricSessionKey
+    ? (parseMetricSessionKey(contribution.metricSessionKey) ?? resolveMetricIdentity(contribution.metricSessionKey))
+    : resolveMetricIdentity(seedKey, {
+        runtime: contribution.runtime,
+        measurementSource: contribution.measurementSource,
+      });
+  const runtime = contribution.runtime ?? seedIdentity.runtime;
+  const measurementSource = contribution.measurementSource ?? seedIdentity.measurementSource;
+  const rawSessionKey = contribution.rawSessionKey ?? seedIdentity.rawSessionKey;
+  const normalizedIdentity = resolveMetricIdentity(rawSessionKey, { runtime, measurementSource });
+  return {
+    ...contribution,
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
 function readProjectSummaryFile(cwd: string): FooksProjectMetricSummaryFile {
   const summary = readJsonFile<FooksProjectMetricSummaryFile>(sessionsSummaryPath(cwd));
-  return isProjectSummaryFile(summary) ? summary : emptyProjectSummaryFile();
+  return isProjectSummaryFile(summary) ? recomputeProjectSummaryFile(summary) : emptyProjectSummaryFile();
 }
 
 function recomputeProjectSummaryFile(summary: FooksProjectMetricSummaryFile, timestamp = nowIso()): FooksProjectMetricSummaryFile {
-  const contributions = Object.values(summary.sessions).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
-  let totals = emptyUsage();
+  const contributions = Object.values(summary.sessions).map(normalizeContribution).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  let aggregate = emptyAggregate();
+  const breakdown = emptyBreakdown();
   for (const contribution of contributions) {
-    totals = addUsage(totals, contribution.totals);
+    const contributionAggregate = aggregateFromContribution(contribution);
+    aggregate = addAggregate(aggregate, contributionAggregate);
+    addBreakdownAggregate(breakdown.byRuntime, contribution.runtime, contributionAggregate);
+    addBreakdownAggregate(breakdown.byMeasurementSource, contribution.measurementSource, contributionAggregate);
+    breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] = addAggregate(
+      breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] ?? emptyAggregate(),
+      contributionAggregate,
+    );
   }
   return {
     ...summary,
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: contributions.length,
-    eventCount: contributions.reduce((total, contribution) => total + contribution.eventCount, 0),
-    comparableEventCount: contributions.reduce((total, contribution) => total + contribution.comparableEventCount, 0),
-    injectCount: contributions.reduce((total, contribution) => total + contribution.injectCount, 0),
-    fallbackCount: contributions.reduce((total, contribution) => total + contribution.fallbackCount, 0),
-    recordCount: contributions.reduce((total, contribution) => total + contribution.recordCount, 0),
-    noopCount: contributions.reduce((total, contribution) => total + contribution.noopCount, 0),
-    observedOpportunityCount: contributions.reduce((total, contribution) => total + contribution.observedOpportunityCount, 0),
-    observedOriginalEstimatedBytes: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedBytes, 0),
-    observedOriginalEstimatedTokens: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedTokens, 0),
-    totals,
-    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.sessionKey),
+    ...aggregate,
+    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.metricSessionKey),
+    sessions: Object.fromEntries(contributions.map((contribution) => [contribution.sanitizedSessionKey, contribution])),
+    breakdown,
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
 
-export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string): FooksProjectMetricStatus {
-  const sessionSummary = readSessionMetricSummary(cwd, sessionKey);
+export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksProjectMetricStatus {
+  const sessionSummary = readSessionMetricSummary(cwd, sessionKey, options);
   const projectSummary = readProjectSummaryFile(cwd);
   projectSummary.sessions[sessionSummary.sanitizedSessionKey] = contributionFromSession(sessionSummary);
   const updated = recomputeProjectSummaryFile(projectSummary);
@@ -360,36 +531,39 @@ export function readProjectMetricSummary(cwd = process.cwd()): FooksProjectMetri
 }
 
 function writeSessionSummary(cwd: string, summary: FooksSessionMetricSummary): void {
-  writeJsonAtomic(sessionSummaryPath(cwd, summary.sessionKey), summary);
+  writeJsonAtomic(sessionSummaryPath(cwd, summary.metricSessionKey), summary);
 }
 
-function appendSessionEvent(cwd: string, sessionKey: string, event: FooksSessionMetricEvent): void {
-  const file = sessionEventsPath(cwd, sessionKey);
+function appendSessionEvent(cwd: string, metricSessionKeyValue: string, event: FooksSessionMetricEvent): void {
+  const file = sessionEventsPath(cwd, metricSessionKeyValue);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.appendFileSync(file, `${JSON.stringify(event)}\n`);
 }
 
-export function initializeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  const summary = isSessionSummary(existing) ? existing : emptySessionSummary(sessionKey);
+export function initializeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey));
+  const summary = isSessionSummary(existing) ? normalizeSessionSummary(existing, identity) : emptySessionSummary(identity.rawSessionKey, identity);
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
-export function finalizeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+export function finalizeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
   const timestamp = nowIso();
   const summary = {
-    ...readSessionMetricSummary(cwd, sessionKey),
+    ...readSessionMetricSummary(cwd, identity.metricSessionKey),
     updatedAt: timestamp,
     stoppedAt: timestamp,
   } satisfies FooksSessionMetricSummary;
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
 export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, input: RecordFooksSessionMetricInput): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, { runtime: input.runtime, measurementSource: input.measurementSource });
   const timestamp = nowIso();
   const comparableForSavings = Boolean(input.comparableForSavings);
   const originalBytes = comparableForSavings ? nonNegativeInteger(input.originalEstimatedBytes) : 0;
@@ -397,11 +571,18 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
   const eventUsage = comparableForSavings ? usageFromBytes(originalBytes, actualBytes) : emptyUsage();
   const observedOriginalEstimatedBytes = nonNegativeInteger(input.observedOriginalEstimatedBytes ?? input.originalEstimatedBytes);
   const observedOpportunity = !comparableForSavings && observedOriginalEstimatedBytes > 0;
+  const eventName = input.eventName ?? input.hookEventName ?? "unknown";
   const event: FooksSessionMetricEvent = {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     timestamp,
-    runtime: input.runtime,
-    sessionKey,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    eventName,
     hookEventName: input.hookEventName,
     action: input.action,
     filePath: input.filePath,
@@ -409,7 +590,6 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     contextMode: input.contextMode,
     contextModeReason: input.contextModeReason ? truncateString(input.contextModeReason) : undefined,
     fallbackReason: input.fallbackReason ? truncateString(input.fallbackReason) : undefined,
-    metricTier: FOOKS_SESSION_METRIC_TIER,
     comparableForSavings,
     estimated: eventUsage,
     observedOpportunity: observedOpportunity
@@ -420,9 +600,9 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
       : undefined,
   };
 
-  appendSessionEvent(cwd, sessionKey, event);
+  appendSessionEvent(cwd, identity.metricSessionKey, event);
 
-  const summary = readSessionMetricSummary(cwd, sessionKey);
+  const summary = readSessionMetricSummary(cwd, identity.metricSessionKey);
   const updated: FooksSessionMetricSummary = {
     ...summary,
     updatedAt: timestamp,
@@ -440,21 +620,21 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
   writeSessionSummary(cwd, updated);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return updated;
 }
 
-export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    initializeSessionMetricSummary(cwd, sessionKey);
+    initializeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }
 }
 
-export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    finalizeSessionMetricSummary(cwd, sessionKey);
+    finalizeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -37,6 +37,7 @@ const {
 } = require(path.join(repoRoot, "dist", "core", "session-metrics.js"));
 const {
   sessionEventsPath,
+  sessionSummaryPath,
   sessionsSummaryPath,
 } = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
@@ -627,9 +628,69 @@ test("bare status reports fast estimated session savings without exposing sessio
   assert.equal(empty.latestSessionCount, 0);
   assert.equal(empty.eventCount, 0);
   assert.equal(empty.totals.savedEstimatedBytes, 0);
+  assert.deepEqual(empty.breakdown.byRuntime, {});
+  assert.deepEqual(empty.breakdown.byMeasurementSource, {});
+  assert.deepEqual(empty.breakdown.byRuntimeAndSource, {});
   assert.equal("sessions" in empty, false);
   assert.equal("latestSessionKeys" in empty, false);
   assert.match(empty.claimBoundary, /not provider billing tokens/);
+});
+
+test("legacy unqualified metric summaries migrate to codex automatic hook identity", () => {
+  const tempDir = makeTempProject();
+  const legacySessionKey = "legacy-session";
+  const timestamp = "2026-04-21T00:00:00.000Z";
+  const usage = {
+    originalEstimatedBytes: 400,
+    actualEstimatedBytes: 100,
+    savedEstimatedBytes: 300,
+    originalEstimatedTokens: 100,
+    actualEstimatedTokens: 25,
+    savedEstimatedTokens: 75,
+    savingsRatio: 0.75,
+  };
+  fs.mkdirSync(path.dirname(sessionSummaryPath(tempDir, legacySessionKey)), { recursive: true });
+  fs.writeFileSync(
+    sessionSummaryPath(tempDir, legacySessionKey),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        metricTier: "estimated",
+        sessionKey: legacySessionKey,
+        sanitizedSessionKey: legacySessionKey,
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        eventCount: 1,
+        comparableEventCount: 1,
+        injectCount: 1,
+        fallbackCount: 0,
+        recordCount: 0,
+        noopCount: 0,
+        observedOpportunityCount: 0,
+        observedOriginalEstimatedBytes: 0,
+        observedOriginalEstimatedTokens: 0,
+        totals: usage,
+        claimBoundary: "legacy local estimate",
+      },
+      null,
+      2,
+    ),
+  );
+
+  const summary = readSessionMetricSummary(tempDir, legacySessionKey);
+  assert.equal(summary.runtime, "codex");
+  assert.equal(summary.measurementSource, "automatic-hook");
+  assert.equal(summary.rawSessionKey, legacySessionKey);
+  assert.equal(summary.metricSessionKey, `codex:automatic-hook:${legacySessionKey}`);
+  assert.equal(summary.sessionKey, summary.metricSessionKey);
+  assert.equal(summary.totals.savedEstimatedBytes, 300);
+
+  const status = refreshProjectMetricSummaryFromSession(tempDir, legacySessionKey);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.latestSessionCount, 1);
+  assert.equal("sessions" in status, false);
 });
 
 test("runtime hook stores redacted estimated metrics for record, inject, fallback, and stop", () => {
@@ -678,7 +739,12 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
     Math.max(0, sessionSummary.totals.originalEstimatedBytes - sessionSummary.totals.actualEstimatedBytes),
   );
 
-  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionId), "utf8");
+  assert.equal(sessionSummary.runtime, "codex");
+  assert.equal(sessionSummary.measurementSource, "automatic-hook");
+  assert.equal(sessionSummary.rawSessionKey, sessionId);
+  assert.match(sessionSummary.metricSessionKey, /^codex:automatic-hook:/);
+
+  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionSummary.metricSessionKey), "utf8");
   assert.doesNotMatch(eventLog, /Again, update/);
   assert.doesNotMatch(eventLog, /additionalContext/);
   assert.doesNotMatch(eventLog, /rawText/);
@@ -721,11 +787,15 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
   assert.equal(status.fallbackCount, 1);
   assert.equal(status.recordCount, 1);
   assert.equal(status.latestSessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 3);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 3);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 3);
   assert.equal("latestSessionKeys" in status, false);
   assert.equal("sessions" in status, false);
 
   const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
   assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(Object.keys(summaryFile.sessions).every((key) => key.startsWith("codex-automatic-hook-")));
 });
 
 test("runtime metric write failures are non-fatal to hook decisions", () => {
@@ -1696,6 +1766,114 @@ test("claude runtime hook records first eligible prompt, injects repeated same-f
   const linkedTs = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Explain src/components/Button.types.ts" }, tempDir);
   assert.equal(linkedTs.action, "noop");
   const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
+  assert.equal(missing.action, "noop");
+});
+
+test("codex and claude estimated metrics are runtime/source-qualified without session collisions", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "same-session";
+  const target = path.join("src", "components", "FormSection.tsx");
+  const targetBytes = fs.statSync(path.join(tempDir, target)).size;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const claudeStart = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(claudeStart.action, "inject");
+  const claudeStartSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(claudeStartSummary.eventCount, 0);
+  assert.equal(claudeStartSummary.injectCount, 0);
+  assert.equal(claudeStartSummary.comparableEventCount, 0);
+
+  const claudeFirst = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Explain ${target}` }, tempDir);
+  assert.equal(claudeFirst.action, "record");
+  const claudeSecond = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, explain ${target}` }, tempDir);
+  assert.equal(claudeSecond.action, "inject");
+  assert.ok(claudeSecond.additionalContext);
+
+  const codexSummary = readSessionMetricSummary(tempDir, sessionId);
+  const claudeSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(codexSummary.runtime, "codex");
+  assert.equal(codexSummary.measurementSource, "automatic-hook");
+  assert.equal(claudeSummary.runtime, "claude");
+  assert.equal(claudeSummary.measurementSource, "project-local-context-hook");
+  assert.equal(codexSummary.rawSessionKey, sessionId);
+  assert.equal(claudeSummary.rawSessionKey, sessionId);
+  assert.notEqual(codexSummary.metricSessionKey, claudeSummary.metricSessionKey);
+  assert.notEqual(sessionSummaryPath(tempDir, codexSummary.metricSessionKey), sessionSummaryPath(tempDir, claudeSummary.metricSessionKey));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, codexSummary.metricSessionKey)));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, claudeSummary.metricSessionKey)));
+
+  assert.equal(claudeSummary.eventCount, 2);
+  assert.equal(claudeSummary.recordCount, 1);
+  assert.equal(claudeSummary.injectCount, 1);
+  assert.equal(claudeSummary.comparableEventCount, 1);
+  assert.equal(claudeSummary.observedOpportunityCount, 1);
+  assert.equal(claudeSummary.observedOriginalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.originalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.actualEstimatedBytes, Buffer.byteLength(claudeSecond.additionalContext, "utf8"));
+
+  const claudeEvents = fs.readFileSync(sessionEventsPath(tempDir, claudeSummary.metricSessionKey), "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  assert.equal(claudeEvents.length, 2);
+  assert.ok(claudeEvents.every((event) => event.metricTier === "estimated"));
+  assert.ok(claudeEvents.every((event) => event.claimBoundary.includes("not provider billing tokens")));
+  assert.ok(claudeEvents.every((event) => event.runtime === "claude"));
+  assert.ok(claudeEvents.every((event) => event.measurementSource === "project-local-context-hook"));
+  assert.ok(claudeEvents.every((event) => event.rawSessionKey === sessionId));
+  assert.ok(claudeEvents.every((event) => event.metricSessionKey === claudeSummary.metricSessionKey));
+  assert.ok(claudeEvents.every((event) => event.eventName === "UserPromptSubmit"));
+
+  const status = run(["status"], tempDir);
+  assert.equal(status.sessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byRuntime.claude.eventCount, 2);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["project-local-context-hook"].eventCount, 2);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["claude:project-local-context-hook"].eventCount, 2);
+
+  const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
+  assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(summaryFile.sessions[codexSummary.sanitizedSessionKey]);
+  assert.ok(summaryFile.sessions[claudeSummary.sanitizedSessionKey]);
+});
+
+test("claude fallback metrics record zero savings and telemetry failures are non-fatal", () => {
+  const tempDir = makeTempProject();
+  const hugeTarget = path.join("src", "components", "HugeRaw.tsx");
+  fs.writeFileSync(
+    path.join(tempDir, hugeTarget),
+    `export const huge = ${JSON.stringify("x".repeat(5000))};\n`,
+  );
+  const hugeBytes = fs.statSync(path.join(tempDir, hugeTarget)).size;
+  const fallbackSession = "claude-fallback-metrics";
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: fallbackSession }, tempDir);
+  assert.equal(handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Explain ${hugeTarget}` }, tempDir).action, "record");
+  const fallback = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Again, explain ${hugeTarget}` }, tempDir);
+  assert.equal(fallback.action, "fallback");
+  const fallbackSummary = readSessionMetricSummary(tempDir, fallbackSession, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(fallbackSummary.fallbackCount, 1);
+  assert.equal(fallbackSummary.comparableEventCount, 1);
+  assert.equal(fallbackSummary.totals.originalEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.actualEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.savedEstimatedBytes, 0);
+
+  const blockedDir = makeTempProject();
+  fs.mkdirSync(path.join(blockedDir, ".fooks"), { recursive: true });
+  fs.writeFileSync(path.join(blockedDir, ".fooks", "sessions"), "not-a-directory");
+  const target = path.join("src", "components", "FormSection.tsx");
+  const blockedSession = "claude-blocked-metrics";
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: blockedSession }, blockedDir);
+  assert.equal(start.action, "inject");
+  assert.match(start.additionalContext, /context hook is active/);
+  const first = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Explain ${target}` }, blockedDir);
+  assert.equal(first.action, "record");
+  const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Again, explain ${target}` }, blockedDir);
+  assert.equal(second.action, "inject");
+  assert.match(second.additionalContext, /fooks: Claude context hook/);
+  const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain this repo" }, blockedDir);
+  assert.equal(noTarget.action, "noop");
+  const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain src/components/MissingPanel.tsx" }, blockedDir);
   assert.equal(missing.action, "noop");
 });
 

--- a/test/metric-cleanup.mjs
+++ b/test/metric-cleanup.mjs
@@ -12,8 +12,20 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
   }
 
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
-      fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(root, entry.name);
+    const summaryPath = path.join(entryPath, "summary.json");
+    let keys = [entry.name];
+    if (fs.existsSync(summaryPath)) {
+      try {
+        const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+        keys = [entry.name, summary.rawSessionKey, summary.metricSessionKey, summary.sessionKey].filter(Boolean);
+      } catch {
+        // Fall back to the directory name for malformed ignored telemetry.
+      }
+    }
+    if (keys.some((key) => prefixes.some((prefix) => String(key).startsWith(prefix)))) {
+      fs.rmSync(entryPath, { recursive: true, force: true });
     }
   }
 
@@ -29,7 +41,7 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
     }
     try {
       const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
-      refreshProjectMetricSummaryFromSession(repoRoot, summary.sessionKey ?? entry.name);
+      refreshProjectMetricSummaryFromSession(repoRoot, summary.metricSessionKey ?? summary.sessionKey ?? entry.name);
       remainingSessionCount += 1;
     } catch {
       // Test cleanup should not fail the suite when ignored telemetry is malformed.


### PR DESCRIPTION
## Summary
- add conservative runtime/source-qualified local estimated metric foundation for fooks status evidence
- keep status telemetry scoped to local `.fooks/sessions` context-size estimates
- preserve claim boundaries: not provider billing tokens, not provider costs, not a `ccusage` replacement

## Claim boundary
- This is a local estimated telemetry foundation only.
- It does not prove provider billing-token reduction, provider cost savings, Claude `Read` interception, or automatic Claude runtime-token savings.
- `.omx` remains a development/planning harness; fooks product evidence lives in `.fooks` artifacts and `fooks status`.

## Stack
- Base: `codex/claude-auto-adapter-design` / PR #96
- Follow-up proof PR: #98

## Verification
- Validated as part of follow-up branch with:
  - `npm run release:smoke`
  - `npm run lint && npm test`
