### PR TITLE
Add local compare proof for frontend context reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # fooks
 
-Frontend context compression for Codex.
+Frontend context compression for Codex and Claude Code.
 
 Public npm package: `oh-my-fooks`
 CLI command: `fooks`
 
-`fooks` helps Codex avoid rereading the same React component source over and over. In an attached Codex project, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time.
+`fooks` helps Codex and Claude Code reduce frontend code context for React component work. In an attached Codex project or a Claude project-local context-hook flow, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time, lowering estimated input-token load and creating a path to lower usage cost.
 
 ## Quick start
 
@@ -70,6 +70,7 @@ fooks status          # local estimated context-size telemetry for this repo
 fooks status codex   # check Codex attach/hook state
 fooks status claude  # check Claude project-local context hook / handoff health
 fooks status cache   # check local fooks cache health
+fooks compare src/components/Button.tsx --json  # local original-vs-fooks payload estimate
 ```
 
 For manual inspection:
@@ -80,6 +81,16 @@ fooks scan
 ```
 
 `fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider billing tokens, provider costs, or a `ccusage` replacement.
+
+## Compare a file locally
+
+Use `fooks compare` when you want immediate, local proof for a specific frontend file:
+
+```bash
+fooks compare src/components/Button.tsx --json
+```
+
+The command compares the original source bytes with the exact fooks model-facing payload produced by `fooks extract <file> --model-payload`. For compressed/hybrid frontend files, that payload is built from fooks' TypeScript AST-derived component contract, behavior, structure, and style signals instead of the full source text. It reports estimated source/model-facing tokens, estimated saved bytes/tokens, and a reduction percent. This is a **local model-facing payload estimate**: it is not provider tokenizer behavior, not runtime hook envelope overhead, not provider billing tokens, not provider costs, and not a `ccusage` replacement. Small raw files may show zero savings because fooks intentionally preserves the original source when that is safer.
 
 ## opencode support
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -47,6 +47,8 @@ proves them.
 
 Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`, including runtime/source breakdowns for Codex automatic hooks and Claude project-local context hooks. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
+`fooks compare <file> --json` is allowed as a local file-level estimate for original source versus the fooks model-facing payload. For compressed/hybrid frontend files, that payload is TypeScript AST-derived component contract/behavior/structure/style context, not a provider-tokenized prompt. Public wording may use it to support estimated input-token/context-load reduction and cost-reduction potential, but it must stay distinct from runtime hook status and provider billing telemetry. Compare output is not provider tokenizer behavior, not runtime hook envelope overhead, not provider billing tokens, not provider costs, and not a `ccusage` replacement.
+
 Codex setup/attach/status readiness is also local state only. It may show that
 Codex hooks, manifests, and trust metadata were prepared, but it is not live
 Codex runtime telemetry and must not be described as proof of runtime-token
@@ -100,6 +102,7 @@ Automated local checks now covered by `npm run release:smoke`:
 - [x] temp-prefix global install smoke test passes.
 - [x] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
 - [x] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.
+- [x] packed CLI `fooks compare <file> --json` smoke keeps local estimated payload comparison separate from provider billing/cost claims.
 
 Authority-gated checks before any real publish:
 
@@ -133,6 +136,7 @@ npm publish --dry-run
 - tarball required-file assertions
 - `npm pack --pack-destination <tmp>`
 - temporary-prefix global install
+- packed CLI `fooks compare <file> --json` local estimate check
 - disposable React/TSX project setup
 - isolated `FOOKS_CODEX_HOME` / `FOOKS_CLAUDE_HOME`
 - empty `FOOKS_ACTIVE_ACCOUNT` / `FOOKS_TARGET_ACCOUNT`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,6 +76,16 @@ Good signs:
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 
+## 4. Compare one frontend file locally
+
+Before opening a runtime, you can inspect the local file-level estimate for a supported frontend file:
+
+```bash
+fooks compare src/components/Button.tsx --json
+```
+
+`fooks compare` compares the original source bytes with the exact model-facing payload produced by `fooks extract <file> --model-payload`. For compressed/hybrid frontend files, that payload comes from fooks' TypeScript AST-derived component contract, behavior, structure, and style signals rather than the full source text. The token values are estimated from local byte counts, so this is a local model-facing payload estimate only. It is not provider tokenizer behavior, not runtime hook envelope overhead, not provider billing tokens, not provider costs, and not a `ccusage` replacement.
+
 ## What the setup result means
 
 | State | Meaning |
