### PR TITLE
Enable Claude project-local context hooks (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd your-react-project
 fooks setup
 ```
 
-Then open Codex in that repo and work normally. The same setup command also prepares bounded Claude handoff artifacts and the project-local opencode helper when those local runtime/tool paths are available.
+Then open Codex in that repo and work normally. The same setup command also prepares Claude project-local context hooks plus handoff artifacts and the project-local opencode helper when those local runtime/tool paths are available.
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files.
 
@@ -65,10 +65,10 @@ These are Codex-focused benchmark/proxy measurements from a 5-task sample. The t
 ## Everyday commands
 
 ```bash
-fooks setup          # one-time readiness: Codex hooks + Claude handoff + opencode helper
+fooks setup          # one-time readiness: Codex hooks + Claude context hooks + opencode helper
 fooks status          # local estimated context-size telemetry for this repo
 fooks status codex   # check Codex attach/hook state
-fooks status claude  # check Claude manual handoff artifact health
+fooks status claude  # check Claude project-local context hook / handoff health
 fooks status cache   # check local fooks cache health
 ```
 
@@ -107,7 +107,7 @@ Use `/fooks-extract path/to/File.tsx` or ask opencode to call `fooks_extract` wh
 | Environment | Current support | Runtime-token claim |
 | --- | --- | --- |
 | Codex | Automatic repeated-file hook path through `fooks setup` | Prepared-context/proxy evidence only; no runtime-token proof until measured telemetry exists |
-| Claude | Manual/shared handoff prepared by `fooks setup` when possible | No automatic runtime-token savings claim |
+| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit` plus manual/shared handoff fallback prepared by `fooks setup` when possible | No `Read` interception and no automatic runtime-token savings claim |
 | opencode | Manual/semi-automatic project-local tool and slash command prepared by `fooks setup` when possible | No read interception and no automatic runtime-token savings claim |
 
 `fooks` is not a universal file-read interceptor. Non-frontend files usually fall back to normal source reading.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd your-react-project
 fooks setup
 ```
 
-Then open Codex in that repo and work normally. The same setup command also prepares Claude project-local context hooks plus handoff artifacts and the project-local opencode helper when those local runtime/tool paths are available.
+Then open Codex in that repo and work normally. The same setup command also prepares Claude project-local context hooks plus handoff artifacts and the project-local opencode helper when those local runtime/tool paths are available; Claude records/prepares the first explicit frontend-file prompt and may add bounded context on a repeated same-file prompt.
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files.
 
@@ -107,7 +107,7 @@ Use `/fooks-extract path/to/File.tsx` or ask opencode to call `fooks_extract` wh
 | Environment | Current support | Runtime-token claim |
 | --- | --- | --- |
 | Codex | Automatic repeated-file hook path through `fooks setup` | Prepared-context/proxy evidence only; no runtime-token proof until measured telemetry exists |
-| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit` plus manual/shared handoff fallback prepared by `fooks setup` when possible | No `Read` interception and no automatic runtime-token savings claim |
+| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared, and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | No `Read` interception and no automatic runtime-token savings claim |
 | opencode | Manual/semi-automatic project-local tool and slash command prepared by `fooks setup` when possible | No read interception and no automatic runtime-token savings claim |
 
 `fooks` is not a universal file-read interceptor. Non-frontend files usually fall back to normal source reading.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fooks extract src/components/Button.tsx --model-payload
 fooks scan
 ```
 
-`fooks status` reads local `.fooks/sessions` summaries produced by the Codex hook path. The values are approximate context-size estimates only; the CLI status output omits per-session details and is not provider billing tokens, provider costs, or a `ccusage` replacement.
+`fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider billing tokens, provider costs, or a `ccusage` replacement.
 
 `fooks status codex` is also only a local attach/trust readiness check. It does not prove Codex runtime-token savings, because this repo does not yet collect Codex runtime telemetry for that claim.
 

--- a/docs/cli/auto-mode-implementation-plan.md
+++ b/docs/cli/auto-mode-implementation-plan.md
@@ -20,7 +20,7 @@
 - `fooks run <task>` - One-shot task execution (missing)
 - `fooks doctor` - Setup diagnostics (missing)
 - Auto fallback chain (compressed→hybrid→raw) - Partially in decide.ts
-- Unified runner UX polish (codex/omx parity)
+- Unified runner UX polish (Codex/Claude product boundary)
 - Typecheck/build verification hooks
 
 ---
@@ -76,12 +76,12 @@ compressed → hybrid → raw → error (no native degrade)
 ---
 
 ### Task 3: Add Runner Adapter Seam
-**Purpose**: Unified UX across codex/omx, hidden vanilla compare
+**Purpose**: Unified UX across Codex/Claude, hidden harness/vanilla compare
 
 **Structure**:
 - `src/adapters/runner.ts` (new) - Adapter interface
 - Codex adapter: primary implementation
-- OMX adapter: compatible structure (placeholder for omx integration)
+- Harness adapters stay internal-only and are not part of the fooks user-facing runtime surface
 - Vanilla adapter: hidden, benchmark-only
 
 **Touched Files**:
@@ -90,7 +90,7 @@ compressed → hybrid → raw → error (no native degrade)
 - `src/cli/run.ts` - Use adapter seam
 
 **Acceptance Criteria**:
-- [ ] Same UX regardless of runner (codex/omx)
+- [ ] Same UX across supported user-facing runtimes (Codex/Claude)
 - [ ] Vanilla compare exists for benchmark validation (hidden from CLI help)
 - [ ] Runner selection: auto-detect or explicit flag
 
@@ -161,5 +161,5 @@ fooks setup
 
 **Key Decisions**:
 - Orchestration-centered: scan → decide → extract → fallback → execute
-- Runner adapter seam: codex first, omx-compatible structure
+- Runner adapter seam: Codex/Claude product surface first; harness adapters stay internal
 - No timeline estimates until implementation starts

--- a/docs/cli/default-auto-mode-spec.md
+++ b/docs/cli/default-auto-mode-spec.md
@@ -16,7 +16,7 @@ Fooks CLI provides **zero-configuration automatic optimization** for frontend AI
 **Defaults**:
 - Creates `.fooks/config.json` with `mode: "auto"`
 - Detects project type (React/TSX/Next.js/Vite/etc.)
-- Sets `runner: "auto"` (detects Codex/OMX availability)
+- Sets `runner: "auto"` (Codex-first product fallback; Claude is supported through setup/context hooks and handoff)
 
 **Output**:
 ```
@@ -35,7 +35,7 @@ Fooks CLI provides **zero-configuration automatic optimization** for frontend AI
 
 **Default flags**:
 - `--mode=auto` (overridable: `--mode=raw|hybrid|compressed`)
-- `--runner=auto` (overridable: `--runner=codex|omx`)
+- `--runner=auto` (overridable: `--runner=codex|claude`)
 - `--fallback=on` (fail-open: compressed→hybrid→raw)
 
 **Output**:
@@ -62,7 +62,7 @@ Fooks CLI provides **zero-configuration automatic optimization** for frontend AI
 **Purpose**: Diagnose setup and suggest fixes  
 **Checks**:
 - Auth configuration
-- Runner availability (codex/omx)
+- Runner availability (Codex/Claude product surface)
 - Project type detection
 - Cache integrity
 
@@ -128,16 +128,16 @@ compressed → hybrid → raw
 
 ### Auto-Detection Priority
 1. `codex` (if `~/.codex/auth.json` exists)
-2. `omx` (if `oh-my-codex` installed)
-3. Error with setup instructions
+2. `codex` compatibility fallback with setup instructions
+3. Claude support is exposed through `fooks setup` project-local context hooks and manual/shared handoff, not an OMX runner fallback
 
 ### Unified UX
 Same command structure across runners:
 ```bash
-# Both work identically from user perspective
+# Product-facing examples
 fooks run "Add button to header"
 fooks run --runner=codex "Add button to header"
-fooks run --runner=omx "Add button to header"
+fooks run --runner=claude "Add button to header"
 ```
 
 ### Debug/Benchmark Path (Hidden)
@@ -237,8 +237,8 @@ User completes `fooks run "<simple task>"` within 3 steps of installation withou
 - Configuring compression settings
 - Debugging runner setup
 
-### Consistency Across Runners
-Same task executed via `codex`, `omx`, or `vanilla` comparison shows:
+### Consistency Across Product Runtimes
+Same task executed via supported product runtimes or hidden benchmark harnesses shows:
 - Identical modified files (outcome parity)
 - Comparable or better token efficiency
 - Acceptable time variance (< 30%)

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,7 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Environment | Release-ready wording | Do not claim |
 | --- | --- | --- |
 | Codex | Automatic repeated-file hook path through `fooks setup`; prepared-context/proxy evidence only | Universal file-read interception or measured runtime-token savings without Codex telemetry |
-| Claude | Manual/shared handoff prepared by `fooks setup` when possible | Automatic hooks, prompt interception, or runtime-token savings |
+| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit` plus manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
 The opencode boundary is intentional. The current bridge may steer users toward
@@ -80,7 +80,7 @@ npm ls -g --depth=0 | grep -E 'fooks|oh-my-fooks'
 | Layer 2 applied-code / multi-task evidence absent | Runner path plus two repeated proposal-only smokes now exist. The applied acceptance gate is implemented/self-tested, but matched live generated outputs and multi-task evidence do not exist yet. | Blocks only stable Layer 2 runtime-token/time win claims and applied-code benchmark-win wording. |
 | Direct-Codex runtime-token regression | Negative/unstable Formbricks evidence is documented and linked. | Blocks stable runtime-token/time win claims. |
 | Local `fooks status` estimates | Bare status is documented as local context-size telemetry only. | Blocks billing-token, provider-cost, or `ccusage` replacement wording. |
-| Claude/opencode automatic savings | Explicit non-goal unless new runtime bridges are designed and measured. | Keep handoff/tool wording only. |
+| Claude/opencode automatic savings | Claude now has bounded project-local context hooks, but no measured runtime-token savings and no `Read` interception. opencode remains a manual/semi-automatic tool bridge. | Keep Claude context-hook wording and opencode tool wording only. |
 
 ## Pre-publish blockers
 
@@ -166,6 +166,6 @@ printf 'export function App(){ return <main>Hello</main>; }\n' > "$TMP_PROJECT/s
 )
 ```
 
-Expected shape: top-level `ready: true`, `runtimes.codex.state: "automatic-ready"`, `runtimes.claude.state: "handoff-ready"` when the Claude home exists, and `runtimes.opencode.state: "tool-ready"`. Claude/opencode blockers are non-fatal and must remain bounded to handoff/tool readiness wording.
+Expected shape: top-level `ready: true`, `runtimes.codex.state: "automatic-ready"`, `runtimes.claude.state: "context-hook-ready"` when the Claude home exists and project-local hooks install cleanly, and `runtimes.opencode.state: "tool-ready"`. Claude/opencode blockers are non-fatal and must remain bounded to Claude context-hook/handoff and opencode tool readiness wording.
 
 The release-prep PR must state that `npm publish` was not run.

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,7 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Environment | Release-ready wording | Do not claim |
 | --- | --- | --- |
 | Codex | Automatic repeated-file hook path through `fooks setup`; prepared-context/proxy evidence only | Universal file-read interception or measured runtime-token savings without Codex telemetry |
-| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit` plus manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
+| Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
 The opencode boundary is intentional. The current bridge may steer users toward
@@ -80,7 +80,7 @@ npm ls -g --depth=0 | grep -E 'fooks|oh-my-fooks'
 | Layer 2 applied-code / multi-task evidence absent | Runner path plus two repeated proposal-only smokes now exist. The applied acceptance gate is implemented/self-tested, but matched live generated outputs and multi-task evidence do not exist yet. | Blocks only stable Layer 2 runtime-token/time win claims and applied-code benchmark-win wording. |
 | Direct-Codex runtime-token regression | Negative/unstable Formbricks evidence is documented and linked. | Blocks stable runtime-token/time win claims. |
 | Local `fooks status` estimates | Bare status is documented as local context-size telemetry only. | Blocks billing-token, provider-cost, or `ccusage` replacement wording. |
-| Claude/opencode automatic savings | Claude now has bounded project-local context hooks, but no measured runtime-token savings and no `Read` interception. opencode remains a manual/semi-automatic tool bridge. | Keep Claude context-hook wording and opencode tool wording only. |
+| Claude/opencode automatic savings | Claude now has bounded project-local context hooks that record/prepare the first eligible frontend-file prompt, then add repeated same-file context, but no measured runtime-token savings and no `Read` interception. opencode remains a manual/semi-automatic tool bridge. | Keep Claude context-hook wording and opencode tool wording only. |
 
 ## Pre-publish blockers
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,7 +45,7 @@ context-compression mechanics and targeted-file behavior, but must not claim
 stable direct runtime-token/time wins until a future multi-task benchmark class
 proves them.
 
-Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
+Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`, including runtime/source breakdowns for Codex automatic hooks and Claude project-local context hooks. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
 Codex setup/attach/status readiness is also local state only. It may show that
 Codex hooks, manifests, and trust metadata were prepared, but it is not live

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Setup fooks
 
-Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex remains the automatic repeated-file hook path. Claude setup is narrower: it installs project-local context hooks for `SessionStart` and `UserPromptSubmit`, plus manual/shared handoff artifacts. opencode setup remains a bounded project-local tool readiness summary.
+Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex remains the automatic repeated-file hook path. Claude setup is narrower: it installs project-local context hooks for `SessionStart` and `UserPromptSubmit`, where the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context, plus manual/shared handoff artifacts. opencode setup remains a bounded project-local tool readiness summary.
 
 ## 1. Install
 
@@ -29,7 +29,7 @@ fooks setup
 1. creates local `.fooks/` state;
 2. prepares Codex attachment metadata and runtime-home files;
 3. merges the fooks hook command into `~/.codex/hooks.json`;
-4. prepares Claude manual/shared handoff artifacts and project-local Claude context hooks when a Claude home is available;
+4. prepares Claude manual/shared handoff artifacts and project-local Claude context hooks when a Claude home is available; Claude records/prepares the first eligible explicit frontend-file prompt and may inject bounded context for repeated same-file prompts;
 5. installs the project-local opencode custom tool and slash command when a supported component exists.
 
 The Codex hook command is:
@@ -147,7 +147,7 @@ The generated tool:
 - does not edit Codex hooks;
 - does not edit global opencode config.
 
-Claude can receive bounded fooks context through project-local `SessionStart` / `UserPromptSubmit` hooks and manual/shared handoff paths. opencode can use fooks payloads through manual/semi-automatic tool paths. This repo does not claim Claude `Read` interception, opencode read interception, or automatic runtime-token savings for Claude and opencode.
+Claude can receive bounded fooks context through project-local `SessionStart` / `UserPromptSubmit` hooks after a first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt occurs; manual/shared handoff paths remain available. opencode can use fooks payloads through manual/semi-automatic tool paths. This repo does not claim Claude `Read` interception, opencode read interception, or automatic runtime-token savings for Claude and opencode.
 
 ## Release smoke check
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Setup fooks
 
-Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex is the only automatic hook path today; Claude and opencode setup results are bounded handoff/tool readiness summaries.
+Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex remains the automatic repeated-file hook path. Claude setup is narrower: it installs project-local context hooks for `SessionStart` and `UserPromptSubmit`, plus manual/shared handoff artifacts. opencode setup remains a bounded project-local tool readiness summary.
 
 ## 1. Install
 
@@ -29,13 +29,19 @@ fooks setup
 1. creates local `.fooks/` state;
 2. prepares Codex attachment metadata and runtime-home files;
 3. merges the fooks hook command into `~/.codex/hooks.json`;
-4. prepares Claude manual/shared handoff artifacts when a Claude home is available;
+4. prepares Claude manual/shared handoff artifacts and project-local Claude context hooks when a Claude home is available;
 5. installs the project-local opencode custom tool and slash command when a supported component exists.
 
-The hook command is:
+The Codex hook command is:
 
 ```bash
 fooks codex-runtime-hook --native-hook
+```
+
+The Claude project-local hook command is:
+
+```bash
+fooks claude-runtime-hook --native-hook
 ```
 
 Package install alone does not edit Codex hooks, Claude files, or opencode project files. Activation only happens when you run `fooks setup`.
@@ -65,7 +71,7 @@ Good signs:
 
 - Bare `fooks status` returns `metricTier: "estimated"` and no error. A fresh repo may show zero sessions/events.
 - Codex status is connected/ready-style.
-- Claude status is `handoff-ready` when the local adapter files and Claude attachment manifest are present. This is a manual handoff health check, not an automatic Claude hook claim.
+- Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
@@ -87,7 +93,7 @@ Likewise, `fooks status codex` and the Codex-ready portions of `fooks setup` rep
 | Runtime field | Ready state | Meaning |
 | --- | --- | --- |
 | `runtimes.codex.state` | `automatic-ready` | Codex attach metadata, trust status, and hook preset are ready. This confirms local setup/readiness only; it is not runtime-token telemetry. |
-| `runtimes.claude.state` | `handoff-ready` or `blocked` | Claude manual/shared handoff artifacts were prepared, or a non-fatal Claude blocker was reported. This does not mean Claude prompt interception is enabled. |
+| `runtimes.claude.state` | `context-hook-ready`, `handoff-ready`, or `blocked` | Claude manual/shared handoff artifacts and, when possible, project-local `SessionStart` / `UserPromptSubmit` hooks were prepared, or a non-fatal Claude blocker was reported. This does not mean Claude `Read` interception or runtime-token savings are enabled. |
 | `runtimes.opencode.state` | `tool-ready`, `manual-step-required`, or `blocked` | The project-local opencode helper is installed, needs an explicit/manual step, or hit a non-fatal blocker. This does not mean opencode read interception or automatic runtime-token savings are enabled. |
 | `blocksOverall` | `true` only for Codex today | Claude/opencode blockers should not make Codex setup look failed when Codex itself is ready. |
 
@@ -141,7 +147,7 @@ The generated tool:
 - does not edit Codex hooks;
 - does not edit global opencode config.
 
-Claude and opencode can use fooks payloads through manual/shared handoff paths, but this repo does not claim automatic runtime-token savings for Claude and opencode.
+Claude can receive bounded fooks context through project-local `SessionStart` / `UserPromptSubmit` hooks and manual/shared handoff paths. opencode can use fooks payloads through manual/semi-automatic tool paths. This repo does not claim Claude `Read` interception, opencode read interception, or automatic runtime-token savings for Claude and opencode.
 
 ## Release smoke check
 
@@ -160,7 +166,9 @@ Mostly for debugging:
 ```bash
 fooks attach codex
 fooks install codex-hooks
+fooks install claude-hooks
 fooks codex-runtime-hook --native-hook
+fooks claude-runtime-hook --native-hook
 fooks scan
 fooks extract <file> --model-payload
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,7 +74,7 @@ Good signs:
 - Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 
-Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex hook path, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
+Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 
 Likewise, `fooks status codex` and the Codex-ready portions of `fooks setup` report local attach/trust readiness only. They do not prove live Codex runtime-token savings, because this repo does not yet collect Codex runtime telemetry for that claim.
 

