### PR TITLE
Harden live provider smoke against CLI boundaries

### DIFF
--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -105,16 +105,20 @@ FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-prov
 
 The first command is safe and only reports installed CLI versions plus the exact opt-in command. The second command may use the local Codex / Claude Code account and can spend provider tokens, so run it only when that is intentional.
 
-Optional flags:
+Optional flags and timeout knobs:
 
 ```bash
 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex
 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-claude
+FOOKS_LIVE_CODEX_TIMEOUT_MS=120000 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-claude
+FOOKS_LIVE_CLAUDE_TIMEOUT_MS=120000 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex
 ```
 
 Expected observations:
 
 - The script creates a disposable frontend project and installs the packed local `fooks` CLI.
 - `fooks setup` must report Codex `automatic-ready` and Claude `context-hook-ready`.
+- Codex normally reports `providerCompleted: true`, `lastMessageExists: true`, and `hookEvidenceObserved: true`.
+- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true` and `providerErrors` records the provider-side failure.
 - Provider-backed CLI invocations must leave `fooks status` at `metricTier: "estimated"` with the provider-billing boundary intact.
 - Any captured evidence remains hook activation / local status evidence only; it is still not provider billing-token or provider-cost proof.

--- a/scripts/live-provider-hook-smoke.mjs
+++ b/scripts/live-provider-hook-smoke.mjs
@@ -17,7 +17,21 @@ function run(command, args, options = {}) {
     input: options.input,
     stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...(options.env ?? {}) },
+    timeout: options.timeout,
   });
+}
+
+function runResult(command, args, options = {}) {
+  try {
+    return { status: 0, stdout: run(command, args, options), stderr: "" };
+  } catch (error) {
+    return {
+      status: typeof error?.status === "number" ? error.status : 1,
+      stdout: String(error?.stdout ?? error?.output?.[1] ?? ""),
+      stderr: String(error?.stderr ?? error?.output?.[2] ?? ""),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function commandVersion(command, args = ["--version"]) {
@@ -111,40 +125,75 @@ function summarizeHookEvents(events) {
   });
 }
 
+function summarizeProviderErrors(events, stderr) {
+  const eventErrors = events.filter((event) => (
+    event?.type === "result" && event?.is_error
+  ) || event?.subtype === "api_retry" || event?.error || event?.api_error_status).slice(-5).map((event) => {
+    const text = JSON.stringify(event);
+    return text.length > 600 ? `${text.slice(0, 600)}…` : text;
+  });
+  if (stderr) eventErrors.push(stderr.length > 600 ? `${stderr.slice(0, 600)}…` : stderr);
+  return eventErrors;
+}
+
 function runCodexProviderSmoke(project, env) {
   const outputPath = path.join(project, ".fooks", "live-codex-last-message.txt");
-  const stdout = run("codex", [
+  const result = runResult("codex", [
     "exec",
+    "--skip-git-repo-check",
     "--cd", project,
     "--sandbox", "read-only",
     "--ephemeral",
     "--json",
     "--output-last-message", outputPath,
     "Reply with exactly FOOKS_CODEX_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
-  ], { cwd: project, env });
-  const events = parseJsonLines(stdout);
+  ], { cwd: project, env, timeout: Number(process.env.FOOKS_LIVE_CODEX_TIMEOUT_MS ?? "60000") });
+  const events = parseJsonLines(result.stdout);
+  const hookEventHints = summarizeHookEvents(events);
+  const providerOutput = `${result.stdout}\n${result.stderr}`;
+  const providerErrors = summarizeProviderErrors(events, result.stderr);
+  const hookEvidenceObserved = hookEventHints.length > 0 || /hook|fooks/i.test(providerOutput);
+  if (result.status !== 0 && !hookEvidenceObserved) {
+    throw new Error(`Codex provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
+  }
   return {
-    command: "codex exec --json --ephemeral",
+    command: "codex exec --skip-git-repo-check --json --ephemeral",
+    exitCode: result.status,
+    providerCompleted: result.status === 0,
     outputPath,
     lastMessageExists: fs.existsSync(outputPath),
-    hookEventHints: summarizeHookEvents(events),
+    hookEvidenceObserved,
+    hookEventHints,
+    providerErrors,
   };
 }
 
 function runClaudeProviderSmoke(project, env) {
-  const stdout = run("claude", [
+  const result = runResult("claude", [
     "--print",
+    "--verbose",
     "--output-format=stream-json",
     "--include-hook-events",
     "--max-budget-usd", process.env.FOOKS_LIVE_CLAUDE_MAX_BUDGET_USD ?? "0.05",
     "--tools", "",
     "--no-session-persistence",
     "Reply with exactly FOOKS_CLAUDE_LIVE_OK after considering src/components/Card.tsx. Do not edit files.",
-  ], { cwd: project, env });
-  const events = parseJsonLines(stdout);
+  ], { cwd: project, env, timeout: Number(process.env.FOOKS_LIVE_CLAUDE_TIMEOUT_MS ?? "60000") });
+  const events = parseJsonLines(result.stdout);
+  const hookEventHints = summarizeHookEvents(events);
+  const providerOutput = `${result.stdout}\n${result.stderr}`;
+  const providerErrors = summarizeProviderErrors(events, result.stderr);
+  const hookEvidenceObserved = /fooks: Claude context hook|UserPromptSubmit|SessionStart/i.test(providerOutput);
+  if (result.status !== 0 && !hookEvidenceObserved) {
+    throw new Error(`Claude provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
+  }
   return {
-    command: "claude --print --output-format=stream-json --include-hook-events",
-    hookEventHints: summarizeHookEvents(events),
+    command: "claude --print --verbose --output-format=stream-json --include-hook-events",
+    exitCode: result.status,
+    providerCompleted: result.status === 0,
+    hookEvidenceObserved,
+    hookEventHints,
+    providerErrors,
     eventCount: events.length,
   };
 }


### PR DESCRIPTION
## Summary\n- add Codex live smoke --skip-git-repo-check for disposable temp projects\n- add Claude --verbose stream-json support and timeout-bounded provider execution\n- separate hookEvidenceObserved from providerCompleted so auth/rate-limit provider failures do not erase hook proof\n- document timeout knobs and expected partial Claude provider outcomes\n\n## Verification\n- FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider\n- node scripts/live-provider-hook-smoke.mjs\n- npm run release:smoke\n- npm run lint && npm test\n\n## Claim boundary\nThis proves installed CLI hook activation plus local estimated status evidence only. It is not provider billing-token proof, provider cost proof, or a ccusage replacement.