### PR TITLE
Clarify Claude live smoke execution context

### DIFF
--- a/docs/internal/live-hook-smoke-checklist.md
+++ b/docs/internal/live-hook-smoke-checklist.md
@@ -105,6 +105,8 @@ FOOKS_LIVE_PROVIDER_SMOKE=1 node scripts/live-provider-hook-smoke.mjs --run-prov
 
 The first command is safe and only reports installed CLI versions plus the exact opt-in command. The second command may use the local Codex / Claude Code account and can spend provider tokens, so run it only when that is intentional.
 
+Execution-context boundary: a Codex-hosted shell can exercise the installed `claude` CLI and prove project-local hook activation, but final Claude provider completion should be rerun from the actual Claude Code environment/account that users will operate. If the Codex-hosted smoke reports `hookEvidenceObserved: true` and `providerCompleted: false`, treat that as a provider/account-context diagnostic rather than a fooks hook failure, then rerun the Claude-only command from Claude Code.
+
 Optional flags and timeout knobs:
 
 ```bash
@@ -126,6 +128,6 @@ Expected observations:
 
 Provider failure triage:
 
-- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command.
-- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun.
-- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`.
+- `auth-denied`: local Claude auth exists, but the upstream provider/account rejected the call. Fix outside fooks by repairing the Claude Code account/provider state, then rerun the Claude-only command from the real Claude Code environment.
+- `auth-unavailable`: Claude Code could not use an auth provider for the requested model/session. Re-authenticate or adjust the local Claude Code provider configuration, then rerun from Claude Code.
+- `rate-limited` / `server-error` / `timeout`: retry later or increase the Claude timeout knob. These do not invalidate hook evidence when `hookEvidenceObserved: true`; for final provider-completion evidence, rerun from Claude Code rather than interpreting a Codex-hosted shell failure as a fooks runtime failure.


### PR DESCRIPTION
## Summary\n- document that Codex-hosted shells can prove installed Claude CLI hook activation, but final Claude provider completion should be rerun from the real Claude Code environment/account\n- clarify that hookEvidenceObserved=true with providerCompleted=false is a provider/account-context diagnostic, not a fooks hook failure\n- update provider failure triage to point final Claude-only reruns at Claude Code\n\n## Verification\n- node scripts/live-provider-hook-smoke.mjs\n- npm run release:smoke\n\n## Claim boundary\nNo provider billing-token, provider-cost, or ccusage replacement claim is added.