--- a/docs/terminal-cli-validation-2026-04-19.md
+++ b/docs/terminal-cli-validation-2026-04-19.md
@@ -18,7 +18,7 @@ Claim boundary: these checks verify setup artifacts, manifests, and handoff payl
 - Prior docs/PR context inspected:
   - closed PR #35, `docs: agent-neutral CLI workflow for Codex/Claude`, closed on 2026-04-19
   - merged PR #37 / commit `9e5be1c`, `docs: validate fooks as agent-neutral terminal CLI`
-  - current `main` already contains the supporting CLI and adapter code paths, plus the merged validation note, but still leaves `fooks run` with Codex/OMX-flavored first-success wording
+  - current `main` already contains the supporting CLI and adapter code paths, plus the merged validation note, but previously left `fooks run` with runner-flavored first-success wording
 - Hermes note:
   - no Hermes-specific integration surface was found in this repo during this pass
 
@@ -100,8 +100,8 @@ node dist/cli/index.js run "Please update fixtures/compressed/FormSection.tsx"
 Observed result after the first-success wording pass:
 
 - output heading is `Shared Handoff Context`
-- output no longer labels the flow as a detected Codex/OMX runner
-- next-step text says `Open this context with your preferred runtime (codex, claude, omx, etc.)`
+- output no longer labels the flow as a detected runner
+- next-step text says `Open this context with your preferred runtime (codex or claude).`
 - context file still contains the same light exact-file selection for `fixtures/compressed/FormSection.tsx`
 
 This keeps the local value check intact while making the first-success path honest about the product surface: `fooks run` prepares a reusable context handoff and does not claim Claude-native runtime automation.

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -117,7 +117,7 @@ const setup = JSON.parse(setupStdout);
 assert(setup.ready === true, `expected setup.ready=true, got ${setup.ready}`);
 assert(setup.runtimes?.codex?.state === "automatic-ready", `unexpected Codex setup state ${setup.runtimes?.codex?.state}`);
 assert(setup.runtimes?.codex?.blocksOverall === true, "Codex should be the only overall-blocking runtime");
-assert(setup.runtimes?.claude?.state === "handoff-ready", `unexpected Claude setup state ${setup.runtimes?.claude?.state}`);
+assert(setup.runtimes?.claude?.state === "context-hook-ready", `unexpected Claude setup state ${setup.runtimes?.claude?.state}`);
 assert(setup.runtimes?.claude?.blocksOverall === false, "Claude readiness should be non-fatal for overall setup");
 assert(setup.runtimes?.opencode?.state === "tool-ready", `unexpected opencode setup state ${setup.runtimes?.opencode?.state}`);
 assert(setup.runtimes?.opencode?.blocksOverall === false, "opencode readiness should be non-fatal for overall setup");
@@ -133,6 +133,21 @@ assert(setup.scope?.userRuntime?.paths?.includes(path.join(codexHome, "hooks.jso
 assert(setup.scope?.userRuntime?.paths?.some((item) => item.startsWith(path.join(codexHome, "fooks", "attachments"))), "setup scope should include isolated Codex runtime manifest path");
 assert(setup.scope?.nonGoals?.some((item) => item.includes("No --scope option")), "setup scope should document that no new scope option is required");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
+const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");
+assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");
+const claudeSettings = JSON.parse(fs.readFileSync(claudeLocalSettings, "utf8"));
+assert(
+  JSON.stringify(Object.keys(claudeSettings.hooks ?? {}).sort()) === JSON.stringify(["SessionStart", "UserPromptSubmit"]),
+  "Claude smoke hooks should be limited to SessionStart and UserPromptSubmit",
+);
+assert(
+  claudeSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
+  "Claude SessionStart smoke hook should use the canonical fooks command",
+);
+assert(
+  claudeSettings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
+  "Claude UserPromptSubmit smoke hook should use the canonical fooks command",
+);
 assert(fs.existsSync(path.join(project, ".opencode", "tools", "fooks_extract.ts")), "opencode helper should be installed project-locally");
 assert(fs.existsSync(path.join(project, ".opencode", "commands", "fooks-extract.md")), "opencode slash command should be installed project-locally");
 

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -148,6 +148,44 @@ assert(
   claudeSettings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
   "Claude UserPromptSubmit smoke hook should use the canonical fooks command",
 );
+const claudeNativeEnv = {
+  ...process.env,
+  HOME: path.join(runtimeRoot, "home"),
+  XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+  FOOKS_CODEX_HOME: codexHome,
+  FOOKS_CLAUDE_HOME: claudeHome,
+};
+const firstClaudePrompt = execFileSync(fooksBin, ["claude-runtime-hook", "--native-hook"], {
+  cwd: project,
+  encoding: "utf8",
+  input: JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    cwd: project,
+    session_id: "release-smoke-claude",
+    prompt: "Explain src/App.tsx",
+  }),
+  env: claudeNativeEnv,
+});
+assert(firstClaudePrompt === "", "Claude first eligible native prompt should record without emitting context");
+const secondClaudePrompt = JSON.parse(execFileSync(fooksBin, ["claude-runtime-hook", "--native-hook"], {
+  cwd: project,
+  encoding: "utf8",
+  input: JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    cwd: project,
+    session_id: "release-smoke-claude",
+    prompt: "Again, explain src/App.tsx",
+  }),
+  env: claudeNativeEnv,
+}));
+assert(
+  secondClaudePrompt.hookSpecificOutput?.hookEventName === "UserPromptSubmit",
+  "Claude repeated same-file native prompt should emit UserPromptSubmit context",
+);
+assert(
+  secondClaudePrompt.hookSpecificOutput?.additionalContext?.includes("src/App.tsx"),
+  "Claude repeated same-file native context should reference the target file",
+);
 assert(fs.existsSync(path.join(project, ".opencode", "tools", "fooks_extract.ts")), "opencode helper should be installed project-locally");
 assert(fs.existsSync(path.join(project, ".opencode", "commands", "fooks-extract.md")), "opencode slash command should be installed project-locally");
 

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -29,6 +29,36 @@ function parsePackJson(stdout) {
   return parsed[0];
 }
 
