### PR TITLE
Clarify Claude provider diagnostics in live smoke

### DIFF
--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -119,6 +119,13 @@ Expected observations:
 - The script creates a disposable frontend project and installs the packed local `fooks` CLI.
 - `fooks setup` must report Codex `automatic-ready` and Claude `context-hook-ready`.
 - Codex normally reports `providerCompleted: true`, `lastMessageExists: true`, and `hookEvidenceObserved: true`.
-- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true` and `providerErrors` records the provider-side failure.
+- Claude can report `providerCompleted: false` when the local account, auth session, or upstream provider returns rate-limit/server/auth errors; this is acceptable only when `hookEvidenceObserved: true`, `providerFailureKind` classifies the failure, and `providerErrors` records the provider-side failure.
+- `authStatus.loggedIn: true` only proves the local Claude Code auth file/session is present. It does not guarantee the upstream provider will complete the model call; `providerCompleted` is the provider completion signal.
 - Provider-backed CLI invocations must leave `fooks status` at `metricTier: "estimated"` with the provider-billing boundary intact.
 - Any captured evidence remains hook activation / local status evidence only; it is still not provider billing-token or provider-cost proof.
+
+Provider failure triage:
+
+- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command.
+- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun.
+- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`.

--- a/scripts/live-provider-hook-smoke.mjs
+++ b/scripts/live-provider-hook-smoke.mjs
@@ -29,6 +29,9 @@ function runResult(command, args, options = {}) {
       status: typeof error?.status === "number" ? error.status : 1,
       stdout: String(error?.stdout ?? error?.output?.[1] ?? ""),
       stderr: String(error?.stderr ?? error?.output?.[2] ?? ""),
+      signal: error?.signal ?? null,
+      code: error?.code ?? null,
+      killed: Boolean(error?.killed),
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -136,6 +139,50 @@ function summarizeProviderErrors(events, stderr) {
   return eventErrors;
 }
 
+function classifyProviderFailure(result, events, providerOutput) {
+  if (result.status === 0) return null;
+  const text = [
+    providerOutput,
+    result.stderr,
+    result.error,
+    result.signal,
+    result.code,
+    ...events.map((event) => JSON.stringify(event)),
+  ].filter(Boolean).join("\n");
+  if (/PERMISSION_DENIED|service has been disabled|disabled in this account|violation of Terms of Service|\b403\b/i.test(text)) {
+    return "auth-denied";
+  }
+  if (/auth_unavailable|no auth available|Failed to authenticate/i.test(text)) {
+    return "auth-unavailable";
+  }
+  if (/rate_limit|\b429\b/i.test(text)) {
+    return "rate-limited";
+  }
+  if (/server_error|\b503\b/i.test(text)) {
+    return "server-error";
+  }
+  if (/ETIMEDOUT|SIGTERM|timeout|timed out/i.test(text)) {
+    return "timeout";
+  }
+  return "provider-error";
+}
+
+function commandJsonResult(command, args, options = {}) {
+  const result = runResult(command, args, options);
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      exitCode: result.status,
+      error: result.stderr || result.error || result.stdout,
+    };
+  }
+  try {
+    return { ok: true, value: JSON.parse(result.stdout) };
+  } catch {
+    return { ok: true, value: result.stdout.trim() };
+  }
+}
+
 function runCodexProviderSmoke(project, env) {
   const outputPath = path.join(project, ".fooks", "live-codex-last-message.txt");
   const result = runResult("codex", [
@@ -153,6 +200,7 @@ function runCodexProviderSmoke(project, env) {
   const providerOutput = `${result.stdout}\n${result.stderr}`;
   const providerErrors = summarizeProviderErrors(events, result.stderr);
   const hookEvidenceObserved = hookEventHints.length > 0 || /hook|fooks/i.test(providerOutput);
+  const providerFailureKind = classifyProviderFailure(result, events, providerOutput);
   if (result.status !== 0 && !hookEvidenceObserved) {
     throw new Error(`Codex provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
   }
@@ -163,6 +211,7 @@ function runCodexProviderSmoke(project, env) {
     outputPath,
     lastMessageExists: fs.existsSync(outputPath),
     hookEvidenceObserved,
+    providerFailureKind,
     hookEventHints,
     providerErrors,
   };
@@ -184,6 +233,8 @@ function runClaudeProviderSmoke(project, env) {
   const providerOutput = `${result.stdout}\n${result.stderr}`;
   const providerErrors = summarizeProviderErrors(events, result.stderr);
   const hookEvidenceObserved = /fooks: Claude context hook|UserPromptSubmit|SessionStart/i.test(providerOutput);
+  const providerFailureKind = classifyProviderFailure(result, events, providerOutput);
+  const authStatus = commandJsonResult("claude", ["auth", "status"], { cwd: project, env, timeout: 10000 });
   if (result.status !== 0 && !hookEvidenceObserved) {
     throw new Error(`Claude provider smoke failed before hook evidence: ${result.stderr || result.error || result.stdout}`);
   }
@@ -192,6 +243,8 @@ function runClaudeProviderSmoke(project, env) {
     exitCode: result.status,
     providerCompleted: result.status === 0,
     hookEvidenceObserved,
+    providerFailureKind,
+    authStatus,
     hookEventHints,
     providerErrors,
     eventCount: events.length,


### PR DESCRIPTION
## Summary\n- classify provider failures separately from hook evidence in the opt-in live smoke\n- include Claude auth status in Claude provider diagnostics\n- document why logged-in Claude auth does not guarantee provider completion\n- add triage guidance for auth-denied/auth-unavailable/rate-limited/server-error/timeout outcomes\n\n## Live evidence\n- Claude-only smoke observed hookEvidenceObserved=true with providerCompleted=false and providerFailureKind=server-error on this machine\n- A separate minimal Claude provider probe showed the local auth can be logged in while provider/account completion still fails outside fooks control\n\n## Verification\n- FOOKS_LIVE_CLAUDE_TIMEOUT_MS=90000 FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-provider --skip-codex\n- node scripts/live-provider-hook-smoke.mjs\n- npm run release:smoke\n- npm run lint && npm test\n\n## Claim boundary\nThis remains hook activation plus local estimated status evidence only; it is not provider billing-token proof, provider-cost proof, or a ccusage replacement.