@@ -169,4 +179,5 @@ fooks codex-runtime-hook --native-hook
 fooks claude-runtime-hook --native-hook
 fooks scan
 fooks extract <file> --model-payload
+fooks compare src/components/Button.tsx --json
 ```

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -190,7 +190,54 @@ fs.writeFileSync(
   `${JSON.stringify({ name: "tmp-fooks-release-smoke", repository: { url: "https://github.com/example-org/tmp-fooks-release-smoke.git" } }, null, 2)}\n`,
 );
 fs.writeFileSync(path.join(project, "src", "App.tsx"), "export function App(){ return <main>Hello</main>; }\n");
-
+fs.writeFileSync(
+  path.join(project, "src", "LargeForm.tsx"),
+  [
+    "type Field = { id: string; label: string; placeholder: string };",
+    "",
+    "type LargeFormProps = {",
+    "  title: string;",
+    "  description: string;",
+    "  fields: Field[];",
+    "  footerText?: string;",
+    "};",
+    "",
+    "function fallbackFooterText(value?: string) {",
+    "  return value ?? 'All fields are required before continuing.';",
+    "}",
+    "",
+    "export function LargeForm({ title, description, fields, footerText }: LargeFormProps) {",
+    "  return (",
+    "    <section className=\"grid gap-6 rounded-lg border border-slate-200 bg-white p-6 shadow-sm\">",
+    "      <header className=\"grid gap-2\">",
+    "        <h2 className=\"text-lg font-semibold text-slate-900\">{title}</h2>",
+    "        <p className=\"text-sm text-slate-600\">{description}</p>",
+    "      </header>",
+    "",
+    "      <div className=\"grid gap-4 md:grid-cols-2\">",
+    "        {fields.map((field) => (",
+    "          <label key={field.id} className=\"grid gap-2 text-sm text-slate-700\">",
+    "            <span className=\"font-medium text-slate-800\">{field.label}</span>",
+    "            <input",
+    "              className=\"rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200\"",
+    "              placeholder={field.placeholder}",
+    "            />",
+    "          </label>",
+    "        ))}",
+    "      </div>",
+    "",
+    "      <footer className=\"flex items-center justify-between border-t border-slate-100 pt-4 text-xs text-slate-500\">",
+    "        <span>{fallbackFooterText(footerText)}</span>",
+    "        <button className=\"inline-flex items-center rounded-md bg-slate-900 px-3 py-2 font-medium text-white\">",
+    "          Continue",
+    "        </button>",
+    "      </footer>",
+    "    </section>",
+    "  );",
+    "}",
+    "",
+  ].join("\n"),
+);
 const setupStdout = execFileSync(fooksBin, ["setup"], {
   cwd: project,
   encoding: "utf8",
@@ -236,11 +283,31 @@ const claudeStatusStdout = execFileSync(fooksBin, ["status", "claude"], {
     FOOKS_CLAUDE_HOME: claudeHome,
   },
 });
+const compareStdout = runInstalledFooks(fooksBin, ["compare", "src/LargeForm.tsx", "--json"], {
+  cwd: project,
+  env: {
+    ...process.env,
+    HOME: path.join(runtimeRoot, "home"),
+    XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+    FOOKS_CODEX_HOME: codexHome,
+    FOOKS_CLAUDE_HOME: claudeHome,
+  },
+});
 assertPublicSurfaceClaimBoundaries({
   "fooks setup output": setupStdout,
   "fooks status output": statusStdout,
   "fooks status claude output": claudeStatusStdout,
+  "fooks compare output": compareStdout,
 });
+const compare = JSON.parse(compareStdout);
+assert(compare.metricTier === "estimated", `compare should expose estimated metric tier, got ${compare.metricTier}`);
+assert(compare.measurement === "local-model-facing-payload", `unexpected compare measurement ${compare.measurement}`);
+assert(compare.claimBoundary?.includes("not provider billing tokens"), "compare should keep provider billing boundary");
+assert(compare.claimBoundary?.includes("not provider costs"), "compare should keep provider cost boundary");
+assert(compare.excludes?.includes("provider-tokenizer-behavior"), "compare should exclude provider tokenizer behavior");
+assert(compare.excludes?.includes("runtime-hook-envelope-overhead"), "compare should exclude runtime hook envelope overhead");
+assert(compare.sourceBytes > compare.modelFacingBytes, "release compare fixture should show a local payload reduction");
+assert(compare.savedEstimatedTokens > 0, "release compare fixture should show positive estimated token reduction");
 const status = JSON.parse(statusStdout);
 assert(status.metricTier === "estimated", `status should expose estimated metric tier, got ${status.metricTier}`);
 assert(status.claimBoundary?.includes("not provider billing tokens"), "status should keep provider billing boundary");
@@ -404,6 +471,13 @@ console.log(JSON.stringify({
       latestSessionCount: postHookStatus.latestSessionCount,
       runtimeSources: Object.keys(postHookStatus.breakdown.byRuntimeAndSource ?? {}).sort(),
       claimBoundary: postHookStatus.claimBoundary,
+    },
+    compare: {
+      measurement: compare.measurement,
+      metricTier: compare.metricTier,
+      reductionPercent: compare.reductionPercent,
+      savedEstimatedTokens: compare.savedEstimatedTokens,
+      claimBoundary: compare.claimBoundary,
     },
   },
   accountDetails: setup.attach.runtimeProof.details.filter((detail) => detail.startsWith("account-")),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -520,7 +520,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|run|scan|extract|decide|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|run|scan|extract|compare|decide|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -531,6 +531,7 @@ Everyday commands:
 
   ${displayCliName} run <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
+  ${displayCliName} compare <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
@@ -568,6 +569,23 @@ function parseExtractArgs(args: string[]): { filePath: string; modelPayload: boo
   }
 
   return { filePath: requireFilePath(filePath), modelPayload };
+}
+
+function parseCompareArgs(args: string[]): { filePath: string } {
+  let filePath: string | undefined;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      continue;
+    }
+    if (!filePath) {
+      filePath = arg;
+      continue;
+    }
+    throw new Error(`Unexpected compare argument: ${arg}`);
+  }
+
+  return { filePath: requireFilePath(filePath) };
 }
 
 function parseCodexRuntimeHookArgs(args: string[]): {
@@ -764,6 +782,13 @@ async function run(): Promise<void> {
         return;
       }
       print(result);
+      return;
+    }
+
+    case "compare": {
+      const { compareModelFacingPayload } = await import("../core/compare.js");
+      const { filePath: file } = parseCompareArgs(rest);
+      print(compareModelFacingPayload(file, process.cwd()));
       return;
     }
     case "decide": {

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,0 +1,78 @@
+import { extractFile } from "./extract";
+import { toModelFacingPayload } from "./payload/model-facing";
+import {
+  FOOKS_METRIC_CLAIM_BOUNDARY,
+  FOOKS_SESSION_METRIC_TIER,
+  estimateTextBytes,
+  estimateTokensFromBytes,
+} from "./session-metrics";
+import type { OutputMode } from "./schema";
+
+export const FOOKS_COMPARE_CLAIM_BOUNDARY = `${FOOKS_METRIC_CLAIM_BOUNDARY} Compare values are local model-facing payload estimates, not provider tokenizer output, not runtime hook envelope overhead, and not provider costs.`;
+
+export type FooksCompareResult = {
+  filePath: string;
+  mode: OutputMode;
+  useOriginal: boolean;
+  sourceBytes: number;
+  modelFacingBytes: number;
+  estimatedSourceTokens: number;
+  estimatedModelFacingTokens: number;
+  savedEstimatedBytes: number;
+  savedEstimatedTokens: number;
+  reductionPercent: number;
+  payloadLarger: boolean;
+  nonSavingReason?: "original-source-preserved-for-small-raw-file" | "model-facing-payload-not-smaller";
+  metricTier: typeof FOOKS_SESSION_METRIC_TIER;
+  measurement: "local-model-facing-payload";
+  excludes: string[];
+  claimBoundary: string;
+};
+
+function roundPercent(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function nonSavingReason(useOriginal: boolean, payloadLarger: boolean): FooksCompareResult["nonSavingReason"] {
+  if (useOriginal) return "original-source-preserved-for-small-raw-file";
+  if (payloadLarger) return "model-facing-payload-not-smaller";
+  return undefined;
+}
+
+export function compareModelFacingPayload(filePath: string, cwd = process.cwd()): FooksCompareResult {
+  const extracted = extractFile(filePath);
+  const payload = toModelFacingPayload(extracted, cwd);
+  const sourceBytes = extracted.meta.rawSizeBytes;
+  const modelFacingBytes = estimateTextBytes(JSON.stringify(payload));
+  const estimatedSourceTokens = estimateTokensFromBytes(sourceBytes);
+  const estimatedModelFacingTokens = estimateTokensFromBytes(modelFacingBytes);
+  const savedEstimatedBytes = Math.max(0, sourceBytes - modelFacingBytes);
+  const savedEstimatedTokens = Math.max(0, estimatedSourceTokens - estimatedModelFacingTokens);
+  const reductionPercent = sourceBytes === 0 ? 0 : roundPercent((savedEstimatedBytes / sourceBytes) * 100);
+  const payloadLarger = modelFacingBytes >= sourceBytes;
+  const useOriginal = extracted.useOriginal === true;
+
+  return {
+    filePath: payload.filePath,
+    mode: extracted.mode,
+    useOriginal,
+    sourceBytes,
+    modelFacingBytes,
+    estimatedSourceTokens,
+    estimatedModelFacingTokens,
+    savedEstimatedBytes,
+    savedEstimatedTokens,
+    reductionPercent,
+    payloadLarger,
+    ...(payloadLarger || useOriginal ? { nonSavingReason: nonSavingReason(useOriginal, payloadLarger) } : {}),
+    metricTier: FOOKS_SESSION_METRIC_TIER,
+    measurement: "local-model-facing-payload",
+    excludes: [
+      "provider-tokenizer-behavior",
+      "runtime-hook-envelope-overhead",
+      "provider-billing-tokens",
+      "provider-costs",
+    ],
+    claimBoundary: FOOKS_COMPARE_CLAIM_BOUNDARY,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { scanProject } from "./core/scan";
 export { extractFile } from "./core/extract";
 export { toModelFacingPayload } from "./core/payload/model-facing";
+export { compareModelFacingPayload } from "./core/compare";
 export { assessPayloadReadiness } from "./core/payload/readiness";
 export { decideMode } from "./core/decide";
 export { classifyPromptContext, discoverRelevantFilesByPolicy, extractPromptTargets } from "./core/context-policy";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -266,6 +266,39 @@ test("extract can return model-facing payload without engine metadata", () => {
   assert.equal(result.style.system, "tailwind");
 });
 
+test("compare reports local estimated model-facing payload reduction", () => {
+  const result = run(["compare", "fixtures/compressed/FormSection.tsx", "--json"]);
+  assert.equal(result.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(result.mode, "compressed");
+  assert.equal(result.useOriginal, false);
+  assert.equal(result.metricTier, "estimated");
+  assert.equal(result.measurement, "local-model-facing-payload");
+  assert.ok(result.sourceBytes > result.modelFacingBytes);
+  assert.ok(result.estimatedSourceTokens > result.estimatedModelFacingTokens);
+  assert.ok(result.savedEstimatedBytes > 0);
+  assert.ok(result.savedEstimatedTokens > 0);
+  assert.ok(result.reductionPercent > 0);
+  assert.equal(result.payloadLarger, false);
+  assert.match(result.claimBoundary, /not provider billing tokens/);
+  assert.match(result.claimBoundary, /not provider costs/);
+  assert.ok(result.excludes.includes("provider-tokenizer-behavior"));
+  assert.ok(result.excludes.includes("runtime-hook-envelope-overhead"));
+});
+
+test("compare keeps tiny raw fallback from reporting false positive savings", () => {
+  const result = run(["compare", "fixtures/raw/SimpleButton.tsx", "--json"]);
+  assert.equal(result.filePath, path.join("fixtures", "raw", "SimpleButton.tsx"));
+  assert.equal(result.mode, "raw");
+  assert.equal(result.useOriginal, true);
+  assert.equal(result.metricTier, "estimated");
+  assert.equal(result.savedEstimatedBytes, 0);
+  assert.equal(result.savedEstimatedTokens, 0);
+  assert.equal(result.reductionPercent, 0);
+  assert.equal(result.payloadLarger, true);
+  assert.equal(result.nonSavingReason, "original-source-preserved-for-small-raw-file");
+  assert.match(result.claimBoundary, /not provider billing tokens/);
+});
+
 test("extract produces compressed output for boilerplate-heavy fixture", () => {
   const result = run(["extract", "fixtures/compressed/FormSection.tsx"]);
   assert.equal(result.mode, "compressed");
@@ -1603,6 +1636,7 @@ test("setup reports blocked state for projects without React components", () => 
 test("cli help advertises setup and package install has no auto hook side effects", () => {
   const help = runText(["--help"]);
   assert.match(help, /fooks setup/);
+  assert.match(help, /fooks compare <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /Codex: automatic repeated-file runtime hook path/);
   assert.match(help, /Claude: project-local context hooks/);
@@ -2387,6 +2421,27 @@ test("package release surface keeps internal docs out of the npm tarball", () =>
   assert.match(releaseSmoke, /packed tarball includes non-public path/);
   assert.match(gitignore, /docs\/internal\//);
   assert.match(gitignore, /\.opencode\//);
+});
+
+test("docs describe local compare estimates without billing-cost claims", () => {
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
+  const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
+  const combined = `${readme}
+${setup}
+${release}`;
+
+  assert.match(readme, /Frontend context compression for Codex and Claude Code/);
+  assert.match(combined, /fooks compare src\/components\/Button\.tsx/);
+  assert.match(combined, /local model-facing payload estimate|local file-level estimate/);
+  assert.match(combined, /TypeScript AST-derived/);
+  assert.match(combined, /estimated input-token load|estimated input-token/);
+  assert.match(combined, /not provider billing tokens/);
+  assert.match(combined, /not provider costs/);
+  assert.match(combined, /Claude.*project-local context hooks|project-local `SessionStart` \/ `UserPromptSubmit` hooks/s);
+  assert.doesNotMatch(combined, /fooks reduces your actual provider bill/i);
+  assert.doesNotMatch(combined, /measured Codex\/Claude billing tokens/i);
+  assert.doesNotMatch(combined, /automatic Claude Read\/tool interception/i);
 });
 
 test("docs keep direct runtime benchmark regressions out of public win claims", () => {


### PR DESCRIPTION
## Summary

- Add `fooks compare <file> [--json]` as a local before/after proof for raw frontend source versus the fooks model-facing payload.
- Frame the result as an estimated input-token/context-load comparison for Codex and Claude Code users, not as provider billing telemetry.
- Extend release smoke and docs/tests so compare output stays bounded: not provider tokenizer behavior, not runtime hook envelope overhead, not provider billing tokens, not provider costs, and not a `ccusage` replacement.

## Scope / claim boundary

This PR intentionally proves only the conservative foundation:

- without fooks: raw frontend source bytes / estimated tokens
- with fooks: TypeScript AST-derived model-facing payload bytes / estimated tokens
- delta: local estimated saved bytes/tokens and reduction percent

It does **not** claim actual Claude/Codex billing-token or provider-cost reduction. Provider-tokenizer/API or ccusage-style usage-log validation should be a follow-up proof PR, not a blocker for this foundation.

## Verification

- `npm run build`
- `npm run lint`
- `node --test test/fooks.test.mjs` — 84 passed
- `npm run release:smoke` — compare smoke included `reductionPercent: 66.35`, `savedEstimatedTokens: 260`
- `npm test` — 129 passed
- `git diff --check`

## Notes

The compare payload is AST-derived today via the existing TypeScript extraction path. It is not an LSP path and the docs avoid saying LSP until such a path exists.