+
+function assertNoForbiddenPublicClaims(label, text) {
+  const forbidden = [
+    /provider billing-token reduction/i,
+    /billing-token savings/i,
+    /provider cost savings/i,
+    /Claude Read interception is enabled/i,
+    /Claude runtime-token savings are enabled/i,
+    /automatic Claude runtime-token savings/i,
+  ];
+  for (const pattern of forbidden) {
+    assert(!pattern.test(text), `${label} contains forbidden positive claim ${pattern}`);
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    if (/ccusage replacement/i.test(line)) {
+      assert(/not (?:a )?ccusage replacement|not provider billing tokens, provider costs, or a ccusage replacement/i.test(line), `${label} contains unbounded ccusage replacement wording: ${line}`);
+    }
+    if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
+      assert(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
+    }
+  }
+}
+
+function assertPublicSurfaceClaimBoundaries(surfaces) {
+  for (const [label, text] of Object.entries(surfaces)) {
+    assertNoForbiddenPublicClaims(label, text);
+  }
+}
+
 function assertPackedFiles(packEntry) {
   const paths = new Set(packEntry.files.map((file) => file.path));
   const required = [
@@ -87,6 +117,13 @@ run("npm", ["install", "-g", "--prefix", prefix, tarballPath]);
 const fooksBin = path.join(prefix, "bin", "fooks");
 assert(fs.existsSync(fooksBin), `installed fooks binary not found at ${fooksBin}`);
 
+assertPublicSurfaceClaimBoundaries({
+  "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
+  "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
+  "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "dist/cli/index.js": fs.readFileSync(path.join(repoRoot, "dist", "cli", "index.js"), "utf8"),
+});
+
 const project = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-project-"));
 const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-"));
 const codexHome = path.join(runtimeRoot, "codex");
@@ -132,6 +169,37 @@ assert(setup.scope?.projectLocal?.paths?.includes(path.join(setupProjectRoot, ".
 assert(setup.scope?.userRuntime?.paths?.includes(path.join(codexHome, "hooks.json")), "setup scope should include isolated Codex hooks path");
 assert(setup.scope?.userRuntime?.paths?.some((item) => item.startsWith(path.join(codexHome, "fooks", "attachments"))), "setup scope should include isolated Codex runtime manifest path");
 assert(setup.scope?.nonGoals?.some((item) => item.includes("No --scope option")), "setup scope should document that no new scope option is required");
+
+const statusStdout = execFileSync(fooksBin, ["status"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+const claudeStatusStdout = execFileSync(fooksBin, ["status", "claude"], {
+  cwd: project,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
+assertPublicSurfaceClaimBoundaries({
+  "fooks setup output": setupStdout,
+  "fooks status output": statusStdout,
+  "fooks status claude output": claudeStatusStdout,
+});
+const status = JSON.parse(statusStdout);
+assert(status.claimBoundary?.includes("not provider billing tokens"), "status should keep provider billing boundary");
+assert(status.breakdown && typeof status.breakdown === "object", "status should expose runtime/source breakdown");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");
 assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");

--- a/src/adapters/claude-hook-preset.ts
+++ b/src/adapters/claude-hook-preset.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const CLAUDE_HOOK_EVENTS = ["SessionStart", "UserPromptSubmit"] as const;
+const CLAUDE_HOOK_SUFFIX = "claude-runtime-hook --native-hook";
+
+export type ClaudeHookEvent = (typeof CLAUDE_HOOK_EVENTS)[number];
+
+type HookCommand = {
+  type: "command";
+  command: string;
+  statusMessage?: string;
+  timeout?: number;
+};
+
+type HookMatcher = {
+  matcher?: string;
+  hooks?: HookCommand[];
+};
+
+type ClaudeSettingsFile = {
+  hooks?: Record<string, HookMatcher[]>;
+  [key: string]: unknown;
+};
+
+export type ClaudeHookPresetInstallResult = {
+  settingsPath: string;
+  backupPath?: string;
+  command: string;
+  created: boolean;
+  modified: boolean;
+  installedEvents: ClaudeHookEvent[];
+  skippedEvents: ClaudeHookEvent[];
+  blocker?: string;
+};
+
+export function defaultClaudeHookCommand(cliName = "fooks"): string {
+  return `${cliName} ${CLAUDE_HOOK_SUFFIX}`;
+}
+
+function compatibleClaudeHookCommands(cliName = "fooks"): string[] {
+  return [...new Set([defaultClaudeHookCommand(cliName), defaultClaudeHookCommand("fooks")])];
+}
+
+function isLegacyNodeBridgeCommand(commandText: string): boolean {
+  return /^node\s+(?:"[^"]+\/dist\/cli\/index\.js"|'[^']+\/dist\/cli\/index\.js'|\S+\/dist\/cli\/index\.js)\s+claude-runtime-hook --native-hook$/.test(commandText);
+}
+
+export function isCompatibleClaudeHookCommand(commandText: string, cliName = "fooks"): boolean {
+  return compatibleClaudeHookCommands(cliName).includes(commandText) || isLegacyNodeBridgeCommand(commandText);
+}
+
+export function claudeLocalSettingsPath(cwd = process.cwd()): string {
+  return path.join(cwd, ".claude", "settings.local.json");
+}
+
+function starterMatcher(event: ClaudeHookEvent, commandText: string): HookMatcher {
+  const command: HookCommand = { type: "command", command: commandText };
+  if (event === "SessionStart") {
+    return { matcher: "startup|resume", hooks: [command] };
+  }
+  return { hooks: [command] };
+}
+
+function findCompatibleCommandHook(matcher: HookMatcher, cliName = "fooks"): HookCommand | undefined {
+  if (!Array.isArray(matcher.hooks)) return undefined;
+  return matcher.hooks.find((hook) => hook?.type === "command" && isCompatibleClaudeHookCommand(hook.command, cliName));
+}
+
+function readSettingsFile(filePath: string): ClaudeSettingsFile {
+  if (!fs.existsSync(filePath)) return {};
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as ClaudeSettingsFile;
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+function ensureEventHook(settingsFile: ClaudeSettingsFile, event: ClaudeHookEvent, command: string): boolean {
+  settingsFile.hooks ||= {};
+  const eventHooks = settingsFile.hooks[event] ?? [];
+  const cliName = command.split(" ")[0];
+  const existingHook = eventHooks.map((matcher) => findCompatibleCommandHook(matcher, cliName)).find(Boolean);
+  if (existingHook) {
+    existingHook.command = command;
+    settingsFile.hooks[event] = eventHooks;
+    return false;
+  }
+  settingsFile.hooks[event] = [starterMatcher(event, command), ...eventHooks];
+  return true;
+}
+
+export function installClaudeHookPreset(cwd = process.cwd(), cliName = "fooks"): ClaudeHookPresetInstallResult {
+  const filePath = claudeLocalSettingsPath(cwd);
+  const command = defaultClaudeHookCommand(cliName);
+  const created = !fs.existsSync(filePath);
+  const installedEvents: ClaudeHookEvent[] = [];
+  const skippedEvents: ClaudeHookEvent[] = [];
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  const existingRaw = created ? "" : fs.readFileSync(filePath, "utf8");
+  let settingsFile: ClaudeSettingsFile;
+  try {
+    settingsFile = readSettingsFile(filePath);
+  } catch (error) {
+    return {
+      settingsPath: filePath,
+      command,
+      created: false,
+      modified: false,
+      installedEvents,
+      skippedEvents,
+      blocker: `Claude local settings are not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  for (const event of CLAUDE_HOOK_EVENTS) {
+    if (ensureEventHook(settingsFile, event, command)) {
+      installedEvents.push(event);
+    } else {
+      skippedEvents.push(event);
+    }
+  }
+
+  const nextRaw = `${JSON.stringify(settingsFile, null, 2)}\n`;
+  const modified = existingRaw !== nextRaw;
+  let backupPath: string | undefined;
+  if (modified && !created) {
+    backupPath = `${filePath}.bak-${Math.floor(Date.now() / 1000)}`;
+    fs.copyFileSync(filePath, backupPath);
+  }
+  if (modified) {
+    fs.writeFileSync(filePath, nextRaw);
+  }
+
+  return {
+    settingsPath: filePath,
+    backupPath,
+    command,
+    created,
+    modified,
+    installedEvents,
+    skippedEvents,
+  };
+}

--- a/src/adapters/claude-native-hook.ts
+++ b/src/adapters/claude-native-hook.ts
@@ -30,6 +30,10 @@ function readPrompt(payload: NativePayload): string {
   return "";
 }
 
+function readSessionId(payload: NativePayload): string | undefined {
+  return safeString(payload.session_id ?? payload.sessionId ?? payload.transcript_path ?? payload.transcriptPath).trim() || undefined;
+}
+
 function findAttachedProjectRoot(startCwd: string): string | null {
   let current = path.resolve(startCwd);
   while (true) {
@@ -62,7 +66,7 @@ export function handleClaudeNativeHookPayload(payload: NativePayload, fallbackCw
   const input: ClaudeRuntimeHookInput = {
     hookEventName,
     prompt: hookEventName === "UserPromptSubmit" ? readPrompt(payload) : undefined,
-    sessionId: safeString(payload.session_id ?? payload.sessionId) || undefined,
+    sessionId: readSessionId(payload),
     cwd: projectRoot,
   };
 

--- a/src/adapters/claude-native-hook.ts
+++ b/src/adapters/claude-native-hook.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { handleClaudeRuntimeHook, type ClaudeRuntimeHookEvent, type ClaudeRuntimeHookInput } from "./claude-runtime-hook";
+
+type NativePayload = Record<string, unknown>;
+
+export type ClaudeNativeHookOutput = {
+  hookSpecificOutput: {
+    hookEventName: ClaudeRuntimeHookEvent;
+    additionalContext: string;
+  };
+};
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readHookEventName(payload: NativePayload): ClaudeRuntimeHookEvent | null {
+  const raw = safeString(payload.hook_event_name ?? payload.hookEventName ?? payload.event ?? payload.name).trim();
+  if (raw === "SessionStart" || raw === "UserPromptSubmit") return raw;
+  return null;
+}
+
+function readPrompt(payload: NativePayload): string {
+  const candidates = [payload.prompt, payload.input, payload.user_prompt, payload.userPrompt, payload.text];
+  for (const candidate of candidates) {
+    const value = safeString(candidate).trim();
+    if (value) return value;
+  }
+  return "";
+}
+
+function findAttachedProjectRoot(startCwd: string): string | null {
+  let current = path.resolve(startCwd);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".fooks", "adapters", "claude", "adapter.json"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function toHookSpecificOutput(hookEventName: ClaudeRuntimeHookEvent, additionalContext: string): ClaudeNativeHookOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName,
+      additionalContext,
+    },
+  };
+}
+
+export function handleClaudeNativeHookPayload(payload: NativePayload, fallbackCwd = process.cwd()): ClaudeNativeHookOutput | null {
+  const hookEventName = readHookEventName(payload);
+  if (!hookEventName) return null;
+
+  const payloadCwd = safeString(payload.cwd).trim() || fallbackCwd;
+  const projectRoot = findAttachedProjectRoot(payloadCwd);
+  if (!projectRoot) return null;
+
+  const input: ClaudeRuntimeHookInput = {
+    hookEventName,
+    prompt: hookEventName === "UserPromptSubmit" ? readPrompt(payload) : undefined,
+    sessionId: safeString(payload.session_id ?? payload.sessionId) || undefined,
+    cwd: projectRoot,
+  };
+
+  const decision = handleClaudeRuntimeHook(input, projectRoot);
+  if ((decision.action === "inject" || decision.action === "fallback") && decision.additionalContext) {
+    return toHookSpecificOutput(hookEventName, decision.additionalContext);
+  }
+
+  return null;
+}

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs";
+import path from "node:path";
+import { decideCodexPreRead } from "./codex-pre-read";
+import { resolvePromptFileContext } from "./codex-runtime-prompt";
+import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
+
+export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
+
+export type ClaudeRuntimeHookEvent = "SessionStart" | "UserPromptSubmit";
+
+export type ClaudeRuntimeHookInput = {
+  hookEventName: ClaudeRuntimeHookEvent;
+  prompt?: string;
+  sessionId?: string;
+  cwd?: string;
+};
+
+export type ClaudeRuntimeHookDecision = {
+  runtime: "claude";
+  hookEventName: ClaudeRuntimeHookEvent;
+  action: "noop" | "inject" | "fallback";
+  filePath?: string;
+  reasons: string[];
+  additionalContext?: string;
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  contextBudget?: ContextBudget;
+  promptSpecificity?: PromptSpecificity;
+  contextPolicyVersion?: "context-policy.v1";
+  debug?: {
+    eligible: boolean;
+    bounded: boolean;
+  };
+  fallback?: {
+    action: "full-read";
+    reason: string;
+  };
+};
+
+function clampAdditionalContext(value: string): string {
+  if (value.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS) return value;
+  return `${value.slice(0, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - 126).trimEnd()}\n\n[fooks: context truncated to stay within Claude hook additionalContext cap. Read the full source file if exact code is required.]`;
+}
+
+function boundedFallbackContext(filePath: string | undefined, reason: string): string {
+  const target = filePath ?? "requested frontend file";
+  return clampAdditionalContext(
+    `fooks: Claude context hook fallback · file: ${target} · reason: ${reason} · Read the full source file for this turn. No Claude Read interception or runtime-token savings is claimed.`,
+  );
+}
+
+function payloadContextMode(payload: NonNullable<ReturnType<typeof decideCodexPreRead>["payload"]>): ContextMode {
+  return payload.useOriginal ? "light-minimal" : "light";
+}
+
+function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<typeof decideCodexPreRead>["payload"]>, contextMode: ContextMode): string {
+  return clampAdditionalContext([
+    `fooks: Claude context hook · file: ${filePath} · context-mode: ${contextMode}`,
+    "This is bounded model-facing context for the explicit frontend file prompt. fooks does not intercept Claude Read/tool calls and does not claim Claude runtime-token savings.",
+    "",
+    JSON.stringify(payload, null, 2),
+  ].join("\n"));
+}
+
+function sessionStartContext(): string {
+  return clampAdditionalContext([
+    "fooks: Claude context hook is active for this project.",
+    "When the user explicitly prompts about an existing in-project .tsx or .jsx file, fooks may add bounded model-facing context through UserPromptSubmit.",
+    "P0 boundary: fooks does not intercept Claude Read/tool calls and does not claim Claude runtime-token savings.",
+  ].join("\n"));
+}
+
+function noopDecision(input: ClaudeRuntimeHookInput, reasons: string[], policy?: ReturnType<typeof resolvePromptFileContext>["policy"]): ClaudeRuntimeHookDecision {
+  return {
+    runtime: "claude",
+    hookEventName: input.hookEventName,
+    action: "noop",
+    reasons,
+    contextMode: policy?.contextMode,
+    contextModeReason: policy?.contextModeReason,
+    contextBudget: policy?.contextBudget,
+    promptSpecificity: policy?.promptSpecificity,
+    contextPolicyVersion: policy?.contextPolicyVersion,
+    debug: {
+      eligible: false,
+      bounded: true,
+    },
+  };
+}
+
+export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = process.cwd()): ClaudeRuntimeHookDecision {
+  const hookEventName = input.hookEventName;
+
+  if (hookEventName === "SessionStart") {
+    return {
+      runtime: "claude",
+      hookEventName,
+      action: "inject",
+      reasons: ["session-start-context"],
+      additionalContext: sessionStartContext(),
+      contextMode: "light-minimal",
+      contextModeReason: "claude-session-start-readiness",
+      debug: {
+        eligible: true,
+        bounded: true,
+      },
+    };
+  }
+
+  const prompt = input.prompt ?? "";
+  const promptContext = resolvePromptFileContext(prompt, cwd);
+  const target = promptContext.filePath;
+  const policy = promptContext.policy;
+
+  if (!target) {
+    return noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+  }
+
+  const resolvedTarget = path.join(cwd, target);
+  if (!fs.existsSync(resolvedTarget)) {
+    return noopDecision(input, ["eligible-file-target-missing"], policy);
+  }
+
+  let decision: ReturnType<typeof decideCodexPreRead>;
+  try {
+    decision = decideCodexPreRead(resolvedTarget, cwd);
+  } catch (error) {
+    return {
+      runtime: "claude",
+      hookEventName,
+      action: "fallback",
+      filePath: target,
+      reasons: ["payload-build-failed"],
+      additionalContext: boundedFallbackContext(target, error instanceof Error ? error.message : String(error)),
+      contextMode: "full",
+      contextModeReason: "payload-build-failed",
+      contextBudget: policy.contextBudget,
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
+      debug: {
+        eligible: true,
+        bounded: true,
+      },
+      fallback: {
+        action: "full-read",
+        reason: "payload-build-failed",
+      },
+    };
+  }
+
+  if (decision.decision === "payload" && decision.payload) {
+    const contextMode = payloadContextMode(decision.payload);
+    return {
+      runtime: "claude",
+      hookEventName,
+      action: "inject",
+      filePath: target,
+      reasons: ["first-eligible-file-prompt"],
+      additionalContext: buildPayloadContext(target, decision.payload, contextMode),
+      contextMode,
+      contextModeReason: contextMode === "light-minimal" ? "first-exact-file-tiny-raw-original" : "first-exact-file-payload",
+      contextBudget: policy.contextBudget,
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
+      debug: {
+        eligible: true,
+        bounded: true,
+      },
+    };
+  }
+
+  return {
+    runtime: "claude",
+    hookEventName,
+    action: "fallback",
+    filePath: target,
+    reasons: decision.reasons,
+    additionalContext: boundedFallbackContext(target, decision.fallback?.reason ?? decision.reasons[0] ?? "full-read"),
+    contextMode: "full",
+    contextModeReason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
+    contextBudget: policy.contextBudget,
+    promptSpecificity: policy.promptSpecificity,
+    contextPolicyVersion: policy.contextPolicyVersion,
+    debug: {
+      eligible: decision.eligible,
+      bounded: true,
+    },
+    fallback: {
+      action: "full-read",
+      reason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
+    },
+  };
+}

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { decideCodexPreRead } from "./codex-pre-read";
+import { initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { resolvePromptFileContext } from "./codex-runtime-prompt";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
 
@@ -18,16 +19,18 @@ export type ClaudeRuntimeHookInput = {
 export type ClaudeRuntimeHookDecision = {
   runtime: "claude";
   hookEventName: ClaudeRuntimeHookEvent;
-  action: "noop" | "inject" | "fallback";
+  action: "noop" | "record" | "inject" | "fallback";
   filePath?: string;
   reasons: string[];
   additionalContext?: string;
+  statePath?: string;
   contextMode?: ContextMode;
   contextModeReason?: string;
   contextBudget?: ContextBudget;
   promptSpecificity?: PromptSpecificity;
   contextPolicyVersion?: "context-policy.v1";
   debug?: {
+    repeatedFile: boolean;
     eligible: boolean;
     bounded: boolean;
   };
@@ -65,7 +68,7 @@ function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<t
 function sessionStartContext(): string {
   return clampAdditionalContext([
     "fooks: Claude context hook is active for this project.",
-    "When the user explicitly prompts about an existing in-project .tsx or .jsx file, fooks may add bounded model-facing context through UserPromptSubmit.",
+    "When the user explicitly prompts about an existing in-project .tsx or .jsx file, fooks records/prepares the first same-session prompt; a repeated same-file prompt may add bounded model-facing context through UserPromptSubmit.",
     "P0 boundary: fooks does not intercept Claude Read/tool calls and does not claim Claude runtime-token savings.",
   ].join("\n"));
 }
@@ -82,6 +85,7 @@ function noopDecision(input: ClaudeRuntimeHookInput, reasons: string[], policy?:
     promptSpecificity: policy?.promptSpecificity,
     contextPolicyVersion: policy?.contextPolicyVersion,
     debug: {
+      repeatedFile: false,
       eligible: false,
       bounded: true,
     },
@@ -90,17 +94,21 @@ function noopDecision(input: ClaudeRuntimeHookInput, reasons: string[], policy?:
 
 export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = process.cwd()): ClaudeRuntimeHookDecision {
   const hookEventName = input.hookEventName;
+  const sessionKey = resolveClaudeRuntimeSessionKey(input.sessionId);
 
   if (hookEventName === "SessionStart") {
+    const statePath = initializeClaudeRuntimeSession(cwd, sessionKey);
     return {
       runtime: "claude",
       hookEventName,
       action: "inject",
       reasons: ["session-start-context"],
       additionalContext: sessionStartContext(),
+      statePath,
       contextMode: "light-minimal",
       contextModeReason: "claude-session-start-readiness",
       debug: {
+        repeatedFile: false,
         eligible: true,
         bounded: true,
       },
@@ -121,6 +129,30 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     return noopDecision(input, ["eligible-file-target-missing"], policy);
   }
 
+  const { statePath, seenCount } = markClaudeRuntimeSeenFile(cwd, sessionKey, target);
+  const repeatedFile = seenCount >= 2;
+
+  if (!repeatedFile) {
+    return {
+      runtime: "claude",
+      hookEventName,
+      action: "record",
+      filePath: target,
+      reasons: ["first-seen-file", "context-mode:no-op"],
+      statePath,
+      contextMode: "no-op",
+      contextModeReason: "first-turn-exact-file-record-only",
+      contextBudget: { ...policy.contextBudget, selectedFiles: 0, totalBytes: 0, skippedFiles: policy.contextBudget.selectedFiles },
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
+      debug: {
+        repeatedFile: false,
+        eligible: true,
+        bounded: true,
+      },
+    };
+  }
+
   let decision: ReturnType<typeof decideCodexPreRead>;
   try {
     decision = decideCodexPreRead(resolvedTarget, cwd);
@@ -130,14 +162,16 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       hookEventName,
       action: "fallback",
       filePath: target,
-      reasons: ["payload-build-failed"],
+      reasons: ["repeated-file", "payload-build-failed"],
       additionalContext: boundedFallbackContext(target, error instanceof Error ? error.message : String(error)),
+      statePath,
       contextMode: "full",
       contextModeReason: "payload-build-failed",
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
       debug: {
+        repeatedFile: true,
         eligible: true,
         bounded: true,
       },
@@ -155,14 +189,16 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       hookEventName,
       action: "inject",
       filePath: target,
-      reasons: ["first-eligible-file-prompt"],
+      reasons: ["repeated-file"],
       additionalContext: buildPayloadContext(target, decision.payload, contextMode),
+      statePath,
       contextMode,
-      contextModeReason: contextMode === "light-minimal" ? "first-exact-file-tiny-raw-original" : "first-exact-file-payload",
+      contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
       debug: {
+        repeatedFile: true,
         eligible: true,
         bounded: true,
       },
@@ -174,14 +210,16 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     hookEventName,
     action: "fallback",
     filePath: target,
-    reasons: decision.reasons,
+    reasons: decision.reasons.includes("repeated-file") ? decision.reasons : ["repeated-file", ...decision.reasons],
     additionalContext: boundedFallbackContext(target, decision.fallback?.reason ?? decision.reasons[0] ?? "full-read"),
+    statePath,
     contextMode: "full",
     contextModeReason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
     contextBudget: policy.contextBudget,
     promptSpecificity: policy.promptSpecificity,
     contextPolicyVersion: policy.contextPolicyVersion,
     debug: {
+      repeatedFile: true,
       eligible: decision.eligible,
       bounded: true,
     },

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -4,6 +4,12 @@ import { decideCodexPreRead } from "./codex-pre-read";
 import { initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { resolvePromptFileContext } from "./codex-runtime-prompt";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
+import {
+  estimateFileBytes,
+  estimateTextBytes,
+  initializeSessionMetricSummarySafe,
+  recordFooksSessionMetricEventSafe,
+} from "../core/session-metrics";
 
 export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
 
@@ -65,6 +71,39 @@ function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<t
   ].join("\n"));
 }
 
+function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
+  return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function recordClaudeMetric(
+  cwd: string,
+  sessionKey: string,
+  decision: ClaudeRuntimeHookDecision,
+  options: {
+    originalEstimatedBytes?: number;
+    actualEstimatedBytes?: number;
+    comparableForSavings?: boolean;
+    observedOriginalEstimatedBytes?: number;
+  } = {},
+): void {
+  recordFooksSessionMetricEventSafe(cwd, sessionKey, {
+    runtime: "claude",
+    measurementSource: "project-local-context-hook",
+    eventName: decision.hookEventName,
+    hookEventName: decision.hookEventName,
+    action: decision.action,
+    filePath: decision.filePath,
+    reasons: decision.reasons,
+    contextMode: decision.contextMode,
+    contextModeReason: decision.contextModeReason,
+    fallbackReason: decision.fallback?.reason,
+    originalEstimatedBytes: options.originalEstimatedBytes,
+    actualEstimatedBytes: options.actualEstimatedBytes,
+    comparableForSavings: options.comparableForSavings,
+    observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+  });
+}
+
 function sessionStartContext(): string {
   return clampAdditionalContext([
     "fooks: Claude context hook is active for this project.",
@@ -98,6 +137,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (hookEventName === "SessionStart") {
     const statePath = initializeClaudeRuntimeSession(cwd, sessionKey);
+    initializeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
     return {
       runtime: "claude",
       hookEventName,
@@ -121,19 +161,23 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
   const policy = promptContext.policy;
 
   if (!target) {
-    return noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    const decision = noopDecision(input, ["no-eligible-file-in-prompt"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const resolvedTarget = path.join(cwd, target);
   if (!fs.existsSync(resolvedTarget)) {
-    return noopDecision(input, ["eligible-file-target-missing"], policy);
+    const decision = noopDecision(input, ["eligible-file-target-missing"], policy);
+    recordClaudeMetric(cwd, sessionKey, decision);
+    return decision;
   }
 
   const { statePath, seenCount } = markClaudeRuntimeSeenFile(cwd, sessionKey, target);
   const repeatedFile = seenCount >= 2;
 
   if (!repeatedFile) {
-    return {
+    const decision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "record",
@@ -151,13 +195,18 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    recordClaudeMetric(cwd, sessionKey, decision, {
+      observedOriginalEstimatedBytes: targetEstimatedBytes(cwd, target),
+    });
+    return decision;
   }
 
   let decision: ReturnType<typeof decideCodexPreRead>;
   try {
     decision = decideCodexPreRead(resolvedTarget, cwd);
   } catch (error) {
-    return {
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "fallback",
@@ -180,17 +229,24 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         reason: "payload-build-failed",
       },
     };
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: originalEstimatedBytes,
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    return {
+    const additionalContext = buildPayloadContext(target, decision.payload, contextMode);
+    const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "inject",
       filePath: target,
       reasons: ["repeated-file"],
-      additionalContext: buildPayloadContext(target, decision.payload, contextMode),
+      additionalContext,
       statePath,
       contextMode,
       contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
@@ -203,9 +259,17 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         bounded: true,
       },
     };
+    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+    recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: estimateTextBytes(additionalContext),
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return runtimeDecision;
   }
 
-  return {
+  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const runtimeDecision: ClaudeRuntimeHookDecision = {
     runtime: "claude",
     hookEventName,
     action: "fallback",
@@ -228,4 +292,10 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       reason: decision.fallback?.reason ?? decision.reasons[0] ?? "full-read",
     },
   };
+  recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
+    originalEstimatedBytes,
+    actualEstimatedBytes: originalEstimatedBytes,
+    comparableForSavings: originalEstimatedBytes !== undefined,
+  });
+  return runtimeDecision;
 }

--- a/src/adapters/claude-runtime-session.ts
+++ b/src/adapters/claude-runtime-session.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sanitizeDataKey } from "../core/paths";
+
+type SeenFileState = {
+  firstSeenAt: string;
+  lastSeenAt: string;
+  seenCount: number;
+};
+
+export type ClaudeRuntimeSessionState = {
+  sessionKey: string;
+  seenFiles: Record<string, SeenFileState>;
+};
+
+function stateRoot(cwd: string): string {
+  return path.join(cwd, ".fooks", "state", "claude-runtime");
+}
+
+function emptyState(sessionKey: string): ClaudeRuntimeSessionState {
+  return {
+    sessionKey,
+    seenFiles: {},
+  };
+}
+
+export function resolveClaudeRuntimeSessionKey(sessionId?: string): string {
+  return sessionId?.trim() || "default-session";
+}
+
+export function claudeRuntimeSessionPath(cwd: string, sessionKey: string): string {
+  return path.join(stateRoot(cwd), `${sanitizeDataKey(sessionKey)}.json`);
+}
+
+export function readClaudeRuntimeSession(cwd: string, sessionKey: string): ClaudeRuntimeSessionState {
+  const file = claudeRuntimeSessionPath(cwd, sessionKey);
+  if (!fs.existsSync(file)) {
+    return emptyState(sessionKey);
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as ClaudeRuntimeSessionState;
+    if (parsed.sessionKey !== sessionKey || typeof parsed.seenFiles !== "object" || parsed.seenFiles === null) {
+      return emptyState(sessionKey);
+    }
+    return parsed;
+  } catch {
+    return emptyState(sessionKey);
+  }
+}
+
+export function writeClaudeRuntimeSession(cwd: string, state: ClaudeRuntimeSessionState): string {
+  const file = claudeRuntimeSessionPath(cwd, state.sessionKey);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(state, null, 2));
+  return file;
+}
+
+export function initializeClaudeRuntimeSession(cwd: string, sessionKey: string): string {
+  return writeClaudeRuntimeSession(cwd, emptyState(sessionKey));
+}
+
+export function markClaudeRuntimeSeenFile(cwd: string, sessionKey: string, filePath: string): { statePath: string; seenCount: number } {
+  const state = readClaudeRuntimeSession(cwd, sessionKey);
+  const now = new Date().toISOString();
+  const existing = state.seenFiles[filePath];
+  state.seenFiles[filePath] = existing
+    ? {
+        ...existing,
+        lastSeenAt: now,
+        seenCount: existing.seenCount + 1,
+      }
+    : {
+        firstSeenAt: now,
+        lastSeenAt: now,
+        seenCount: 1,
+      };
+
+  return {
+    statePath: writeClaudeRuntimeSession(cwd, state),
+    seenCount: state.seenFiles[filePath].seenCount,
+  };
+}
+
+export function clearClaudeRuntimeSession(cwd: string, sessionKey: string): string {
+  const file = claudeRuntimeSessionPath(cwd, sessionKey);
+  if (fs.existsSync(file)) {
+    fs.rmSync(file);
+  }
+  return file;
+}

--- a/src/adapters/claude-status.ts
+++ b/src/adapters/claude-status.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { adapterDir } from "../core/paths";
+import { claudeLocalSettingsPath, CLAUDE_HOOK_EVENTS, defaultClaudeHookCommand, isCompatibleClaudeHookCommand, type ClaudeHookEvent } from "./claude-hook-preset";
 import { runtimeManifestPath } from "./shared";
 
-type ClaudeStatusState = "handoff-ready" | "blocked";
+type ClaudeStatusState = "context-hook-ready" | "handoff-ready" | "blocked";
+type ClaudeStatusMode = "automatic-context-hook" | "manual-shared-handoff";
 
 type FileStatus = {
   path: string;
@@ -23,10 +25,37 @@ type ClaudeManifestStatus = {
   blocker?: string;
 };
 
+type HookCommand = {
+  type?: unknown;
+  command?: unknown;
+};
+
+type HookMatcher = {
+  hooks?: unknown;
+};
+
+type ClaudeSettingsFile = {
+  hooks?: Record<string, HookMatcher[]>;
+  disableAllHooks?: unknown;
+};
+
+export type ClaudeHookStatus = {
+  path: string;
+  exists: boolean;
+  ready: boolean;
+  valid?: boolean;
+  installedEvents: ClaudeHookEvent[];
+  missingEvents: ClaudeHookEvent[];
+  unexpectedFooksEvents: string[];
+  commandMatches?: boolean;
+  disabledByLocalSettings?: boolean;
+  blocker?: string;
+};
+
 export type ClaudeRuntimeStatus = {
   runtime: "claude";
   state: ClaudeStatusState;
-  mode: "manual-shared-handoff";
+  mode: ClaudeStatusMode;
   ready: boolean;
   blockers: string[];
   adapter: {
@@ -36,6 +65,7 @@ export type ClaudeRuntimeStatus = {
     contextTemplate: FileStatus;
   };
   manifest: ClaudeManifestStatus;
+  hooks: ClaudeHookStatus;
   nextSteps: string[];
   notes: string[];
 };
@@ -122,7 +152,77 @@ function manifestStatus(cwd: string): ClaudeManifestStatus {
   }
 }
 
-function blockersFrom(...items: Array<FileStatus | ClaudeManifestStatus>): string[] {
+function hookCommandsForEvent(settings: ClaudeSettingsFile, event: string): string[] {
+  const matchers = settings.hooks?.[event] ?? [];
+  if (!Array.isArray(matchers)) return [];
+  return matchers.flatMap((matcher) => {
+    if (!Array.isArray(matcher?.hooks)) return [];
+    return (matcher.hooks as HookCommand[])
+      .filter((hook) => hook?.type === "command" && typeof hook.command === "string")
+      .map((hook) => hook.command as string);
+  });
+}
+
+function hookStatus(cwd: string): ClaudeHookStatus {
+  const filePath = claudeLocalSettingsPath(cwd);
+  if (!fs.existsSync(filePath)) {
+    return {
+      path: filePath,
+      exists: false,
+      ready: false,
+      installedEvents: [],
+      missingEvents: [...CLAUDE_HOOK_EVENTS],
+      unexpectedFooksEvents: [],
+      commandMatches: false,
+    };
+  }
+
+  let settings: ClaudeSettingsFile;
+  try {
+    settings = readJson(filePath) as ClaudeSettingsFile;
+  } catch (error) {
+    return {
+      path: filePath,
+      exists: true,
+      ready: false,
+      valid: false,
+      installedEvents: [],
+      missingEvents: [...CLAUDE_HOOK_EVENTS],
+      unexpectedFooksEvents: [],
+      commandMatches: false,
+      blocker: `Claude local settings are not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const command = defaultClaudeHookCommand("fooks");
+  const installedEvents = CLAUDE_HOOK_EVENTS.filter((event) => hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, "fooks"))) as ClaudeHookEvent[];
+  const missingEvents = CLAUDE_HOOK_EVENTS.filter((event) => !installedEvents.includes(event)) as ClaudeHookEvent[];
+  const unexpectedFooksEvents = Object.keys(settings.hooks ?? {}).filter(
+    (event) => !CLAUDE_HOOK_EVENTS.includes(event as ClaudeHookEvent) && hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, "fooks")),
+  );
+  const disabledByLocalSettings = settings.disableAllHooks === true;
+  const commandMatches = installedEvents.every((event) => hookCommandsForEvent(settings, event).some((item) => item === command));
+  const blocker = disabledByLocalSettings
+    ? "Claude hooks are disabled by local settings"
+    : unexpectedFooksEvents.length > 0
+      ? `Unsupported fooks Claude hook events are installed: ${unexpectedFooksEvents.join(", ")}`
+      : undefined;
+
+  return {
+    path: filePath,
+    exists: true,
+    ready: missingEvents.length === 0 && unexpectedFooksEvents.length === 0 && !disabledByLocalSettings,
+    valid: true,
+    installedEvents,
+    missingEvents,
+    unexpectedFooksEvents,
+    commandMatches,
+    disabledByLocalSettings,
+    blocker,
+  };
+}
+
+function blockersFrom(...items: Array<FileStatus | ClaudeManifestStatus | ClaudeHookStatus>): string[] {
   return items.flatMap((item) => (item.blocker ? [item.blocker] : []));
 }
 
@@ -131,13 +231,17 @@ export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatu
   const adapterJson = adapterJsonStatus(path.join(directory, "adapter.json"));
   const contextTemplate = contextTemplateStatus(path.join(directory, "context-template.md"));
   const manifest = manifestStatus(cwd);
-  const blockers = blockersFrom(adapterJson, contextTemplate, manifest);
-  const ready = blockers.length === 0;
+  const hooks = hookStatus(cwd);
+  const baseBlockers = blockersFrom(adapterJson, contextTemplate, manifest);
+  const blockers = blockersFrom(adapterJson, contextTemplate, manifest, hooks);
+  const handoffReady = baseBlockers.length === 0;
+  const state: ClaudeStatusState = handoffReady ? (hooks.ready ? "context-hook-ready" : hooks.blocker ? "blocked" : "handoff-ready") : "blocked";
+  const ready = state === "context-hook-ready" || state === "handoff-ready";
 
   return {
     runtime: "claude",
-    state: ready ? "handoff-ready" : "blocked",
-    mode: "manual-shared-handoff",
+    state,
+    mode: state === "context-hook-ready" ? "automatic-context-hook" : "manual-shared-handoff",
     ready,
     blockers,
     adapter: {
@@ -147,18 +251,24 @@ export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatu
       contextTemplate,
     },
     manifest,
-    nextSteps: ready
+    hooks,
+    nextSteps: state === "context-hook-ready"
       ? [
-          "Use fooks extract <file> --model-payload or the generated Claude handoff artifacts when sharing reduced context with Claude.",
-          "Do not describe this as Claude prompt interception or automatic Claude token savings.",
+          "Open Claude Code in this repo; fooks can add bounded context on SessionStart and explicit .tsx/.jsx UserPromptSubmit prompts.",
+          "Use fooks status claude to inspect project-local hook readiness.",
         ]
-      : [
-          "Run fooks attach claude or fooks setup after ensuring the Claude runtime home exists.",
-          "Use fooks extract <file> --model-payload for explicit manual handoff until Claude status becomes handoff-ready.",
-        ],
+      : handoffReady
+        ? [
+            "Run fooks install claude-hooks to enable project-local Claude context hooks.",
+            "Manual/shared handoff remains available with fooks extract <file> --model-payload.",
+          ]
+        : [
+            "Run fooks attach claude or fooks setup after ensuring the Claude runtime home exists.",
+            "Use fooks extract <file> --model-payload for explicit manual handoff until Claude status becomes ready.",
+          ],
     notes: [
-      "Claude automatic hooks are not enabled by fooks.",
-      "Claude status is a read-only handoff-artifact health check, not a runtime interception or token-savings claim.",
+      "Claude P0 uses project-local context hooks in .claude/settings.local.json only; fooks does not mutate ~/.claude/settings.json.",
+      "Claude P0 supports SessionStart/UserPromptSubmit context injection only; it does not intercept Read/tool calls or claim runtime-token savings.",
     ],
   };
 }

--- a/src/adapters/claude-status.ts
+++ b/src/adapters/claude-status.ts
@@ -254,7 +254,7 @@ export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatu
     hooks,
     nextSteps: state === "context-hook-ready"
       ? [
-          "Open Claude Code in this repo; fooks can add bounded context on SessionStart and explicit .tsx/.jsx UserPromptSubmit prompts.",
+          "Open Claude Code in this repo; fooks records/prepares the first explicit .tsx/.jsx prompt and may add bounded context on a repeated same-file UserPromptSubmit.",
           "Use fooks status claude to inspect project-local hook readiness.",
         ]
       : handoffReady
@@ -268,7 +268,7 @@ export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatu
           ],
     notes: [
       "Claude P0 uses project-local context hooks in .claude/settings.local.json only; fooks does not mutate ~/.claude/settings.json.",
-      "Claude P0 supports SessionStart/UserPromptSubmit context injection only; it does not intercept Read/tool calls or claim runtime-token savings.",
+      "Claude P0 supports project-local SessionStart/UserPromptSubmit context hooks only: first eligible frontend-file prompts are recorded/prepared, repeated same-file prompts may inject bounded context, and fooks does not intercept Read/tool calls or claim runtime-token savings.",
     ],
   };
 }

--- a/src/adapters/codex-runtime-session.ts
+++ b/src/adapters/codex-runtime-session.ts
@@ -14,7 +14,7 @@ export type CodexRuntimeSessionState = {
 };
 
 function stateRoot(cwd: string): string {
-  return path.join(cwd, ".omx", "state", "codex-runtime");
+  return path.join(cwd, ".fooks", "state", "codex-runtime");
 }
 
 function sanitizeKey(sessionKey: string): string {
@@ -42,7 +42,15 @@ export function readCodexRuntimeSession(cwd: string, sessionKey: string): CodexR
     return emptyState(sessionKey);
   }
 
-  return JSON.parse(fs.readFileSync(file, "utf8")) as CodexRuntimeSessionState;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as CodexRuntimeSessionState;
+    if (parsed.sessionKey !== sessionKey || typeof parsed.seenFiles !== "object" || parsed.seenFiles === null) {
+      return emptyState(sessionKey);
+    }
+    return parsed;
+  } catch {
+    return emptyState(sessionKey);
+  }
 }
 
 export function writeCodexRuntimeSession(cwd: string, state: CodexRuntimeSessionState): string {

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -128,7 +128,7 @@ export async function prepareExecutionContext(
   fs.writeFileSync(tempContextPath, contextContent);
 
   // Adapter contract: handoff command is abstracted, exact invocation not yet standardized
-  // This allows swapping between Codex, OMX, Claude, or other runtimes
+  // This keeps the reduced context reusable across supported coding runtimes such as Codex and Claude.
   const handoffCommand = `[runtime-adapter] ${prompt} --context ${tempContextPath}`;
 
   return {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -104,7 +104,14 @@ async function initializeProject(cwd = process.cwd()): Promise<{ config: string;
 
 type SetupState = "ready" | "partial" | "blocked";
 type RuntimeName = "codex" | "claude" | "opencode";
-type RuntimeSetupState = "automatic-ready" | "handoff-ready" | "tool-ready" | "manual-step-required" | "partial" | "blocked";
+type RuntimeSetupState =
+  | "automatic-ready"
+  | "context-hook-ready"
+  | "handoff-ready"
+  | "tool-ready"
+  | "manual-step-required"
+  | "partial"
+  | "blocked";
 
 type RuntimeReadiness = {
   runtime: RuntimeName;
@@ -237,8 +244,8 @@ function buildSetupScopeSummary(options: {
 function setupClaimBoundaries(): string[] {
   return [
     "Codex setup installs the automatic fooks hook path when Codex trust checks pass, but it does not collect Codex runtime-token telemetry.",
-    "Claude setup prepares manual/shared handoff artifacts only; it does not enable automatic hooks or prompt interception.",
-    "opencode setup prepares a manual/semi-automatic custom tool and slash command only; it does not intercept read calls or provide runtime-token telemetry.",
+    "Claude setup installs project-local context hooks for SessionStart/UserPromptSubmit when handoff artifacts and local settings are valid; it does not intercept Read/tool calls or claim runtime-token savings.",
+    "opencode setup prepares a manual/semi-automatic custom tool and slash command only; it does not intercept read calls or prove runtime-token savings.",
     "Projects without supported React .tsx/.jsx component candidates stay blocked for automatic setup instead of pretending unrelated files are ready.",
   ];
 }
@@ -276,7 +283,7 @@ function codexRuntimeReadiness(
           "Fix Codex setup blockers, then run fooks setup again.",
           "Use fooks status codex for current runtime state and inspect runtimes.codex.blockers above.",
         ],
-    notes: ["Codex is the only runtime in this setup command with an automatic hook path today."],
+    notes: ["Codex has the automatic repeated-file hook path; Claude P0 has a project-local context hook path for explicit frontend prompts."],
   };
 }
 
@@ -294,34 +301,50 @@ function blockedClaudeReadiness(blockers: string[], details: unknown = null): Ru
       "Until then, use fooks extract <file> --model-payload for explicit manual handoff.",
     ],
     notes: [
-      "Claude automatic hooks are not enabled by fooks setup.",
-      "Claude support remains manual/shared handoff oriented; this is non-fatal for Codex readiness.",
+      "Claude context hooks are project-local only when installed; no user-global Claude settings are mutated.",
+      "Claude support remains non-fatal for Codex readiness and does not claim Read interception or runtime-token savings.",
     ],
   };
 }
 
-function claudeRuntimeReadiness(attach: { runtimeProof?: { status?: string; blocker?: string } }): RuntimeReadiness {
-  if (attach.runtimeProof?.status === "passed") {
+function claudeRuntimeReadiness(
+  attach: { runtimeProof?: { status?: string; blocker?: string } } | null,
+  hooks: unknown,
+  status: { state?: RuntimeSetupState; ready?: boolean; blockers?: string[]; mode?: string } | null,
+): RuntimeReadiness {
+  if (status) {
+    const state = status.state === "context-hook-ready" || status.state === "handoff-ready" || status.state === "blocked" ? status.state : "blocked";
+    const ready = status.ready === true;
     return {
       runtime: "claude",
-      state: "handoff-ready",
-      mode: "manual-shared-handoff",
-      ready: true,
+      state,
+      mode: status.mode ?? (state === "context-hook-ready" ? "automatic-context-hook" : "manual-shared-handoff"),
+      ready,
       blocksOverall: false,
-      details: { attach },
-      blockers: [],
-      nextSteps: [
-        "Use fooks extract <file> --model-payload or the generated Claude handoff artifacts when sharing reduced context with Claude.",
-        "Do not describe this as Claude prompt interception or automatic Claude token savings.",
-      ],
+      details: { attach, hooks, status },
+      blockers: status.blockers ?? [],
+      nextSteps: ready
+        ? state === "context-hook-ready"
+          ? [
+              "Open Claude Code in this repo; fooks can add bounded context on SessionStart and explicit .tsx/.jsx UserPromptSubmit prompts.",
+              "Use fooks status claude to inspect project-local hook readiness.",
+            ]
+          : [
+              "Run fooks install claude-hooks to enable project-local Claude context hooks.",
+              "Manual/shared Claude handoff artifacts remain available through fooks extract <file> --model-payload.",
+            ]
+        : [
+            "Fix the Claude blockers, then run fooks setup or fooks install claude-hooks again.",
+            "Until then, use fooks extract <file> --model-payload for explicit manual handoff if adapter artifacts are available.",
+          ],
       notes: [
-        "Claude automatic hooks are not enabled by fooks setup.",
-        "Claude readiness means manual/shared handoff artifacts were prepared successfully.",
+        "Claude P0 context hooks are project-local only and do not mutate ~/.claude/settings.json.",
+        "Claude P0 does not intercept Read/tool calls and does not claim runtime-token savings.",
       ],
     };
   }
 
-  return blockedClaudeReadiness([attach.runtimeProof?.blocker ?? "Claude handoff proof blocked"], { attach });
+  return blockedClaudeReadiness([attach?.runtimeProof?.blocker ?? "Claude handoff proof blocked"], { attach, hooks });
 }
 
 function opencodeRuntimeReadiness(installResult: unknown): RuntimeReadiness {
@@ -409,14 +432,18 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
     { attachCodex },
     { attachClaude },
     { installCodexHookPreset },
+    { installClaudeHookPreset },
     { installOpenCodeToolPreset },
     { readCodexTrustStatus },
+    { readClaudeRuntimeStatus },
   ] = await Promise.all([
     import("../adapters/codex.js"),
     import("../adapters/claude.js"),
     import("../adapters/codex-hook-preset.js"),
+    import("../adapters/claude-hook-preset.js"),
     import("../adapters/opencode-tool-preset.js"),
     import("../adapters/codex-runtime-trust.js"),
+    import("../adapters/claude-status.js"),
   ]);
 
   const bridgeCommand = `${displayCliName} codex-runtime-hook --native-hook`;
@@ -443,9 +470,12 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 
   let claude: RuntimeReadiness;
   try {
-    claude = claudeRuntimeReadiness(attachClaude(sampleFile, cwd));
+    const claudeAttach = attachClaude(sampleFile, cwd);
+    const claudeHooks = installClaudeHookPreset(cwd, displayCliName);
+    const claudeStatus = readClaudeRuntimeStatus(cwd);
+    claude = claudeRuntimeReadiness(claudeAttach, claudeHooks, claudeStatus);
   } catch (error) {
-    claude = blockedClaudeReadiness([`Claude handoff setup failed: ${error instanceof Error ? error.message : String(error)}`]);
+    claude = blockedClaudeReadiness([`Claude setup failed: ${error instanceof Error ? error.message : String(error)}`]);
   }
 
   let opencode: RuntimeReadiness;
@@ -479,29 +509,30 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
       ? [
           "Open Codex in this repo and work normally; fooks will run through the installed Codex hooks.",
           "Use fooks status codex if you want to inspect the runtime trust state.",
-          "Claude and opencode entries under runtimes are non-fatal handoff/tool readiness summaries, not automatic hook claims.",
+          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 is context hooks only, not Read interception or token savings.",
         ]
       : [
           "Fix setup blockers, then run fooks setup again.",
           "Use fooks status codex for current runtime state and inspect the blockers field above.",
-          "Claude and opencode entries under runtimes are non-fatal handoff/tool readiness summaries, not automatic hook claims.",
+          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 is context hooks only, not Read interception or token savings.",
         ],
   };
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
       Prepare one-command readiness for supported runtimes:
-      - Codex: automatic runtime hook path when trust checks pass.
-      - Claude: manual/shared handoff artifacts only; no automatic hooks or prompt interception.
-      - opencode: manual/semi-automatic custom tool and slash command; no read interception or runtime-token telemetry claim.
+      - Codex: automatic repeated-file runtime hook path when trust checks pass.
+      - Claude: project-local context hooks for SessionStart/UserPromptSubmit; no Read interception or runtime-token claim.
+      - opencode: manual/semi-automatic custom tool and slash command; no read interception or runtime-token claim.
 
   ${displayCliName} run <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} install codex-hooks
+  ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
   ${displayCliName} codex-pre-read <file> [--json]
   ${displayCliName} status
@@ -510,6 +541,8 @@ Everyday commands:
   ${displayCliName} status cache
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
+  ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit> [--session-id <id>] [--prompt <text>] [--json]
+  ${displayCliName} claude-runtime-hook --native-hook
 
 Install: npm install -g oh-my-fooks
 CLI command: ${displayCliName}`);
@@ -596,12 +629,63 @@ function parseCodexRuntimeHookArgs(args: string[]): {
   return { nativeHook, event, prompt, sessionId, threadId, turnId };
 }
 
-async function readStdinJson(): Promise<Record<string, unknown>> {
+function parseClaudeRuntimeHookArgs(args: string[]): {
+  nativeHook: boolean;
+  event: "SessionStart" | "UserPromptSubmit";
+  prompt?: string;
+  sessionId?: string;
+} {
+  let nativeHook = false;
+  let event: "SessionStart" | "UserPromptSubmit" | undefined;
+  let prompt: string | undefined;
+  let sessionId: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--json":
+        break;
+      case "--native-hook":
+        nativeHook = true;
+        break;
+      case "--event":
+        event = args[index + 1] as typeof event;
+        index += 1;
+        break;
+      case "--prompt":
+        prompt = args[index + 1];
+        index += 1;
+        break;
+      case "--session-id":
+        sessionId = args[index + 1];
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unexpected claude-runtime-hook argument: ${arg}`);
+    }
+  }
+
+  if (nativeHook) {
+    return { nativeHook, event: "SessionStart", prompt, sessionId };
+  }
+
+  if (event !== "SessionStart" && event !== "UserPromptSubmit") {
+    throw new Error("claude-runtime-hook requires --event <SessionStart|UserPromptSubmit>");
+  }
+
+  return { nativeHook, event, prompt, sessionId };
+}
+
+async function readStdinText(): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  return Buffer.concat(chunks).toString("utf8").trim();
+}
+
+async function readStdinJson(): Promise<Record<string, unknown>> {
+  const raw = await readStdinText();
   return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
 }
 
@@ -716,12 +800,17 @@ async function run(): Promise<void> {
         print(installCodexHookPreset(displayCliName));
         return;
       }
+      if (arg1 === "claude-hooks") {
+        const { installClaudeHookPreset } = await import("../adapters/claude-hook-preset.js");
+        print({ ...installClaudeHookPreset(process.cwd(), displayCliName), command: "install claude-hooks", runtime: "claude" });
+        return;
+      }
       if (arg1 === "opencode-tool") {
         const { installOpenCodeToolPreset } = await import("../adapters/opencode-tool-preset.js");
         print(installOpenCodeToolPreset(process.cwd(), displayCliName));
         return;
       }
-      throw new Error("install expects 'codex-hooks' or 'opencode-tool'");
+      throw new Error("install expects 'codex-hooks', 'claude-hooks', or 'opencode-tool'");
     }
     case "status": {
       if (!arg1) {
@@ -774,6 +863,38 @@ async function run(): Promise<void> {
             sessionId: options.sessionId,
             threadId: options.threadId,
             turnId: options.turnId,
+          },
+          process.cwd(),
+        ),
+      );
+      return;
+    }
+    case "claude-runtime-hook": {
+      const { handleClaudeRuntimeHook } = await import("../adapters/claude-runtime-hook.js");
+      const options = parseClaudeRuntimeHookArgs(rest);
+      if (options.nativeHook) {
+        const { handleClaudeNativeHookPayload } = await import("../adapters/claude-native-hook.js");
+        const raw = await readStdinText();
+        let payload: Record<string, unknown>;
+        try {
+          payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+        } catch (error) {
+          console.error(`fooks claude-runtime-hook: invalid JSON payload: ${error instanceof Error ? error.message : String(error)}`);
+          process.exitCode = 1;
+          return;
+        }
+        const output = handleClaudeNativeHookPayload(payload, process.cwd());
+        if (output) {
+          print(output);
+        }
+        return;
+      }
+      print(
+        handleClaudeRuntimeHook(
+          {
+            hookEventName: options.event,
+            prompt: options.prompt,
+            sessionId: options.sessionId,
           },
           process.cwd(),
         ),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -362,7 +362,7 @@ function opencodeRuntimeReadiness(installResult: unknown): RuntimeReadiness {
     ],
     notes: [
       "opencode setup does not intercept read calls.",
-      "opencode setup does not provide automatic runtime-token telemetry.",
+      "opencode setup does not prove automatic runtime-token savings.",
     ],
   };
 }
@@ -382,7 +382,7 @@ function manualOpenCodeReadiness(blockers: string[], details: unknown = null): R
     ],
     notes: [
       "opencode setup does not intercept read calls.",
-      "opencode setup does not provide automatic runtime-token telemetry.",
+      "opencode setup does not prove automatic runtime-token savings.",
     ],
   };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -244,7 +244,7 @@ function buildSetupScopeSummary(options: {
 function setupClaimBoundaries(): string[] {
   return [
     "Codex setup installs the automatic fooks hook path when Codex trust checks pass, but it does not collect Codex runtime-token telemetry.",
-    "Claude setup installs project-local context hooks for SessionStart/UserPromptSubmit when handoff artifacts and local settings are valid; it does not intercept Read/tool calls or claim runtime-token savings.",
+    "Claude setup installs project-local context hooks for SessionStart/UserPromptSubmit when handoff artifacts and local settings are valid; first eligible frontend-file prompts are recorded/prepared and repeated same-file prompts may receive bounded context; it does not intercept Read/tool calls or claim runtime-token savings.",
     "opencode setup prepares a manual/semi-automatic custom tool and slash command only; it does not intercept read calls or prove runtime-token savings.",
     "Projects without supported React .tsx/.jsx component candidates stay blocked for automatic setup instead of pretending unrelated files are ready.",
   ];
@@ -283,7 +283,7 @@ function codexRuntimeReadiness(
           "Fix Codex setup blockers, then run fooks setup again.",
           "Use fooks status codex for current runtime state and inspect runtimes.codex.blockers above.",
         ],
-    notes: ["Codex has the automatic repeated-file hook path; Claude P0 has a project-local context hook path for explicit frontend prompts."],
+    notes: ["Codex has the automatic repeated-file hook path; Claude P0 mirrors the explicit frontend-file record-then-inject flow through project-local context hooks."],
   };
 }
 
@@ -326,7 +326,7 @@ function claudeRuntimeReadiness(
       nextSteps: ready
         ? state === "context-hook-ready"
           ? [
-              "Open Claude Code in this repo; fooks can add bounded context on SessionStart and explicit .tsx/.jsx UserPromptSubmit prompts.",
+              "Open Claude Code in this repo; fooks records/prepares the first explicit .tsx/.jsx prompt and may add bounded context on a repeated same-file UserPromptSubmit.",
               "Use fooks status claude to inspect project-local hook readiness.",
             ]
           : [
@@ -339,7 +339,7 @@ function claudeRuntimeReadiness(
           ],
       notes: [
         "Claude P0 context hooks are project-local only and do not mutate ~/.claude/settings.json.",
-        "Claude P0 does not intercept Read/tool calls and does not claim runtime-token savings.",
+        "Claude P0 records/prepares first eligible frontend-file prompts, may inject bounded context on repeated same-file prompts, and does not intercept Read/tool calls or claim runtime-token savings.",
       ],
     };
   }
@@ -509,12 +509,12 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
       ? [
           "Open Codex in this repo and work normally; fooks will run through the installed Codex hooks.",
           "Use fooks status codex if you want to inspect the runtime trust state.",
-          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 is context hooks only, not Read interception or token savings.",
+          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 records/prepares first prompts, then uses repeated same-file context hooks only; it is not Read interception or token savings.",
         ]
       : [
           "Fix setup blockers, then run fooks setup again.",
           "Use fooks status codex for current runtime state and inspect the blockers field above.",
-          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 is context hooks only, not Read interception or token savings.",
+          "Claude and opencode entries under runtimes are non-fatal readiness summaries; Claude P0 records/prepares first prompts, then uses repeated same-file context hooks only; it is not Read interception or token savings.",
         ],
   };
 }
@@ -526,7 +526,7 @@ Everyday commands:
   ${displayCliName} setup
       Prepare one-command readiness for supported runtimes:
       - Codex: automatic repeated-file runtime hook path when trust checks pass.
-      - Claude: project-local context hooks for SessionStart/UserPromptSubmit; no Read interception or runtime-token claim.
+      - Claude: project-local context hooks; first eligible frontend-file prompts are recorded/prepared, repeated same-file prompts may receive bounded context; no Read interception or runtime-token claim.
       - opencode: manual/semi-automatic custom tool and slash command; no read interception or runtime-token claim.
 
   ${displayCliName} run <prompt>

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { scanProject } from "../core/scan.js";
 import { extractFile } from "../core/extract.js";
 import { decideMode } from "../core/decide.js";
@@ -14,7 +13,7 @@ import { readCodexTrustStatus } from "../adapters/codex-runtime-trust.js";
 export interface RunOptions {
   prompt: string;
   mode?: "auto" | "raw" | "hybrid" | "compressed";
-  runner?: "auto" | "codex" | "omx";
+  runner?: "auto" | "codex" | "claude";
   verbose?: boolean;
 }
 
@@ -73,7 +72,7 @@ function printSharedHandoff(executionContext: {
   console.log(`Inspect the shared context: cat ${quotedContextPath}`);
   console.log(`Codex: start \`codex\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
   console.log(`Claude: start \`claude\` in this repo, then paste your prompt and the context from ${quotedContextPath}`);
-  console.log("\nNext: Open this context with your preferred runtime (codex, claude, omx, etc.)");
+  console.log("\nNext: Open this context with your preferred runtime (codex or claude).");
   console.log(`Context file: ${executionContext.contextPath}`);
   console.log("======================\n");
 }
@@ -122,7 +121,7 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
     const runner = (options.runner === "auto" || !options.runner) ? detectRunner() : options.runner;
 
     let executionContext;
-    if (runner === "codex" || runner === "omx") {
+    if (runner === "codex" || runner === "claude") {
       executionContext = await prepareExecutionContext(options.prompt, processedFiles, cwd, selection.policy);
       printSharedHandoff(executionContext);
     }
@@ -185,18 +184,9 @@ function hasCodexAuth(): boolean {
   return fs.existsSync(path.join(codexHome(), "auth.json"));
 }
 
-function commandExists(command: string): boolean {
-  const result = spawnSync(command, ["--version"], { stdio: "ignore" });
-  return !result.error;
-}
-
-export function detectRunner(): "codex" | "omx" {
+export function detectRunner(): "codex" {
   if (hasCodexAuth()) {
     return "codex";
-  }
-
-  if (commandExists("omx")) {
-    return "omx";
   }
 
   return "codex";

--- a/src/core/context-policy.ts
+++ b/src/core/context-policy.ts
@@ -138,7 +138,7 @@ export function classifyPromptContext(prompt: string, cwd = process.cwd()): Prom
 
 export function resolvePromptFileContext(prompt: string, cwd = process.cwd()): { filePath?: string; source: "prompt-target" | "none"; policy: PromptContextPolicy } {
   const policy = classifyPromptContext(prompt, cwd);
-  const filePath = policy.targets[0]?.filePath;
+  const filePath = policy.targets.find((target) => target.exists)?.filePath ?? policy.targets[0]?.filePath;
   return filePath ? { filePath, source: "prompt-target", policy } : { source: "none", policy };
 }
 

--- a/src/core/session-metrics.ts
+++ b/src/core/session-metrics.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { sessionEventsPath, sessionSummaryPath, sessionsSummaryPath, sanitizeDataKey } from "./paths";
-import type { CodexRuntimeHookInput, ContextMode } from "./schema";
+import type { ContextMode } from "./schema";
 
 export const FOOKS_SESSION_METRICS_SCHEMA_VERSION = 1;
 export const FOOKS_SESSION_METRIC_TIER = "estimated" as const;
@@ -9,9 +9,15 @@ export const ESTIMATED_BYTES_PER_TOKEN = 4;
 export const FOOKS_METRIC_CLAIM_BOUNDARY =
   "Estimated local context-size telemetry only; values are not provider billing tokens, provider costs, or a ccusage replacement.";
 
+export type FooksMetricRuntime = "codex" | "claude";
+export type FooksMeasurementSource = "automatic-hook" | "project-local-context-hook" | "manual-handoff" | "local-simulation";
 type MetricTier = typeof FOOKS_SESSION_METRIC_TIER;
-type HookEventName = CodexRuntimeHookInput["hookEventName"];
 export type FooksSessionMetricAction = "inject" | "fallback" | "record" | "noop";
+
+export type FooksMetricIdentityOptions = {
+  runtime?: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+};
 
 export type FooksEstimatedUsage = {
   originalEstimatedBytes: number;
@@ -23,35 +29,7 @@ export type FooksEstimatedUsage = {
   savingsRatio: number;
 };
 
-export type FooksSessionMetricEvent = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  timestamp: string;
-  runtime: "codex";
-  sessionKey: string;
-  hookEventName: HookEventName;
-  action: FooksSessionMetricAction;
-  filePath?: string;
-  reasons: string[];
-  contextMode?: ContextMode;
-  contextModeReason?: string;
-  fallbackReason?: string;
-  metricTier: MetricTier;
-  comparableForSavings: boolean;
-  estimated: FooksEstimatedUsage;
-  observedOpportunity?: {
-    originalEstimatedBytes: number;
-    originalEstimatedTokens: number;
-  };
-};
-
-export type FooksSessionMetricSummary = {
-  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
-  metricTier: MetricTier;
-  sessionKey: string;
-  sanitizedSessionKey: string;
-  startedAt: string;
-  updatedAt: string;
-  stoppedAt?: string;
+export type FooksMetricAggregate = {
   eventCount: number;
   comparableEventCount: number;
   injectCount: number;
@@ -62,11 +40,61 @@ export type FooksSessionMetricSummary = {
   observedOriginalEstimatedBytes: number;
   observedOriginalEstimatedTokens: number;
   totals: FooksEstimatedUsage;
+};
+
+export type FooksMetricBreakdown = {
+  byRuntime: Partial<Record<FooksMetricRuntime, FooksMetricAggregate>>;
+  byMeasurementSource: Partial<Record<FooksMeasurementSource, FooksMetricAggregate>>;
+  byRuntimeAndSource: Record<string, FooksMetricAggregate>;
+};
+
+export type FooksSessionMetricEvent = {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  timestamp: string;
+  metricTier: MetricTier;
+  claimBoundary: string;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  eventName: string;
+  hookEventName?: string;
+  action: FooksSessionMetricAction;
+  filePath?: string;
+  reasons: string[];
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  fallbackReason?: string;
+  comparableForSavings: boolean;
+  estimated: FooksEstimatedUsage;
+  observedOpportunity?: {
+    originalEstimatedBytes: number;
+    originalEstimatedTokens: number;
+  };
+};
+
+export type FooksSessionMetricSummary = FooksMetricAggregate & {
+  schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
+  metricTier: MetricTier;
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+  sessionKey: string;
+  sanitizedSessionKey: string;
+  startedAt: string;
+  updatedAt: string;
+  stoppedAt?: string;
   claimBoundary: string;
 };
 
 export type FooksSessionMetricContribution = Pick<
   FooksSessionMetricSummary,
+  | "runtime"
+  | "measurementSource"
+  | "rawSessionKey"
+  | "metricSessionKey"
   | "sessionKey"
   | "sanitizedSessionKey"
   | "startedAt"
@@ -84,23 +112,14 @@ export type FooksSessionMetricContribution = Pick<
   | "totals"
 >;
 
-export type FooksProjectMetricSummaryFile = {
+export type FooksProjectMetricSummaryFile = FooksMetricAggregate & {
   schemaVersion: typeof FOOKS_SESSION_METRICS_SCHEMA_VERSION;
   metricTier: MetricTier;
   updatedAt: string;
   sessionCount: number;
-  eventCount: number;
-  comparableEventCount: number;
-  injectCount: number;
-  fallbackCount: number;
-  recordCount: number;
-  noopCount: number;
-  observedOpportunityCount: number;
-  observedOriginalEstimatedBytes: number;
-  observedOriginalEstimatedTokens: number;
-  totals: FooksEstimatedUsage;
   latestSessionKeys: string[];
   sessions: Record<string, FooksSessionMetricContribution>;
+  breakdown: FooksMetricBreakdown;
   claimBoundary: string;
 };
 
@@ -109,8 +128,10 @@ export type FooksProjectMetricStatus = Omit<FooksProjectMetricSummaryFile, "sess
 };
 
 export type RecordFooksSessionMetricInput = {
-  runtime: "codex";
-  hookEventName: HookEventName;
+  runtime: FooksMetricRuntime;
+  measurementSource?: FooksMeasurementSource;
+  eventName?: string;
+  hookEventName?: string;
   action: FooksSessionMetricAction;
   filePath?: string;
   reasons?: string[];
@@ -123,8 +144,60 @@ export type RecordFooksSessionMetricInput = {
   observedOriginalEstimatedBytes?: number;
 };
 
+type MetricIdentity = {
+  runtime: FooksMetricRuntime;
+  measurementSource: FooksMeasurementSource;
+  rawSessionKey: string;
+  metricSessionKey: string;
+};
+
+const MEASUREMENT_SOURCES: FooksMeasurementSource[] = ["automatic-hook", "project-local-context-hook", "manual-handoff", "local-simulation"];
+const RUNTIMES: FooksMetricRuntime[] = ["codex", "claude"];
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function defaultMeasurementSource(runtime: FooksMetricRuntime): FooksMeasurementSource {
+  return runtime === "claude" ? "project-local-context-hook" : "automatic-hook";
+}
+
+export function metricSessionKey(rawSessionKey: string, options: Required<FooksMetricIdentityOptions>): string {
+  return `${options.runtime}:${options.measurementSource}:${rawSessionKey}`;
+}
+
+function parseMetricSessionKey(value: string): MetricIdentity | null {
+  for (const runtime of RUNTIMES) {
+    for (const measurementSource of MEASUREMENT_SOURCES) {
+      const prefix = `${runtime}:${measurementSource}:`;
+      if (value.startsWith(prefix)) {
+        const rawSessionKey = value.slice(prefix.length) || "default-session";
+        return {
+          runtime,
+          measurementSource,
+          rawSessionKey,
+          metricSessionKey: value,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function resolveMetricIdentity(rawOrMetricSessionKey: string, options: FooksMetricIdentityOptions = {}): MetricIdentity {
+  if (!options.runtime && !options.measurementSource) {
+    const parsed = parseMetricSessionKey(rawOrMetricSessionKey);
+    if (parsed) return parsed;
+  }
+  const runtime = options.runtime ?? "codex";
+  const measurementSource = options.measurementSource ?? defaultMeasurementSource(runtime);
+  const rawSessionKey = rawOrMetricSessionKey || "default-session";
+  return {
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: metricSessionKey(rawSessionKey, { runtime, measurementSource }),
+  };
 }
 
 function nonNegativeInteger(value: number | undefined): number {
@@ -168,6 +241,21 @@ function emptyUsage(): FooksEstimatedUsage {
   };
 }
 
+function emptyAggregate(): FooksMetricAggregate {
+  return {
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: emptyUsage(),
+  };
+}
+
 function usageFromBytes(originalBytes: number, actualBytes: number): FooksEstimatedUsage {
   const originalEstimatedBytes = nonNegativeInteger(originalBytes);
   const actualEstimatedBytes = nonNegativeInteger(actualBytes);
@@ -205,6 +293,40 @@ function addUsage(left: FooksEstimatedUsage, right: FooksEstimatedUsage): FooksE
   });
 }
 
+function addAggregate(left: FooksMetricAggregate, right: FooksMetricAggregate): FooksMetricAggregate {
+  return {
+    eventCount: left.eventCount + right.eventCount,
+    comparableEventCount: left.comparableEventCount + right.comparableEventCount,
+    injectCount: left.injectCount + right.injectCount,
+    fallbackCount: left.fallbackCount + right.fallbackCount,
+    recordCount: left.recordCount + right.recordCount,
+    noopCount: left.noopCount + right.noopCount,
+    observedOpportunityCount: left.observedOpportunityCount + right.observedOpportunityCount,
+    observedOriginalEstimatedBytes: left.observedOriginalEstimatedBytes + right.observedOriginalEstimatedBytes,
+    observedOriginalEstimatedTokens: left.observedOriginalEstimatedTokens + right.observedOriginalEstimatedTokens,
+    totals: addUsage(left.totals, right.totals),
+  };
+}
+
+function aggregateFromContribution(contribution: FooksSessionMetricContribution): FooksMetricAggregate {
+  return {
+    eventCount: nonNegativeInteger(contribution.eventCount),
+    comparableEventCount: nonNegativeInteger(contribution.comparableEventCount),
+    injectCount: nonNegativeInteger(contribution.injectCount),
+    fallbackCount: nonNegativeInteger(contribution.fallbackCount),
+    recordCount: nonNegativeInteger(contribution.recordCount),
+    noopCount: nonNegativeInteger(contribution.noopCount),
+    observedOpportunityCount: nonNegativeInteger(contribution.observedOpportunityCount),
+    observedOriginalEstimatedBytes: nonNegativeInteger(contribution.observedOriginalEstimatedBytes),
+    observedOriginalEstimatedTokens: nonNegativeInteger(contribution.observedOriginalEstimatedTokens),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
+function addBreakdownAggregate<T extends string>(target: Partial<Record<T, FooksMetricAggregate>>, key: T, aggregate: FooksMetricAggregate): void {
+  target[key] = addAggregate(target[key] ?? emptyAggregate(), aggregate);
+}
+
 function truncateString(value: string, maxLength = 240): string {
   return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
 }
@@ -231,25 +353,28 @@ function writeJsonAtomic(file: string, value: unknown): void {
   fs.renameSync(tmp, file);
 }
 
-function emptySessionSummary(sessionKey: string, timestamp = nowIso()): FooksSessionMetricSummary {
+function emptySessionSummary(rawSessionKey: string, identity = resolveMetricIdentity(rawSessionKey), timestamp = nowIso()): FooksSessionMetricSummary {
   return {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     metricTier: FOOKS_SESSION_METRIC_TIER,
-    sessionKey,
-    sanitizedSessionKey: sanitizeDataKey(sessionKey),
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(identity.metricSessionKey),
     startedAt: timestamp,
     updatedAt: timestamp,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+function emptyBreakdown(): FooksMetricBreakdown {
+  return {
+    byRuntime: {},
+    byMeasurementSource: {},
+    byRuntimeAndSource: {},
   };
 }
 
@@ -259,18 +384,10 @@ function emptyProjectSummaryFile(timestamp = nowIso()): FooksProjectMetricSummar
     metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: 0,
-    eventCount: 0,
-    comparableEventCount: 0,
-    injectCount: 0,
-    fallbackCount: 0,
-    recordCount: 0,
-    noopCount: 0,
-    observedOpportunityCount: 0,
-    observedOriginalEstimatedBytes: 0,
-    observedOriginalEstimatedTokens: 0,
-    totals: emptyUsage(),
+    ...emptyAggregate(),
     latestSessionKeys: [],
     sessions: {},
+    breakdown: emptyBreakdown(),
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
@@ -283,14 +400,41 @@ function isProjectSummaryFile(value: FooksProjectMetricSummaryFile | null): valu
   return Boolean(value && value.schemaVersion === FOOKS_SESSION_METRICS_SCHEMA_VERSION && value.metricTier === FOOKS_SESSION_METRIC_TIER && value.sessions);
 }
 
-export function readSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const summary = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  return isSessionSummary(summary) ? summary : emptySessionSummary(sessionKey);
+function normalizeSessionSummary(summary: FooksSessionMetricSummary, identity: MetricIdentity): FooksSessionMetricSummary {
+  const normalizedIdentity = {
+    runtime: summary.runtime ?? identity.runtime,
+    measurementSource: summary.measurementSource ?? identity.measurementSource,
+    rawSessionKey: summary.rawSessionKey ?? identity.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey ?? identity.metricSessionKey,
+  };
+  return {
+    ...emptySessionSummary(normalizedIdentity.rawSessionKey, normalizedIdentity, summary.startedAt),
+    ...summary,
+    runtime: normalizedIdentity.runtime,
+    measurementSource: normalizedIdentity.measurementSource,
+    rawSessionKey: normalizedIdentity.rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+  };
+}
+
+export function readSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const summary =
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey)) ??
+    readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
+  return isSessionSummary(summary) ? normalizeSessionSummary(summary, identity) : emptySessionSummary(identity.rawSessionKey, identity);
 }
 
 function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessionMetricContribution {
   return {
-    sessionKey: summary.sessionKey,
+    runtime: summary.runtime,
+    measurementSource: summary.measurementSource,
+    rawSessionKey: summary.rawSessionKey,
+    metricSessionKey: summary.metricSessionKey,
+    sessionKey: summary.metricSessionKey,
     sanitizedSessionKey: summary.sanitizedSessionKey,
     startedAt: summary.startedAt,
     updatedAt: summary.updatedAt,
@@ -308,38 +452,65 @@ function contributionFromSession(summary: FooksSessionMetricSummary): FooksSessi
   };
 }
 
+function normalizeContribution(contribution: FooksSessionMetricContribution): FooksSessionMetricContribution {
+  const seedKey = contribution.metricSessionKey ?? contribution.sessionKey ?? contribution.rawSessionKey ?? "default-session";
+  const seedIdentity = contribution.metricSessionKey
+    ? (parseMetricSessionKey(contribution.metricSessionKey) ?? resolveMetricIdentity(contribution.metricSessionKey))
+    : resolveMetricIdentity(seedKey, {
+        runtime: contribution.runtime,
+        measurementSource: contribution.measurementSource,
+      });
+  const runtime = contribution.runtime ?? seedIdentity.runtime;
+  const measurementSource = contribution.measurementSource ?? seedIdentity.measurementSource;
+  const rawSessionKey = contribution.rawSessionKey ?? seedIdentity.rawSessionKey;
+  const normalizedIdentity = resolveMetricIdentity(rawSessionKey, { runtime, measurementSource });
+  return {
+    ...contribution,
+    runtime,
+    measurementSource,
+    rawSessionKey,
+    metricSessionKey: normalizedIdentity.metricSessionKey,
+    sessionKey: normalizedIdentity.metricSessionKey,
+    sanitizedSessionKey: sanitizeDataKey(normalizedIdentity.metricSessionKey),
+    totals: contribution.totals ?? emptyUsage(),
+  };
+}
+
 function readProjectSummaryFile(cwd: string): FooksProjectMetricSummaryFile {
   const summary = readJsonFile<FooksProjectMetricSummaryFile>(sessionsSummaryPath(cwd));
-  return isProjectSummaryFile(summary) ? summary : emptyProjectSummaryFile();
+  return isProjectSummaryFile(summary) ? recomputeProjectSummaryFile(summary) : emptyProjectSummaryFile();
 }
 
 function recomputeProjectSummaryFile(summary: FooksProjectMetricSummaryFile, timestamp = nowIso()): FooksProjectMetricSummaryFile {
-  const contributions = Object.values(summary.sessions).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
-  let totals = emptyUsage();
+  const contributions = Object.values(summary.sessions).map(normalizeContribution).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  let aggregate = emptyAggregate();
+  const breakdown = emptyBreakdown();
   for (const contribution of contributions) {
-    totals = addUsage(totals, contribution.totals);
+    const contributionAggregate = aggregateFromContribution(contribution);
+    aggregate = addAggregate(aggregate, contributionAggregate);
+    addBreakdownAggregate(breakdown.byRuntime, contribution.runtime, contributionAggregate);
+    addBreakdownAggregate(breakdown.byMeasurementSource, contribution.measurementSource, contributionAggregate);
+    breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] = addAggregate(
+      breakdown.byRuntimeAndSource[`${contribution.runtime}:${contribution.measurementSource}`] ?? emptyAggregate(),
+      contributionAggregate,
+    );
   }
   return {
     ...summary,
+    schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
     updatedAt: timestamp,
     sessionCount: contributions.length,
-    eventCount: contributions.reduce((total, contribution) => total + contribution.eventCount, 0),
-    comparableEventCount: contributions.reduce((total, contribution) => total + contribution.comparableEventCount, 0),
-    injectCount: contributions.reduce((total, contribution) => total + contribution.injectCount, 0),
-    fallbackCount: contributions.reduce((total, contribution) => total + contribution.fallbackCount, 0),
-    recordCount: contributions.reduce((total, contribution) => total + contribution.recordCount, 0),
-    noopCount: contributions.reduce((total, contribution) => total + contribution.noopCount, 0),
-    observedOpportunityCount: contributions.reduce((total, contribution) => total + contribution.observedOpportunityCount, 0),
-    observedOriginalEstimatedBytes: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedBytes, 0),
-    observedOriginalEstimatedTokens: contributions.reduce((total, contribution) => total + contribution.observedOriginalEstimatedTokens, 0),
-    totals,
-    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.sessionKey),
+    ...aggregate,
+    latestSessionKeys: contributions.slice(0, 20).map((contribution) => contribution.metricSessionKey),
+    sessions: Object.fromEntries(contributions.map((contribution) => [contribution.sanitizedSessionKey, contribution])),
+    breakdown,
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
 }
 
-export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string): FooksProjectMetricStatus {
-  const sessionSummary = readSessionMetricSummary(cwd, sessionKey);
+export function refreshProjectMetricSummaryFromSession(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksProjectMetricStatus {
+  const sessionSummary = readSessionMetricSummary(cwd, sessionKey, options);
   const projectSummary = readProjectSummaryFile(cwd);
   projectSummary.sessions[sessionSummary.sanitizedSessionKey] = contributionFromSession(sessionSummary);
   const updated = recomputeProjectSummaryFile(projectSummary);
@@ -360,36 +531,39 @@ export function readProjectMetricSummary(cwd = process.cwd()): FooksProjectMetri
 }
 
 function writeSessionSummary(cwd: string, summary: FooksSessionMetricSummary): void {
-  writeJsonAtomic(sessionSummaryPath(cwd, summary.sessionKey), summary);
+  writeJsonAtomic(sessionSummaryPath(cwd, summary.metricSessionKey), summary);
 }
 
-function appendSessionEvent(cwd: string, sessionKey: string, event: FooksSessionMetricEvent): void {
-  const file = sessionEventsPath(cwd, sessionKey);
+function appendSessionEvent(cwd: string, metricSessionKeyValue: string, event: FooksSessionMetricEvent): void {
+  const file = sessionEventsPath(cwd, metricSessionKeyValue);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.appendFileSync(file, `${JSON.stringify(event)}\n`);
 }
 
-export function initializeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
-  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, sessionKey));
-  const summary = isSessionSummary(existing) ? existing : emptySessionSummary(sessionKey);
+export function initializeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
+  const existing = readJsonFile<FooksSessionMetricSummary>(sessionSummaryPath(cwd, identity.metricSessionKey));
+  const summary = isSessionSummary(existing) ? normalizeSessionSummary(existing, identity) : emptySessionSummary(identity.rawSessionKey, identity);
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
-export function finalizeSessionMetricSummary(cwd: string, sessionKey: string): FooksSessionMetricSummary {
+export function finalizeSessionMetricSummary(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, options);
   const timestamp = nowIso();
   const summary = {
-    ...readSessionMetricSummary(cwd, sessionKey),
+    ...readSessionMetricSummary(cwd, identity.metricSessionKey),
     updatedAt: timestamp,
     stoppedAt: timestamp,
   } satisfies FooksSessionMetricSummary;
   writeSessionSummary(cwd, summary);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return summary;
 }
 
 export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, input: RecordFooksSessionMetricInput): FooksSessionMetricSummary {
+  const identity = resolveMetricIdentity(sessionKey, { runtime: input.runtime, measurementSource: input.measurementSource });
   const timestamp = nowIso();
   const comparableForSavings = Boolean(input.comparableForSavings);
   const originalBytes = comparableForSavings ? nonNegativeInteger(input.originalEstimatedBytes) : 0;
@@ -397,11 +571,18 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
   const eventUsage = comparableForSavings ? usageFromBytes(originalBytes, actualBytes) : emptyUsage();
   const observedOriginalEstimatedBytes = nonNegativeInteger(input.observedOriginalEstimatedBytes ?? input.originalEstimatedBytes);
   const observedOpportunity = !comparableForSavings && observedOriginalEstimatedBytes > 0;
+  const eventName = input.eventName ?? input.hookEventName ?? "unknown";
   const event: FooksSessionMetricEvent = {
     schemaVersion: FOOKS_SESSION_METRICS_SCHEMA_VERSION,
     timestamp,
-    runtime: input.runtime,
-    sessionKey,
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
+    runtime: identity.runtime,
+    measurementSource: identity.measurementSource,
+    rawSessionKey: identity.rawSessionKey,
+    metricSessionKey: identity.metricSessionKey,
+    sessionKey: identity.metricSessionKey,
+    eventName,
     hookEventName: input.hookEventName,
     action: input.action,
     filePath: input.filePath,
@@ -409,7 +590,6 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     contextMode: input.contextMode,
     contextModeReason: input.contextModeReason ? truncateString(input.contextModeReason) : undefined,
     fallbackReason: input.fallbackReason ? truncateString(input.fallbackReason) : undefined,
-    metricTier: FOOKS_SESSION_METRIC_TIER,
     comparableForSavings,
     estimated: eventUsage,
     observedOpportunity: observedOpportunity
@@ -420,9 +600,9 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
       : undefined,
   };
 
-  appendSessionEvent(cwd, sessionKey, event);
+  appendSessionEvent(cwd, identity.metricSessionKey, event);
 
-  const summary = readSessionMetricSummary(cwd, sessionKey);
+  const summary = readSessionMetricSummary(cwd, identity.metricSessionKey);
   const updated: FooksSessionMetricSummary = {
     ...summary,
     updatedAt: timestamp,
@@ -440,21 +620,21 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     claimBoundary: FOOKS_METRIC_CLAIM_BOUNDARY,
   };
   writeSessionSummary(cwd, updated);
-  refreshProjectMetricSummaryFromSession(cwd, sessionKey);
+  refreshProjectMetricSummaryFromSession(cwd, identity.metricSessionKey);
   return updated;
 }
 
-export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function initializeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    initializeSessionMetricSummary(cwd, sessionKey);
+    initializeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }
 }
 
-export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string): void {
+export function finalizeSessionMetricSummarySafe(cwd: string, sessionKey: string, options: FooksMetricIdentityOptions = {}): void {
   try {
-    finalizeSessionMetricSummary(cwd, sessionKey);
+    finalizeSessionMetricSummary(cwd, sessionKey, options);
   } catch {
     // Metrics are observational only; hook behavior must not depend on telemetry writes.
   }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -201,7 +201,7 @@ test("detectRunner prefers codex when auth.json is present", () => {
   });
 });
 
-test("detectRunner falls back to omx when codex auth is absent and omx is available", () => {
+test("detectRunner keeps codex as the product fallback even when omx is available", () => {
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-bin-"));
   const omxPath = path.join(binDir, "omx");
@@ -209,7 +209,7 @@ test("detectRunner falls back to omx when codex auth is absent and omx is availa
   fs.chmodSync(omxPath, 0o755);
 
   withEnv({ FOOKS_CODEX_HOME: codexHome, PATH: binDir }, () => {
-    assert.equal(detectRunner(), "omx");
+    assert.equal(detectRunner(), "codex");
   });
 });
 
@@ -504,7 +504,7 @@ test("cli run keeps exact-file prompts to one light context file", () => {
   assert.match(output, /Inspect the shared context: cat /);
   assert.match(output, /Codex: start `codex` in this repo, then paste your prompt and the context from .*temp-context\.md/);
   assert.match(output, /Claude: start `claude` in this repo, then paste your prompt and the context from .*temp-context\.md/);
-  assert.match(output, /preferred runtime \(codex, claude, omx, etc\.\)/);
+  assert.match(output, /preferred runtime \(codex or claude\)/);
   assert.match(output, /estimated extraction opportunity \d+%/);
   assert.doesNotMatch(output, /\d+% smaller/);
   assert.doesNotMatch(output, /Detected runner:/);
@@ -531,7 +531,7 @@ test("cli run gives direct no-op guidance for new or missing exact-file targets"
   assert.match(output, /Metadata-only context file: .*temp-context\.md/);
   assert.doesNotMatch(output, /Inspect the shared context: cat /);
   assert.doesNotMatch(output, /then paste your prompt and the context from/);
-  assert.doesNotMatch(output, /preferred runtime \(codex, claude, omx, etc\.\)/);
+  assert.doesNotMatch(output, /preferred runtime \(codex or claude\)/);
   const context = fs.readFileSync(path.join(tempDir, ".fooks", "temp-context.md"), "utf8");
   assert.match(context, /"contextMode":"no-op"/);
   assert.doesNotMatch(context, /## src\/components\/NewPanel\.tsx/);
@@ -567,6 +567,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   const sessionId = `hook-repeat-${Date.now()}`;
   const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
   assert.equal(start.action, "noop");
+  assert.match(start.statePath, /\.fooks\/state\/codex-runtime/);
   assert.ok(fs.existsSync(codexRuntimeSessionPath(repoRoot, sessionId)));
 
   const first = handleCodexRuntimeHook(
@@ -582,6 +583,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(first.contextMode, "no-op");
   assert.equal(first.promptSpecificity, "exact-file");
   assert.equal(first.additionalContext, undefined);
+  assert.match(first.statePath, /\.fooks\/state\/codex-runtime/);
 
   const second = handleCodexRuntimeHook(
     {
@@ -602,6 +604,18 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.additionalContext.includes("#fooks-full-read"), false);
   assert.equal(second.additionalContext.includes("#fooks-disable-pre-read"), false);
   assert.equal(second.debug.repeatedFile, true);
+
+  fs.writeFileSync(second.statePath, "{not-json");
+  const afterCorruptState = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Again, update fixtures/compressed/FormSection.tsx",
+    },
+    repoRoot,
+  );
+  assert.equal(afterCorruptState.action, "record");
+  assert.equal(afterCorruptState.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
 });
 
 test("bare status reports fast estimated session savings without exposing session contribution internals", () => {
@@ -1594,26 +1608,114 @@ test("install claude-hooks reports malformed local settings without overwriting"
   assert.equal(fs.readFileSync(localSettings, "utf8"), "{not-json");
 });
 
-test("claude runtime hook injects on first eligible prompt and no-ops unsupported prompts", () => {
+test("claude runtime hook records first eligible prompt, injects repeated same-file prompt, and no-ops unsupported prompts", () => {
   const tempDir = makeTempProject();
-  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: "claude-start" }, tempDir);
+  const sessionId = "claude-repeated-flow";
+  const target = path.join("src", "components", "FormSection.tsx");
+  const otherTarget = path.join("src", "components", "SimpleButton.tsx");
+  const readSeenCount = (statePath, filePath) => JSON.parse(fs.readFileSync(statePath, "utf8")).seenFiles[filePath]?.seenCount;
+
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
   assert.equal(start.action, "inject");
   assert.ok(start.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
   assert.match(start.additionalContext, /does not intercept Claude Read\/tool calls/);
+  assert.match(start.additionalContext, /records\/prepares/);
+  assert.match(start.statePath, /\.fooks\/state\/claude-runtime/);
+  assert.deepEqual(JSON.parse(fs.readFileSync(start.statePath, "utf8")).seenFiles, {});
 
-  const prompt = handleClaudeRuntimeHook(
+  const first = handleClaudeRuntimeHook(
     {
       hookEventName: "UserPromptSubmit",
-      sessionId: "claude-first",
+      sessionId,
       prompt: "Explain src/components/FormSection.tsx",
     },
     tempDir,
   );
-  assert.equal(prompt.action, "inject");
-  assert.equal(prompt.filePath, path.join("src", "components", "FormSection.tsx"));
-  assert.ok(prompt.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
-  assert.match(prompt.additionalContext, /fooks: Claude context hook/);
-  assert.match(prompt.additionalContext, /src\/components\/FormSection\.tsx/);
+  assert.equal(first.action, "record");
+  assert.equal(first.filePath, target);
+  assert.equal(first.additionalContext, undefined);
+  assert.equal(first.contextMode, "no-op");
+  assert.match(first.statePath, /\.fooks\/state\/claude-runtime/);
+  assert.equal(first.debug.eligible, true);
+  assert.equal(first.debug.repeatedFile, false);
+  assert.equal(readSeenCount(first.statePath, target), 1);
+
+  const second = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Again, explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(second.action, "inject");
+  assert.equal(second.filePath, target);
+  assert.ok(second.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+  assert.match(second.additionalContext, /fooks: Claude context hook/);
+  assert.match(second.additionalContext, /src\/components\/FormSection\.tsx/);
+  assert.doesNotMatch(second.additionalContext, /Claude Read interception is enabled/i);
+  assert.doesNotMatch(second.additionalContext, /Claude runtime-token savings are enabled/i);
+  assert.equal(second.debug.repeatedFile, true);
+  assert.equal(readSeenCount(second.statePath, target), 2);
+
+  const differentFile = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Explain src/components/SimpleButton.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(differentFile.action, "record");
+  assert.equal(differentFile.filePath, otherTarget);
+  assert.equal(differentFile.additionalContext, undefined);
+  assert.equal(readSeenCount(differentFile.statePath, otherTarget), 1);
+
+  const freshSession = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: "claude-repeated-flow-fresh-session",
+      prompt: "Explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(freshSession.action, "record");
+  assert.notEqual(freshSession.statePath, second.statePath);
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const afterReset = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(afterReset.action, "record");
+  assert.equal(readSeenCount(afterReset.statePath, target), 1);
+
+  fs.writeFileSync(afterReset.statePath, "{not-json");
+  const afterCorruptState = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Again, explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(afterCorruptState.action, "record");
+  assert.equal(readSeenCount(afterCorruptState.statePath, target), 1);
+
+  const multiTarget = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: "claude-repeated-flow-multi-target",
+      prompt: "Create src/components/MissingPanel.tsx and explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(multiTarget.action, "record");
+  assert.equal(multiTarget.filePath, target);
 
   const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Tell me about this repo" }, tempDir);
   assert.equal(noTarget.action, "noop");
@@ -1642,7 +1744,7 @@ test("claude native hook bridge activates only in attached Claude projects", () 
   assert.equal(sessionStart.hookSpecificOutput.hookEventName, "SessionStart");
   assert.ok(sessionStart.hookSpecificOutput.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
 
-  const prompt = handleClaudeNativeHookPayload(
+  const firstPrompt = handleClaudeNativeHookPayload(
     {
       hook_event_name: "UserPromptSubmit",
       cwd: attachedDir,
@@ -1651,16 +1753,53 @@ test("claude native hook bridge activates only in attached Claude projects", () 
     },
     attachedDir,
   );
+  assert.equal(firstPrompt, null);
+
+  const prompt = handleClaudeNativeHookPayload(
+    {
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Again, explain src/components/FormSection.tsx",
+      session_id: "claude-native-first",
+    },
+    attachedDir,
+  );
   assert.equal(prompt.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(prompt.hookSpecificOutput.additionalContext, /src\/components\/FormSection\.tsx/);
+  assert.doesNotMatch(prompt.hookSpecificOutput.additionalContext, /Claude Read interception is enabled/i);
+
+  assert.equal(handleClaudeNativeHookPayload(
+    {
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Explain src/components/SimpleButton.tsx",
+      transcript_path: path.join(attachedDir, ".claude", "transcripts", "session.jsonl"),
+    },
+    attachedDir,
+  ), null);
+  const transcriptFallbackPrompt = handleClaudeNativeHookPayload(
+    {
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Again, explain src/components/SimpleButton.tsx",
+      transcript_path: path.join(attachedDir, ".claude", "transcripts", "session.jsonl"),
+    },
+    attachedDir,
+  );
+  assert.equal(transcriptFallbackPrompt.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(transcriptFallbackPrompt.hookSpecificOutput.additionalContext, /src\/components\/SimpleButton\.tsx/);
+
   assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "PreToolUse", cwd: attachedDir }, attachedDir), null);
+  assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "PostToolUse", cwd: attachedDir }, attachedDir), null);
+  assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "Read", cwd: attachedDir }, attachedDir), null);
+  assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "Stop", cwd: attachedDir }, attachedDir), null);
   assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "SubagentStop", cwd: attachedDir }, attachedDir), null);
 });
 
 test("cli claude-runtime-hook handles native JSON and malformed JSON", () => {
   const attachedDir = makeTempProject();
   run(["attach", "claude"], attachedDir, { FOOKS_CLAUDE_HOME: fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-")) });
-  const output = JSON.parse(runTextWithInput(
+  const firstOutput = runTextWithInput(
     ["claude-runtime-hook", "--native-hook"],
     JSON.stringify({
       hook_event_name: "UserPromptSubmit",
@@ -1669,8 +1808,32 @@ test("cli claude-runtime-hook handles native JSON and malformed JSON", () => {
       session_id: "cli-claude-native",
     }),
     attachedDir,
+  );
+  assert.equal(firstOutput, "");
+
+  const output = JSON.parse(runTextWithInput(
+    ["claude-runtime-hook", "--native-hook"],
+    JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Again, explain src/components/FormSection.tsx",
+      session_id: "cli-claude-native",
+    }),
+    attachedDir,
   ));
   assert.equal(output.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(output.hookSpecificOutput.additionalContext, /src\/components\/FormSection\.tsx/);
+
+  const unsupportedOutput = runTextWithInput(
+    ["claude-runtime-hook", "--native-hook"],
+    JSON.stringify({
+      hook_event_name: "PreToolUse",
+      cwd: attachedDir,
+      session_id: "cli-claude-native",
+    }),
+    attachedDir,
+  );
+  assert.equal(unsupportedOutput, "");
 
   let failure = "";
   try {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -43,6 +43,9 @@ const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.jo
 const { prepareExecutionContext } = require(path.join(repoRoot, "dist", "adapters", "codex.js"));
 const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude.js"));
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
+const { installClaudeHookPreset, claudeLocalSettingsPath } = require(path.join(repoRoot, "dist", "adapters", "claude-hook-preset.js"));
+const { handleClaudeRuntimeHook, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+const { handleClaudeNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "claude-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 const ts = require("typescript");
 
@@ -1233,7 +1236,7 @@ test("setup prepares explicit one-time Codex activation", () => {
   assert.equal(result.status.lifecycleState, "ready");
   assert.equal(result.runtimes.codex.state, "automatic-ready");
   assert.equal(result.runtimes.codex.blocksOverall, true);
-  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.claude.state, "context-hook-ready");
   assert.equal(result.runtimes.claude.blocksOverall, false);
   assert.equal(result.runtimes.opencode.state, "tool-ready");
   assert.equal(result.runtimes.opencode.blocksOverall, false);
@@ -1253,8 +1256,8 @@ test("setup prepares explicit one-time Codex activation", () => {
   assert.ok(result.scope.userRuntime.paths.includes(runtimeManifestPath(result.attach)));
   assert.ok(result.scope.userRuntime.paths.includes(runtimeManifestPath(result.runtimes.claude.details.attach)));
   assert.ok(result.scope.nonGoals.some((item) => item.includes("No --scope option")));
-  assert.deepEqual(result.summary, ["codex:automatic-ready:ready", "claude:handoff-ready:ready", "opencode:tool-ready:ready"]);
-  assert.ok(result.claimBoundaries.some((item) => item.includes("Claude setup prepares manual/shared handoff artifacts only")));
+  assert.deepEqual(result.summary, ["codex:automatic-ready:ready", "claude:context-hook-ready:ready", "opencode:tool-ready:ready"]);
+  assert.ok(result.claimBoundaries.some((item) => item.includes("Claude setup installs project-local context hooks")));
   assert.ok(result.nextSteps.some((item) => item.includes("Codex")));
   assert.ok(fs.existsSync(path.join(tempDir, ".opencode", "tools", "fooks_extract.ts")));
   assert.ok(fs.existsSync(path.join(tempDir, ".opencode", "commands", "fooks-extract.md")));
@@ -1280,7 +1283,7 @@ test("setup can become ready for a public repo without an active account overrid
   assert.equal(result.ready, true);
   assert.equal(result.state, "ready");
   assert.equal(result.runtimes.codex.state, "automatic-ready");
-  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.claude.state, "context-hook-ready");
   assert.equal(result.runtimes.opencode.state, "tool-ready");
   assert.ok(result.attach.runtimeProof.details.includes("account-source=package-repository"));
   assert.ok(result.attach.runtimeProof.details.includes("account-context=example-org"));
@@ -1366,7 +1369,7 @@ test("setup reports partial activation when Codex hooks cannot be parsed", () =>
   assert.equal(result.hooks, null);
   assert.equal(result.runtimes.codex.state, "partial");
   assert.equal(result.runtimes.codex.blocksOverall, true);
-  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.claude.state, "context-hook-ready");
   assert.equal(result.runtimes.opencode.state, "tool-ready");
   assert.ok(result.blockers.some((item) => item.includes("Codex hook preset install failed")));
   assert.ok(result.nextSteps.some((item) => item.includes("Fix setup blockers")));
@@ -1391,7 +1394,7 @@ test("setup reports partial activation when the Codex runtime manifest path cann
   assert.equal(result.state, "partial");
   assert.equal(result.attach.runtimeProof.status, "blocked");
   assert.equal(result.runtimes.codex.state, "partial");
-  assert.equal(result.runtimes.claude.state, "handoff-ready");
+  assert.equal(result.runtimes.claude.state, "context-hook-ready");
   assert.ok(result.attach.runtimeProof.blocker.includes("Codex runtime manifest install failed"));
   assert.ok(result.attach.runtimeProof.blocker.match(/EEXIST|ENOTDIR/));
   assert.ok(result.blockers.some((item) => item.includes("Codex runtime manifest install failed")));
@@ -1432,8 +1435,8 @@ test("cli help advertises setup and package install has no auto hook side effect
   const help = runText(["--help"]);
   assert.match(help, /fooks setup/);
   assert.match(help, /fooks status claude/);
-  assert.match(help, /Codex: automatic runtime hook path/);
-  assert.match(help, /Claude: manual\/shared handoff artifacts only/);
+  assert.match(help, /Codex: automatic repeated-file runtime hook path/);
+  assert.match(help, /Claude: project-local context hooks/);
   assert.match(help, /opencode: manual\/semi-automatic custom tool/);
   assert.doesNotMatch(help, /--scope/);
   assert.doesNotMatch(help, /Unknown command/);
@@ -1469,30 +1472,27 @@ test("setup runtime summary keeps Claude and opencode claims bounded", () => {
 
   assert.equal(result.runtimes.claude.blocksOverall, false);
   assert.equal(result.runtimes.opencode.blocksOverall, false);
-  assert.match(text, /Claude automatic hooks are not enabled by fooks setup/);
+  assert.match(text, /Claude P0 context hooks are project-local only/);
   assert.match(text, /opencode setup does not intercept read calls/);
   assert.match(text, /Codex setup installs the automatic fooks hook path when Codex trust checks pass, but it does not collect Codex runtime-token telemetry/);
-  assert.match(text, /opencode setup does not provide automatic runtime-token telemetry/);
+  assert.match(text, /opencode setup does not prove automatic runtime-token savings/);
   assert.match(text, /runtime-token-telemetry=not-collected/);
-  assert.doesNotMatch(text, /Claude automatic hooks are enabled/i);
-  assert.doesNotMatch(text, /Claude prompt interception is enabled/i);
+  assert.doesNotMatch(text, /Claude Read interception is enabled/i);
+  assert.doesNotMatch(text, /Claude runtime-token savings are enabled/i);
   assert.doesNotMatch(text, /automatic opencode read interception is enabled/i);
   assert.doesNotMatch(text, /automatic opencode runtime-token savings are enabled/i);
   assert.doesNotMatch(text, /Codex runtime-token savings proof/i);
 });
 
-test("status claude reports handoff-ready artifacts without automatic runtime claims", () => {
+test("status claude reports handoff-ready artifacts when project-local hooks are absent", () => {
   const tempDir = makeTempProject();
-  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));
   const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
   const env = {
     FOOKS_ACTIVE_ACCOUNT: "minislively",
-    FOOKS_CODEX_HOME: codexHome,
     FOOKS_CLAUDE_HOME: claudeHome,
   };
 
-  const setup = run(["setup"], tempDir, env);
-  assert.equal(setup.runtimes.claude.state, "handoff-ready");
+  run(["attach", "claude"], tempDir, env);
 
   const status = run(["status", "claude"], tempDir, env);
   assert.equal(status.runtime, "claude");
@@ -1501,23 +1501,184 @@ test("status claude reports handoff-ready artifacts without automatic runtime cl
   assert.equal(status.mode, "manual-shared-handoff");
   assert.deepEqual(status.blockers, []);
   assert.equal(status.adapter.installed, true);
-  assert.equal(status.adapter.adapterJson.exists, true);
   assert.equal(status.adapter.adapterJson.valid, true);
-  assert.equal(status.adapter.contextTemplate.exists, true);
   assert.equal(status.adapter.contextTemplate.valid, true);
   assert.equal(status.manifest.home, claudeHome);
-  assert.equal(status.manifest.exists, true);
   assert.equal(status.manifest.valid, true);
-  assert.equal(status.manifest.runtimeMatches, true);
-  assert.equal(status.manifest.projectRootMatches, true);
-  assert.equal(fs.existsSync(status.manifest.path), true);
+  assert.equal(status.hooks.exists, false);
+  assert.equal(status.hooks.ready, false);
+  assert.deepEqual(status.hooks.missingEvents, ["SessionStart", "UserPromptSubmit"]);
 
   const text = collectStrings(status).join("\n");
   assert.match(text, /manual-shared-handoff/);
-  assert.match(text, /Claude automatic hooks are not enabled by fooks/);
-  assert.match(text, /read-only handoff-artifact health check/);
-  assert.doesNotMatch(text, /Claude prompt interception is enabled/i);
+  assert.match(text, /Run fooks install claude-hooks/);
+  assert.doesNotMatch(text, /Claude Read interception is enabled/i);
   assert.doesNotMatch(text, /automatic Claude token savings are enabled/i);
+});
+
+test("install claude-hooks creates local settings and status reports context-hook-ready", () => {
+  const tempDir = makeTempProject();
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  const env = { FOOKS_CLAUDE_HOME: claudeHome };
+  run(["attach", "claude"], tempDir, env);
+
+  const result = run(["install", "claude-hooks"], tempDir, env);
+  assert.equal(result.command, "install claude-hooks");
+  assert.equal(result.runtime, "claude");
+  assert.equal(result.created, true);
+  assert.equal(result.modified, true);
+  assert.deepEqual(result.installedEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.equal(result.settingsPath, path.join(fs.realpathSync(tempDir), ".claude", "settings.local.json"));
+
+  const settings = JSON.parse(fs.readFileSync(path.join(tempDir, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(settings.hooks.SessionStart[0].hooks[0].command, "fooks claude-runtime-hook --native-hook");
+  assert.equal(settings.hooks.UserPromptSubmit[0].hooks[0].command, "fooks claude-runtime-hook --native-hook");
+  assert.equal(settings.hooks.Read, undefined);
+  assert.equal(settings.hooks.PreToolUse, undefined);
+  assert.equal(settings.hooks.PostToolUse, undefined);
+  assert.equal(settings.hooks.Stop, undefined);
+  assert.equal(settings.hooks.SubagentStop, undefined);
+  assert.equal(fs.existsSync(path.join(tempDir, ".claude", "settings.json")), false);
+
+  const second = run(["install", "claude-hooks"], tempDir, env);
+  assert.equal(second.modified, false);
+  assert.deepEqual(second.skippedEvents, ["SessionStart", "UserPromptSubmit"]);
+
+  const status = run(["status", "claude"], tempDir, env);
+  assert.equal(status.state, "context-hook-ready");
+  assert.equal(status.mode, "automatic-context-hook");
+  assert.equal(status.ready, true);
+  assert.equal(status.hooks.ready, true);
+  assert.deepEqual(status.hooks.installedEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.deepEqual(status.hooks.missingEvents, []);
+  assert.deepEqual(status.hooks.unexpectedFooksEvents, []);
+});
+
+test("install claude-hooks preserves settings and avoids global/shared mutation", () => {
+  const tempDir = makeTempProject();
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-home-"));
+  const globalClaudeDir = path.join(fakeHome, ".claude");
+  fs.mkdirSync(globalClaudeDir, { recursive: true });
+  const globalSettings = path.join(globalClaudeDir, "settings.json");
+  fs.writeFileSync(globalSettings, JSON.stringify({ hooks: { UserPromptSubmit: [] }, keep: true }, null, 2));
+  fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true });
+  const sharedSettings = path.join(tempDir, ".claude", "settings.json");
+  fs.writeFileSync(sharedSettings, JSON.stringify({ shared: true }, null, 2));
+  const localSettings = claudeLocalSettingsPath(tempDir);
+  fs.writeFileSync(localSettings, JSON.stringify({
+    permissions: { allow: ["Bash(echo:*)"] },
+    hooks: {
+      UserPromptSubmit: [{ hooks: [{ type: "command", command: "node /tmp/other.js" }] }],
+    },
+  }, null, 2));
+
+  const result = installClaudeHookPreset(tempDir, "fooks");
+  assert.equal(result.created, false);
+  assert.equal(result.modified, true);
+  assert.ok(result.backupPath);
+  const merged = JSON.parse(fs.readFileSync(localSettings, "utf8"));
+  assert.deepEqual(merged.permissions, { allow: ["Bash(echo:*)"] });
+  assert.ok(merged.hooks.UserPromptSubmit.some((matcher) => matcher.hooks.some((hook) => hook.command === "node /tmp/other.js")));
+  assert.equal(fs.readFileSync(globalSettings, "utf8"), JSON.stringify({ hooks: { UserPromptSubmit: [] }, keep: true }, null, 2));
+  assert.equal(fs.readFileSync(sharedSettings, "utf8"), JSON.stringify({ shared: true }, null, 2));
+});
+
+test("install claude-hooks reports malformed local settings without overwriting", () => {
+  const tempDir = makeTempProject();
+  fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true });
+  const localSettings = claudeLocalSettingsPath(tempDir);
+  fs.writeFileSync(localSettings, "{not-json");
+  const result = installClaudeHookPreset(tempDir, "fooks");
+  assert.equal(result.modified, false);
+  assert.match(result.blocker, /not valid JSON/);
+  assert.equal(fs.readFileSync(localSettings, "utf8"), "{not-json");
+});
+
+test("claude runtime hook injects on first eligible prompt and no-ops unsupported prompts", () => {
+  const tempDir = makeTempProject();
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: "claude-start" }, tempDir);
+  assert.equal(start.action, "inject");
+  assert.ok(start.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+  assert.match(start.additionalContext, /does not intercept Claude Read\/tool calls/);
+
+  const prompt = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: "claude-first",
+      prompt: "Explain src/components/FormSection.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(prompt.action, "inject");
+  assert.equal(prompt.filePath, path.join("src", "components", "FormSection.tsx"));
+  assert.ok(prompt.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+  assert.match(prompt.additionalContext, /fooks: Claude context hook/);
+  assert.match(prompt.additionalContext, /src\/components\/FormSection\.tsx/);
+
+  const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Tell me about this repo" }, tempDir);
+  assert.equal(noTarget.action, "noop");
+  const linkedTs = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Explain src/components/Button.types.ts" }, tempDir);
+  assert.equal(linkedTs.action, "noop");
+  const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
+  assert.equal(missing.action, "noop");
+});
+
+test("claude native hook bridge activates only in attached Claude projects", () => {
+  const detachedDir = makeTempProject();
+  const detached = handleClaudeNativeHookPayload(
+    {
+      hook_event_name: "UserPromptSubmit",
+      cwd: detachedDir,
+      prompt: "Explain src/components/FormSection.tsx",
+      session_id: "claude-detached",
+    },
+    detachedDir,
+  );
+  assert.equal(detached, null);
+
+  const attachedDir = makeTempProject();
+  run(["attach", "claude"], attachedDir, { FOOKS_CLAUDE_HOME: fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-")) });
+  const sessionStart = handleClaudeNativeHookPayload({ hook_event_name: "SessionStart", cwd: attachedDir, session_id: "claude-native-start" }, attachedDir);
+  assert.equal(sessionStart.hookSpecificOutput.hookEventName, "SessionStart");
+  assert.ok(sessionStart.hookSpecificOutput.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+
+  const prompt = handleClaudeNativeHookPayload(
+    {
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Explain src/components/FormSection.tsx",
+      session_id: "claude-native-first",
+    },
+    attachedDir,
+  );
+  assert.equal(prompt.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(prompt.hookSpecificOutput.additionalContext, /src\/components\/FormSection\.tsx/);
+  assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "PreToolUse", cwd: attachedDir }, attachedDir), null);
+  assert.equal(handleClaudeNativeHookPayload({ hook_event_name: "SubagentStop", cwd: attachedDir }, attachedDir), null);
+});
+
+test("cli claude-runtime-hook handles native JSON and malformed JSON", () => {
+  const attachedDir = makeTempProject();
+  run(["attach", "claude"], attachedDir, { FOOKS_CLAUDE_HOME: fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-")) });
+  const output = JSON.parse(runTextWithInput(
+    ["claude-runtime-hook", "--native-hook"],
+    JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      cwd: attachedDir,
+      prompt: "Explain src/components/FormSection.tsx",
+      session_id: "cli-claude-native",
+    }),
+    attachedDir,
+  ));
+  assert.equal(output.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+
+  let failure = "";
+  try {
+    runTextWithInput(["claude-runtime-hook", "--native-hook"], "{not-json", attachedDir);
+  } catch (error) {
+    failure = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.match(failure, /fooks claude-runtime-hook: invalid JSON payload/);
 });
 
 test("status claude reports blocked state without creating artifacts", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -37,6 +37,7 @@ const {
 } = require(path.join(repoRoot, "dist", "core", "session-metrics.js"));
 const {
   sessionEventsPath,
+  sessionSummaryPath,
   sessionsSummaryPath,
 } = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
@@ -627,9 +628,69 @@ test("bare status reports fast estimated session savings without exposing sessio
   assert.equal(empty.latestSessionCount, 0);
   assert.equal(empty.eventCount, 0);
   assert.equal(empty.totals.savedEstimatedBytes, 0);
+  assert.deepEqual(empty.breakdown.byRuntime, {});
+  assert.deepEqual(empty.breakdown.byMeasurementSource, {});
+  assert.deepEqual(empty.breakdown.byRuntimeAndSource, {});
   assert.equal("sessions" in empty, false);
   assert.equal("latestSessionKeys" in empty, false);
   assert.match(empty.claimBoundary, /not provider billing tokens/);
+});
+
+test("legacy unqualified metric summaries migrate to codex automatic hook identity", () => {
+  const tempDir = makeTempProject();
+  const legacySessionKey = "legacy-session";
+  const timestamp = "2026-04-21T00:00:00.000Z";
+  const usage = {
+    originalEstimatedBytes: 400,
+    actualEstimatedBytes: 100,
+    savedEstimatedBytes: 300,
+    originalEstimatedTokens: 100,
+    actualEstimatedTokens: 25,
+    savedEstimatedTokens: 75,
+    savingsRatio: 0.75,
+  };
+  fs.mkdirSync(path.dirname(sessionSummaryPath(tempDir, legacySessionKey)), { recursive: true });
+  fs.writeFileSync(
+    sessionSummaryPath(tempDir, legacySessionKey),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        metricTier: "estimated",
+        sessionKey: legacySessionKey,
+        sanitizedSessionKey: legacySessionKey,
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        eventCount: 1,
+        comparableEventCount: 1,
+        injectCount: 1,
+        fallbackCount: 0,
+        recordCount: 0,
+        noopCount: 0,
+        observedOpportunityCount: 0,
+        observedOriginalEstimatedBytes: 0,
+        observedOriginalEstimatedTokens: 0,
+        totals: usage,
+        claimBoundary: "legacy local estimate",
+      },
+      null,
+      2,
+    ),
+  );
+
+  const summary = readSessionMetricSummary(tempDir, legacySessionKey);
+  assert.equal(summary.runtime, "codex");
+  assert.equal(summary.measurementSource, "automatic-hook");
+  assert.equal(summary.rawSessionKey, legacySessionKey);
+  assert.equal(summary.metricSessionKey, `codex:automatic-hook:${legacySessionKey}`);
+  assert.equal(summary.sessionKey, summary.metricSessionKey);
+  assert.equal(summary.totals.savedEstimatedBytes, 300);
+
+  const status = refreshProjectMetricSummaryFromSession(tempDir, legacySessionKey);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.latestSessionCount, 1);
+  assert.equal("sessions" in status, false);
 });
 
 test("runtime hook stores redacted estimated metrics for record, inject, fallback, and stop", () => {
@@ -678,7 +739,12 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
     Math.max(0, sessionSummary.totals.originalEstimatedBytes - sessionSummary.totals.actualEstimatedBytes),
   );
 
-  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionId), "utf8");
+  assert.equal(sessionSummary.runtime, "codex");
+  assert.equal(sessionSummary.measurementSource, "automatic-hook");
+  assert.equal(sessionSummary.rawSessionKey, sessionId);
+  assert.match(sessionSummary.metricSessionKey, /^codex:automatic-hook:/);
+
+  const eventLog = fs.readFileSync(sessionEventsPath(tempDir, sessionSummary.metricSessionKey), "utf8");
   assert.doesNotMatch(eventLog, /Again, update/);
   assert.doesNotMatch(eventLog, /additionalContext/);
   assert.doesNotMatch(eventLog, /rawText/);
@@ -721,11 +787,15 @@ test("runtime hook stores redacted estimated metrics for record, inject, fallbac
   assert.equal(status.fallbackCount, 1);
   assert.equal(status.recordCount, 1);
   assert.equal(status.latestSessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 3);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 3);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 3);
   assert.equal("latestSessionKeys" in status, false);
   assert.equal("sessions" in status, false);
 
   const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
   assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(Object.keys(summaryFile.sessions).every((key) => key.startsWith("codex-automatic-hook-")));
 });
 
 test("runtime metric write failures are non-fatal to hook decisions", () => {
@@ -1722,6 +1792,114 @@ test("claude runtime hook records first eligible prompt, injects repeated same-f
   const linkedTs = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Explain src/components/Button.types.ts" }, tempDir);
   assert.equal(linkedTs.action, "noop");
   const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
+  assert.equal(missing.action, "noop");
+});
+
+test("codex and claude estimated metrics are runtime/source-qualified without session collisions", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "same-session";
+  const target = path.join("src", "components", "FormSection.tsx");
+  const targetBytes = fs.statSync(path.join(tempDir, target)).size;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const claudeStart = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(claudeStart.action, "inject");
+  const claudeStartSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(claudeStartSummary.eventCount, 0);
+  assert.equal(claudeStartSummary.injectCount, 0);
+  assert.equal(claudeStartSummary.comparableEventCount, 0);
+
+  const claudeFirst = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Explain ${target}` }, tempDir);
+  assert.equal(claudeFirst.action, "record");
+  const claudeSecond = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, explain ${target}` }, tempDir);
+  assert.equal(claudeSecond.action, "inject");
+  assert.ok(claudeSecond.additionalContext);
+
+  const codexSummary = readSessionMetricSummary(tempDir, sessionId);
+  const claudeSummary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(codexSummary.runtime, "codex");
+  assert.equal(codexSummary.measurementSource, "automatic-hook");
+  assert.equal(claudeSummary.runtime, "claude");
+  assert.equal(claudeSummary.measurementSource, "project-local-context-hook");
+  assert.equal(codexSummary.rawSessionKey, sessionId);
+  assert.equal(claudeSummary.rawSessionKey, sessionId);
+  assert.notEqual(codexSummary.metricSessionKey, claudeSummary.metricSessionKey);
+  assert.notEqual(sessionSummaryPath(tempDir, codexSummary.metricSessionKey), sessionSummaryPath(tempDir, claudeSummary.metricSessionKey));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, codexSummary.metricSessionKey)));
+  assert.ok(fs.existsSync(sessionSummaryPath(tempDir, claudeSummary.metricSessionKey)));
+
+  assert.equal(claudeSummary.eventCount, 2);
+  assert.equal(claudeSummary.recordCount, 1);
+  assert.equal(claudeSummary.injectCount, 1);
+  assert.equal(claudeSummary.comparableEventCount, 1);
+  assert.equal(claudeSummary.observedOpportunityCount, 1);
+  assert.equal(claudeSummary.observedOriginalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.originalEstimatedBytes, targetBytes);
+  assert.equal(claudeSummary.totals.actualEstimatedBytes, Buffer.byteLength(claudeSecond.additionalContext, "utf8"));
+
+  const claudeEvents = fs.readFileSync(sessionEventsPath(tempDir, claudeSummary.metricSessionKey), "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  assert.equal(claudeEvents.length, 2);
+  assert.ok(claudeEvents.every((event) => event.metricTier === "estimated"));
+  assert.ok(claudeEvents.every((event) => event.claimBoundary.includes("not provider billing tokens")));
+  assert.ok(claudeEvents.every((event) => event.runtime === "claude"));
+  assert.ok(claudeEvents.every((event) => event.measurementSource === "project-local-context-hook"));
+  assert.ok(claudeEvents.every((event) => event.rawSessionKey === sessionId));
+  assert.ok(claudeEvents.every((event) => event.metricSessionKey === claudeSummary.metricSessionKey));
+  assert.ok(claudeEvents.every((event) => event.eventName === "UserPromptSubmit"));
+
+  const status = run(["status"], tempDir);
+  assert.equal(status.sessionCount, 2);
+  assert.equal(status.breakdown.byRuntime.codex.eventCount, 1);
+  assert.equal(status.breakdown.byRuntime.claude.eventCount, 2);
+  assert.equal(status.breakdown.byMeasurementSource["automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byMeasurementSource["project-local-context-hook"].eventCount, 2);
+  assert.equal(status.breakdown.byRuntimeAndSource["codex:automatic-hook"].eventCount, 1);
+  assert.equal(status.breakdown.byRuntimeAndSource["claude:project-local-context-hook"].eventCount, 2);
+
+  const summaryFile = JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8"));
+  assert.equal(Object.keys(summaryFile.sessions).length, 2);
+  assert.ok(summaryFile.sessions[codexSummary.sanitizedSessionKey]);
+  assert.ok(summaryFile.sessions[claudeSummary.sanitizedSessionKey]);
+});
+
+test("claude fallback metrics record zero savings and telemetry failures are non-fatal", () => {
+  const tempDir = makeTempProject();
+  const hugeTarget = path.join("src", "components", "HugeRaw.tsx");
+  fs.writeFileSync(
+    path.join(tempDir, hugeTarget),
+    `export const huge = ${JSON.stringify("x".repeat(5000))};\n`,
+  );
+  const hugeBytes = fs.statSync(path.join(tempDir, hugeTarget)).size;
+  const fallbackSession = "claude-fallback-metrics";
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: fallbackSession }, tempDir);
+  assert.equal(handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Explain ${hugeTarget}` }, tempDir).action, "record");
+  const fallback = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: fallbackSession, prompt: `Again, explain ${hugeTarget}` }, tempDir);
+  assert.equal(fallback.action, "fallback");
+  const fallbackSummary = readSessionMetricSummary(tempDir, fallbackSession, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  assert.equal(fallbackSummary.fallbackCount, 1);
+  assert.equal(fallbackSummary.comparableEventCount, 1);
+  assert.equal(fallbackSummary.totals.originalEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.actualEstimatedBytes, hugeBytes);
+  assert.equal(fallbackSummary.totals.savedEstimatedBytes, 0);
+
+  const blockedDir = makeTempProject();
+  fs.mkdirSync(path.join(blockedDir, ".fooks"), { recursive: true });
+  fs.writeFileSync(path.join(blockedDir, ".fooks", "sessions"), "not-a-directory");
+  const target = path.join("src", "components", "FormSection.tsx");
+  const blockedSession = "claude-blocked-metrics";
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: blockedSession }, blockedDir);
+  assert.equal(start.action, "inject");
+  assert.match(start.additionalContext, /context hook is active/);
+  const first = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Explain ${target}` }, blockedDir);
+  assert.equal(first.action, "record");
+  const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: `Again, explain ${target}` }, blockedDir);
+  assert.equal(second.action, "inject");
+  assert.match(second.additionalContext, /fooks: Claude context hook/);
+  const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain this repo" }, blockedDir);
+  assert.equal(noTarget.action, "noop");
+  const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: blockedSession, prompt: "Explain src/components/MissingPanel.tsx" }, blockedDir);
   assert.equal(missing.action, "noop");
 });
 

--- a/test/metric-cleanup.mjs
+++ b/test/metric-cleanup.mjs
@@ -12,8 +12,20 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
   }
 
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
-      fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(root, entry.name);
+    const summaryPath = path.join(entryPath, "summary.json");
+    let keys = [entry.name];
+    if (fs.existsSync(summaryPath)) {
+      try {
+        const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+        keys = [entry.name, summary.rawSessionKey, summary.metricSessionKey, summary.sessionKey].filter(Boolean);
+      } catch {
+        // Fall back to the directory name for malformed ignored telemetry.
+      }
+    }
+    if (keys.some((key) => prefixes.some((prefix) => String(key).startsWith(prefix)))) {
+      fs.rmSync(entryPath, { recursive: true, force: true });
     }
   }
 
@@ -29,7 +41,7 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
     }
     try {
       const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
-      refreshProjectMetricSummaryFromSession(repoRoot, summary.sessionKey ?? entry.name);
+      refreshProjectMetricSummaryFromSession(repoRoot, summary.metricSessionKey ?? summary.sessionKey ?? entry.name);
       remainingSessionCount += 1;
     } catch {
       // Test cleanup should not fail the suite when ignored telemetry is malformed.

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanupMetricSessions } from "./metric-cleanup.mjs";
@@ -8,11 +9,38 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
-test.after(() => cleanupMetricSessions(repoRoot, ["bridge-contract-"]));
+const {
+  CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS,
+  handleClaudeRuntimeHook,
+} = await import(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+
+function cleanupRuntimeSessions(repoRoot, runtime, prefixes) {
+  const root = path.join(repoRoot, ".fooks", "state", runtime);
+  if (!fs.existsSync(root)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isFile() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
+      fs.rmSync(path.join(root, entry.name), { force: true });
+    }
+  }
+
+  if (fs.readdirSync(root).length === 0) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test.after(async () => {
+  await cleanupMetricSessions(repoRoot, ["bridge-contract-"]);
+  cleanupRuntimeSessions(repoRoot, "codex-runtime", ["bridge-contract-"]);
+  cleanupRuntimeSessions(repoRoot, "claude-runtime", ["bridge-contract-claude-"]);
+});
 
 test("runtime bridge contract keeps repeated-read inject and fallback semantics stable", () => {
   const injectSession = `bridge-contract-inject-${Date.now()}`;
-  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: injectSession }, repoRoot);
+  const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: injectSession }, repoRoot);
+  assert.match(start.statePath, /\.fooks\/state\/codex-runtime/);
 
   const firstInject = handleCodexRuntimeHook(
     {
@@ -85,4 +113,77 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
 
   assert.equal(legacyOverride.action, "fallback");
   assert.equal(legacyOverride.fallback.reason, "escape-hatch-full-read");
+});
+
+test("claude runtime bridge follows record-then-inject repeated same-file contract", () => {
+  const target = path.join("fixtures", "compressed", "FormSection.tsx");
+  const otherTarget = path.join("fixtures", "raw", "SimpleButton.tsx");
+  const readState = (statePath) => JSON.parse(fs.readFileSync(statePath, "utf8"));
+
+  const injectSession = `bridge-contract-claude-inject-${Date.now()}`;
+  const start = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: injectSession }, repoRoot);
+  assert.equal(start.action, "inject");
+  assert.match(start.statePath, /\.fooks\/state\/claude-runtime/);
+
+  const first = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: injectSession,
+      prompt: "Please update fixtures/compressed/FormSection.tsx",
+    },
+    repoRoot,
+  );
+  assert.equal(first.action, "record");
+  assert.equal(first.filePath, target);
+  assert.equal(first.additionalContext, undefined);
+  assert.equal(first.debug.repeatedFile, false);
+  assert.equal(readState(first.statePath).seenFiles[target].seenCount, 1);
+
+  const second = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: injectSession,
+      prompt: "Again, update fixtures/compressed/FormSection.tsx",
+    },
+    repoRoot,
+  );
+  assert.equal(second.action, "inject");
+  assert.equal(second.filePath, target);
+  assert.ok(second.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+  assert.match(second.additionalContext, /fixtures\/compressed\/FormSection\.tsx/);
+  assert.doesNotMatch(second.additionalContext, /Claude Read interception is enabled/i);
+  assert.equal(second.debug.repeatedFile, true);
+  assert.equal(readState(second.statePath).seenFiles[target].seenCount, 2);
+
+  const differentFile = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: injectSession,
+      prompt: "Please inspect fixtures/raw/SimpleButton.tsx",
+    },
+    repoRoot,
+  );
+  assert.equal(differentFile.action, "record");
+  assert.equal(differentFile.filePath, otherTarget);
+  assert.equal(readState(differentFile.statePath).seenFiles[otherTarget].seenCount, 1);
+
+  const differentSession = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: `bridge-contract-claude-other-${Date.now()}`,
+      prompt: "Please update fixtures/compressed/FormSection.tsx",
+    },
+    repoRoot,
+  );
+  assert.equal(differentSession.action, "record");
+  assert.notEqual(differentSession.statePath, second.statePath);
+
+  const noTarget = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: injectSession, prompt: "Explain this repo" }, repoRoot);
+  assert.equal(noTarget.action, "noop");
+  const missing = handleClaudeRuntimeHook({
+    hookEventName: "UserPromptSubmit",
+    sessionId: injectSession,
+    prompt: "Create fixtures/raw/MissingPanel.tsx",
+  }, repoRoot);
+  assert.equal(missing.action, "noop");
 });


### PR DESCRIPTION
Rebased version of PR #96. Enables Claude project-local context hooks and keeps fooks runtime state product-owned.