### PR TITLE
Prove estimated provider usage cost before billing claims

### DIFF
--- a/benchmarks/layer2-frontend-task/CASE1_EXECUTION_SPEC.md
+++ b/benchmarks/layer2-frontend-task/CASE1_EXECUTION_SPEC.md
@@ -28,7 +28,7 @@ cd ~/Workspace/fooks-test-repos/ui
 
 # 2. Vanilla 실행 (fooks 미사용)
 npx codex exec \
-  --model gpt-4o \
+  --model gpt-5.4 \
   --full-auto \
   --skip-git-repo-check \
   --prompt "Split this 1,249 line combobox component into modular files:
@@ -60,7 +60,7 @@ console.log(JSON.stringify(result, null, 2));
 
 # 2. Fooks 실행
 npx codex exec \
-  --model gpt-4o \
+  --model gpt-5.4 \
   --full-auto \
   --skip-git-repo-check \
   --prompt "$(cat /tmp/case1-fooks-context.json)

--- a/benchmarks/layer2-frontend-task/CASE1_FAILURE_ANALYSIS.md
+++ b/benchmarks/layer2-frontend-task/CASE1_FAILURE_ANALYSIS.md
@@ -34,7 +34,7 @@
 ```bash
 cd ~/Workspace/fooks-test-repos/nextjs
 echo 'Move the "Sign in with GitHub" button from the left side to the right side of the page. Maintain all existing functionality and styling.' | \
-npx codex exec -m gpt-4o --full-auto --skip-git-repo-check
+npx codex exec -m gpt-5.4 --full-auto --skip-git-repo-check
 ```
 
 **스크립트:** `/tmp/vanilla-400-repro.sh`
@@ -55,7 +55,7 @@ npx codex exec -m gpt-4o --full-auto --skip-git-repo-check
 ```bash
 cd ~/Workspace/fooks
 node -e "const f=require('./dist/index.js');const r=f.extractFile('examples/auth/app/page.tsx');console.log('Move button:\n'+r.rawText)" | \
-npx codex exec -m gpt-4o --full-auto --skip-git-repo-check
+npx codex exec -m gpt-5.4 --full-auto --skip-git-repo-check
 ```
 
 **스크립트:** `/tmp/fooks-502-repro.sh`

--- a/benchmarks/layer2-frontend-task/CASE1_RUNBOOK.md
+++ b/benchmarks/layer2-frontend-task/CASE1_RUNBOOK.md
@@ -62,7 +62,7 @@ CONTEXT: [FOOKS EXTRACTION RESULT HERE]
 ```bash
 cd ~/Workspace/fooks-test-repos/ui && \
 npx codex exec \
-  --model gpt-4o \
+  --model gpt-5.4 \
   --full-auto \
   --skip-git-repo-check \
   --prompt "Split combobox component into modular files (components/, hooks/, utils/, types/, index.ts). Max 200 lines per file. No circular deps. Maintain functionality." \
@@ -81,7 +81,7 @@ fs.writeFileSync('/tmp/case1-fooks-context.json', JSON.stringify(result, null, 2
 # 2. Run with fooks context
 cd ~/Workspace/fooks-test-repos/ui && \
 npx codex exec \
-  --model gpt-4o \
+  --model gpt-5.4 \
   --full-auto \
   --skip-git-repo-check \
   --prompt-file /tmp/case1-fooks-context.json \

--- a/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
+++ b/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
@@ -1,0 +1,269 @@
+# Provider cost import validation runbook
+
+This runbook is the non-live path for answering: **how much estimated OpenAI API cost changed for matched baseline vs fooks runs?**
+
+It intentionally does **not** prove provider invoice/dashboard billing savings and does **not** prove stable runtime-token/time savings.
+
+## Evidence standard
+
+Launch-grade estimated API cost evidence requires:
+
+- 3 predeclared task classes;
+- 5 accepted matched baseline/fooks pairs per task class;
+- same model, endpoint, service tier, reasoning, max output token, and setup identity inside each comparable group;
+- provenance `validated-provider-import` or `live-openai-usage`;
+- positive median estimated total API cost reduction per task and overall;
+- quality gates pass for both baseline and fooks artifacts;
+- campaign manifest + attempted-pair ledger preserving the denominator, including failed, missing, neutral, regressed, and omitted pairs;
+- explicit pricing assumptions for input, cached-input, output, endpoint/service tier, long-context, and regional/data-residency treatment.
+
+Fixture samples only prove mechanics. They should classify as `fixture-launch-grade-mechanics`, not public positive evidence.
+
+## Files in the import kit
+
+Fixture mechanics kit:
+
+- `fixtures/provider-cost-import-kit/import-manifest.json`
+- `fixtures/provider-cost-import-kit/campaign-manifest.json`
+- `fixtures/provider-cost-import-kit/attempted-pair-ledger.json`
+- `fixtures/provider-cost-import-kit/pair-evidence/*.json`
+
+The fixture kit is safe to run without credentials and should not make a real provider-cost claim.
+
+Live OpenAI campaign template:
+
+- `provider-cost-live-campaign-tasks.json`
+
+This template predeclares 3 task classes × 5 matched pairs. It is the live path for estimated API cost evidence, but it requires an OpenAI credential and explicit spend caps. The default auth mode is `auto`: `OPENAI_API_KEY`/`OPEN_AI_APIKEY` first, then Codex OAuth from `$FOOKS_CODEX_HOME/auth.json`, `$CODEX_HOME/auth.json`, or `~/.codex/auth.json`. Use `--auth-mode=codex-oauth --transport=codex-exec` when validating the common Codex/ChatGPT sign-in path; that transport shells out to `codex exec --json` and reads the `turn.completed.usage` event instead of requiring a platform API key. Without credentials, the runner records a local blocker artifact and makes no request.
+
+Corrected real-payload campaign builder:
+
+- `build-provider-cost-corrected-manifest.js`
+
+Use this when the goal is to test the real fooks product mechanism rather than a
+synthetic "compact prepared context" label. The builder creates a generated
+manifest under `.fooks/evidence/provider-cost/<run-id>/` with full-source
+baseline payload files, real `fooks extract --model-payload` JSON payload files,
+per-task prompt payload-size stats, AB/BA order, and a no-tool quality gate.
+
+## One-command mechanics check
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json \
+  --run-id=provider-cost-import-kit-smoke
+```
+
+Expected mechanics status:
+
+```text
+fixture-launch-grade-mechanics
+```
+
+Generated output:
+
+- `.fooks/evidence/provider-cost/provider-cost-import-kit-smoke/summary.json`
+- `.fooks/evidence/provider-cost/provider-cost-import-kit-smoke/summary.md`
+- `.fooks/evidence/provider-cost/provider-cost-import-kit-smoke/campaign-ledger.json`
+
+## Real provider usage import
+
+For a real import campaign:
+
+1. Copy the fixture kit to a private/local evidence directory.
+2. Replace each pair evidence JSON with real matched baseline/fooks OpenAI usage artifacts.
+3. Set pair evidence provenance/source kind to `validated-provider-import`.
+4. Keep every attempted pair in `attempted-pair-ledger.json`, including failures, missing usage, neutral outcomes, regressions, and omitted pairs with reasons.
+5. Update `campaign-manifest.json` with the actual model, endpoint, service tier, reasoning settings, quality gate, pricing source URL, and checked date.
+6. Run the repeated provider-cost import command.
+
+The summary may claim `launch-grade-estimated-cost-evidence` only when the threshold passes. Otherwise it must remain narrow/diagnostic.
+
+## Real live OpenAI campaign
+
+Check the plan without making requests:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --dry-run-live \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --task-manifest=benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15
+```
+
+Run the actual capped campaign only in a shell that has a resolved API key or Codex OAuth login:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --task-manifest=benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15 \
+  --run-id=provider-cost-live-campaign
+```
+
+The runner writes `.fooks/evidence/provider-cost/<run-id>/summary.json`, `summary.md`, `campaign-ledger.json`, and pair evidence under `pairs/`. A no-credential run is expected to report `live-openai-credentials-missing` with `requestMade: false`; that is a safe blocker, not evidence of cost reduction. If Codex OAuth is present but the provider rejects the request, the status is `live-openai-request-failed`; keep that artifact and inspect the attempted-pair ledger before rerunning.
+
+## Corrected real-payload live campaign
+
+The first live Codex OAuth campaign proved the OAuth usage pipeline and the
+3 × 5 denominator, but it also showed why a one-pair smoke was not enough: the
+smoke was positive, while the full campaign had 14/15 estimated-cost
+regressions. It should be treated as a diagnostic against cherry-picking, not
+as a final product-mechanism test, because the fooks side did not include a real
+fooks payload and Codex workspace/tool activity dominated the token count.
+
+Build a corrected manifest after `dist/` is available:
+
+```bash
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --run-id=provider-cost-corrected-real-payload \
+  --target-pair-count=5
+```
+
+Dry-run the corrected campaign:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --dry-run-live \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --codex-workdir=isolated \
+  --pair-order=abba \
+  --require-no-tool-use=true \
+  --task-manifest=.fooks/evidence/provider-cost/provider-cost-corrected-real-payload/corrected-task-manifest.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15
+```
+
+Run it only when spend is acceptable:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --codex-workdir=isolated \
+  --pair-order=abba \
+  --require-no-tool-use=true \
+  --task-manifest=.fooks/evidence/provider-cost/provider-cost-corrected-real-payload/corrected-task-manifest.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --fetch-pricing \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15 \
+  --run-id=provider-cost-corrected-real-payload
+```
+
+The corrected manifest builder is intentionally payload-only: it writes
+full-source baseline contexts, fooks model-facing payload contexts, and
+payload-size stats. It does not write pricing rates or estimated costs. Pricing
+is resolved only by `run-provider-cost-repeated.js` when the campaign is
+executed (`--fetch-pricing`, `--pricing-catalog`, or explicit pricing args), so
+cost estimation cannot change extraction behavior or prompt construction.
+
+Interpretation guardrails:
+
+- `--codex-workdir=isolated` keeps Codex away from repo/evidence workdirs.
+- `--pair-order=abba` alternates baseline/fooks ordering to reduce order bias.
+- `--require-no-tool-use=true` fails the pair-side quality gate if Codex JSONL
+  contains `command_execution` events.
+- Positive prompt payload reduction in the generated manifest is not enough by
+  itself; the live campaign still needs positive median estimated API cost
+  deltas across the required accepted pairs.
+
+Known 2026-04-22 corrected campaign outcome:
+
+- run id: `provider-cost-corrected-real-payload-campaign-20260422`;
+- status: `launch-grade-estimated-cost-evidence`;
+- 15/15 accepted pairs across 3 task classes;
+- no-tool gate passed for every side (`command_execution` count 0);
+- median estimated API cost reduction: `4.171%`;
+- aggregate estimated API cost reduction: `$0.0340775` (5.787%) under the
+  recorded pricing assumption;
+- 4/15 individual pairs still regressed, so follow-up campaigns should preserve
+  the full denominator and not present only favorable pairs.
+
+This supports only estimate-scoped API-cost language. It still does not support
+provider invoice/dashboard savings, actual charged-cost savings,
+provider-billing-token savings, stable runtime-token savings, or stable
+wall-clock/latency savings.
+
+## Large public-code corrected profiles
+
+Use larger public-code profiles when the question is whether the small fixture
+effect was diluted by Codex fixed prompt/runtime overhead:
+
+```bash
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --profile=nextjs-large \
+  --nextjs-root=~/Workspace/fooks-test-repos/nextjs \
+  --run-id=provider-cost-nextjs-large-real-payload \
+  --target-pair-count=5
+
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --profile=tailwind-large \
+  --tailwindcss-root=~/Workspace/fooks-test-repos/tailwindcss \
+  --run-id=provider-cost-tailwind-large-real-payload \
+  --target-pair-count=5
+```
+
+Then run the generated manifest with the same dry-run/full command shape as the
+fixture corrected lane, changing only `--task-manifest` and `--run-id`.
+
+Known 2026-04-22 outcomes:
+
+- Next.js large: `provider-cost-nextjs-large-real-payload-campaign-20260422`
+  - `launch-grade-estimated-cost-evidence`;
+  - 15/15 accepted, 0 regressions, 0 command executions;
+  - median estimated API cost reduction `26.492%`;
+  - aggregate provider-reported total usage-token reduction `14.371%`;
+  - aggregate estimated API cost reduction `$0.23889` (`27.028%`).
+- Tailwind large: `provider-cost-tailwind-large-real-payload-campaign-20260422`
+  - `launch-grade-estimated-cost-evidence`;
+  - 15/15 accepted, 0 regressions, 0 command executions;
+  - median estimated API cost reduction `38.238%`;
+  - aggregate provider-reported total usage-token reduction `46.9%`;
+  - aggregate estimated API cost reduction `$0.950345` (`59.438%`).
+
+These are stronger than the small fixture lane because the source payloads are
+large enough for fooks payload compression to dominate Codex's fixed prompt
+overhead. The allowed wording is still estimate-scoped; do not claim
+invoice/dashboard savings or stable wall-clock/runtime wins from these runs.
+
+## Interpreting statuses
+
+- `launch-grade-estimated-cost-evidence`: estimated API cost positive evidence threshold passed.
+- `narrow-estimated-cost-candidate`: positive evidence exists but not enough task coverage or accepted pairs for launch-grade.
+- `fixture-launch-grade-mechanics`: fixture-only threshold mechanics passed; not a public positive cost claim.
+- `mixed-identity`: model/setup/endpoint/service-tier identity differs inside comparable groups.
+- `missing-usage`: provider usage tokens are missing or inconclusive.
+- `insufficient-accepted-pairs`: denominator is visible but threshold is not met.
+- `diagnostic-only`: evidence is not claimable; inspect diagnostics.
+
+## Claim boundary
+
+Allowed after real launch-grade estimated-cost evidence:
+
+> In this benchmark campaign, fooks reduced estimated OpenAI API cost under explicit pricing assumptions.
+
+Not allowed from this lane:
+
+- provider invoice/dashboard billing savings;
+- actual charged-cost savings;
+- provider billing-token savings;
+- stable runtime-token savings;
+- stable wall-clock/time/latency savings;
+- Claude/opencode automatic cost savings.

--- a/benchmarks/layer2-frontend-task/R4-metric-schema.md
+++ b/benchmarks/layer2-frontend-task/R4-metric-schema.md
@@ -25,7 +25,7 @@
 ### 동일 조건 보장
 | 조건 | 동일성 |
 |------|--------|
-| LLM model | 동일 (예: gpt-4o/claude-sonnet) |
+| LLM model | 동일 (예: gpt-5.4/claude-sonnet) |
 | Temperature | 0.1 (deterministic) |
 | System prompt | 동일한 task instruction |
 | max_tokens | 동일 (예: 8192) |

--- a/benchmarks/layer2-frontend-task/R4-runner-implementation-plan.md
+++ b/benchmarks/layer2-frontend-task/R4-runner-implementation-plan.md
@@ -71,7 +71,7 @@ async function runCodex(context, prompt) {
   
   // Codex CLI 호출
   const codex = spawn('codex', [
-    '--model', 'gpt-4o',
+    '--model', process.env.OPENAI_MODEL || 'gpt-5.4',
     '--temperature', '0.1',
     '--prompt', buildPrompt(context, prompt)
   ]);

--- a/benchmarks/layer2-frontend-task/billing-import-evidence.js
+++ b/benchmarks/layer2-frontend-task/billing-import-evidence.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { ensureEvidenceDir, evidencePaths, timestampRunId } = require('./evidence-paths');
+
+const BILLING_IMPORT_SCHEMA_VERSION = 'billing-import-evidence.v1';
+
+function billingImportSchema() {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    title: 'fooks manual billing import evidence',
+    type: 'object',
+    additionalProperties: false,
+    required: ['schemaVersion', 'provider', 'period', 'source', 'claimability'],
+    properties: {
+      schemaVersion: { const: BILLING_IMPORT_SCHEMA_VERSION },
+      provider: { type: 'string', minLength: 1 },
+      account: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string' },
+          projectId: { type: 'string' },
+          redacted: { type: 'boolean' },
+        },
+      },
+      period: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['start', 'end'],
+        properties: {
+          start: { type: 'string', description: 'Inclusive billing/usage period start date or timestamp' },
+          end: { type: 'string', description: 'Exclusive billing/usage period end date or timestamp' },
+        },
+      },
+      model: { type: 'string' },
+      currency: { type: 'string', minLength: 3, maxLength: 3 },
+      usage: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          inputTokens: { type: 'number', minimum: 0 },
+          outputTokens: { type: 'number', minimum: 0 },
+          cachedInputTokens: { type: 'number', minimum: 0 },
+          cacheCreationInputTokens: { type: 'number', minimum: 0 },
+        },
+      },
+      billedAmount: { type: 'number', minimum: 0 },
+      source: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'timestamp'],
+        properties: {
+          type: {
+            enum: ['invoice', 'dashboard-export', 'usage-export', 'manual-entry'],
+          },
+          timestamp: { type: 'string' },
+          redacted: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+      },
+      claimability: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['providerInvoiceOrBillingSavings', 'providerBillingTokenSavings'],
+        properties: {
+          providerInvoiceOrBillingSavings: { const: false },
+          providerBillingTokenSavings: { const: false },
+        },
+      },
+    },
+  };
+}
+
+function renderBillingImportReadme(runId) {
+  return [
+    '# Billing manual-import evidence tier',
+    '',
+    `Run ID: \`${runId}\``,
+    '',
+    'This directory is a placeholder for future manual provider billing imports.',
+    '',
+    '## Claim boundary',
+    '',
+    '- This schema does not prove provider invoice or billing savings.',
+    '- This tier does not collect provider credentials or call billing dashboards/APIs.',
+    '- Actual billing savings require a later reconciliation step against invoice/dashboard/export data.',
+    '',
+  ].join('\n');
+}
+
+function writeBillingImportArtifacts({ cwd = process.cwd(), runId = timestampRunId('billing-import') } = {}) {
+  const paths = evidencePaths({
+    cwd,
+    tier: 'billing-import',
+    runId,
+    jsonName: 'import.schema.json',
+    markdownName: 'README.md',
+  });
+  ensureEvidenceDir({ cwd, tier: 'billing-import', runId });
+  fs.writeFileSync(paths.json, `${JSON.stringify(billingImportSchema(), null, 2)}\n`);
+  fs.writeFileSync(paths.markdown, renderBillingImportReadme(paths.runId));
+  return {
+    runId: paths.runId,
+    schemaPath: paths.json,
+    readmePath: paths.markdown,
+    claimability: {
+      providerInvoiceOrBillingSavings: false,
+      providerBillingTokenSavings: false,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  return argv.reduce((acc, arg) => {
+    if (!arg.startsWith('--')) return acc;
+    const index = arg.indexOf('=');
+    if (index === -1) acc[arg.slice(2)] = true;
+    else acc[arg.slice(2, index)] = arg.slice(index + 1);
+    return acc;
+  }, {});
+}
+
+function relativePath(filePath) {
+  return path.relative(process.cwd(), path.resolve(filePath)).split(path.sep).join('/');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    console.log('Usage: node benchmarks/layer2-frontend-task/billing-import-evidence.js [--run-id=<id>]');
+    return;
+  }
+
+  const result = writeBillingImportArtifacts({ runId: args['run-id'] });
+  console.log(JSON.stringify({
+    runId: result.runId,
+    schemaPath: relativePath(result.schemaPath),
+    readmePath: relativePath(result.readmePath),
+    claimability: result.claimability,
+  }, null, 2));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[billing-import-evidence] ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  BILLING_IMPORT_SCHEMA_VERSION,
+  billingImportSchema,
+  renderBillingImportReadme,
+  writeBillingImportArtifacts,
+};

--- a/benchmarks/layer2-frontend-task/build-provider-cost-corrected-manifest.js
+++ b/benchmarks/layer2-frontend-task/build-provider-cost-corrected-manifest.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) continue;
+    const index = arg.indexOf('=');
+    const key = index === -1 ? arg.slice(2) : arg.slice(2, index);
+    const value = index === -1 ? true : arg.slice(index + 1);
+    args[key] = value;
+  }
+  return args;
+}
+
+function repoRootFromHere() {
+  return path.resolve(__dirname, '..', '..');
+}
+
+function expandHome(value) {
+  if (!value || !value.startsWith('~')) return value;
+  return path.join(process.env.HOME || '', value.slice(1));
+}
+
+function bytes(text) {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+function pctReduction(baselineBytes, fooksBytes) {
+  if (!baselineBytes) return null;
+  return Number(((1 - (fooksBytes / baselineBytes)) * 100).toFixed(3));
+}
+
+function loadFooksExtractors(repoRoot) {
+  const distIndex = path.join(repoRoot, 'dist', 'index.js');
+  const distPayload = path.join(repoRoot, 'dist', 'core', 'payload', 'model-facing.js');
+  if (!fs.existsSync(distIndex) || !fs.existsSync(distPayload)) {
+    throw new Error('Built dist files are required. Run `npm run build` before building a corrected provider-cost manifest.');
+  }
+  return {
+    extractFile: require(distIndex).extractFile,
+    toModelFacingPayload: require(distPayload).toModelFacingPayload,
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function makeTask({
+  contextsDir,
+  extractFile,
+  toModelFacingPayload,
+  id,
+  sourceRoot,
+  sourceRootLabel,
+  targetFile,
+  instruction,
+  targetPairCount,
+}) {
+  const absoluteTarget = path.resolve(sourceRoot, targetFile);
+  if (!fs.existsSync(absoluteTarget)) {
+    throw new Error(`Target file not found for ${id}: ${absoluteTarget}`);
+  }
+  const sourceText = fs.readFileSync(absoluteTarget, 'utf8');
+  const fooksPayload = toModelFacingPayload(extractFile(absoluteTarget), sourceRoot);
+  const fooksPayloadText = JSON.stringify(fooksPayload, null, 2);
+  const baselineContextPath = path.join(contextsDir, `${id}.baseline.source.txt`);
+  const fooksContextPath = path.join(contextsDir, `${id}.fooks.payload.json`);
+  fs.writeFileSync(baselineContextPath, sourceText);
+  fs.writeFileSync(fooksContextPath, fooksPayloadText);
+  const sourceBytes = bytes(sourceText);
+  const payloadBytes = bytes(fooksPayloadText);
+  return {
+    id,
+    targetPairCount,
+    repetitions: targetPairCount,
+    targetFile,
+    sourceRootLabel,
+    instruction,
+    baselineContextPath: path.relative(path.dirname(path.join(contextsDir, '..', 'manifest.json')), baselineContextPath).split(path.sep).join('/'),
+    fooksContextPath: path.relative(path.dirname(path.join(contextsDir, '..', 'manifest.json')), fooksContextPath).split(path.sep).join('/'),
+    baselineContextFormat: 'source',
+    fooksContextFormat: 'json',
+    setupIdentity: 'corrected-real-payload-no-tool',
+    pairOrder: 'abba',
+    requireNoToolUse: true,
+    qualityGate: {
+      id: 'corrected-payload-validation',
+      version: 'v1',
+      status: 'passed',
+      command: 'answers must use only the prompt payload; runner may fail the side gate when Codex command_execution events are observed',
+    },
+    payloadStats: {
+      baselineBytes: sourceBytes,
+      fooksPayloadBytes: payloadBytes,
+      promptPayloadReductionPct: pctReduction(sourceBytes, payloadBytes),
+      fooksMode: fooksPayload.mode,
+    },
+  };
+}
+
+function requireSourceRoot(value, label) {
+  const resolved = path.resolve(expandHome(value || ''));
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`${label} root not found: ${resolved}`);
+  }
+  return resolved;
+}
+
+function taskSpecsForProfile(profile, args, repoRoot) {
+  const nextjsRoot = args['nextjs-root']
+    || process.env.FOOKS_NEXTJS_ROOT
+    || '~/Workspace/fooks-test-repos/nextjs';
+  const tailwindRoot = args['tailwindcss-root']
+    || args['tailwind-root']
+    || process.env.FOOKS_TAILWINDCSS_ROOT
+    || '~/Workspace/fooks-test-repos/tailwindcss';
+
+  const fixtures = [
+    {
+      id: 'form-section-component-summary',
+      sourceRoot: repoRoot,
+      sourceRootLabel: 'fooks-fixtures',
+      targetFile: 'fixtures/compressed/FormSection.tsx',
+      instruction: 'Summarize this React form section component. Include component responsibilities, props/state contract, behavior boundaries, and extraction risks.',
+    },
+    {
+      id: 'form-section-refactor-plan',
+      sourceRoot: repoRoot,
+      sourceRootLabel: 'fooks-fixtures',
+      targetFile: 'fixtures/compressed/FormSection.tsx',
+      instruction: 'Draft a concise behavior-preserving refactor plan for this React form section. Include split boundaries, tests, migration steps, and rollback signals.',
+    },
+    {
+      id: 'dashboard-test-strategy',
+      sourceRoot: repoRoot,
+      sourceRootLabel: 'fooks-fixtures',
+      targetFile: 'fixtures/hybrid/DashboardPanel.tsx',
+      instruction: 'Create a behavior-preserving test strategy for this dashboard component. Include unit/integration coverage, interaction risks, edge cases, and acceptance criteria.',
+    },
+  ];
+
+  const nextjsLarge = () => {
+    const root = requireSourceRoot(nextjsRoot, 'Next.js');
+    return [
+      {
+        id: 'nextjs-app-router-summary',
+        sourceRoot: root,
+        sourceRootLabel: 'nextjs',
+        targetFile: 'packages/next/src/client/components/app-router.tsx',
+        instruction: 'Summarize this Next.js App Router client component. Include responsibilities, state/context contract, navigation boundaries, and risks for editing it.',
+      },
+      {
+        id: 'nextjs-layout-router-refactor-plan',
+        sourceRoot: root,
+        sourceRootLabel: 'nextjs',
+        targetFile: 'packages/next/src/client/components/layout-router.tsx',
+        instruction: 'Draft a behavior-preserving refactor/extraction plan for this Next.js layout router component. Include boundaries, invariants, tests, and rollback signals.',
+      },
+      {
+        id: 'nextjs-error-boundary-test-strategy',
+        sourceRoot: root,
+        sourceRootLabel: 'nextjs',
+        targetFile: 'packages/next/src/client/components/error-boundary.tsx',
+        instruction: 'Create a behavior-preserving test strategy for this Next.js error boundary component. Include rendering paths, recovery behavior, edge cases, and acceptance criteria.',
+      },
+    ];
+  };
+
+  const tailwindLarge = () => {
+    const root = requireSourceRoot(tailwindRoot, 'TailwindCSS');
+    return [
+      {
+        id: 'tailwind-utilities-summary',
+        sourceRoot: root,
+        sourceRootLabel: 'tailwindcss',
+        targetFile: 'packages/tailwindcss/src/utilities.ts',
+        instruction: 'Summarize this Tailwind CSS utilities module. Include API responsibilities, parsing/generation boundaries, extension points, and correctness risks.',
+      },
+      {
+        id: 'tailwind-variants-refactor-plan',
+        sourceRoot: root,
+        sourceRootLabel: 'tailwindcss',
+        targetFile: 'packages/tailwindcss/src/variants.ts',
+        instruction: 'Draft a behavior-preserving refactor plan for this Tailwind CSS variants module. Include invariants, split boundaries, tests, and rollback signals.',
+      },
+      {
+        id: 'tailwind-css-parser-test-strategy',
+        sourceRoot: root,
+        sourceRootLabel: 'tailwindcss',
+        targetFile: 'packages/tailwindcss/src/css-parser.ts',
+        instruction: 'Create a behavior-preserving test strategy for this Tailwind CSS parser module. Include parser edge cases, regression fixtures, malformed input, and acceptance criteria.',
+      },
+    ];
+  };
+
+  if (profile === 'fixtures') return fixtures;
+  if (profile === 'nextjs-large') return nextjsLarge();
+  if (profile === 'tailwind-large' || profile === 'tailwindcss-large') return tailwindLarge();
+  if (profile === 'nextjs-tailwind-large') return [
+    ...nextjsLarge().slice(0, 2),
+    tailwindLarge()[0],
+  ];
+  throw new Error(`Unknown --profile=${profile}; expected fixtures, nextjs-large, tailwind-large, or nextjs-tailwind-large`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    console.log([
+      'Usage:',
+      '  node benchmarks/layer2-frontend-task/build-provider-cost-corrected-manifest.js [--profile=fixtures|nextjs-large|tailwind-large|nextjs-tailwind-large] [--output=<json>] [--target-pair-count=5]',
+      '',
+      'Builds a corrected provider-cost task manifest with real full-source baseline payloads and real fooks model-facing payloads.',
+      'External profiles use --nextjs-root=<dir> and/or --tailwindcss-root=<dir> (defaults under ~/Workspace/fooks-test-repos).',
+    ].join('\n'));
+    return;
+  }
+
+  const repoRoot = repoRootFromHere();
+  const profile = args.profile || 'fixtures';
+  const runId = args['run-id'] || 'provider-cost-corrected-real-payload';
+  const outputPath = path.resolve(args.output || path.join(repoRoot, '.fooks', 'evidence', 'provider-cost', runId, 'corrected-task-manifest.json'));
+  const contextsDir = path.join(path.dirname(outputPath), 'contexts');
+  const targetPairCount = Number(args['target-pair-count'] || 5);
+  if (!Number.isFinite(targetPairCount) || targetPairCount <= 0) {
+    throw new Error(`Invalid --target-pair-count: ${args['target-pair-count']}`);
+  }
+  fs.mkdirSync(contextsDir, { recursive: true });
+  const { extractFile, toModelFacingPayload } = loadFooksExtractors(repoRoot);
+
+  const taskSpecs = taskSpecsForProfile(profile, args, repoRoot);
+
+  const tasks = taskSpecs.map((spec) => makeTask({
+    contextsDir,
+    extractFile,
+    toModelFacingPayload,
+    targetPairCount,
+    ...spec,
+  }));
+
+  const manifest = {
+    schemaVersion: 'provider-cost-task-manifest.v1',
+    description: 'Corrected provider-cost campaign: real full-source baseline payloads vs real fooks model-facing payloads, AB/BA order, isolated/no-tool evidence policy.',
+    profile,
+    requiredTaskClasses: 3,
+    requiredAcceptedPairsPerTask: targetPairCount,
+    recommendedRunnerArgs: {
+      liveOpenAI: true,
+      authMode: 'codex-oauth',
+      transport: 'codex-exec',
+      codexWorkdir: 'isolated',
+      pairOrder: 'abba',
+      requireNoToolUse: true,
+    },
+    tasks,
+  };
+  writeJson(outputPath, manifest);
+  console.log(JSON.stringify({
+    output: path.relative(process.cwd(), outputPath).split(path.sep).join('/'),
+    contextsDir: path.relative(process.cwd(), contextsDir).split(path.sep).join('/'),
+    profile,
+    taskCount: tasks.length,
+    payloadStats: tasks.map((task) => ({ id: task.id, ...task.payloadStats })),
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[provider-cost-corrected-manifest] ${error.message}`);
+  process.exit(1);
+}

--- a/benchmarks/layer2-frontend-task/direct-executor.js
+++ b/benchmarks/layer2-frontend-task/direct-executor.js
@@ -7,6 +7,10 @@
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const {
+  parseCliArgs,
+  resolveOpenAIModel,
+} = require('./model-resolution.js');
 
 const API_KEY = process.env.OPENAI_API_KEY;
 if (!API_KEY) {
@@ -14,10 +18,13 @@ if (!API_KEY) {
   process.exit(1);
 }
 
-const targetFile = process.argv[2] || 'apps/v4/registry/bases/radix/examples/combobox-example.tsx';
-const mode = process.argv[3] || 'vanilla';
+const args = parseCliArgs(process.argv.slice(2));
+const modelConfig = resolveOpenAIModel({ modelArg: args.model });
+const MODEL = modelConfig.model;
+const targetFile = args.target || args._[0] || 'apps/v4/registry/bases/radix/examples/combobox-example.tsx';
+const mode = args.mode || args._[1] || 'vanilla';
 
-console.log(`[Direct Executor] Mode: ${mode}, Target: ${targetFile}`);
+console.log(`[Direct Executor] Mode: ${mode}, Target: ${targetFile}, Model: ${MODEL} (${modelConfig.modelSource})`);
 console.log(`[Direct Executor] Starting CASE-1 execution...`);
 
 // Read target file
@@ -33,7 +40,7 @@ const prompt = mode === 'vanilla'
 
 // API call
 const data = JSON.stringify({
-  model: 'gpt-4o',
+  model: MODEL,
   messages: [{ role: 'user', content: prompt }],
   temperature: 0.1
 });
@@ -61,11 +68,14 @@ const req = https.request(options, (res) => {
     
     if (res.statusCode === 200) {
       const result = JSON.parse(body);
-      const outputTokens = result.usage?.completion_tokens || 0;
-      const inputTokens = result.usage?.prompt_tokens || 0;
+      const usage = result.usage || {};
+      const outputTokens = Number.isFinite(usage.completion_tokens) ? usage.completion_tokens : null;
+      const inputTokens = Number.isFinite(usage.prompt_tokens) ? usage.prompt_tokens : null;
+      const usageAvailable = inputTokens !== null && outputTokens !== null;
+      const model = result.model || MODEL;
       
-      console.log(`[Direct Executor] Input tokens: ${inputTokens}`);
-      console.log(`[Direct Executor] Output tokens: ${outputTokens}`);
+      console.log(`[Direct Executor] Input tokens: ${inputTokens ?? 'unavailable'}`);
+      console.log(`[Direct Executor] Output tokens: ${outputTokens ?? 'unavailable'}`);
       console.log(`[Direct Executor] Content preview: ${result.choices[0].message.content.substring(0, 200)}...`);
       
       // Save result
@@ -73,7 +83,18 @@ const req = https.request(options, (res) => {
       fs.mkdirSync(outputDir.replace('~', process.env.HOME), { recursive: true });
       fs.writeFileSync(
         path.join(outputDir.replace('~', process.env.HOME), 'api-response.json'),
-        JSON.stringify({ latency, inputTokens, outputTokens, status: 'success', timestamp: new Date().toISOString() }, null, 2)
+        JSON.stringify({
+          provider: 'openai',
+          model,
+          requestedModel: MODEL,
+          modelSource: modelConfig.modelSource,
+          usageSource: 'live-openai-usage',
+          latency,
+          inputTokens,
+          outputTokens,
+          status: usageAvailable ? 'success' : 'usage-unavailable',
+          timestamp: new Date().toISOString(),
+        }, null, 2)
       );
       console.log(`[Direct Executor] Result saved to ${outputDir}/api-response.json`);
     } else {

--- a/benchmarks/layer2-frontend-task/evidence-paths.js
+++ b/benchmarks/layer2-frontend-task/evidence-paths.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FOOKS_DIR = '.fooks';
+const EVIDENCE_DIR = 'evidence';
+
+function sanitizeRunId(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^a-z0-9._-]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'run';
+}
+
+function timestampRunId(prefix = 'run', date = new Date()) {
+  const stamp = date.toISOString().replace(/[:.]/g, '-');
+  return sanitizeRunId(`${prefix}-${stamp}`);
+}
+
+function evidenceDir({ cwd = process.cwd(), tier, runId } = {}) {
+  if (!tier) throw new Error('Missing evidence tier');
+  const safeRunId = sanitizeRunId(runId || timestampRunId(tier));
+  return path.join(cwd, FOOKS_DIR, EVIDENCE_DIR, sanitizeRunId(tier), safeRunId);
+}
+
+function ensureEvidenceDir(options = {}) {
+  const dir = evidenceDir(options);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function evidencePaths({ cwd = process.cwd(), tier, runId, jsonName = 'evidence.json', markdownName = 'evidence.md' } = {}) {
+  const dir = evidenceDir({ cwd, tier, runId });
+  return {
+    dir,
+    runId: path.basename(dir),
+    json: path.join(dir, jsonName),
+    markdown: path.join(dir, markdownName),
+  };
+}
+
+module.exports = {
+  FOOKS_DIR,
+  EVIDENCE_DIR,
+  sanitizeRunId,
+  timestampRunId,
+  evidenceDir,
+  ensureEvidenceDir,
+  evidencePaths,
+};

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/attempted-pair-ledger.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/attempted-pair-ledger.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "provider-cost-attempted-pair-ledger.v1",
+  "plannedPairCount": 15,
+  "attemptedPairCount": 15,
+  "acceptedPairCount": 15,
+  "failedPairCount": 0,
+  "rejectedPairCount": 0,
+  "missingUsagePairCount": 0,
+  "neutralPairCount": 0,
+  "regressedPairCount": 0,
+  "omittedPairs": [],
+  "attemptedPairs": [
+    {
+      "pairId": "frontend-component-summary-1",
+      "taskClass": "frontend-component-summary",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-component-summary-2",
+      "taskClass": "frontend-component-summary",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-component-summary-3",
+      "taskClass": "frontend-component-summary",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-component-summary-4",
+      "taskClass": "frontend-component-summary",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-component-summary-5",
+      "taskClass": "frontend-component-summary",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-refactor-plan-1",
+      "taskClass": "frontend-refactor-plan",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-refactor-plan-2",
+      "taskClass": "frontend-refactor-plan",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-refactor-plan-3",
+      "taskClass": "frontend-refactor-plan",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-refactor-plan-4",
+      "taskClass": "frontend-refactor-plan",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-refactor-plan-5",
+      "taskClass": "frontend-refactor-plan",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-type-extraction-1",
+      "taskClass": "frontend-type-extraction",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-type-extraction-2",
+      "taskClass": "frontend-type-extraction",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-type-extraction-3",
+      "taskClass": "frontend-type-extraction",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-type-extraction-4",
+      "taskClass": "frontend-type-extraction",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    },
+    {
+      "pairId": "frontend-type-extraction-5",
+      "taskClass": "frontend-type-extraction",
+      "status": "estimated-cost-reduction",
+      "included": true,
+      "sourceKind": "fixture-mechanics"
+    }
+  ],
+  "note": "Fixture mechanics ledger. Replace with real attempted-pair ledger for validated-provider-import campaigns."
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/campaign-manifest.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/campaign-manifest.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "provider-cost-campaign-manifest.v1",
+  "campaignId": "provider-cost-import-kit-fixture",
+  "model": "gpt-5.4",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "reasoning": "default",
+  "maxOutputTokens": 512,
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "pricingSourceUrl": "https://openai.com/api/pricing/",
+  "pricingCheckedDate": "2026-04-22",
+  "requiredTaskClasses": 3,
+  "requiredAcceptedPairsPerTask": 5,
+  "taskClasses": [
+    {
+      "id": "frontend-component-summary",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "version": "v1",
+        "command": "manual/imported artifact gate"
+      }
+    },
+    {
+      "id": "frontend-refactor-plan",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "version": "v1",
+        "command": "manual/imported artifact gate"
+      }
+    },
+    {
+      "id": "frontend-type-extraction",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "version": "v1",
+        "command": "manual/imported artifact gate"
+      }
+    }
+  ],
+  "caps": {
+    "maxEstimatedUsd": 5,
+    "campaignMaxEstimatedUsd": 15,
+    "maxMatchedPairs": 20,
+    "maxBatches": 3
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "provider-cost-import-manifest.v1",
+  "description": "Fixture mechanics import kit. Proves threshold mechanics only; not public positive provider-cost evidence.",
+  "campaignManifestPath": "campaign-manifest.json",
+  "attemptedPairLedgerPath": "attempted-pair-ledger.json",
+  "pairEvidence": [
+    "pair-evidence/frontend-component-summary-1.json",
+    "pair-evidence/frontend-component-summary-2.json",
+    "pair-evidence/frontend-component-summary-3.json",
+    "pair-evidence/frontend-component-summary-4.json",
+    "pair-evidence/frontend-component-summary-5.json",
+    "pair-evidence/frontend-refactor-plan-1.json",
+    "pair-evidence/frontend-refactor-plan-2.json",
+    "pair-evidence/frontend-refactor-plan-3.json",
+    "pair-evidence/frontend-refactor-plan-4.json",
+    "pair-evidence/frontend-refactor-plan-5.json",
+    "pair-evidence/frontend-type-extraction-1.json",
+    "pair-evidence/frontend-type-extraction-2.json",
+    "pair-evidence/frontend-type-extraction-3.json",
+    "pair-evidence/frontend-type-extraction-4.json",
+    "pair-evidence/frontend-type-extraction-5.json"
+  ]
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-1.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-1.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:39.652Z",
+  "runId": "frontend-component-summary-1",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 101000,
+      "outputTokens": 10100,
+      "totalTokens": 111100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2525,
+        "inputStandard": 0.2525,
+        "inputCached": 0,
+        "output": 0.1515,
+        "total": 0.404,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 52500,
+      "outputTokens": 8280,
+      "totalTokens": 60780,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13125,
+        "inputStandard": 0.13125,
+        "inputCached": 0,
+        "output": 0.1242,
+        "total": 0.25545,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 48500,
+      "reductionPct": 48.02
+    },
+    "outputTokens": {
+      "absolute": 1820,
+      "reductionPct": 18.02
+    },
+    "totalTokens": {
+      "absolute": 50320,
+      "reductionPct": 45.293
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12125,
+      "reductionPct": 48.02
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0273,
+      "reductionPct": 18.02
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.14855,
+      "reductionPct": 36.77
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-component-summary",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-2.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-2.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:39.736Z",
+  "runId": "frontend-component-summary-2",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 102000,
+      "outputTokens": 10200,
+      "totalTokens": 112200,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.255,
+        "inputStandard": 0.255,
+        "inputCached": 0,
+        "output": 0.153,
+        "total": 0.408,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53000,
+      "outputTokens": 8360,
+      "totalTokens": 61360,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.1325,
+        "inputStandard": 0.1325,
+        "inputCached": 0,
+        "output": 0.1254,
+        "total": 0.2579,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49000,
+      "reductionPct": 48.039
+    },
+    "outputTokens": {
+      "absolute": 1840,
+      "reductionPct": 18.039
+    },
+    "totalTokens": {
+      "absolute": 50840,
+      "reductionPct": 45.312
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.1225,
+      "reductionPct": 48.039
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0276,
+      "reductionPct": 18.039
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1501,
+      "reductionPct": 36.789
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-component-summary",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-3.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-3.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:39.821Z",
+  "runId": "frontend-component-summary-3",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 103000,
+      "outputTokens": 10300,
+      "totalTokens": 113300,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2575,
+        "inputStandard": 0.2575,
+        "inputCached": 0,
+        "output": 0.1545,
+        "total": 0.412,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53500,
+      "outputTokens": 8440,
+      "totalTokens": 61940,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13375,
+        "inputStandard": 0.13375,
+        "inputCached": 0,
+        "output": 0.1266,
+        "total": 0.26035,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49500,
+      "reductionPct": 48.058
+    },
+    "outputTokens": {
+      "absolute": 1860,
+      "reductionPct": 18.058
+    },
+    "totalTokens": {
+      "absolute": 51360,
+      "reductionPct": 45.331
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12375,
+      "reductionPct": 48.058
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0279,
+      "reductionPct": 18.058
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15165,
+      "reductionPct": 36.808
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-component-summary",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-4.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-4.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:39.907Z",
+  "runId": "frontend-component-summary-4",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 104000,
+      "outputTokens": 10400,
+      "totalTokens": 114400,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.26,
+        "inputStandard": 0.26,
+        "inputCached": 0,
+        "output": 0.156,
+        "total": 0.416,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54000,
+      "outputTokens": 8520,
+      "totalTokens": 62520,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.135,
+        "inputStandard": 0.135,
+        "inputCached": 0,
+        "output": 0.1278,
+        "total": 0.2628,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50000,
+      "reductionPct": 48.077
+    },
+    "outputTokens": {
+      "absolute": 1880,
+      "reductionPct": 18.077
+    },
+    "totalTokens": {
+      "absolute": 51880,
+      "reductionPct": 45.35
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.125,
+      "reductionPct": 48.077
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0282,
+      "reductionPct": 18.077
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1532,
+      "reductionPct": 36.827
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-component-summary",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-5.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-component-summary-5.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:39.992Z",
+  "runId": "frontend-component-summary-5",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 105000,
+      "outputTokens": 10500,
+      "totalTokens": 115500,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2625,
+        "inputStandard": 0.2625,
+        "inputCached": 0,
+        "output": 0.1575,
+        "total": 0.42,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54500,
+      "outputTokens": 8600,
+      "totalTokens": 63100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-component-summary",
+      "taskIdentity": "frontend-component-summary",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13625,
+        "inputStandard": 0.13625,
+        "inputCached": 0,
+        "output": 0.129,
+        "total": 0.26525,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50500,
+      "reductionPct": 48.095
+    },
+    "outputTokens": {
+      "absolute": 1900,
+      "reductionPct": 18.095
+    },
+    "totalTokens": {
+      "absolute": 52400,
+      "reductionPct": 45.368
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12625,
+      "reductionPct": 48.095
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0285,
+      "reductionPct": 18.095
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15475,
+      "reductionPct": 36.845
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-component-summary",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-1.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-1.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.076Z",
+  "runId": "frontend-refactor-plan-1",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 101000,
+      "outputTokens": 10100,
+      "totalTokens": 111100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2525,
+        "inputStandard": 0.2525,
+        "inputCached": 0,
+        "output": 0.1515,
+        "total": 0.404,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 52500,
+      "outputTokens": 8280,
+      "totalTokens": 60780,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13125,
+        "inputStandard": 0.13125,
+        "inputCached": 0,
+        "output": 0.1242,
+        "total": 0.25545,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 48500,
+      "reductionPct": 48.02
+    },
+    "outputTokens": {
+      "absolute": 1820,
+      "reductionPct": 18.02
+    },
+    "totalTokens": {
+      "absolute": 50320,
+      "reductionPct": 45.293
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12125,
+      "reductionPct": 48.02
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0273,
+      "reductionPct": 18.02
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.14855,
+      "reductionPct": 36.77
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-refactor-plan",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-2.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-2.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.162Z",
+  "runId": "frontend-refactor-plan-2",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 102000,
+      "outputTokens": 10200,
+      "totalTokens": 112200,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.255,
+        "inputStandard": 0.255,
+        "inputCached": 0,
+        "output": 0.153,
+        "total": 0.408,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53000,
+      "outputTokens": 8360,
+      "totalTokens": 61360,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.1325,
+        "inputStandard": 0.1325,
+        "inputCached": 0,
+        "output": 0.1254,
+        "total": 0.2579,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49000,
+      "reductionPct": 48.039
+    },
+    "outputTokens": {
+      "absolute": 1840,
+      "reductionPct": 18.039
+    },
+    "totalTokens": {
+      "absolute": 50840,
+      "reductionPct": 45.312
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.1225,
+      "reductionPct": 48.039
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0276,
+      "reductionPct": 18.039
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1501,
+      "reductionPct": 36.789
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-refactor-plan",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-3.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-3.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.246Z",
+  "runId": "frontend-refactor-plan-3",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 103000,
+      "outputTokens": 10300,
+      "totalTokens": 113300,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2575,
+        "inputStandard": 0.2575,
+        "inputCached": 0,
+        "output": 0.1545,
+        "total": 0.412,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53500,
+      "outputTokens": 8440,
+      "totalTokens": 61940,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13375,
+        "inputStandard": 0.13375,
+        "inputCached": 0,
+        "output": 0.1266,
+        "total": 0.26035,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49500,
+      "reductionPct": 48.058
+    },
+    "outputTokens": {
+      "absolute": 1860,
+      "reductionPct": 18.058
+    },
+    "totalTokens": {
+      "absolute": 51360,
+      "reductionPct": 45.331
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12375,
+      "reductionPct": 48.058
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0279,
+      "reductionPct": 18.058
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15165,
+      "reductionPct": 36.808
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-refactor-plan",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-4.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-4.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.329Z",
+  "runId": "frontend-refactor-plan-4",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 104000,
+      "outputTokens": 10400,
+      "totalTokens": 114400,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.26,
+        "inputStandard": 0.26,
+        "inputCached": 0,
+        "output": 0.156,
+        "total": 0.416,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54000,
+      "outputTokens": 8520,
+      "totalTokens": 62520,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.135,
+        "inputStandard": 0.135,
+        "inputCached": 0,
+        "output": 0.1278,
+        "total": 0.2628,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50000,
+      "reductionPct": 48.077
+    },
+    "outputTokens": {
+      "absolute": 1880,
+      "reductionPct": 18.077
+    },
+    "totalTokens": {
+      "absolute": 51880,
+      "reductionPct": 45.35
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.125,
+      "reductionPct": 48.077
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0282,
+      "reductionPct": 18.077
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1532,
+      "reductionPct": 36.827
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-refactor-plan",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-5.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-refactor-plan-5.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.412Z",
+  "runId": "frontend-refactor-plan-5",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 105000,
+      "outputTokens": 10500,
+      "totalTokens": 115500,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2625,
+        "inputStandard": 0.2625,
+        "inputCached": 0,
+        "output": 0.1575,
+        "total": 0.42,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54500,
+      "outputTokens": 8600,
+      "totalTokens": 63100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-refactor-plan",
+      "taskIdentity": "frontend-refactor-plan",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13625,
+        "inputStandard": 0.13625,
+        "inputCached": 0,
+        "output": 0.129,
+        "total": 0.26525,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50500,
+      "reductionPct": 48.095
+    },
+    "outputTokens": {
+      "absolute": 1900,
+      "reductionPct": 18.095
+    },
+    "totalTokens": {
+      "absolute": 52400,
+      "reductionPct": 45.368
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12625,
+      "reductionPct": 48.095
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0285,
+      "reductionPct": 18.095
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15475,
+      "reductionPct": 36.845
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-refactor-plan",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-1.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-1.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.498Z",
+  "runId": "frontend-type-extraction-1",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 101000,
+      "outputTokens": 10100,
+      "totalTokens": 111100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2525,
+        "inputStandard": 0.2525,
+        "inputCached": 0,
+        "output": 0.1515,
+        "total": 0.404,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 52500,
+      "outputTokens": 8280,
+      "totalTokens": 60780,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13125,
+        "inputStandard": 0.13125,
+        "inputCached": 0,
+        "output": 0.1242,
+        "total": 0.25545,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 48500,
+      "reductionPct": 48.02
+    },
+    "outputTokens": {
+      "absolute": 1820,
+      "reductionPct": 18.02
+    },
+    "totalTokens": {
+      "absolute": 50320,
+      "reductionPct": 45.293
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12125,
+      "reductionPct": 48.02
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0273,
+      "reductionPct": 18.02
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.14855,
+      "reductionPct": 36.77
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-type-extraction",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-2.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-2.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.581Z",
+  "runId": "frontend-type-extraction-2",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 102000,
+      "outputTokens": 10200,
+      "totalTokens": 112200,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.255,
+        "inputStandard": 0.255,
+        "inputCached": 0,
+        "output": 0.153,
+        "total": 0.408,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53000,
+      "outputTokens": 8360,
+      "totalTokens": 61360,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.1325,
+        "inputStandard": 0.1325,
+        "inputCached": 0,
+        "output": 0.1254,
+        "total": 0.2579,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49000,
+      "reductionPct": 48.039
+    },
+    "outputTokens": {
+      "absolute": 1840,
+      "reductionPct": 18.039
+    },
+    "totalTokens": {
+      "absolute": 50840,
+      "reductionPct": 45.312
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.1225,
+      "reductionPct": 48.039
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0276,
+      "reductionPct": 18.039
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1501,
+      "reductionPct": 36.789
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-type-extraction",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-3.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-3.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.667Z",
+  "runId": "frontend-type-extraction-3",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 103000,
+      "outputTokens": 10300,
+      "totalTokens": 113300,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2575,
+        "inputStandard": 0.2575,
+        "inputCached": 0,
+        "output": 0.1545,
+        "total": 0.412,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 53500,
+      "outputTokens": 8440,
+      "totalTokens": 61940,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13375,
+        "inputStandard": 0.13375,
+        "inputCached": 0,
+        "output": 0.1266,
+        "total": 0.26035,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 49500,
+      "reductionPct": 48.058
+    },
+    "outputTokens": {
+      "absolute": 1860,
+      "reductionPct": 18.058
+    },
+    "totalTokens": {
+      "absolute": 51360,
+      "reductionPct": 45.331
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12375,
+      "reductionPct": 48.058
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0279,
+      "reductionPct": 18.058
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15165,
+      "reductionPct": 36.808
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-type-extraction",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-4.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-4.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.754Z",
+  "runId": "frontend-type-extraction-4",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 104000,
+      "outputTokens": 10400,
+      "totalTokens": 114400,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.26,
+        "inputStandard": 0.26,
+        "inputCached": 0,
+        "output": 0.156,
+        "total": 0.416,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54000,
+      "outputTokens": 8520,
+      "totalTokens": 62520,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.135,
+        "inputStandard": 0.135,
+        "inputCached": 0,
+        "output": 0.1278,
+        "total": 0.2628,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50000,
+      "reductionPct": 48.077
+    },
+    "outputTokens": {
+      "absolute": 1880,
+      "reductionPct": 18.077
+    },
+    "totalTokens": {
+      "absolute": 51880,
+      "reductionPct": 45.35
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.125,
+      "reductionPct": 48.077
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0282,
+      "reductionPct": 18.077
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.1532,
+      "reductionPct": 36.827
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-type-extraction",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-5.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/pair-evidence/frontend-type-extraction-5.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "provider-cost-evidence.v1",
+  "evidenceTier": "L2-provider-usage-estimated-cost",
+  "claimBoundary": "estimated-api-cost-only",
+  "generatedAt": "2026-04-22T07:10:40.840Z",
+  "runId": "frontend-type-extraction-5",
+  "sourceKind": "fixture-mechanics",
+  "status": "estimated-cost-reduction",
+  "statusReasons": [],
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "pricingAssumption": {
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "currency": "USD",
+    "inputPer1MTokens": 2.5,
+    "outputPer1MTokens": 15,
+    "cachedInputPer1MTokens": 0.25,
+    "cacheCreationInputPer1MTokens": null,
+    "sourceUrl": "https://openai.com/api/pricing/",
+    "checkedDate": "2026-04-22",
+    "pricingSourceKind": null,
+    "catalogModelKey": null,
+    "catalogMatchKind": null,
+    "catalogLookupReasons": [],
+    "endpoint": "chat.completions",
+    "serviceTier": "standard",
+    "pricingTreatment": {
+      "longContextApplies": false,
+      "regionalProcessingApplies": false
+    },
+    "note": "Estimated API cost only; not an invoice, charge, or provider billing statement."
+  },
+  "runs": {
+    "baseline": {
+      "role": "baseline",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 105000,
+      "outputTokens": 10500,
+      "totalTokens": 115500,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.2625,
+        "inputStandard": 0.2625,
+        "inputCached": 0,
+        "output": 0.1575,
+        "total": 0.42,
+        "currency": "USD"
+      }
+    },
+    "fooks": {
+      "role": "fooks",
+      "status": "usage-available",
+      "artifactStatus": null,
+      "usageSource": "fixture-mechanics",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "timestamp": null,
+      "runId": null,
+      "inputTokens": 54500,
+      "outputTokens": 8600,
+      "totalTokens": 63100,
+      "cachedInputTokens": null,
+      "reasoningOutputTokens": null,
+      "taskClass": "frontend-type-extraction",
+      "taskIdentity": "frontend-type-extraction",
+      "setupIdentity": "provider-cost-import-kit-fixture",
+      "endpoint": "chat.completions",
+      "serviceTier": "standard",
+      "reasoning": null,
+      "maxOutputTokens": null,
+      "qualityGate": {
+        "id": "artifact-shape-and-output-review",
+        "status": "passed",
+        "version": "v1"
+      },
+      "reasons": [],
+      "estimatedApiCost": {
+        "input": 0.13625,
+        "inputStandard": 0.13625,
+        "inputCached": 0,
+        "output": 0.129,
+        "total": 0.26525,
+        "currency": "USD"
+      }
+    }
+  },
+  "deltas": {
+    "inputTokens": {
+      "absolute": 50500,
+      "reductionPct": 48.095
+    },
+    "outputTokens": {
+      "absolute": 1900,
+      "reductionPct": 18.095
+    },
+    "totalTokens": {
+      "absolute": 52400,
+      "reductionPct": 45.368
+    },
+    "estimatedApiCostInput": {
+      "absolute": 0.12625,
+      "reductionPct": 48.095
+    },
+    "estimatedApiCostOutput": {
+      "absolute": 0.0285,
+      "reductionPct": 18.095
+    },
+    "estimatedApiCostTotal": {
+      "absolute": 0.15475,
+      "reductionPct": 36.845
+    }
+  },
+  "claimability": {
+    "estimatedApiCostDelta": true,
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false,
+    "stableRuntimeTokenSavings": false,
+    "stableTimeOrLatencySavings": false
+  },
+  "claimBoundaryNotes": [
+    "This is estimated API cost evidence from provider usage tokens and pricing assumptions only.",
+    "It is not provider invoice, dashboard, charge, or billing-grade savings evidence.",
+    "It does not establish stable runtime-token, wall-clock, or latency savings."
+  ],
+  "taskClass": "frontend-type-extraction",
+  "setupIdentity": "provider-cost-import-kit-fixture",
+  "endpoint": "chat.completions",
+  "serviceTier": "standard",
+  "qualityGate": {
+    "id": "artifact-shape-and-output-review",
+    "status": "passed",
+    "version": "v1"
+  }
+}

--- a/benchmarks/layer2-frontend-task/model-resolution.js
+++ b/benchmarks/layer2-frontend-task/model-resolution.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const DEFAULT_OPENAI_MODEL = 'gpt-5.4';
+
+function parseCliArgs(argv) {
+  return argv.reduce((acc, arg) => {
+    if (!arg.startsWith('--')) {
+      acc._.push(arg);
+      return acc;
+    }
+    const index = arg.indexOf('=');
+    if (index === -1) {
+      acc[arg.slice(2)] = true;
+    } else {
+      acc[arg.slice(2, index)] = arg.slice(index + 1);
+    }
+    return acc;
+  }, { _: [] });
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function resolveOpenAIModel({ modelArg, env = process.env, defaultModel = DEFAULT_OPENAI_MODEL } = {}) {
+  const cliModel = nonEmptyString(modelArg);
+  if (cliModel) {
+    return {
+      provider: 'openai',
+      model: cliModel,
+      modelSource: 'cli --model',
+      defaultModel,
+    };
+  }
+
+  const envModel = nonEmptyString(env.OPENAI_MODEL);
+  if (envModel) {
+    return {
+      provider: 'openai',
+      model: envModel,
+      modelSource: 'OPENAI_MODEL',
+      defaultModel,
+    };
+  }
+
+  return {
+    provider: 'openai',
+    model: defaultModel,
+    modelSource: 'current default',
+    defaultModel,
+  };
+}
+
+module.exports = {
+  DEFAULT_OPENAI_MODEL,
+  parseCliArgs,
+  resolveOpenAIModel,
+};

--- a/benchmarks/layer2-frontend-task/openai-live-auth.js
+++ b/benchmarks/layer2-frontend-task/openai-live-auth.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function codexHomeFrom({ args = {}, env = process.env } = {}) {
+  return path.resolve(
+    nonEmptyString(args['codex-home'])
+      || nonEmptyString(env.FOOKS_CODEX_HOME)
+      || nonEmptyString(env.CODEX_HOME)
+      || path.join(os.homedir(), '.codex'),
+  );
+}
+
+function safeReadJson(filePath) {
+  try {
+    return { ok: true, value: JSON.parse(fs.readFileSync(filePath, 'utf8')) };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function codexAuthPathFrom({ args = {}, env = process.env } = {}) {
+  return path.resolve(
+    nonEmptyString(args['codex-auth-json'])
+      || path.join(codexHomeFrom({ args, env }), 'auth.json'),
+  );
+}
+
+function authHeaders(auth) {
+  const headers = {
+    Authorization: `Bearer ${auth.token}`,
+  };
+  if (auth.credentialKind === 'codex-oauth' && auth.accountId) {
+    headers['chatgpt-account-id'] = auth.accountId;
+  }
+  return headers;
+}
+
+function resolveOpenAILiveAuth({ args = {}, env = process.env } = {}) {
+  const mode = nonEmptyString(args['auth-mode'] || args['openai-auth-mode']) || 'auto';
+  const reasons = [];
+  if (!['auto', 'api-key', 'codex-oauth'].includes(mode)) {
+    return {
+      ok: false,
+      mode,
+      credentialKind: null,
+      source: null,
+      token: null,
+      accountId: null,
+      authJsonPath: null,
+      headers: {},
+      reasons: [`unsupported auth mode: ${mode}`],
+    };
+  }
+
+  const envApiKey = nonEmptyString(env.OPENAI_API_KEY || env.OPEN_AI_APIKEY);
+  if (mode !== 'codex-oauth' && envApiKey) {
+    return {
+      ok: true,
+      mode,
+      credentialKind: 'openai-api-key',
+      source: env.OPENAI_API_KEY ? 'env:OPENAI_API_KEY' : 'env:OPEN_AI_APIKEY',
+      token: envApiKey,
+      accountId: null,
+      authJsonPath: null,
+      headers: { Authorization: `Bearer ${envApiKey}` },
+      reasons: [],
+    };
+  }
+  if (mode !== 'codex-oauth') {
+    reasons.push('OPENAI_API_KEY/OPEN_AI_APIKEY not set');
+  }
+
+  const envOAuth = nonEmptyString(env.CODEX_OAUTH_ACCESS_TOKEN || env.OPENAI_OAUTH_ACCESS_TOKEN);
+  const envAccountId = nonEmptyString(env.CODEX_ACCOUNT_ID || env.OPENAI_CHATGPT_ACCOUNT_ID);
+  if (mode !== 'api-key' && envOAuth) {
+    const resolved = {
+      ok: true,
+      mode,
+      credentialKind: 'codex-oauth',
+      source: env.CODEX_OAUTH_ACCESS_TOKEN ? 'env:CODEX_OAUTH_ACCESS_TOKEN' : 'env:OPENAI_OAUTH_ACCESS_TOKEN',
+      token: envOAuth,
+      accountId: envAccountId,
+      authJsonPath: null,
+      headers: {},
+      reasons: envAccountId ? [] : ['Codex OAuth access token found in env without account id header'],
+    };
+    resolved.headers = authHeaders(resolved);
+    return resolved;
+  }
+  if (mode !== 'api-key') {
+    reasons.push('CODEX_OAUTH_ACCESS_TOKEN/OPENAI_OAUTH_ACCESS_TOKEN not set');
+  }
+
+  const authJsonPath = codexAuthPathFrom({ args, env });
+  if (mode !== 'api-key') {
+    if (!fs.existsSync(authJsonPath)) {
+      reasons.push(`Codex auth.json not found at ${authJsonPath}`);
+    } else {
+      const parsed = safeReadJson(authJsonPath);
+      if (!parsed.ok) {
+        reasons.push(`Codex auth.json could not be parsed: ${parsed.error.message}`);
+      } else {
+        const authJson = parsed.value || {};
+        const accessToken = nonEmptyString(authJson.tokens?.access_token);
+        const accountId = nonEmptyString(authJson.tokens?.account_id);
+        if (accessToken) {
+          const resolved = {
+            ok: true,
+            mode,
+            credentialKind: 'codex-oauth',
+            source: 'codex-auth-json',
+            token: accessToken,
+            accountId,
+            authJsonPath,
+            authMode: nonEmptyString(authJson.auth_mode),
+            headers: {},
+            reasons: accountId ? [] : ['Codex auth.json access token found without tokens.account_id'],
+          };
+          resolved.headers = authHeaders(resolved);
+          return resolved;
+        }
+        reasons.push(`Codex auth.json at ${authJsonPath} does not contain tokens.access_token`);
+
+        const authJsonApiKey = nonEmptyString(authJson.OPENAI_API_KEY);
+        if (mode === 'auto' && authJsonApiKey) {
+          return {
+            ok: true,
+            mode,
+            credentialKind: 'openai-api-key',
+            source: 'codex-auth-json:OPENAI_API_KEY',
+            token: authJsonApiKey,
+            accountId: null,
+            authJsonPath,
+            headers: { Authorization: `Bearer ${authJsonApiKey}` },
+            reasons: [],
+          };
+        }
+      }
+    }
+  }
+
+  return {
+    ok: false,
+    mode,
+    credentialKind: null,
+    source: null,
+    token: null,
+    accountId: null,
+    authJsonPath: mode === 'api-key' ? null : authJsonPath,
+    headers: {},
+    reasons,
+  };
+}
+
+function publicAuthSummary(auth) {
+  return {
+    ok: auth.ok,
+    mode: auth.mode,
+    credentialKind: auth.credentialKind,
+    source: auth.source,
+    authJsonPath: auth.authJsonPath,
+    authMode: auth.authMode,
+    hasAccountId: Boolean(auth.accountId),
+    headerNames: Object.keys(auth.headers || {}),
+    reasons: auth.reasons || [],
+  };
+}
+
+module.exports = {
+  codexHomeFrom,
+  codexAuthPathFrom,
+  resolveOpenAILiveAuth,
+  publicAuthSummary,
+};

--- a/benchmarks/layer2-frontend-task/provider-cost-evidence.js
+++ b/benchmarks/layer2-frontend-task/provider-cost-evidence.js
@@ -1,0 +1,396 @@
+'use strict';
+
+const CLAIM_BOUNDARY = 'estimated-api-cost-only';
+const EVIDENCE_TIER = 'L2-provider-usage-estimated-cost';
+const SCHEMA_VERSION = 'provider-cost-evidence.v1';
+const VALID_SOURCE_KINDS = new Set([
+  'fixture',
+  'fixture-mechanics',
+  'validated-provider-import',
+  'live-openai-usage',
+]);
+
+const DEFAULT_PRICING_SOURCE_URL = 'https://openai.com/api/pricing/';
+const DEFAULT_PRICING_CHECKED_DATE = '2026-04-22';
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNonNegativeNumber(value) {
+  if (typeof value === 'string' && value.trim() !== '') value = Number(value);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function firstFiniteNonNegative(...values) {
+  for (const value of values) {
+    const normalized = finiteNonNegativeNumber(value);
+    if (normalized !== null) return normalized;
+  }
+  return null;
+}
+
+function hasProviderUsageTokens(usage) {
+  return firstFiniteNonNegative(usage.prompt_tokens, usage.input_tokens) !== null
+    && firstFiniteNonNegative(usage.completion_tokens, usage.output_tokens) !== null;
+}
+
+function usageInputDetails(usage) {
+  return isObject(usage.input_tokens_details) ? usage.input_tokens_details : {};
+}
+
+function usageOutputDetails(usage) {
+  return isObject(usage.output_tokens_details) ? usage.output_tokens_details : {};
+}
+
+function unusableArtifactStatus(status) {
+  return [
+    'failed',
+    'error',
+    'implementation-in-progress',
+    'usage-unavailable',
+  ].includes(status);
+}
+
+function normalizeUsageArtifact(artifact, role = 'run', options = {}) {
+  const sourceKind = options.sourceKind || 'fixture';
+  if (!isObject(artifact)) {
+    return {
+      role,
+      status: 'invalid-artifact',
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: null,
+      reasons: [`${role} artifact is not an object`],
+    };
+  }
+
+  const usage = isObject(artifact.usage) ? artifact.usage : {};
+  const metrics = isObject(artifact.metrics) ? artifact.metrics : {};
+  const artifactStatus = artifact.status || null;
+  const providerEvidenceSource = sourceKind === 'live-openai-usage' || sourceKind === 'validated-provider-import';
+  const sourceMatches = artifact.usageSource === sourceKind
+    || artifact.usageSource === 'live-openai-usage'
+    || artifact.usageSource === 'validated-provider-import';
+  const liveProviderUsageAvailable = sourceMatches || hasProviderUsageTokens(usage);
+
+  const inputCandidates = providerEvidenceSource
+    ? [artifact.inputTokens, artifact.promptTokens, artifact.prompt_tokens, usage.prompt_tokens, usage.input_tokens]
+    : [
+        artifact.inputTokens,
+        artifact.promptTokens,
+        artifact.prompt_tokens,
+        usage.prompt_tokens,
+        usage.input_tokens,
+        metrics.inputTokens,
+        metrics.promptTokens,
+        metrics.promptTokensApprox,
+      ];
+  const outputCandidates = providerEvidenceSource
+    ? [artifact.outputTokens, artifact.completionTokens, artifact.completion_tokens, usage.completion_tokens, usage.output_tokens]
+    : [
+        artifact.outputTokens,
+        artifact.completionTokens,
+        artifact.completion_tokens,
+        usage.completion_tokens,
+        usage.output_tokens,
+        metrics.outputTokens,
+        metrics.completionTokens,
+      ];
+
+  const inputTokens = firstFiniteNonNegative(...inputCandidates);
+  const outputTokens = firstFiniteNonNegative(...outputCandidates);
+  const totalTokens = firstFiniteNonNegative(
+    artifact.totalTokens,
+    artifact.total_tokens,
+    usage.total_tokens,
+    inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null,
+  );
+  const cachedInputTokens = firstFiniteNonNegative(
+    artifact.cachedInputTokens,
+    artifact.cached_input_tokens,
+    usageInputDetails(usage).cached_tokens,
+  );
+  const reasoningOutputTokens = firstFiniteNonNegative(
+    artifact.reasoningOutputTokens,
+    artifact.reasoning_output_tokens,
+    usageOutputDetails(usage).reasoning_tokens,
+  );
+
+  const reasons = [];
+  if (unusableArtifactStatus(artifactStatus)) reasons.push(`${role} artifact status is not usable: ${artifactStatus}`);
+  if (providerEvidenceSource && !liveProviderUsageAvailable) {
+    reasons.push(sourceKind === 'live-openai-usage'
+      ? `${role} artifact lacks live provider usage provenance`
+      : `${role} artifact lacks validated provider usage provenance`);
+  }
+  if (inputTokens === null) reasons.push(`${role} input tokens are missing`);
+  if (outputTokens === null) reasons.push(`${role} output tokens are missing`);
+
+  return {
+    role,
+    status: reasons.length ? 'incomplete-usage' : 'usage-available',
+    artifactStatus,
+    usageSource: artifact.usageSource || (hasProviderUsageTokens(usage) ? 'provider-usage-object' : null),
+    provider: artifact.provider || usage.provider || null,
+    model: artifact.model || usage.model || null,
+    timestamp: artifact.timestamp || null,
+    runId: artifact.runId || artifact.id || null,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens,
+    reasoningOutputTokens,
+    taskClass: artifact.taskClass || artifact.taskId || artifact.taskIdentity || null,
+    taskIdentity: artifact.taskIdentity || artifact.taskClass || artifact.taskId || null,
+    setupIdentity: artifact.setupIdentity || null,
+    endpoint: artifact.endpoint || null,
+    serviceTier: artifact.serviceTier || artifact.service_tier || null,
+    reasoning: artifact.reasoning || null,
+    maxOutputTokens: firstFiniteNonNegative(artifact.maxOutputTokens, artifact.max_output_tokens),
+    qualityGate: artifact.qualityGate || artifact.quality_gate || null,
+    reasons,
+  };
+}
+
+function normalizePricingAssumption(pricing = {}, artifacts = []) {
+  const provider = pricing.provider || artifacts.find((artifact) => artifact.provider)?.provider || null;
+  const model = pricing.model || artifacts.find((artifact) => artifact.model)?.model || null;
+  const inputPer1MTokens = firstFiniteNonNegative(pricing.inputPer1MTokens, pricing.input_per_1m_tokens);
+  const outputPer1MTokens = firstFiniteNonNegative(pricing.outputPer1MTokens, pricing.output_per_1m_tokens);
+
+  return {
+    provider,
+    model,
+    currency: pricing.currency || 'USD',
+    inputPer1MTokens,
+    outputPer1MTokens,
+    cachedInputPer1MTokens: firstFiniteNonNegative(pricing.cachedInputPer1MTokens, pricing.cached_input_per_1m_tokens),
+    cacheCreationInputPer1MTokens: firstFiniteNonNegative(
+      pricing.cacheCreationInputPer1MTokens,
+      pricing.cache_creation_input_per_1m_tokens,
+    ),
+    sourceUrl: pricing.sourceUrl || pricing.source_url || DEFAULT_PRICING_SOURCE_URL,
+    checkedDate: pricing.checkedDate || pricing.checked_date || DEFAULT_PRICING_CHECKED_DATE,
+    pricingSourceKind: pricing.pricingSourceKind || pricing.pricing_source_kind || null,
+    catalogModelKey: pricing.catalogModelKey || pricing.catalog_model_key || null,
+    catalogMatchKind: pricing.catalogMatchKind || pricing.catalog_match_kind || null,
+    catalogLookupReasons: Array.isArray(pricing.catalogLookupReasons) ? pricing.catalogLookupReasons : [],
+    endpoint: pricing.endpoint || null,
+    serviceTier: pricing.serviceTier || pricing.service_tier || null,
+    pricingTreatment: isObject(pricing.pricingTreatment)
+      ? pricing.pricingTreatment
+      : isObject(pricing.pricing_treatment)
+        ? pricing.pricing_treatment
+        : null,
+    note: pricing.note || 'Estimated API cost only; not an invoice, charge, or provider billing statement.',
+  };
+}
+
+function estimatedCost(tokens, per1MTokens) {
+  if (tokens === null || per1MTokens === null) return null;
+  return (tokens / 1_000_000) * per1MTokens;
+}
+
+function roundMoney(value) {
+  return value === null ? null : Number(value.toFixed(8));
+}
+
+function roundPct(value) {
+  return value === null ? null : Number(value.toFixed(3));
+}
+
+function deltaReduction(baseline, fooks) {
+  if (baseline === null || fooks === null) return { absolute: null, reductionPct: null };
+  const absolute = baseline - fooks;
+  return {
+    absolute,
+    reductionPct: baseline > 0 ? (absolute / baseline) * 100 : null,
+  };
+}
+
+function normalizeSourceKind(sourceKind) {
+  if (VALID_SOURCE_KINDS.has(sourceKind)) return { value: sourceKind, reasons: [] };
+  return {
+    value: 'invalid-source-kind',
+    reasons: [`sourceKind must be one of: ${Array.from(VALID_SOURCE_KINDS).join(', ')}`],
+  };
+}
+
+function withEstimatedCosts(run, pricing) {
+  const cachedInputTokens = run.cachedInputTokens || 0;
+  const standardInputTokens = run.inputTokens === null
+    ? null
+    : Math.max(run.inputTokens - cachedInputTokens, 0);
+  const estimatedStandardInput = estimatedCost(standardInputTokens, pricing.inputPer1MTokens);
+  const estimatedCachedInput = cachedInputTokens > 0
+    ? estimatedCost(cachedInputTokens, pricing.cachedInputPer1MTokens)
+    : 0;
+  const estimatedApiCostInput = estimatedStandardInput === null || estimatedCachedInput === null
+    ? null
+    : estimatedStandardInput + estimatedCachedInput;
+  const estimatedApiCostOutput = estimatedCost(run.outputTokens, pricing.outputPer1MTokens);
+  const estimatedApiCostTotal = estimatedApiCostInput === null || estimatedApiCostOutput === null
+    ? null
+    : estimatedApiCostInput + estimatedApiCostOutput;
+
+  return {
+    ...run,
+    estimatedApiCost: {
+      input: roundMoney(estimatedApiCostInput),
+      inputStandard: roundMoney(estimatedStandardInput),
+      inputCached: roundMoney(estimatedCachedInput),
+      output: roundMoney(estimatedApiCostOutput),
+      total: roundMoney(estimatedApiCostTotal),
+      currency: pricing.currency,
+    },
+  };
+}
+
+function tokenDelta(baseline, fooks) {
+  const delta = deltaReduction(baseline, fooks);
+  return { absolute: delta.absolute, reductionPct: roundPct(delta.reductionPct) };
+}
+
+function costDelta(baseline, fooks) {
+  const delta = deltaReduction(baseline, fooks);
+  return { absolute: roundMoney(delta.absolute), reductionPct: roundPct(delta.reductionPct) };
+}
+
+function compareRuns(baseline, fooks) {
+  return {
+    inputTokens: tokenDelta(baseline.inputTokens, fooks.inputTokens),
+    outputTokens: tokenDelta(baseline.outputTokens, fooks.outputTokens),
+    totalTokens: tokenDelta(baseline.totalTokens, fooks.totalTokens),
+    estimatedApiCostInput: costDelta(baseline.estimatedApiCost.input, fooks.estimatedApiCost.input),
+    estimatedApiCostOutput: costDelta(baseline.estimatedApiCost.output, fooks.estimatedApiCost.output),
+    estimatedApiCostTotal: costDelta(baseline.estimatedApiCost.total, fooks.estimatedApiCost.total),
+  };
+}
+
+function pricingReasons(pricing) {
+  const reasons = [];
+  if (!pricing.provider) reasons.push('pricing provider is missing');
+  if (!pricing.model) reasons.push('pricing model is missing');
+  if (pricing.inputPer1MTokens === null) reasons.push('pricing input rate is missing');
+  if (pricing.outputPer1MTokens === null) reasons.push('pricing output rate is missing');
+  if (Array.isArray(pricing.catalogLookupReasons)) reasons.push(...pricing.catalogLookupReasons);
+  return reasons;
+}
+
+function evidenceStatus(baseline, fooks, deltas, additionalReasons = []) {
+  const reasons = [...baseline.reasons, ...fooks.reasons, ...additionalReasons];
+  if (reasons.length) return { status: 'inconclusive', reasons };
+  if (baseline.totalTokens === 0 || baseline.estimatedApiCost.total === 0) {
+    return { status: 'inconclusive', reasons: ['baseline usage tokens are zero, so reduction evidence is not meaningful'] };
+  }
+  const totalDelta = deltas.estimatedApiCostTotal.absolute;
+  if (totalDelta === null) return { status: 'inconclusive', reasons: ['estimated total API cost delta is unavailable'] };
+  if (totalDelta > 0) return { status: 'estimated-cost-reduction', reasons: [] };
+  if (totalDelta < 0) return { status: 'estimated-cost-regression', reasons: [] };
+  return { status: 'estimated-cost-neutral', reasons: [] };
+}
+
+function buildProviderCostEvidence({
+  baselineArtifact,
+  fooksArtifact,
+  pricing = {},
+  sourceKind = 'fixture',
+  generatedAt = new Date().toISOString(),
+  runId = null,
+} = {}) {
+  const sourceKindResult = normalizeSourceKind(sourceKind);
+  const usageOptions = { sourceKind: sourceKindResult.value };
+  const baselineUsage = normalizeUsageArtifact(baselineArtifact, 'baseline', usageOptions);
+  const fooksUsage = normalizeUsageArtifact(fooksArtifact, 'fooks', usageOptions);
+  const pricingAssumption = normalizePricingAssumption(pricing, [baselineUsage, fooksUsage]);
+  const baseline = withEstimatedCosts(baselineUsage, pricingAssumption);
+  const fooks = withEstimatedCosts(fooksUsage, pricingAssumption);
+  const deltas = compareRuns(baseline, fooks);
+  const status = evidenceStatus(
+    baseline,
+    fooks,
+    deltas,
+    [...sourceKindResult.reasons, ...pricingReasons(pricingAssumption)],
+  );
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    evidenceTier: EVIDENCE_TIER,
+    claimBoundary: CLAIM_BOUNDARY,
+    generatedAt,
+    runId,
+    sourceKind: sourceKindResult.value,
+    status: status.status,
+    statusReasons: status.reasons,
+    provider: pricingAssumption.provider,
+    model: pricingAssumption.model,
+    pricingAssumption,
+    runs: { baseline, fooks },
+    deltas,
+    claimability: {
+      estimatedApiCostDelta: status.status !== 'inconclusive',
+      providerInvoiceOrBillingSavings: false,
+      providerBillingTokenSavings: false,
+      stableRuntimeTokenSavings: false,
+      stableTimeOrLatencySavings: false,
+    },
+    claimBoundaryNotes: [
+      'This is estimated API cost evidence from provider usage tokens and pricing assumptions only.',
+      'It is not provider invoice, dashboard, charge, or billing-grade savings evidence.',
+      'It does not establish stable runtime-token, wall-clock, or latency savings.',
+    ],
+  };
+}
+
+function formatPct(value) {
+  return value === null ? 'n/a' : `${value}%`;
+}
+
+function formatValue(value, suffix = '') {
+  return value === null ? 'n/a' : `${value}${suffix}`;
+}
+
+function renderProviderCostEvidenceMarkdown(evidence) {
+  const total = evidence.deltas.estimatedApiCostTotal;
+  const token = evidence.deltas.totalTokens;
+  const currency = evidence.pricingAssumption.currency;
+
+  return [
+    '# Provider usage estimated-cost evidence',
+    '',
+    `- Schema: \`${evidence.schemaVersion}\``,
+    `- Tier: \`${evidence.evidenceTier}\``,
+    `- Status: \`${evidence.status}\``,
+    `- Claim boundary: \`${evidence.claimBoundary}\``,
+    `- Source kind: \`${evidence.sourceKind}\``,
+    `- Provider/model: \`${evidence.provider}/${evidence.model}\``,
+    `- Pricing source: ${evidence.pricingAssumption.sourceUrl} (checked ${evidence.pricingAssumption.checkedDate})`,
+    evidence.pricingAssumption.catalogModelKey
+      ? `- Pricing catalog key: \`${evidence.pricingAssumption.catalogModelKey}\``
+      : null,
+    '',
+    '## Estimated deltas',
+    '',
+    `- Total tokens reduction: ${formatPct(token.reductionPct)} (${formatValue(token.absolute, ' tokens')})`,
+    `- Estimated total API cost reduction: ${formatPct(total.reductionPct)} (${formatValue(total.absolute, ` ${currency}`)})`,
+    '',
+    '## Claim boundary',
+    '',
+    '- This is estimated API cost evidence only.',
+    '- This is not provider invoice/billing savings evidence.',
+    '- This is not stable runtime-token, wall-clock, or latency savings evidence.',
+    '',
+  ].filter(Boolean).join('\n');
+}
+
+module.exports = {
+  CLAIM_BOUNDARY,
+  EVIDENCE_TIER,
+  SCHEMA_VERSION,
+  VALID_SOURCE_KINDS,
+  normalizeUsageArtifact,
+  normalizePricingAssumption,
+  buildProviderCostEvidence,
+  renderProviderCostEvidenceMarkdown,
+};

--- a/benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json
+++ b/benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "provider-cost-task-manifest.v1",
+  "description": "Launch-grade live OpenAI estimated API cost campaign template: 3 task classes × 5 matched baseline/fooks pairs. Uses OpenAI API key or Codex OAuth auth.json credentials with explicit spend caps.",
+  "requiredTaskClasses": 3,
+  "requiredAcceptedPairsPerTask": 5,
+  "tasks": [
+    {
+      "id": "frontend-component-summary",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "applied-validation",
+        "version": "v1",
+        "command": "manual review: baseline and fooks answers must both correctly summarize responsibilities and extraction boundaries"
+      },
+      "baselinePrompt": "Summarize the responsibilities of a React combobox component and list likely extraction boundaries. Include accessibility, keyboard handling, option rendering, and state management concerns.",
+      "fooksPrompt": "Using a compact prepared context for a React combobox, summarize responsibilities and extraction boundaries: accessibility, keyboard handling, option rendering, state management."
+    },
+    {
+      "id": "frontend-refactor-plan",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "applied-validation",
+        "version": "v1",
+        "command": "manual review: baseline and fooks answers must both provide an actionable TSX refactor plan"
+      },
+      "baselinePrompt": "Draft a concise refactor plan for splitting a large TypeScript React form section into components, hooks, utilities, and types. Include migration steps, test coverage, and rollback strategy.",
+      "fooksPrompt": "Using compact prepared context for a large TS React form section, draft a concise split plan: components, hooks, utilities, types, tests, rollback."
+    },
+    {
+      "id": "frontend-test-strategy",
+      "targetPairCount": 5,
+      "qualityGate": {
+        "id": "applied-validation",
+        "version": "v1",
+        "command": "manual review: baseline and fooks answers must both identify behavior-preserving tests and risk coverage"
+      },
+      "baselinePrompt": "Create a behavior-preserving test strategy for extracting frontend utilities from a mixed React component. Cover unit tests, integration tests, snapshot risks, edge cases, and acceptance criteria.",
+      "fooksPrompt": "Using compact prepared context for frontend utility extraction, create a behavior-preserving test strategy: unit, integration, snapshot risks, edge cases, acceptance criteria."
+    }
+  ]
+}

--- a/benchmarks/layer2-frontend-task/provider-cost-repeated-summary.js
+++ b/benchmarks/layer2-frontend-task/provider-cost-repeated-summary.js
@@ -1,0 +1,542 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SCHEMA_VERSION = 'provider-cost-repeated-summary.v1';
+const CLAIM_BOUNDARY = 'estimated-api-cost-only';
+const ELIGIBLE_LAUNCH_PROVENANCE = new Set(['validated-provider-import', 'live-openai-usage']);
+const FIXTURE_PROVENANCE = new Set(['fixture', 'fixture-mechanics']);
+const DEFAULT_REQUIRED_TASK_CLASSES = 3;
+const DEFAULT_REQUIRED_ACCEPTED_PAIRS_PER_TASK = 5;
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNumber(value) {
+  if (typeof value === 'string' && value.trim() !== '') value = Number(value);
+  return Number.isFinite(value) ? value : null;
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function stableValue(value) {
+  if (value === undefined || value === null || value === '') return null;
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function median(values) {
+  const sorted = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const mid = Math.floor(sorted.length / 2);
+  const value = sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  return Number(value.toFixed(6));
+}
+
+function roundMoney(value) {
+  return value === null || value === undefined || !Number.isFinite(value) ? null : Number(value.toFixed(8));
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null) return [];
+  return [value];
+}
+
+function normalizeTaskClasses(manifest) {
+  const taskClasses = Array.isArray(manifest?.taskClasses)
+    ? manifest.taskClasses
+    : Array.isArray(manifest?.tasks)
+      ? manifest.tasks
+      : [];
+  return taskClasses.map((task, index) => ({
+    id: stableValue(task.id || task.taskClass || task.taskId || task.name || `task-${index + 1}`),
+    targetPairCount: Number(task.targetPairCount || task.requiredAcceptedPairs || task.pairs || DEFAULT_REQUIRED_ACCEPTED_PAIRS_PER_TASK),
+    qualityGate: normalizeQualityGate(task.qualityGate || task.quality_gate || task.gate),
+  })).filter((task) => task.id);
+}
+
+function normalizeQualityGate(gate) {
+  if (!isObject(gate)) {
+    if (typeof gate === 'string' && gate.trim() !== '') {
+      return { id: gate.trim(), version: null, command: null, status: null };
+    }
+    return null;
+  }
+  return {
+    id: nonEmptyString(gate.id || gate.name || gate.kind),
+    version: nonEmptyString(gate.version),
+    command: nonEmptyString(gate.command),
+    status: nonEmptyString(gate.status || gate.result),
+  };
+}
+
+function qualityGatePassed(gate) {
+  const normalized = normalizeQualityGate(gate);
+  if (!normalized || !normalized.id) return false;
+  if (normalized.id === 'usage-smoke') return false;
+  if (!normalized.status) return true;
+  return ['pass', 'passed', 'success', 'ok'].includes(normalized.status);
+}
+
+function pairQualityGateStatus(pair, evidence) {
+  const evidenceGate = evidence.qualityGate || evidence.quality_gate;
+  const pairGate = pair.qualityGate || pair.quality_gate;
+  const baselineGate = pair.baselineQualityGate || evidence.runs?.baseline?.qualityGate;
+  const fooksGate = pair.fooksQualityGate || evidence.runs?.fooks?.qualityGate;
+
+  const hasSideGates = baselineGate || fooksGate;
+  const passed = hasSideGates
+    ? qualityGatePassed(baselineGate) && qualityGatePassed(fooksGate)
+    : qualityGatePassed(pairGate || evidenceGate);
+
+  return {
+    passed,
+    evidenceGate: normalizeQualityGate(pairGate || evidenceGate),
+    baselineGate: normalizeQualityGate(baselineGate),
+    fooksGate: normalizeQualityGate(fooksGate),
+    reasons: passed ? [] : ['quality gate is missing, usage-smoke, or failed'],
+  };
+}
+
+function normalizePairEvidence(pairInput, index) {
+  const pair = isObject(pairInput) ? pairInput : { evidencePath: String(pairInput) };
+  const evidence = pair.evidence || (pair.evidencePath ? readJson(pair.evidencePath) : pair);
+  const pairId = stableValue(pair.pairId || pair.id || evidence.pairId || evidence.runId || `pair-${index + 1}`);
+  const taskClass = stableValue(
+    pair.taskClass
+      || pair.taskId
+      || pair.taskIdentity
+      || evidence.taskClass
+      || evidence.taskId
+      || evidence.taskIdentity
+      || evidence.runs?.baseline?.taskClass
+      || evidence.runs?.baseline?.taskIdentity,
+  );
+  const model = stableValue(pair.model || evidence.model || evidence.runs?.baseline?.model);
+  const provider = stableValue(pair.provider || evidence.provider || evidence.runs?.baseline?.provider);
+  const setupIdentity = stableValue(pair.setupIdentity || evidence.setupIdentity || evidence.runs?.baseline?.setupIdentity || 'default');
+  const endpoint = stableValue(pair.endpoint || evidence.endpoint || evidence.pricingAssumption?.endpoint || evidence.runs?.baseline?.endpoint);
+  const serviceTier = stableValue(pair.serviceTier || pair.service_tier || evidence.serviceTier || evidence.pricingAssumption?.serviceTier);
+  const reasoning = stableValue(pair.reasoning || evidence.reasoning || evidence.runs?.baseline?.reasoning);
+  const maxOutputTokens = finiteNumber(pair.maxOutputTokens || evidence.maxOutputTokens || evidence.runs?.baseline?.maxOutputTokens);
+  const sourceKind = evidence.sourceKind || pair.sourceKind || 'fixture';
+  const totalDelta = finiteNumber(evidence.deltas?.estimatedApiCostTotal?.absolute);
+  const reductionPct = finiteNumber(evidence.deltas?.estimatedApiCostTotal?.reductionPct);
+  const status = evidence.status || 'unknown';
+  const usageAvailable = status !== 'inconclusive'
+    && totalDelta !== null
+    && evidence.runs?.baseline?.estimatedApiCost?.total !== null
+    && evidence.runs?.fooks?.estimatedApiCost?.total !== null;
+  const quality = pairQualityGateStatus(pair, evidence);
+  const accepted = usageAvailable && quality.passed;
+  const identity = { provider, model, setupIdentity, endpoint, serviceTier, reasoning, maxOutputTokens };
+
+  return {
+    pairId,
+    pairIndex: index + 1,
+    taskClass,
+    sourceKind,
+    eligibleLaunchProvenance: ELIGIBLE_LAUNCH_PROVENANCE.has(sourceKind),
+    fixtureProvenance: FIXTURE_PROVENANCE.has(sourceKind),
+    accepted,
+    status,
+    statusReasons: Array.isArray(evidence.statusReasons) ? evidence.statusReasons : [],
+    qualityGate: quality,
+    identity,
+    deltas: {
+      estimatedApiCostTotal: {
+        absolute: totalDelta,
+        reductionPct,
+      },
+      estimatedApiCostInput: evidence.deltas?.estimatedApiCostInput || null,
+      estimatedApiCostOutput: evidence.deltas?.estimatedApiCostOutput || null,
+    },
+    pricingAssumption: evidence.pricingAssumption || {},
+    cachedInputTokens: (finiteNumber(evidence.runs?.baseline?.cachedInputTokens) || 0)
+      + (finiteNumber(evidence.runs?.fooks?.cachedInputTokens) || 0),
+    evidencePath: pair.evidencePath ? path.relative(process.cwd(), path.resolve(pair.evidencePath)).split(path.sep).join('/') : null,
+  };
+}
+
+function identityKey(identity) {
+  return JSON.stringify({
+    provider: identity.provider,
+    model: identity.model,
+    setupIdentity: identity.setupIdentity,
+    endpoint: identity.endpoint,
+    serviceTier: identity.serviceTier,
+    reasoning: identity.reasoning,
+    maxOutputTokens: identity.maxOutputTokens,
+  });
+}
+
+function pricingIssuesForPair(pair) {
+  const pricing = pair.pricingAssumption || {};
+  const reasons = [];
+  if (!pricing.sourceUrl && !pricing.source_url) reasons.push(`${pair.pairId}: pricing source URL missing`);
+  if (!pricing.checkedDate && !pricing.checked_date) reasons.push(`${pair.pairId}: pricing checked date missing`);
+  if (finiteNumber(pricing.inputPer1MTokens ?? pricing.input_per_1m_tokens) === null) reasons.push(`${pair.pairId}: input pricing rate missing`);
+  if (finiteNumber(pricing.outputPer1MTokens ?? pricing.output_per_1m_tokens) === null) reasons.push(`${pair.pairId}: output pricing rate missing`);
+
+  const cachedTokens = pair.cachedInputTokens
+    || finiteNumber(pair.pricingAssumption?.cachedInputTokens)
+    || finiteNumber(pair.pricingAssumption?.cached_input_tokens)
+    || 0;
+  if (cachedTokens > 0 && finiteNumber(pricing.cachedInputPer1MTokens ?? pricing.cached_input_per_1m_tokens) === null) {
+    reasons.push(`${pair.pairId}: cached input tokens present but cached input rate missing`);
+  }
+
+  if (!pair.identity.endpoint) reasons.push(`${pair.pairId}: endpoint missing`);
+  if (!pair.identity.serviceTier) reasons.push(`${pair.pairId}: service tier missing`);
+  const treatment = pricing.pricingTreatment || pricing.pricing_treatment || {};
+  const hasLongContext = Object.prototype.hasOwnProperty.call(treatment, 'longContextApplies')
+    || Object.prototype.hasOwnProperty.call(treatment, 'long_context_applies');
+  const hasRegional = Object.prototype.hasOwnProperty.call(treatment, 'regionalProcessingApplies')
+    || Object.prototype.hasOwnProperty.call(treatment, 'regional_processing_applies');
+  if (!hasLongContext) reasons.push(`${pair.pairId}: long-context pricing treatment unknown`);
+  if (!hasRegional) reasons.push(`${pair.pairId}: regional/data-residency pricing treatment unknown`);
+  return reasons;
+}
+
+function normalizeLedger(ledger, pairs) {
+  if (!isObject(ledger)) {
+    return {
+      present: false,
+      plannedPairCount: null,
+      attemptedPairCount: pairs.length,
+      acceptedPairCount: pairs.filter((pair) => pair.accepted).length,
+      failedPairCount: pairs.filter((pair) => !pair.accepted).length,
+      rejectedPairCount: 0,
+      missingUsagePairCount: pairs.filter((pair) => pair.status === 'inconclusive').length,
+      neutralPairCount: pairs.filter((pair) => pair.accepted && pair.deltas.estimatedApiCostTotal.absolute === 0).length,
+      regressedPairCount: pairs.filter((pair) => pair.accepted && pair.deltas.estimatedApiCostTotal.absolute < 0).length,
+      omittedPairs: [],
+      reasons: ['campaign attempted-pair ledger is missing'],
+    };
+  }
+
+  const attemptedPairs = Array.isArray(ledger.attemptedPairs) ? ledger.attemptedPairs : [];
+  const plannedPairCount = Number(ledger.plannedPairCount ?? ledger.planned_pair_count ?? (attemptedPairs.length || pairs.length));
+  const attemptedPairCount = Number(ledger.attemptedPairCount ?? ledger.attempted_pair_count ?? (attemptedPairs.length || pairs.length));
+  const acceptedPairCount = Number(ledger.acceptedPairCount ?? ledger.accepted_pair_count ?? pairs.filter((pair) => pair.accepted).length);
+  const failedPairCount = Number(ledger.failedPairCount ?? ledger.failed_pair_count ?? pairs.filter((pair) => !pair.accepted).length);
+  const rejectedPairCount = Number(ledger.rejectedPairCount ?? ledger.rejected_pair_count ?? 0);
+  const missingUsagePairCount = Number(ledger.missingUsagePairCount ?? ledger.missing_usage_pair_count ?? pairs.filter((pair) => pair.status === 'inconclusive').length);
+  const neutralPairCount = Number(ledger.neutralPairCount ?? ledger.neutral_pair_count ?? pairs.filter((pair) => pair.accepted && pair.deltas.estimatedApiCostTotal.absolute === 0).length);
+  const regressedPairCount = Number(ledger.regressedPairCount ?? ledger.regressed_pair_count ?? pairs.filter((pair) => pair.accepted && pair.deltas.estimatedApiCostTotal.absolute < 0).length);
+  const omittedPairs = Array.isArray(ledger.omittedPairs) ? ledger.omittedPairs : [];
+  const reasons = [];
+
+  if (!Number.isFinite(plannedPairCount)) reasons.push('ledger planned pair count is missing');
+  if (!Number.isFinite(attemptedPairCount)) reasons.push('ledger attempted pair count is missing');
+  if (attemptedPairCount < pairs.length) reasons.push('ledger attempted pair count is less than imported pair count');
+  if (acceptedPairCount > attemptedPairCount) reasons.push('ledger accepted pair count exceeds attempted pair count');
+  if (plannedPairCount < attemptedPairCount) reasons.push('ledger planned pair count is less than attempted pair count');
+
+  return {
+    present: true,
+    plannedPairCount,
+    attemptedPairCount,
+    acceptedPairCount,
+    failedPairCount,
+    rejectedPairCount,
+    missingUsagePairCount,
+    neutralPairCount,
+    regressedPairCount,
+    omittedPairs,
+    attemptedPairs,
+    reasons,
+  };
+}
+
+function summarizeByTask(pairs, requiredAcceptedPairsPerTask) {
+  const byTask = new Map();
+  for (const pair of pairs) {
+    const key = pair.taskClass || 'unknown-task';
+    if (!byTask.has(key)) byTask.set(key, []);
+    byTask.get(key).push(pair);
+  }
+
+  return Array.from(byTask.entries()).map(([taskClass, taskPairs]) => {
+    const acceptedPairs = taskPairs.filter((pair) => pair.accepted);
+    const positiveAcceptedPairs = acceptedPairs.filter((pair) => pair.deltas.estimatedApiCostTotal.absolute > 0);
+    const reductions = acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.reductionPct).filter(Number.isFinite);
+    const totalDeltas = acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.absolute).filter(Number.isFinite);
+    const identityKeys = [...new Set(acceptedPairs.map((pair) => identityKey(pair.identity)))];
+    const missingIdentity = acceptedPairs.some((pair) => !pair.taskClass || !pair.identity.model || !pair.identity.setupIdentity);
+    return {
+      taskClass,
+      attemptedPairCount: taskPairs.length,
+      acceptedPairCount: acceptedPairs.length,
+      positiveAcceptedPairCount: positiveAcceptedPairs.length,
+      regressedPairCount: acceptedPairs.filter((pair) => pair.deltas.estimatedApiCostTotal.absolute < 0).length,
+      neutralPairCount: acceptedPairs.filter((pair) => pair.deltas.estimatedApiCostTotal.absolute === 0).length,
+      requiredAcceptedPairs: requiredAcceptedPairsPerTask,
+      medianEstimatedApiCostReductionPct: median(reductions),
+      medianEstimatedApiCostDelta: roundMoney(median(totalDeltas)),
+      positiveMedian: median(totalDeltas) !== null && median(totalDeltas) > 0,
+      identity: {
+        mixed: identityKeys.length > 1,
+        missing: missingIdentity,
+        keys: identityKeys,
+      },
+      pairs: taskPairs.map((pair) => ({
+        pairId: pair.pairId,
+        accepted: pair.accepted,
+        sourceKind: pair.sourceKind,
+        status: pair.status,
+        qualityGatePassed: pair.qualityGate.passed,
+        estimatedApiCostDelta: pair.deltas.estimatedApiCostTotal.absolute,
+        estimatedApiCostReductionPct: pair.deltas.estimatedApiCostTotal.reductionPct,
+      })),
+    };
+  });
+}
+
+function buildDiagnostics({ statusReasons, taskSummaries, requiredTaskClasses, requiredAcceptedPairsPerTask, capState }) {
+  const recommendations = [];
+  if (statusReasons.some((reason) => /pricing/i.test(reason))) recommendations.push('Resolve current model pricing assumptions before treating cost deltas as launch-grade evidence.');
+  if (statusReasons.some((reason) => /quality gate/i.test(reason))) recommendations.push('Attach a non-usage-smoke quality gate per task class and record baseline/fooks pass status.');
+  if (statusReasons.some((reason) => /ledger|manifest|cherry/i.test(reason))) recommendations.push('Use a campaign manifest and attempted-pair ledger so failed, omitted, neutral, and regressed pairs stay in the denominator.');
+  if (taskSummaries.length < requiredTaskClasses) recommendations.push(`Add task classes: ${taskSummaries.length}/${requiredTaskClasses} represented.`);
+  for (const task of taskSummaries) {
+    if (task.acceptedPairCount < requiredAcceptedPairsPerTask) recommendations.push(`${task.taskClass}: collect accepted pairs ${task.acceptedPairCount}/${requiredAcceptedPairsPerTask}.`);
+    if (!task.positiveMedian && task.acceptedPairCount > 0) recommendations.push(`${task.taskClass}: diagnose negative/neutral median estimated-cost result before rerunning.`);
+    if (task.identity.mixed || task.identity.missing) recommendations.push(`${task.taskClass}: normalize task/model/setup identity before aggregation.`);
+  }
+  if (capState && capState.blocked) recommendations.push('Increase campaign budget explicitly or use validated imports; default capped live smoke cannot reach launch-grade threshold.');
+  if (recommendations.length === 0) recommendations.push('No diagnostic recommendation; threshold appears satisfied for the reported classification.');
+  return recommendations;
+}
+
+function summarizeProviderCostCampaign(input = {}) {
+  const generatedAt = input.generatedAt || new Date().toISOString();
+  const runId = input.runId || input.campaignManifest?.campaignId || input.campaignManifest?.runId || null;
+  const requiredTaskClasses = Number(input.requiredTaskClasses || input.campaignManifest?.requiredTaskClasses || DEFAULT_REQUIRED_TASK_CLASSES);
+  const requiredAcceptedPairsPerTask = Number(
+    input.requiredAcceptedPairsPerTask
+      || input.campaignManifest?.requiredAcceptedPairsPerTask
+      || DEFAULT_REQUIRED_ACCEPTED_PAIRS_PER_TASK,
+  );
+  const manifest = isObject(input.campaignManifest) ? input.campaignManifest : null;
+  const manifestTasks = normalizeTaskClasses(manifest);
+  const pairs = toArray(input.pairEvidence || input.pairs).map(normalizePairEvidence);
+  const ledger = normalizeLedger(input.attemptedPairLedger || input.ledger, pairs);
+  const taskSummaries = summarizeByTask(pairs, requiredAcceptedPairsPerTask);
+  const acceptedPairs = pairs.filter((pair) => pair.accepted);
+  const acceptedEligiblePairs = acceptedPairs.filter((pair) => pair.eligibleLaunchProvenance);
+  const acceptedFixturePairs = acceptedPairs.filter((pair) => pair.fixtureProvenance);
+  const allAcceptedFixture = acceptedPairs.length > 0 && acceptedFixturePairs.length === acceptedPairs.length;
+  const representedPassingTasks = taskSummaries.filter((task) => task.acceptedPairCount >= requiredAcceptedPairsPerTask);
+  const positivePassingTasks = representedPassingTasks.filter((task) => task.positiveMedian);
+  const overallMedianDelta = median(acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.absolute));
+  const overallMedianReductionPct = median(acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.reductionPct));
+
+  const statusReasons = [];
+  if (!manifest) statusReasons.push('campaign manifest is missing');
+  if (manifest && manifestTasks.length < requiredTaskClasses) statusReasons.push(`campaign manifest task classes ${manifestTasks.length}/${requiredTaskClasses}`);
+  for (const task of manifestTasks) {
+    if (!task.qualityGate || !task.qualityGate.id) statusReasons.push(`${task.id}: quality gate declaration missing`);
+    if (task.qualityGate?.id === 'usage-smoke') statusReasons.push(`${task.id}: usage-smoke quality gate cannot count toward launch-grade`);
+  }
+  statusReasons.push(...ledger.reasons);
+  if (pairs.length === 0) statusReasons.push('no pair evidence provided');
+  if (acceptedPairs.length === 0 && pairs.length > 0) statusReasons.push('no accepted provider-cost pairs');
+
+  const missingUsagePairs = pairs.filter((pair) => pair.status === 'inconclusive');
+  if (missingUsagePairs.length > 0) statusReasons.push(`missing or inconclusive provider usage pairs: ${missingUsagePairs.length}`);
+
+  const taskClassesRepresented = taskSummaries.filter((task) => task.acceptedPairCount > 0).length;
+  if (taskClassesRepresented < requiredTaskClasses) statusReasons.push(`accepted task classes ${taskClassesRepresented}/${requiredTaskClasses}`);
+  for (const task of taskSummaries) {
+    if (task.acceptedPairCount < requiredAcceptedPairsPerTask) statusReasons.push(`${task.taskClass}: accepted pairs ${task.acceptedPairCount}/${requiredAcceptedPairsPerTask}`);
+    if (task.identity.missing) statusReasons.push(`${task.taskClass}: missing model/setup/task identity`);
+    if (task.identity.mixed) statusReasons.push(`${task.taskClass}: mixed identity within accepted pairs`);
+    if (!task.positiveMedian && task.acceptedPairCount >= requiredAcceptedPairsPerTask) statusReasons.push(`${task.taskClass}: median estimated API cost delta is not positive`);
+  }
+
+  const pricingQualityReasons = acceptedEligiblePairs.flatMap(pricingIssuesForPair);
+  statusReasons.push(...pricingQualityReasons);
+  const qualityGateFailedPairs = pairs.filter((pair) => !pair.qualityGate.passed);
+  if (qualityGateFailedPairs.length > 0) statusReasons.push(`quality gate failed or missing for ${qualityGateFailedPairs.length} pair(s)`);
+
+  const mixedIdentity = taskSummaries.some((task) => task.identity.mixed);
+  const missingIdentity = taskSummaries.some((task) => task.identity.missing);
+  const thresholdShapeMet = representedPassingTasks.length >= requiredTaskClasses
+    && positivePassingTasks.length >= requiredTaskClasses
+    && overallMedianDelta !== null
+    && overallMedianDelta > 0
+    && !mixedIdentity
+    && !missingIdentity;
+  const eligibleLaunchShape = thresholdShapeMet
+    && acceptedEligiblePairs.length === acceptedPairs.length
+    && manifest
+    && ledger.present
+    && ledger.reasons.length === 0
+    && pricingQualityReasons.length === 0
+    && qualityGateFailedPairs.length === 0
+    && manifestTasks.length >= requiredTaskClasses;
+
+  let status = 'diagnostic-only';
+  if (pairs.length === 0) {
+    status = 'diagnostic-only';
+  } else if (mixedIdentity) {
+    status = 'mixed-identity';
+  } else if (missingUsagePairs.length > 0) {
+    status = 'missing-usage';
+  } else if (allAcceptedFixture && thresholdShapeMet) {
+    status = 'fixture-launch-grade-mechanics';
+  } else if (eligibleLaunchShape) {
+    status = 'launch-grade-estimated-cost-evidence';
+  } else if (representedPassingTasks.length >= 1 && positivePassingTasks.length >= 1 && overallMedianDelta > 0) {
+    status = 'narrow-estimated-cost-candidate';
+  } else if (acceptedPairs.length < requiredAcceptedPairsPerTask || taskClassesRepresented < requiredTaskClasses) {
+    status = 'insufficient-accepted-pairs';
+  }
+
+  const launchGrade = status === 'launch-grade-estimated-cost-evidence';
+  const summary = {
+    schemaVersion: SCHEMA_VERSION,
+    claimBoundary: CLAIM_BOUNDARY,
+    generatedAt,
+    runId,
+    status,
+    statusReasons: launchGrade ? [] : statusReasons,
+    requiredTaskClasses,
+    requiredAcceptedPairsPerTask,
+    campaignManifest: manifest ? {
+      campaignId: manifest.campaignId || manifest.runId || runId,
+      model: manifest.model || null,
+      endpoint: manifest.endpoint || null,
+      serviceTier: manifest.serviceTier || manifest.service_tier || null,
+      pricingSourceUrl: manifest.pricingSourceUrl || manifest.pricing_source_url || null,
+      pricingCheckedDate: manifest.pricingCheckedDate || manifest.pricing_checked_date || null,
+      taskClasses: manifestTasks,
+      caps: manifest.caps || null,
+    } : null,
+    attemptedPairLedger: ledger,
+    counts: {
+      plannedPairCount: ledger.plannedPairCount,
+      attemptedPairCount: ledger.attemptedPairCount,
+      importedPairCount: pairs.length,
+      acceptedPairCount: acceptedPairs.length,
+      acceptedEligibleLaunchPairCount: acceptedEligiblePairs.length,
+      acceptedFixturePairCount: acceptedFixturePairs.length,
+      failedPairCount: ledger.failedPairCount,
+      rejectedPairCount: ledger.rejectedPairCount,
+      missingUsagePairCount: ledger.missingUsagePairCount,
+      neutralPairCount: ledger.neutralPairCount,
+      regressedPairCount: ledger.regressedPairCount,
+    },
+    distributions: {
+      estimatedApiCostDelta: acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.absolute).filter(Number.isFinite),
+      estimatedApiCostReductionPct: acceptedPairs.map((pair) => pair.deltas.estimatedApiCostTotal.reductionPct).filter(Number.isFinite),
+    },
+    medians: {
+      estimatedApiCostDelta: roundMoney(overallMedianDelta),
+      estimatedApiCostReductionPct: overallMedianReductionPct,
+    },
+    taskSummaries,
+    pairs,
+    diagnostics: buildDiagnostics({ statusReasons, taskSummaries, requiredTaskClasses, requiredAcceptedPairsPerTask, capState: input.capState }),
+    claimability: {
+      estimatedApiCostPositiveEvidence: launchGrade,
+      estimatedApiCostDelta: launchGrade,
+      providerInvoiceOrBillingSavings: false,
+      providerBillingTokenSavings: false,
+      stableRuntimeTokenSavings: false,
+      stableTimeOrLatencySavings: false,
+    },
+    claimBoundaryNotes: [
+      'This summary can only unlock estimated API cost positive evidence when campaign-level thresholds pass.',
+      'It is not provider invoice, dashboard, charge, or billing-grade savings evidence.',
+      'It does not establish stable runtime-token, wall-clock, or latency savings.',
+      'Fixture mechanics can validate threshold logic but cannot unlock public-positive claimability.',
+    ],
+  };
+
+  return summary;
+}
+
+function shouldStartNextPair({
+  currentBatchEstimatedUsd = 0,
+  currentCampaignEstimatedUsd = 0,
+  nextWorstCaseEstimatedUsd = 0,
+  maxEstimatedUsd = 5,
+  campaignMaxEstimatedUsd = maxEstimatedUsd,
+  attemptedMatchedPairs = 0,
+  maxMatchedPairs = 10,
+} = {}) {
+  const reasons = [];
+  const next = Number(nextWorstCaseEstimatedUsd);
+  const batch = Number(currentBatchEstimatedUsd);
+  const campaign = Number(currentCampaignEstimatedUsd);
+  if (!Number.isFinite(next) || next < 0) reasons.push('next worst-case estimate is invalid');
+  if (Number.isFinite(maxMatchedPairs) && attemptedMatchedPairs >= maxMatchedPairs) reasons.push('matched pair cap reached');
+  if (Number.isFinite(maxEstimatedUsd) && batch + next > maxEstimatedUsd) reasons.push('batch estimated spend cap would be exceeded');
+  if (Number.isFinite(campaignMaxEstimatedUsd) && campaign + next > campaignMaxEstimatedUsd) reasons.push('campaign estimated spend cap would be exceeded');
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    projectedBatchEstimatedUsd: roundMoney(Number.isFinite(batch + next) ? batch + next : null),
+    projectedCampaignEstimatedUsd: roundMoney(Number.isFinite(campaign + next) ? campaign + next : null),
+  };
+}
+
+function renderProviderCostCampaignMarkdown(summary) {
+  return [
+    '# Provider cost repeated campaign summary',
+    '',
+    `- Schema: \`${summary.schemaVersion}\``,
+    `- Status: \`${summary.status}\``,
+    `- Claim boundary: \`${summary.claimBoundary}\``,
+    `- Accepted pairs: ${summary.counts.acceptedPairCount}/${summary.counts.attemptedPairCount}`,
+    `- Median estimated API cost delta: ${summary.medians.estimatedApiCostDelta ?? 'n/a'}`,
+    `- Median estimated API cost reduction: ${summary.medians.estimatedApiCostReductionPct ?? 'n/a'}%`,
+    '',
+    '## Claimability',
+    '',
+    `- Estimated API cost positive evidence: ${summary.claimability.estimatedApiCostPositiveEvidence}`,
+    '- Provider invoice/billing savings: false',
+    '- Stable runtime-token/time savings: false',
+    '',
+    '## Task summaries',
+    '',
+    ...summary.taskSummaries.map((task) => `- ${task.taskClass}: accepted ${task.acceptedPairCount}/${task.requiredAcceptedPairs}, median cost delta ${task.medianEstimatedApiCostDelta ?? 'n/a'}`),
+    '',
+    '## Diagnostics',
+    '',
+    ...summary.diagnostics.map((item) => `- ${item}`),
+    '',
+  ].join('\n');
+}
+
+function writeProviderCostCampaignSummary({ outputPath, markdownPath, summary }) {
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+  }
+  if (markdownPath) {
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderProviderCostCampaignMarkdown(summary));
+  }
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  CLAIM_BOUNDARY,
+  ELIGIBLE_LAUNCH_PROVENANCE,
+  FIXTURE_PROVENANCE,
+  summarizeProviderCostCampaign,
+  shouldStartNextPair,
+  renderProviderCostCampaignMarkdown,
+  writeProviderCostCampaignSummary,
+};

--- a/benchmarks/layer2-frontend-task/provider-cost-tasks.json
+++ b/benchmarks/layer2-frontend-task/provider-cost-tasks.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "provider-cost-task-manifest.v1",
+  "description": "Small capped-live smoke manifest for estimated API cost evidence. Usage-only live smoke is not launch-grade until quality gates and the full campaign threshold are satisfied.",
+  "tasks": [
+    {
+      "id": "frontend-component-summary",
+      "targetPairCount": 1,
+      "qualityGate": {
+        "id": "provider-cost-import-smoke",
+        "version": "v1",
+        "command": "manual review or imported artifact gate"
+      },
+      "baselinePrompt": "Summarize the responsibilities of a React combobox component and list likely extraction boundaries.",
+      "fooksPrompt": "Using a compact prepared context, summarize the responsibilities of a React combobox component and list likely extraction boundaries."
+    },
+    {
+      "id": "frontend-refactor-plan",
+      "targetPairCount": 1,
+      "qualityGate": {
+        "id": "provider-cost-import-smoke",
+        "version": "v1",
+        "command": "manual review or imported artifact gate"
+      },
+      "baselinePrompt": "Draft a concise refactor plan for splitting a large TSX form section into components, hooks, utils, and types.",
+      "fooksPrompt": "Using a compact prepared context, draft a concise refactor plan for splitting a large TSX form section into components, hooks, utils, and types."
+    }
+  ]
+}

--- a/benchmarks/layer2-frontend-task/provider-pricing.js
+++ b/benchmarks/layer2-frontend-task/provider-pricing.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const fs = require('fs');
+
+const LITELLM_PRICING_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json';
+const DEFAULT_PROVIDER_PREFIXES = [
+  'anthropic/',
+  'claude-3-5-',
+  'claude-3-',
+  'claude-',
+  'openai/',
+  'azure/',
+  'openrouter/openai/',
+];
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNonNegativeNumber(value) {
+  if (typeof value === 'string' && value.trim() !== '') value = Number(value);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function perTokenToPer1M(value) {
+  const normalized = finiteNonNegativeNumber(value);
+  return normalized === null ? null : normalized * 1_000_000;
+}
+
+function createModelCandidates(provider, model, providerPrefixes = DEFAULT_PROVIDER_PREFIXES) {
+  const candidates = new Set();
+  if (typeof model !== 'string' || model.trim() === '') return [];
+  const normalizedModel = model.trim();
+  candidates.add(normalizedModel);
+
+  if (typeof provider === 'string' && provider.trim() !== '') {
+    candidates.add(`${provider.trim()}/${normalizedModel}`);
+  }
+
+  for (const prefix of providerPrefixes) {
+    candidates.add(`${prefix}${normalizedModel}`);
+  }
+
+  return Array.from(candidates);
+}
+
+function findPricingEntry(dataset, { provider, model, providerPrefixes } = {}) {
+  if (!isObject(dataset)) return null;
+  const candidates = createModelCandidates(provider, model, providerPrefixes);
+  for (const candidate of candidates) {
+    const entry = dataset[candidate];
+    if (isObject(entry)) return { modelKey: candidate, pricing: entry, matchKind: 'exact-or-prefixed' };
+  }
+
+  const lowerEntries = new Map(
+    Object.entries(dataset).map(([key, value]) => [key.toLowerCase(), { key, value }]),
+  );
+  for (const candidate of candidates) {
+    const found = lowerEntries.get(candidate.toLowerCase());
+    if (found && isObject(found.value)) {
+      return { modelKey: found.key, pricing: found.value, matchKind: 'case-insensitive' };
+    }
+  }
+
+  return null;
+}
+
+function pricingAssumptionFromLiteLLMCatalog({
+  dataset,
+  provider,
+  model,
+  sourceUrl = LITELLM_PRICING_URL,
+  checkedDate = new Date().toISOString().slice(0, 10),
+  currency = 'USD',
+  providerPrefixes,
+} = {}) {
+  const reasons = [];
+  const normalizedProvider = typeof provider === 'string' && provider.trim() !== '' ? provider.trim() : null;
+  const normalizedModel = typeof model === 'string' && model.trim() !== '' ? model.trim() : null;
+
+  if (!normalizedProvider) reasons.push('pricing provider is missing for catalog lookup');
+  if (!normalizedModel) reasons.push('pricing model is missing for catalog lookup');
+  if (!isObject(dataset)) reasons.push('pricing catalog is not an object');
+
+  if (reasons.length) {
+    return {
+      pricing: {
+        provider: normalizedProvider,
+        model: normalizedModel,
+        currency,
+        sourceUrl,
+        checkedDate,
+        pricingSourceKind: 'litellm-pricing-catalog',
+        note: 'Estimated API cost only; not an invoice, charge, or provider billing statement.',
+      },
+      reasons,
+    };
+  }
+
+  const match = findPricingEntry(dataset, {
+    provider: normalizedProvider,
+    model: normalizedModel,
+    providerPrefixes,
+  });
+
+  if (!match) {
+    return {
+      pricing: {
+        provider: normalizedProvider,
+        model: normalizedModel,
+        currency,
+        sourceUrl,
+        checkedDate,
+        pricingSourceKind: 'litellm-pricing-catalog',
+        note: 'Estimated API cost only; not an invoice, charge, or provider billing statement.',
+      },
+      reasons: [`pricing catalog has no entry for ${normalizedProvider}/${normalizedModel}`],
+    };
+  }
+
+  const inputPer1MTokens = perTokenToPer1M(match.pricing.input_cost_per_token);
+  const outputPer1MTokens = perTokenToPer1M(match.pricing.output_cost_per_token);
+  const cachedInputPer1MTokens = perTokenToPer1M(match.pricing.cache_read_input_token_cost);
+  const cacheCreationInputPer1MTokens = perTokenToPer1M(match.pricing.cache_creation_input_token_cost);
+  const missingRateReasons = [];
+  if (inputPer1MTokens === null) missingRateReasons.push(`pricing catalog entry ${match.modelKey} lacks input_cost_per_token`);
+  if (outputPer1MTokens === null) missingRateReasons.push(`pricing catalog entry ${match.modelKey} lacks output_cost_per_token`);
+
+  return {
+    pricing: {
+      provider: normalizedProvider,
+      model: normalizedModel,
+      currency,
+      inputPer1MTokens,
+      outputPer1MTokens,
+      cachedInputPer1MTokens,
+      cacheCreationInputPer1MTokens,
+      sourceUrl,
+      checkedDate,
+      pricingSourceKind: 'litellm-pricing-catalog',
+      catalogModelKey: match.modelKey,
+      catalogMatchKind: match.matchKind,
+      note: 'Estimated API cost only; derived from provider usage tokens and a LiteLLM-shaped pricing catalog; not an invoice, charge, or provider billing statement.',
+    },
+    reasons: missingRateReasons,
+  };
+}
+
+function readPricingCatalog(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+async function fetchPricingCatalog(url = LITELLM_PRICING_URL) {
+  if (typeof fetch !== 'function') {
+    throw new Error('Global fetch is unavailable; use --pricing-catalog=<json> instead');
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch pricing catalog: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+module.exports = {
+  LITELLM_PRICING_URL,
+  createModelCandidates,
+  findPricingEntry,
+  pricingAssumptionFromLiteLLMCatalog,
+  readPricingCatalog,
+  fetchPricingCatalog,
+};

--- a/benchmarks/layer2-frontend-task/r4-repeated-summary.js
+++ b/benchmarks/layer2-frontend-task/r4-repeated-summary.js
@@ -35,15 +35,96 @@ function median(values) {
   return round1((sorted[mid - 1] + sorted[mid]) / 2);
 }
 
-function artifactStatus(artifactPath, artifact) {
+function stableIdentityValue(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function targetIdentityFromPath(filePath) {
+  if (!filePath) return null;
+  const normalized = path.relative(process.cwd(), path.resolve(filePath)).split(path.sep).join('/');
+  return `target:${normalized}`;
+}
+
+function firstIdentityCandidate(candidates) {
+  for (const candidate of candidates) {
+    const value = stableIdentityValue(candidate.value);
+    if (value !== null) return { value, source: candidate.source };
+  }
+  return { value: null, source: null };
+}
+
+function artifactIdentity(artifact, defaults) {
+  const taskIdentity = firstIdentityCandidate([
+    { value: artifact.taskIdentity, source: 'artifact.taskIdentity' },
+    { value: artifact.targetIdentity, source: 'artifact.targetIdentity' },
+    { value: defaults.taskIdentity, source: defaults.taskIdentitySource },
+    { value: targetIdentityFromPath(artifact.targetFile), source: 'artifact.targetFile' },
+  ]);
+  const model = firstIdentityCandidate([
+    { value: artifact.model, source: 'artifact.model' },
+    { value: defaults.model, source: defaults.modelSource },
+  ]);
+  const setupIdentity = firstIdentityCandidate([
+    { value: artifact.setupIdentity, source: 'artifact.setupIdentity' },
+    { value: defaults.setupIdentity, source: defaults.setupIdentitySource },
+  ]);
+  return {
+    taskIdentity: taskIdentity.value,
+    model: model.value,
+    setupIdentity: setupIdentity.value,
+    sources: {
+      taskIdentity: taskIdentity.source,
+      model: model.source,
+      setupIdentity: setupIdentity.source,
+    },
+  };
+}
+
+function sameIdentity(left, right) {
+  return left.taskIdentity === right.taskIdentity
+    && left.model === right.model
+    && left.setupIdentity === right.setupIdentity;
+}
+
+function missingIdentityFields(pair) {
+  const fields = [];
+  if (!pair.vanilla.identity.taskIdentity || !pair.fooks.identity.taskIdentity) fields.push('missing-task-identity');
+  if (!pair.vanilla.identity.model || !pair.fooks.identity.model) fields.push('missing-model');
+  if (!pair.vanilla.identity.setupIdentity || !pair.fooks.identity.setupIdentity) fields.push('missing-setup-identity');
+  return fields;
+}
+
+function inheritedIdentityFields(pair) {
+  const fields = [];
+  for (const side of ['vanilla', 'fooks']) {
+    for (const field of ['taskIdentity', 'model', 'setupIdentity']) {
+      const source = pair[side].identity.sources?.[field] || null;
+      if (source && !source.startsWith('artifact.')) {
+        fields.push(`${side}-${field}-from-${source}`);
+      }
+    }
+  }
+  return fields;
+}
+
+function uniqueFiniteValues(values) {
+  return [...new Set(values.filter((value) => value !== null && value !== undefined))];
+}
+
+function artifactStatus(artifactPath, artifact, defaults) {
   const metrics = artifact.metrics || {};
+  const runtimeTokenTelemetryAvailable = metrics.runtimeTokenClaimAvailable === true
+    || metrics.runtimeTokenTelemetryAvailable === true;
   return {
     path: artifactPath ? path.relative(process.cwd(), path.resolve(artifactPath)).split(path.sep).join('/') : null,
     status: artifact.status || null,
     validationStatus: artifact.validation?.status || null,
+    identity: artifactIdentity(artifact, defaults),
     promptTokensApprox: Number.isFinite(metrics.promptTokensApprox) ? metrics.promptTokensApprox : null,
     runtimeTokensTotal: Number.isFinite(metrics.runtimeTokensTotal) ? metrics.runtimeTokensTotal : null,
-    runtimeTokenClaimAvailable: metrics.runtimeTokenClaimAvailable === true,
+    runtimeTokenTelemetryAvailable,
     latencyMs: Number.isFinite(metrics.latencyMs) ? metrics.latencyMs : null,
     artifactError: artifact.artifactError || null,
   };
@@ -56,20 +137,44 @@ function acceptedRun(status) {
 function summarizeRepeatedPairs(input) {
   const requiredAcceptedPairs = Number(input.requiredAcceptedPairs || 5);
   const timestamp = input.timestamp || new Date().toISOString();
+  const runId = input.runId || null;
+  const taskIdentity = stableIdentityValue(input.taskIdentity || targetIdentityFromPath(input.target));
+  const model = stableIdentityValue(input.model || null);
+  const setupIdentity = stableIdentityValue(input.setupIdentity || null);
+  const identityDefaults = {
+    taskIdentity,
+    taskIdentitySource: taskIdentity ? 'run.taskIdentity' : null,
+    model,
+    modelSource: model ? 'run.model' : null,
+    setupIdentity,
+    setupIdentitySource: setupIdentity ? 'run.setupIdentity' : null,
+  };
   const pairSpecs = input.pairs || [];
   const pairs = pairSpecs.map((pair, index) => {
     const vanillaArtifact = pair.vanillaArtifact || readArtifact(pair.vanillaPath);
     const fooksArtifact = pair.fooksArtifact || readArtifact(pair.fooksPath);
-    const vanilla = artifactStatus(pair.vanillaPath, vanillaArtifact);
-    const fooks = artifactStatus(pair.fooksPath, fooksArtifact);
+    const pairDefaults = {
+      ...identityDefaults,
+      taskIdentity: stableIdentityValue(pair.taskIdentity || identityDefaults.taskIdentity),
+      taskIdentitySource: pair.taskIdentity ? 'pair.taskIdentity' : identityDefaults.taskIdentitySource,
+      model: stableIdentityValue(pair.model || identityDefaults.model),
+      modelSource: pair.model ? 'pair.model' : identityDefaults.modelSource,
+      setupIdentity: stableIdentityValue(pair.setupIdentity || identityDefaults.setupIdentity),
+      setupIdentitySource: pair.setupIdentity ? 'pair.setupIdentity' : identityDefaults.setupIdentitySource,
+    };
+    const vanilla = artifactStatus(pair.vanillaPath, vanillaArtifact, pairDefaults);
+    const fooks = artifactStatus(pair.fooksPath, fooksArtifact, pairDefaults);
     const accepted = acceptedRun(vanilla) && acceptedRun(fooks);
-    const runtimeComparable = accepted && vanilla.runtimeTokenClaimAvailable && fooks.runtimeTokenClaimAvailable
+    const identityMatched = sameIdentity(vanilla.identity, fooks.identity);
+    const runtimeComparable = accepted && vanilla.runtimeTokenTelemetryAvailable && fooks.runtimeTokenTelemetryAvailable
       && Number.isFinite(vanilla.runtimeTokensTotal) && Number.isFinite(fooks.runtimeTokensTotal);
     const latencyComparable = accepted && Number.isFinite(vanilla.latencyMs) && Number.isFinite(fooks.latencyMs);
 
     return {
       pairIndex: pair.pairIndex || index + 1,
       accepted,
+      identityMatched,
+      identity: identityMatched ? vanilla.identity : null,
       vanilla,
       fooks,
       deltas: {
@@ -84,6 +189,21 @@ function summarizeRepeatedPairs(input) {
   const runtimeTokenDeltas = acceptedPairs.map((pair) => pair.deltas.runtimeTokenReductionPct).filter(Number.isFinite);
   const latencyDeltas = acceptedPairs.map((pair) => pair.deltas.latencyReductionPct).filter(Number.isFinite);
   const promptDeltas = acceptedPairs.map((pair) => pair.deltas.promptReductionPct).filter(Number.isFinite);
+  const identityMatchedAcceptedPairs = acceptedPairs.filter((pair) => pair.identityMatched);
+  const mixedIdentityReasons = [];
+  const acceptedTaskIdentities = uniqueFiniteValues(identityMatchedAcceptedPairs.map((pair) => pair.identity?.taskIdentity));
+  const acceptedModels = uniqueFiniteValues(identityMatchedAcceptedPairs.map((pair) => pair.identity?.model));
+  const acceptedSetupIdentities = uniqueFiniteValues(identityMatchedAcceptedPairs.map((pair) => pair.identity?.setupIdentity));
+  if (acceptedPairs.some((pair) => !pair.identityMatched)) mixedIdentityReasons.push('pair-identity-mismatch');
+  if (acceptedTaskIdentities.length > 1) mixedIdentityReasons.push('mixed-task-identity');
+  if (acceptedModels.length > 1) mixedIdentityReasons.push('mixed-model');
+  if (acceptedSetupIdentities.length > 1) mixedIdentityReasons.push('mixed-setup-identity');
+  const missingIdentityReasons = uniqueFiniteValues(acceptedPairs.flatMap(missingIdentityFields));
+  const inheritedIdentityReasons = uniqueFiniteValues(acceptedPairs.flatMap(inheritedIdentityFields));
+  const resolvedTaskIdentity = taskIdentity || (acceptedTaskIdentities.length === 1 ? acceptedTaskIdentities[0] : null);
+  const resolvedModel = model || (acceptedModels.length === 1 ? acceptedModels[0] : null);
+  const resolvedSetupIdentity = setupIdentity
+    || (acceptedSetupIdentities.length === 1 ? acceptedSetupIdentities[0] : null);
   const medians = {
     promptReductionPct: median(promptDeltas),
     runtimeTokenReductionPct: median(runtimeTokenDeltas),
@@ -98,36 +218,96 @@ function summarizeRepeatedPairs(input) {
   const latencyComparablePairCount = latencyDeltas.length;
 
   let classification = 'diagnostic-only';
+  let candidateStatus = 'diagnostic-only';
+  const candidateReasons = [];
   if (acceptedPairs.length < requiredAcceptedPairs) {
     classification = 'insufficient-accepted-pairs';
+    candidateStatus = 'insufficient-accepted-pairs';
+    candidateReasons.push(`accepted pairs ${acceptedPairs.length}/${requiredAcceptedPairs}`);
+  } else if (missingIdentityReasons.length > 0) {
+    classification = 'missing-identity';
+    candidateStatus = 'missing-identity';
+    candidateReasons.push(...missingIdentityReasons);
+  } else if (mixedIdentityReasons.length > 0) {
+    classification = 'mixed-identity';
+    candidateStatus = 'mixed-identity';
+    candidateReasons.push(...mixedIdentityReasons);
   } else if (runtimeTokenComparablePairCount < requiredAcceptedPairs) {
     classification = 'runtime-token-unavailable';
+    candidateStatus = 'runtime-token-unavailable';
+    candidateReasons.push(`runtime-token comparable pairs ${runtimeTokenComparablePairCount}/${requiredAcceptedPairs}`);
+  } else if (latencyComparablePairCount < requiredAcceptedPairs) {
+    classification = 'latency-unavailable';
+    candidateStatus = 'latency-unavailable';
+    candidateReasons.push(`latency comparable pairs ${latencyComparablePairCount}/${requiredAcceptedPairs}`);
   } else if (
     medians.runtimeTokenReductionPct > 0
     && medians.latencyReductionPct > 0
     && outliers.severeRuntimeTokenRegressionCount === 0
   ) {
     classification = 'narrow-l1-candidate';
+    candidateStatus = 'candidate-evidence';
+    candidateReasons.push('5+ same-task/model/setup accepted pairs with positive runtime-token and latency medians');
+  } else {
+    candidateReasons.push('candidate threshold not met');
   }
 
   return {
     schemaVersion: 'layer2-r4-repeated-summary.v1',
+    runId,
     timestamp,
+    taskIdentity: resolvedTaskIdentity,
+    model: resolvedModel,
+    setupIdentity: resolvedSetupIdentity,
     requiredAcceptedPairs,
     attemptedPairCount: pairs.length,
     acceptedPairCount: acceptedPairs.length,
     failedPairCount: pairs.length - acceptedPairs.length,
     runtimeTokenComparablePairCount,
     latencyComparablePairCount,
+    distributions: {
+      promptReductionPct: promptDeltas,
+      runtimeTokenReductionPct: runtimeTokenDeltas,
+      latencyReductionPct: latencyDeltas,
+    },
     medians,
     outliers,
+    identity: {
+      taskIdentity: resolvedTaskIdentity,
+      model: resolvedModel,
+      setupIdentity: resolvedSetupIdentity,
+      acceptedTaskIdentities,
+      acceptedModels,
+      acceptedSetupIdentities,
+      mixed: mixedIdentityReasons.length > 0,
+      mixedReasons: mixedIdentityReasons,
+      missing: missingIdentityReasons.length > 0,
+      missingReasons: missingIdentityReasons,
+      inherited: inheritedIdentityReasons.length > 0,
+      inheritedReasons: inheritedIdentityReasons,
+      sourcePolicy: 'Candidate evidence requires every accepted pair to have the same resolved task/model/setup identity. Artifact, pair, and run-level identity sources are accepted; inherited non-artifact sources are reported for auditability.',
+    },
+    candidate: {
+      status: candidateStatus,
+      achieved: candidateStatus === 'candidate-evidence',
+      reasons: candidateReasons,
+      claimBoundary: 'Candidate evidence is internal repeated local telemetry only; stable runtime-token/time claimability remains false.',
+    },
     pairs,
     claimBoundary: [
       'Accepted pairs require both vanilla and fooks to pass local applied acceptance gates.',
       'Runtime-token comparisons are Level 1 CLI runtime-reported telemetry only, not provider billing tokens or costs.',
+      'Telemetry availability/comparability is not product claimability.',
+      'A candidate evidence summary is internal evidence only, not a stable public runtime-token/time savings claim.',
       'A narrow L1 candidate still does not support provider billing-token, cost-savings, broad multi-task, Claude, or opencode savings claims.',
       'Broad/stable claims require later multi-task repeated evidence.',
     ],
+    claimability: {
+      providerInvoiceOrBillingSavings: false,
+      providerBillingTokenSavings: false,
+      stableRuntimeTokenSavings: false,
+      stableTimeOrLatencySavings: false,
+    },
     classification,
   };
 }

--- a/benchmarks/layer2-frontend-task/run-provider-cost-evidence.js
+++ b/benchmarks/layer2-frontend-task/run-provider-cost-evidence.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  buildProviderCostEvidence,
+  renderProviderCostEvidenceMarkdown,
+} = require('./provider-cost-evidence.js');
+const {
+  LITELLM_PRICING_URL,
+  fetchPricingCatalog,
+  pricingAssumptionFromLiteLLMCatalog,
+  readPricingCatalog,
+} = require('./provider-pricing.js');
+const {
+  ensureEvidenceDir,
+  evidencePaths,
+  timestampRunId,
+} = require('./evidence-paths.js');
+
+function parseArgs(argv) {
+  return argv.reduce((acc, arg) => {
+    if (!arg.startsWith('--')) return acc;
+    const index = arg.indexOf('=');
+    if (index === -1) {
+      acc[arg.slice(2)] = true;
+    } else {
+      acc[arg.slice(2, index)] = arg.slice(index + 1);
+    }
+    return acc;
+  }, {});
+}
+
+function readJson(filePath, label) {
+  if (!filePath) throw new Error(`Missing --${label}=<json>`);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function optionalNumber(value) {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`Invalid non-negative number: ${value}`);
+  return parsed;
+}
+
+function firstArtifactField(artifacts, field) {
+  const artifact = artifacts.find((item) => item && item[field]);
+  return artifact ? artifact[field] : undefined;
+}
+
+function relativePath(filePath) {
+  return path.relative(process.cwd(), path.resolve(filePath)).split(path.sep).join('/');
+}
+
+async function pricingFromArgs(args, artifacts) {
+  const pricing = args.pricing ? readJson(args.pricing, 'pricing') : {};
+  const merged = {
+    ...pricing,
+    provider: args.provider || pricing.provider || firstArtifactField(artifacts, 'provider'),
+    model: args.model || pricing.model || firstArtifactField(artifacts, 'model'),
+    currency: args.currency || pricing.currency,
+    inputPer1MTokens: optionalNumber(args['input-rate-per-1m']) ?? pricing.inputPer1MTokens,
+    outputPer1MTokens: optionalNumber(args['output-rate-per-1m']) ?? pricing.outputPer1MTokens,
+    sourceUrl: args['pricing-source-url'] || pricing.sourceUrl,
+    checkedDate: args['pricing-checked-date'] || pricing.checkedDate,
+    note: args['pricing-note'] || pricing.note,
+  };
+
+  const shouldUseCatalog = args['pricing-catalog'] || args['pricing-catalog-url'] || args['fetch-pricing'];
+  const hasManualRates = merged.inputPer1MTokens !== undefined && merged.outputPer1MTokens !== undefined;
+  if (!shouldUseCatalog || hasManualRates) return merged;
+
+  const sourceUrl = args['pricing-catalog-url'] || LITELLM_PRICING_URL;
+  const catalog = args['pricing-catalog']
+    ? readPricingCatalog(args['pricing-catalog'])
+    : await fetchPricingCatalog(sourceUrl);
+  const fromCatalog = pricingAssumptionFromLiteLLMCatalog({
+    dataset: catalog,
+    provider: merged.provider,
+    model: merged.model,
+    sourceUrl,
+    checkedDate: merged.checkedDate,
+    currency: merged.currency,
+  });
+
+  return {
+    ...fromCatalog.pricing,
+    ...Object.fromEntries(
+      Object.entries(merged).filter(([, value]) => value !== undefined && value !== null),
+    ),
+    catalogLookupReasons: fromCatalog.reasons,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    console.log([
+      'Usage:',
+      '  node benchmarks/layer2-frontend-task/run-provider-cost-evidence.js --baseline=<json> --fooks=<json> [--output=<json>] [options]',
+      '',
+      'Options:',
+      '  --pricing=<json>                 Pricing assumption JSON',
+      '  --provider=openai                Provider label',
+      '  --model=<model>                  Model label (defaults to artifact model when present)',
+      '  --input-rate-per-1m=2.5          Input token rate per 1M tokens',
+      '  --output-rate-per-1m=15          Output token rate per 1M tokens',
+      '  --pricing-catalog=<json>         LiteLLM-shaped local pricing catalog',
+      `  --pricing-catalog-url=<url>      Pricing catalog URL (default: ${LITELLM_PRICING_URL})`,
+      '  --fetch-pricing                  Fetch pricing catalog URL when manual rates are absent',
+      '  --pricing-source-url=<url>       Pricing source URL',
+      '  --pricing-checked-date=YYYY-MM-DD',
+      '  --source-kind=fixture            fixture|fixture-mechanics|validated-provider-import|live-openai-usage',
+      '  --markdown-output=<md>           Optional Markdown summary output',
+      '',
+      'Default output:',
+      '  When --output is omitted, writes to .fooks/evidence/provider-cost/<run-id>/evidence.json',
+      '  and .fooks/evidence/provider-cost/<run-id>/evidence.md.',
+    ].join('\n'));
+    return;
+  }
+
+  const baselineArtifact = readJson(args.baseline, 'baseline');
+  const fooksArtifact = readJson(args.fooks, 'fooks');
+  const runId = args['run-id'] || timestampRunId('provider-cost');
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact,
+    fooksArtifact,
+    pricing: await pricingFromArgs(args, [baselineArtifact, fooksArtifact]),
+    sourceKind: args['source-kind'] || 'fixture',
+    runId,
+  });
+
+  const defaultPaths = args.output ? null : evidencePaths({ tier: 'provider-cost', runId });
+  const output = args.output || defaultPaths.json;
+  if (defaultPaths) ensureEvidenceDir({ tier: 'provider-cost', runId });
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  const markdownOutput = args['markdown-output'] || (defaultPaths ? defaultPaths.markdown : null);
+  if (markdownOutput) {
+    fs.mkdirSync(path.dirname(markdownOutput), { recursive: true });
+    fs.writeFileSync(markdownOutput, renderProviderCostEvidenceMarkdown(evidence));
+  }
+
+  console.log(JSON.stringify({
+    output: relativePath(output),
+    markdownOutput: markdownOutput ? relativePath(markdownOutput) : null,
+    runId,
+    status: evidence.status,
+    claimBoundary: evidence.claimBoundary,
+  }, null, 2));
+}
+
+try {
+  main().catch((error) => {
+    console.error(`[provider-cost-evidence] ${error.message}`);
+    process.exit(1);
+  });
+} catch (error) {
+  console.error(`[provider-cost-evidence] ${error.message}`);
+  process.exit(1);
+}

--- a/benchmarks/layer2-frontend-task/run-provider-cost-repeated.js
+++ b/benchmarks/layer2-frontend-task/run-provider-cost-repeated.js
@@ -1,0 +1,864 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const os = require('os');
+const { spawnSync } = require('child_process');
+const {
+  buildProviderCostEvidence,
+} = require('./provider-cost-evidence.js');
+const {
+  summarizeProviderCostCampaign,
+  shouldStartNextPair,
+  renderProviderCostCampaignMarkdown,
+} = require('./provider-cost-repeated-summary.js');
+const {
+  evidencePaths,
+  timestampRunId,
+} = require('./evidence-paths.js');
+const {
+  LITELLM_PRICING_URL,
+  fetchPricingCatalog,
+  pricingAssumptionFromLiteLLMCatalog,
+  readPricingCatalog,
+} = require('./provider-pricing.js');
+const {
+  resolveOpenAIModel,
+} = require('./model-resolution.js');
+const {
+  resolveOpenAILiveAuth,
+  publicAuthSummary,
+} = require('./openai-live-auth.js');
+
+function parseRepeatedArgs(argv) {
+  const args = { _: [] };
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) {
+      args._.push(arg);
+      continue;
+    }
+    const index = arg.indexOf('=');
+    const key = index === -1 ? arg.slice(2) : arg.slice(2, index);
+    const value = index === -1 ? true : arg.slice(index + 1);
+    if (['pair-evidence', 'pair'].includes(key)) {
+      if (!Array.isArray(args[key])) args[key] = [];
+      args[key].push(value);
+    } else {
+      args[key] = value;
+    }
+  }
+  return args;
+}
+
+function readJson(filePath, label) {
+  if (!filePath) throw new Error(`Missing --${label}=<json>`);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readJsonWithBaseDir(filePath, label) {
+  const absolutePath = path.resolve(filePath);
+  return {
+    value: readJson(absolutePath, label),
+    baseDir: path.dirname(absolutePath),
+  };
+}
+
+function optionalNumber(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`Invalid non-negative number: ${value}`);
+  return parsed;
+}
+
+function relativePath(filePath) {
+  return path.relative(process.cwd(), path.resolve(filePath)).split(path.sep).join('/');
+}
+
+function firstArtifactField(artifacts, field) {
+  const artifact = artifacts.find((item) => item && item[field]);
+  return artifact ? artifact[field] : undefined;
+}
+
+async function pricingFromArgs(args, artifacts) {
+  const pricing = args.pricing ? readJson(args.pricing, 'pricing') : {};
+  const merged = {
+    ...pricing,
+    provider: args.provider || pricing.provider || firstArtifactField(artifacts, 'provider') || 'openai',
+    model: args.model || pricing.model || firstArtifactField(artifacts, 'model'),
+    currency: args.currency || pricing.currency,
+    inputPer1MTokens: optionalNumber(args['input-rate-per-1m'], pricing.inputPer1MTokens),
+    outputPer1MTokens: optionalNumber(args['output-rate-per-1m'], pricing.outputPer1MTokens),
+    cachedInputPer1MTokens: optionalNumber(args['cached-input-rate-per-1m'], pricing.cachedInputPer1MTokens),
+    sourceUrl: args['pricing-source-url'] || pricing.sourceUrl,
+    checkedDate: args['pricing-checked-date'] || pricing.checkedDate,
+    endpoint: args.endpoint || pricing.endpoint || 'chat.completions',
+    serviceTier: args['service-tier'] || pricing.serviceTier || 'standard',
+    pricingTreatment: pricing.pricingTreatment || {
+      longContextApplies: args['long-context-applies'] === 'true' || false,
+      regionalProcessingApplies: args['regional-processing-applies'] === 'true' || false,
+    },
+  };
+
+  const shouldUseCatalog = args['pricing-catalog'] || args['pricing-catalog-url'] || args['fetch-pricing'];
+  const hasManualRates = merged.inputPer1MTokens !== undefined && merged.outputPer1MTokens !== undefined;
+  if (!shouldUseCatalog || hasManualRates) return merged;
+
+  const sourceUrl = args['pricing-catalog-url'] || LITELLM_PRICING_URL;
+  const catalog = args['pricing-catalog']
+    ? readPricingCatalog(args['pricing-catalog'])
+    : await fetchPricingCatalog(sourceUrl);
+  const fromCatalog = pricingAssumptionFromLiteLLMCatalog({
+    dataset: catalog,
+    provider: merged.provider,
+    model: merged.model,
+    sourceUrl,
+    checkedDate: merged.checkedDate,
+    currency: merged.currency,
+  });
+
+  return {
+    ...fromCatalog.pricing,
+    ...Object.fromEntries(Object.entries(merged).filter(([, value]) => value !== undefined && value !== null)),
+    catalogLookupReasons: fromCatalog.reasons,
+  };
+}
+
+function normalizePairEvidenceArgs(values) {
+  return values.flatMap((value) => String(value).split(',').filter(Boolean)).map((evidencePath) => ({ evidencePath }));
+}
+
+function resolveRelative(baseDir, value) {
+  if (!value) return value;
+  return path.isAbsolute(value) ? value : path.join(baseDir, value);
+}
+
+function loadImportManifest(filePath) {
+  const absolutePath = path.resolve(filePath);
+  const baseDir = path.dirname(absolutePath);
+  const manifest = readJson(absolutePath, 'import-manifest');
+  const pairEvidence = Array.isArray(manifest.pairEvidence)
+    ? manifest.pairEvidence.map((entry) => {
+        if (typeof entry === 'string') return { evidencePath: resolveRelative(baseDir, entry) };
+        return {
+          ...entry,
+          evidencePath: resolveRelative(baseDir, entry.evidencePath),
+        };
+      })
+    : [];
+  return {
+    manifest,
+    campaignManifest: manifest.campaignManifestPath
+      ? readJson(resolveRelative(baseDir, manifest.campaignManifestPath), 'campaign-manifest')
+      : manifest.campaignManifest,
+    attemptedPairLedger: manifest.attemptedPairLedgerPath
+      ? readJson(resolveRelative(baseDir, manifest.attemptedPairLedgerPath), 'attempted-pair-ledger')
+      : manifest.attemptedPairLedger,
+    pairEvidence,
+  };
+}
+
+function normalizeTaskManifestTasks(taskManifest) {
+  const rawTasks = Array.isArray(taskManifest?.tasks)
+    ? taskManifest.tasks
+    : Array.isArray(taskManifest?.taskClasses)
+      ? taskManifest.taskClasses
+      : [];
+  return rawTasks.map((task, index) => {
+    const id = task.id || task.taskClass || task.taskId || task.name || `task-${index + 1}`;
+    return {
+      ...task,
+      id,
+      targetPairCount: optionalNumber(task.targetPairCount ?? task.requiredAcceptedPairs ?? task.pairs ?? task.repetitions, 1),
+      repetitions: optionalNumber(task.repetitions ?? task.targetPairCount ?? task.requiredAcceptedPairs ?? task.pairs, 1),
+      qualityGate: task.qualityGate || task.quality_gate || task.gate,
+    };
+  });
+}
+
+function readTextRelative(baseDir, value, label) {
+  if (!value) return null;
+  const filePath = resolveRelative(baseDir, value);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} not found: ${value}`);
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function buildCorrectedPayloadPrompt({ task, role, payload }) {
+  const instruction = task.instruction || task.taskInstruction || task.promptInstruction || task.prompt || [
+    'Analyze the supplied frontend payload and return a concise, behavior-preserving answer.',
+    'Cover responsibilities, extraction/refactor boundaries, risks, and tests when relevant.',
+  ].join(' ');
+  const targetFile = task.targetFile || task.target || 'unknown-target';
+  const payloadKind = role === 'baseline' ? 'full-source' : 'fooks-model-facing-payload';
+  const format = role === 'baseline' ? (task.baselineContextFormat || 'source') : (task.fooksContextFormat || 'json');
+  return [
+    instruction,
+    '',
+    'STRICT EVIDENCE RULES:',
+    '- Answer only from the payload in this prompt.',
+    '- Do not inspect the filesystem, run shell commands, search the workspace, or use external files.',
+    '- If the payload lacks information needed for a claim, say what is missing instead of looking it up.',
+    '- Keep the answer compact and comparable across baseline/fooks variants.',
+    '',
+    `TARGET_FILE: ${targetFile}`,
+    `PAYLOAD_KIND: ${payloadKind}`,
+    `PAYLOAD_FORMAT: ${format}`,
+    'BEGIN_PAYLOAD',
+    payload,
+    'END_PAYLOAD',
+  ].join('\n');
+}
+
+function hydrateTaskManifest(taskManifest, baseDir = process.cwd()) {
+  if (!taskManifest) return taskManifest;
+  const rawTasks = Array.isArray(taskManifest.tasks)
+    ? taskManifest.tasks
+    : Array.isArray(taskManifest.taskClasses)
+      ? taskManifest.taskClasses
+      : [];
+  const tasks = rawTasks.map((task) => {
+    const baselinePayload = readTextRelative(baseDir, task.baselineContextPath || task.baselinePayloadPath, 'baseline context');
+    const fooksPayload = readTextRelative(baseDir, task.fooksContextPath || task.fooksPayloadPath, 'fooks context');
+    if (!baselinePayload && !fooksPayload) return task;
+    if (!baselinePayload || !fooksPayload) {
+      throw new Error(`Task ${task.id || task.taskClass || task.name || '<unknown>'} must provide both baseline and fooks context paths`);
+    }
+    return {
+      ...task,
+      baselinePrompt: task.baselinePrompt || buildCorrectedPayloadPrompt({ task, role: 'baseline', payload: baselinePayload }),
+      fooksPrompt: task.fooksPrompt || buildCorrectedPayloadPrompt({ task, role: 'fooks', payload: fooksPayload }),
+      setupIdentity: task.setupIdentity || 'corrected-real-payload-no-tool',
+    };
+  });
+  if (Array.isArray(taskManifest.tasks)) return { ...taskManifest, tasks };
+  if (Array.isArray(taskManifest.taskClasses)) return { ...taskManifest, taskClasses: tasks };
+  return taskManifest;
+}
+
+function plannedPairsFromTasks(tasks) {
+  return tasks.reduce((sum, task) => sum + optionalNumber(task.repetitions ?? task.targetPairCount, 1), 0);
+}
+
+function pairFromArg(value) {
+  const [baselinePath, fooksPath, taskClass] = String(value).split(':');
+  if (!baselinePath || !fooksPath || !taskClass) {
+    throw new Error('--pair must be <baseline.json>:<fooks.json>:<task-class>');
+  }
+  return { baselinePath, fooksPath, taskClass };
+}
+
+function createDefaultManifest({ runId, model, taskClasses, tasks = [], args, pricing }) {
+  const uniqueTasks = [...new Set(taskClasses.filter(Boolean))];
+  const manifestTasks = tasks.length > 0
+    ? tasks
+    : uniqueTasks.map((id) => ({
+        id,
+        targetPairCount: optionalNumber(args['required-accepted-pairs-per-task'], 5),
+        qualityGate: {
+          id: args['quality-gate-id'] || 'provider-cost-import-smoke',
+          version: args['quality-gate-version'] || 'v1',
+          command: args['quality-gate-command'] || 'imported-artifact-quality-gate',
+        },
+      }));
+  return {
+    campaignId: runId,
+    model,
+    endpoint: args.endpoint || pricing.endpoint || 'chat.completions',
+    serviceTier: args['service-tier'] || pricing.serviceTier || 'standard',
+    reasoning: args.reasoning || null,
+    maxOutputTokens: optionalNumber(args['max-output-tokens'], null),
+    pricingSourceUrl: pricing.sourceUrl,
+    pricingCheckedDate: pricing.checkedDate,
+    taskClasses: manifestTasks.map((task) => ({
+      id: task.id,
+      targetPairCount: optionalNumber(task.targetPairCount ?? args['required-accepted-pairs-per-task'], 5),
+      qualityGate: task.qualityGate || {
+        id: args['quality-gate-id'] || 'provider-cost-import-smoke',
+        version: args['quality-gate-version'] || 'v1',
+        command: args['quality-gate-command'] || 'imported-artifact-quality-gate',
+      },
+    })),
+    caps: {
+      maxEstimatedUsd: optionalNumber(args['max-estimated-usd'], 5),
+      campaignMaxEstimatedUsd: optionalNumber(args['campaign-max-estimated-usd'], optionalNumber(args['max-estimated-usd'], 5)),
+      maxMatchedPairs: optionalNumber(args['max-matched-pairs'], 10),
+      maxBatches: optionalNumber(args['max-batches'], 1),
+    },
+  };
+}
+
+function createLedgerFromPairs({ pairs, plannedPairCount }) {
+  return {
+    plannedPairCount: plannedPairCount || pairs.length,
+    attemptedPairCount: pairs.length,
+    acceptedPairCount: pairs.filter((pair) => pair.evidence?.status !== 'inconclusive').length,
+    failedPairCount: pairs.filter((pair) => pair.evidence?.status === 'inconclusive').length,
+    rejectedPairCount: 0,
+    missingUsagePairCount: pairs.filter((pair) => pair.evidence?.status === 'inconclusive').length,
+    neutralPairCount: pairs.filter((pair) => pair.evidence?.deltas?.estimatedApiCostTotal?.absolute === 0).length,
+    regressedPairCount: pairs.filter((pair) => pair.evidence?.deltas?.estimatedApiCostTotal?.absolute < 0).length,
+    omittedPairs: [],
+    attemptedPairs: pairs.map((pair, index) => ({
+      pairId: pair.evidence?.runId || pair.pairId || `pair-${index + 1}`,
+      taskClass: pair.taskClass || pair.evidence?.taskClass,
+      status: pair.evidence?.status || 'unknown',
+    })),
+  };
+}
+
+function createLiveLedger({ pairs, attemptedPairs, plannedPairCount, failedPairCount = 0, missingUsagePairCount = 0 }) {
+  return {
+    plannedPairCount,
+    attemptedPairCount: attemptedPairs.length,
+    acceptedPairCount: pairs.filter((pair) => pair.evidence?.status !== 'inconclusive').length,
+    failedPairCount: failedPairCount || pairs.filter((pair) => pair.evidence?.status === 'inconclusive').length,
+    rejectedPairCount: 0,
+    missingUsagePairCount: missingUsagePairCount || pairs.filter((pair) => pair.evidence?.status === 'inconclusive').length,
+    neutralPairCount: pairs.filter((pair) => pair.evidence?.deltas?.estimatedApiCostTotal?.absolute === 0).length,
+    regressedPairCount: pairs.filter((pair) => pair.evidence?.deltas?.estimatedApiCostTotal?.absolute < 0).length,
+    omittedPairs: [],
+    attemptedPairs,
+  };
+}
+
+function pairOrderFor({ args, task, repetition }) {
+  const mode = task.pairOrder || task.pair_order || args['pair-order'] || 'baseline-first';
+  if (mode === 'baseline-first' || mode === 'ab') return ['baseline', 'fooks'];
+  if (mode === 'fooks-first' || mode === 'ba') return ['fooks', 'baseline'];
+  if (mode === 'abba' || mode === 'alternating') {
+    return repetition % 2 === 1 ? ['baseline', 'fooks'] : ['fooks', 'baseline'];
+  }
+  throw new Error(`Invalid --pair-order/task pairOrder: ${mode}`);
+}
+
+function resolveCodexWorkDirRoot({ args, outputDir }) {
+  const explicitRoot = args['codex-workdir-root'];
+  if (explicitRoot) return path.resolve(explicitRoot);
+  const mode = args['codex-workdir'] || args['codex-workdir-mode'] || 'evidence';
+  if (mode === 'evidence') return outputDir;
+  if (mode === 'isolated') return path.join(os.tmpdir(), 'fooks-provider-cost-codex');
+  throw new Error(`Invalid --codex-workdir: ${mode}`);
+}
+
+function countCodexCommandExecutions(events) {
+  return events.filter((event) => event.item?.type === 'command_execution').length;
+}
+
+function qualityGateForArtifact({ baseGate, artifact, requireNoToolUse }) {
+  if (!requireNoToolUse) return baseGate;
+  const commandExecutionCount = artifact.commandExecutionCount || 0;
+  const inherited = baseGate && typeof baseGate === 'object'
+    ? baseGate
+    : { id: baseGate || 'corrected-payload-validation' };
+  const noToolStatus = commandExecutionCount === 0 ? 'passed' : 'failed';
+  const command = [
+    inherited.command || 'payload-only answer validation',
+    `no-tool-use:${noToolStatus}`,
+    `commandExecutionCount:${commandExecutionCount}`,
+  ].join('; ');
+  return {
+    ...inherited,
+    id: inherited.id || 'corrected-payload-validation',
+    status: commandExecutionCount === 0 ? (inherited.status || noToolStatus) : 'failed',
+    command,
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function openAiChatCompletion({ auth, model, prompt, maxOutputTokens }) {
+  const payload = JSON.stringify({
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0,
+    ...(maxOutputTokens ? { max_tokens: maxOutputTokens } : {}),
+  });
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const req = https.request({
+      hostname: 'api.openai.com',
+      path: '/v1/chat/completions',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...auth.headers,
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => {
+        let parsed = null;
+        try { parsed = JSON.parse(body); } catch (error) { /* preserve body */ }
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`OpenAI request failed: ${res.statusCode} ${body.slice(0, 200)}`));
+          return;
+        }
+        const usage = parsed?.usage || {};
+        resolve({
+          provider: 'openai',
+          model: parsed?.model || model,
+          requestedModel: model,
+          usageSource: 'live-openai-usage',
+          authSource: auth.credentialKind,
+          authCredentialSource: auth.source,
+          usage,
+          inputTokens: usage.prompt_tokens ?? usage.input_tokens ?? null,
+          outputTokens: usage.completion_tokens ?? usage.output_tokens ?? null,
+          totalTokens: usage.total_tokens ?? null,
+          status: usage ? 'success' : 'usage-unavailable',
+          latencyMs: Date.now() - started,
+          timestamp: new Date().toISOString(),
+        });
+      });
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+function parseCodexJsonEvents(stdout) {
+  const events = String(stdout)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('{'))
+    .map((line) => {
+      try { return JSON.parse(line); } catch (error) { return null; }
+    })
+    .filter(Boolean);
+  const completed = [...events].reverse().find((event) => event.type === 'turn.completed' && event.usage);
+  const message = [...events].reverse().find((event) => event.type === 'item.completed' && event.item?.type === 'agent_message');
+  return { events, completed, message };
+}
+
+function codexExecCompletion({ model, prompt, maxOutputTokens, outputDir, workDirRoot, taskClass, side, repetition }) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.mkdirSync(workDirRoot, { recursive: true });
+  const workDir = fs.mkdtempSync(path.join(workDirRoot, `codex-${taskClass}-${side}-${repetition}-`));
+  const args = [
+    'exec',
+    '--json',
+    '--sandbox',
+    'read-only',
+    '--skip-git-repo-check',
+    '--ephemeral',
+    '-C',
+    workDir,
+    '--model',
+    model,
+  ];
+  if (maxOutputTokens) {
+    args.push('-c', `model_max_output_tokens=${JSON.stringify(maxOutputTokens)}`);
+  }
+  args.push(prompt);
+
+  const started = Date.now();
+  const result = spawnSync('codex', args, {
+    cwd: workDir,
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+    env: { ...process.env },
+  });
+  const latencyMs = Date.now() - started;
+  const jsonlPath = path.join(outputDir, 'codex-jsonl', `${taskClass}-${side}-${repetition}.jsonl`);
+  writeJson(`${jsonlPath}.meta.json`, {
+    command: 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral',
+    model,
+    exitCode: result.status,
+    signal: result.signal,
+    latencyMs,
+  });
+  fs.mkdirSync(path.dirname(jsonlPath), { recursive: true });
+  fs.writeFileSync(jsonlPath, result.stdout || '');
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`codex exec failed: exit ${result.status}; ${String(result.stderr || result.stdout).slice(0, 300)}`);
+  }
+
+  const parsed = parseCodexJsonEvents(result.stdout);
+  const usage = parsed.completed?.usage || {};
+  const commandExecutionCount = countCodexCommandExecutions(parsed.events);
+  if (!parsed.completed) {
+    throw new Error('codex exec completed without turn.completed usage event');
+  }
+  return {
+    provider: 'openai',
+    model,
+    requestedModel: model,
+    usageSource: 'live-openai-usage',
+    authSource: 'codex-oauth',
+    authCredentialSource: 'codex-auth-json',
+    transport: 'codex-exec',
+    usage: {
+      input_tokens: usage.input_tokens ?? null,
+      output_tokens: usage.output_tokens ?? null,
+      total_tokens: usage.input_tokens !== undefined && usage.output_tokens !== undefined
+        ? usage.input_tokens + usage.output_tokens
+        : null,
+      input_tokens_details: usage.cached_input_tokens !== undefined
+        ? { cached_tokens: usage.cached_input_tokens }
+        : undefined,
+    },
+    inputTokens: usage.input_tokens ?? null,
+    cachedInputTokens: usage.cached_input_tokens ?? null,
+    outputTokens: usage.output_tokens ?? null,
+    totalTokens: usage.input_tokens !== undefined && usage.output_tokens !== undefined
+      ? usage.input_tokens + usage.output_tokens
+      : null,
+    status: usage.input_tokens !== undefined && usage.output_tokens !== undefined ? 'success' : 'usage-unavailable',
+    latencyMs,
+    timestamp: new Date().toISOString(),
+    responseText: parsed.message?.item?.text || null,
+    commandExecutionCount,
+    noToolUse: commandExecutionCount === 0,
+    rawEventPath: path.relative(process.cwd(), jsonlPath).split(path.sep).join('/'),
+  };
+}
+
+async function collectLivePairs({ args, runId, pricing, outputDir, taskManifest }) {
+  const tasks = normalizeTaskManifestTasks(taskManifest);
+  const plannedPairCount = plannedPairsFromTasks(tasks);
+  const auth = resolveOpenAILiveAuth({ args });
+  if (!auth.ok) {
+    return {
+      blocker: `OpenAI live auth is required for --live-openai; no request was made (${auth.reasons.join('; ')})`,
+      auth,
+      pairs: [],
+      ledger: {
+        plannedPairCount,
+        attemptedPairCount: 0,
+        acceptedPairCount: 0,
+        failedPairCount: 0,
+        rejectedPairCount: 0,
+        missingUsagePairCount: 0,
+        neutralPairCount: 0,
+        regressedPairCount: 0,
+        omittedPairs: [],
+        attemptedPairs: [],
+      },
+    };
+  }
+
+  const modelConfig = resolveOpenAIModel({ modelArg: args.model });
+  const maxMatchedPairs = optionalNumber(args['max-matched-pairs'], 10);
+  const maxEstimatedUsd = optionalNumber(args['max-estimated-usd'], 5);
+  const campaignMaxEstimatedUsd = optionalNumber(args['campaign-max-estimated-usd'], maxEstimatedUsd);
+  const worstCase = optionalNumber(args['worst-case-pair-estimated-usd'], maxEstimatedUsd / Math.max(maxMatchedPairs, 1));
+  const maxOutputTokens = optionalNumber(args['max-output-tokens'], null);
+  const pairs = [];
+  const attemptedPairs = [];
+  const transport = args.transport || args['live-transport'] || (auth.credentialKind === 'codex-oauth' ? 'codex-exec' : 'direct-api');
+  const codexWorkDirRoot = resolveCodexWorkDirRoot({ args, outputDir });
+  const requireNoToolUse = args['require-no-tool-use'] === 'true' || args['require-no-tool-use'] === true;
+  let currentBatchEstimatedUsd = 0;
+  let currentCampaignEstimatedUsd = 0;
+
+  for (const task of tasks) {
+    const taskClass = task.id || task.taskClass || task.name;
+    const repetitions = Number(task.repetitions || task.targetPairCount || 1);
+    for (let i = 0; i < repetitions; i += 1) {
+      const gate = shouldStartNextPair({
+        currentBatchEstimatedUsd,
+        currentCampaignEstimatedUsd,
+        nextWorstCaseEstimatedUsd: worstCase,
+        maxEstimatedUsd,
+        campaignMaxEstimatedUsd,
+        attemptedMatchedPairs: pairs.length,
+        maxMatchedPairs,
+      });
+      if (!gate.allowed) {
+        return {
+          pairs,
+          auth,
+          requestAttempted: attemptedPairs.length > 0,
+          capState: { blocked: true, reasons: gate.reasons },
+          stoppedBeforePair: { taskClass, repetition: i + 1 },
+          ledger: createLiveLedger({ pairs, attemptedPairs, plannedPairCount }),
+        };
+      }
+      const pairId = `${runId}-${taskClass}-${i + 1}`;
+      const executionOrder = pairOrderFor({ args, task, repetition: i + 1 });
+      attemptedPairs.push({ pairId, taskClass, status: 'started', executionOrder });
+      let baselineArtifact;
+      let fooksArtifact;
+      try {
+        const artifacts = {};
+        for (const side of executionOrder) {
+          const prompt = side === 'baseline'
+            ? task.baselinePrompt || task.prompt
+            : task.fooksPrompt || task.prompt;
+          if (transport === 'codex-exec') {
+            artifacts[side] = codexExecCompletion({
+              model: modelConfig.model,
+              prompt,
+              maxOutputTokens,
+              outputDir,
+              workDirRoot: codexWorkDirRoot,
+              taskClass,
+              side,
+              repetition: i + 1,
+            });
+          } else {
+            artifacts[side] = await openAiChatCompletion({ auth, model: modelConfig.model, prompt, maxOutputTokens });
+          }
+        }
+        baselineArtifact = artifacts.baseline;
+        fooksArtifact = artifacts.fooks;
+      } catch (error) {
+        attemptedPairs[attemptedPairs.length - 1] = {
+          pairId,
+          taskClass,
+          status: 'request-failed',
+          reason: error.message,
+        };
+        return {
+          pairs,
+          auth,
+          requestAttempted: true,
+          blocker: `OpenAI live request failed; campaign stopped without claiming savings (${error.message})`,
+          capState: { blocked: true, reasons: [error.message] },
+          ledger: createLiveLedger({ pairs, attemptedPairs, plannedPairCount, failedPairCount: 1, missingUsagePairCount: 1 }),
+        };
+      }
+      const evidence = buildProviderCostEvidence({
+        baselineArtifact: {
+          ...baselineArtifact,
+          taskClass,
+          setupIdentity: task.setupIdentity || 'live-openai-campaign',
+          endpoint: 'chat.completions',
+          serviceTier: args['service-tier'] || 'standard',
+          qualityGate: qualityGateForArtifact({ baseGate: task.qualityGate, artifact: baselineArtifact, requireNoToolUse }),
+        },
+        fooksArtifact: {
+          ...fooksArtifact,
+          taskClass,
+          setupIdentity: task.setupIdentity || 'live-openai-campaign',
+          endpoint: 'chat.completions',
+          serviceTier: args['service-tier'] || 'standard',
+          qualityGate: qualityGateForArtifact({ baseGate: task.qualityGate, artifact: fooksArtifact, requireNoToolUse }),
+        },
+        pricing,
+        sourceKind: 'live-openai-usage',
+        runId: pairId,
+      });
+      const pairPath = path.join(outputDir, 'pairs', `${taskClass}-${i + 1}.json`);
+      writeJson(pairPath, evidence);
+      pairs.push({ pairId: evidence.runId, taskClass, evidence, evidencePath: pairPath, qualityGate: task.qualityGate });
+      attemptedPairs[attemptedPairs.length - 1] = {
+        pairId,
+        taskClass,
+        executionOrder,
+        status: evidence.status,
+        commandExecutionCount: {
+          baseline: baselineArtifact.commandExecutionCount || 0,
+          fooks: fooksArtifact.commandExecutionCount || 0,
+        },
+      };
+      currentBatchEstimatedUsd += evidence.runs.baseline.estimatedApiCost.total || 0;
+      currentBatchEstimatedUsd += evidence.runs.fooks.estimatedApiCost.total || 0;
+      currentCampaignEstimatedUsd = currentBatchEstimatedUsd;
+    }
+  }
+  return {
+    pairs,
+    auth,
+    requestAttempted: attemptedPairs.length > 0,
+    capState: { blocked: false, reasons: [] },
+    ledger: createLiveLedger({ pairs, attemptedPairs, plannedPairCount }),
+  };
+}
+
+async function main() {
+  const args = parseRepeatedArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    console.log([
+      'Usage:',
+      '  node benchmarks/layer2-frontend-task/run-provider-cost-repeated.js --pair-evidence=<json> --campaign-manifest=<json> --attempted-pair-ledger=<json> [options]',
+      '  node benchmarks/layer2-frontend-task/run-provider-cost-repeated.js --import-manifest=<json> [options]',
+      '  node benchmarks/layer2-frontend-task/run-provider-cost-repeated.js --pair=<baseline.json>:<fooks.json>:<task-class> [options]',
+      '  node benchmarks/layer2-frontend-task/run-provider-cost-repeated.js --live-openai --task-manifest=<json> [capped live options]',
+      '',
+      'Options:',
+      '  --output=<json> / --markdown-output=<md>',
+      '  --run-id=<id>',
+      '  --source-kind=validated-provider-import|fixture-mechanics|live-openai-usage',
+      '  --auth-mode=auto|codex-oauth|api-key --codex-auth-json=<path> --codex-home=<dir>',
+      '  --transport=codex-exec|direct-api (default: codex-exec for Codex OAuth, direct-api for API keys)',
+      '  --codex-workdir=evidence|isolated --pair-order=baseline-first|fooks-first|abba --require-no-tool-use=true',
+      '  Corrected manifests may use baselineContextPath/fooksContextPath + instruction to compare real full-source vs real fooks payloads.',
+      '  --max-estimated-usd=5 --max-matched-pairs=10 --campaign-max-estimated-usd=5 --max-batches=1',
+      '  Launch-grade live template: benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json (3 tasks × 5 pairs)',
+      '  --dry-run-live',
+    ].join('\n'));
+    return;
+  }
+
+  const runId = args['run-id'] || timestampRunId('provider-cost-campaign');
+  const defaultPaths = args.output ? null : evidencePaths({ tier: 'provider-cost', runId, jsonName: 'summary.json', markdownName: 'summary.md' });
+  const outputPath = args.output || defaultPaths.json;
+  const markdownPath = args['markdown-output'] || (defaultPaths ? defaultPaths.markdown : null);
+  const outputDir = defaultPaths ? defaultPaths.dir : path.dirname(outputPath);
+  const sourceKind = args['source-kind'] || (args['live-openai'] ? 'live-openai-usage' : 'validated-provider-import');
+  const importBundle = args['import-manifest'] ? loadImportManifest(args['import-manifest']) : null;
+  const taskManifestBundle = args['task-manifest'] ? readJsonWithBaseDir(args['task-manifest'], 'task-manifest') : null;
+  const taskManifest = taskManifestBundle
+    ? hydrateTaskManifest(taskManifestBundle.value, taskManifestBundle.baseDir)
+    : null;
+  const taskManifestTasks = normalizeTaskManifestTasks(taskManifest);
+  const rawPairEvidencePaths = [
+    ...(importBundle ? importBundle.pairEvidence : []),
+    ...normalizePairEvidenceArgs(Array.isArray(args['pair-evidence']) ? args['pair-evidence'] : []),
+  ];
+  const rawPairSpecs = (Array.isArray(args.pair) ? args.pair : []).map(pairFromArg);
+  const pairArtifacts = [];
+  for (const spec of rawPairSpecs) {
+    pairArtifacts.push(readJson(spec.baselinePath, 'pair baseline'));
+    pairArtifacts.push(readJson(spec.fooksPath, 'pair fooks'));
+  }
+  const pricing = await pricingFromArgs(args, pairArtifacts);
+
+  if (args['dry-run-live']) {
+    const maxMatchedPairs = optionalNumber(args['max-matched-pairs'], 10);
+    const maxEstimatedUsd = optionalNumber(args['max-estimated-usd'], 5);
+    const campaignMaxEstimatedUsd = optionalNumber(args['campaign-max-estimated-usd'], maxEstimatedUsd);
+    const worstCase = optionalNumber(args['worst-case-pair-estimated-usd'], maxEstimatedUsd / Math.max(maxMatchedPairs, 1));
+    const gate = shouldStartNextPair({
+      nextWorstCaseEstimatedUsd: worstCase,
+      maxEstimatedUsd,
+      campaignMaxEstimatedUsd,
+      maxMatchedPairs,
+    });
+    console.log(JSON.stringify({
+      dryRun: true,
+      liveOpenAI: Boolean(args['live-openai']),
+      requestMade: false,
+      runId,
+      authPlan: publicAuthSummary(resolveOpenAILiveAuth({ args })),
+      transport: args.transport || args['live-transport'] || 'auto',
+      capPlan: { maxEstimatedUsd, campaignMaxEstimatedUsd, maxMatchedPairs, worstCasePairEstimatedUsd: worstCase, firstPairGate: gate },
+    }, null, 2));
+    return;
+  }
+
+  let pairs = rawPairEvidencePaths;
+  for (const spec of rawPairSpecs) {
+    const baselineArtifact = readJson(spec.baselinePath, 'pair baseline');
+    const fooksArtifact = readJson(spec.fooksPath, 'pair fooks');
+    const evidence = buildProviderCostEvidence({
+      baselineArtifact: { ...baselineArtifact, taskClass: spec.taskClass },
+      fooksArtifact: { ...fooksArtifact, taskClass: spec.taskClass },
+      pricing,
+      sourceKind,
+      runId: `${runId}-${spec.taskClass}-${pairs.length + 1}`,
+    });
+    const pairPath = path.join(outputDir, 'pairs', `${spec.taskClass}-${pairs.length + 1}.json`);
+    writeJson(pairPath, evidence);
+    pairs.push({ pairId: evidence.runId, taskClass: spec.taskClass, evidence, evidencePath: pairPath });
+  }
+
+  let capState = null;
+  let liveBlocker = null;
+  let liveLedger = null;
+  let liveAuth = null;
+  let liveRequestMade = false;
+  let liveRequestAttempted = false;
+  if (args['live-openai']) {
+    const liveResult = await collectLivePairs({ args, runId, pricing, outputDir, taskManifest });
+    pairs = pairs.concat(liveResult.pairs || []);
+    capState = liveResult.capState || null;
+    liveBlocker = liveResult.blocker || null;
+    liveLedger = liveResult.ledger || null;
+    liveAuth = liveResult.auth || null;
+    liveRequestAttempted = Boolean(liveResult.requestAttempted);
+    liveRequestMade = liveRequestAttempted;
+  }
+
+  const manifest = args['campaign-manifest']
+    ? readJson(args['campaign-manifest'], 'campaign-manifest')
+    : importBundle?.campaignManifest
+      ? importBundle.campaignManifest
+    : createDefaultManifest({
+        runId,
+        model: args.model || pricing.model,
+        taskClasses: pairs.map((pair) => pair.taskClass || pair.evidence?.taskClass),
+        tasks: taskManifestTasks,
+        args,
+        pricing,
+      });
+  const ledger = args['attempted-pair-ledger']
+    ? readJson(args['attempted-pair-ledger'], 'attempted-pair-ledger')
+    : importBundle?.attemptedPairLedger
+      ? importBundle.attemptedPairLedger
+    : liveLedger
+      ? liveLedger
+    : createLedgerFromPairs({ pairs, plannedPairCount: Math.max(pairs.length, liveLedger?.plannedPairCount || 0) });
+
+  const ledgerPath = defaultPaths ? path.join(outputDir, 'campaign-ledger.json') : null;
+  if (ledgerPath) writeJson(ledgerPath, ledger);
+
+  let summary = summarizeProviderCostCampaign({
+    runId,
+    campaignManifest: manifest,
+    attemptedPairLedger: ledger,
+    pairEvidence: pairs,
+    capState,
+    requiredTaskClasses: optionalNumber(args['required-task-classes'], undefined),
+    requiredAcceptedPairsPerTask: optionalNumber(args['required-accepted-pairs-per-task'], undefined),
+  });
+  if (liveBlocker) {
+    const authMissing = !liveAuth || liveAuth.ok === false;
+    summary = {
+      ...summary,
+      status: authMissing ? 'live-openai-credentials-missing' : 'live-openai-request-failed',
+      statusReasons: [liveBlocker, ...summary.statusReasons],
+      diagnostics: [
+        authMissing
+          ? 'Set OPENAI_API_KEY or use Codex OAuth via ~/.codex/auth.json; no live provider request was made.'
+          : 'A live provider request was attempted but failed; inspect attempted-pair ledger before rerunning.',
+        ...summary.diagnostics,
+      ],
+    };
+  }
+  if (liveAuth) {
+    summary = {
+      ...summary,
+      liveAuth: publicAuthSummary(liveAuth),
+    };
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+  if (markdownPath) {
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderProviderCostCampaignMarkdown(summary));
+  }
+
+  console.log(JSON.stringify({
+    output: relativePath(outputPath),
+    markdownOutput: markdownPath ? relativePath(markdownPath) : null,
+    ledgerOutput: ledgerPath ? relativePath(ledgerPath) : null,
+    runId,
+    status: summary.status,
+    claimBoundary: summary.claimBoundary,
+    requestMade: liveRequestMade,
+    auth: liveAuth ? publicAuthSummary(liveAuth) : null,
+  }, null, 2));
+}
+
+try {
+  main().catch((error) => {
+    console.error(`[provider-cost-repeated] ${error.message}`);
+    process.exit(1);
+  });
+} catch (error) {
+  console.error(`[provider-cost-repeated] ${error.message}`);
+  process.exit(1);
+}

--- a/benchmarks/layer2-frontend-task/run-r4-repeated.js
+++ b/benchmarks/layer2-frontend-task/run-r4-repeated.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { summarizeRepeatedPairs, writeSummary } = require('./r4-repeated-summary');
+const { ensureEvidenceDir, evidencePaths, timestampRunId } = require('./evidence-paths');
 
 function parseArgs(argv) {
   return argv.reduce((acc, arg) => {
@@ -57,27 +58,61 @@ function seedPairs(values) {
 }
 
 function usage() {
-  return 'Usage: node run-r4-repeated.js --target=<file> --output=<summary.json> [--results-dir=<dir>] [--required-accepted=5] [--max-pairs=8] [--model=gpt-5.4-mini] [--timeoutMs=300000] [--run-id=<id>] [--seed-pair=<vanilla.json>:<fooks.json>] [--keep-workdir]';
+  return 'Usage: node run-r4-repeated.js --target=<file> [--output=<summary.json>] [--results-dir=<dir>] [--required-accepted=5] [--max-pairs=8] [--model=gpt-5.4-mini] [--timeoutMs=300000] [--run-id=<id>] [--task-id=<id>] [--setup-id=<id>] [--seed-pair=<vanilla.json>:<fooks.json>] [--keep-workdir]';
+}
+
+function taskIdentityFromTarget(target) {
+  if (!target) return null;
+  return `target:${path.relative(process.cwd(), path.resolve(target)).split(path.sep).join('/')}`;
+}
+
+function setupIdentity({ taskIdentity, model, requiredAcceptedPairs, explicitSetupId }) {
+  if (explicitSetupId) return explicitSetupId;
+  return [
+    `task=${taskIdentity || 'unspecified-task'}`,
+    `model=${model || 'unspecified-model'}`,
+    'runner=run-r4-repeated',
+    'prompt=R4-feature-module-split-v1',
+    'validator=validate-r4-applied',
+    'modePair=vanilla-vs-fooks',
+    `requiredAccepted=${requiredAcceptedPairs}`,
+  ].join('|');
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const target = args.target;
-  const output = args.output;
+  const runId = args['run-id'] || timestampRunId('runtime');
+  const defaultPaths = args.output ? null : evidencePaths({
+    tier: 'runtime',
+    runId,
+    jsonName: 'summary.json',
+    markdownName: 'summary.md',
+  });
+  const output = args.output || defaultPaths.json;
   const requiredAcceptedPairs = Number(args['required-accepted'] || 5);
   const maxPairs = Number(args['max-pairs'] || requiredAcceptedPairs);
   const model = args.model || process.env.CODEX_MODEL || 'gpt-5.4-mini';
+  const taskIdentity = args['task-id'] || taskIdentityFromTarget(target);
+  const resolvedSetupIdentity = setupIdentity({
+    taskIdentity,
+    model,
+    requiredAcceptedPairs,
+    explicitSetupId: args['setup-id'] || args['setup-identity'],
+  });
   const timeoutMs = Number(args.timeoutMs || process.env.CODEX_TIMEOUT_MS || 300000);
-  const runId = args['run-id'] || new Date().toISOString().slice(0, 10);
-  const resultsDir = args['results-dir'] || path.dirname(output || path.join('benchmarks', 'layer2-frontend-task', 'results', 'summary.json'));
+  const resultsDir = args['results-dir'] || (defaultPaths
+    ? path.join(defaultPaths.dir, 'pairs')
+    : path.dirname(output));
   const keepWorkdir = Boolean(args['keep-workdir']);
+  const pairs = seedPairs(args['seed-pair']);
 
-  if (!target || !output || requiredAcceptedPairs < 1 || maxPairs < 1) {
+  if ((!target && pairs.length < maxPairs) || !output || requiredAcceptedPairs < 1 || maxPairs < 1) {
     console.error(usage());
     process.exit(1);
   }
-
-  const pairs = seedPairs(args['seed-pair']);
+  if (defaultPaths) ensureEvidenceDir({ tier: 'runtime', runId });
+  fs.mkdirSync(resultsDir, { recursive: true });
   let nextPairIndex = pairs.length + 1;
 
   while (pairs.length < maxPairs) {
@@ -91,14 +126,35 @@ async function main() {
     runApplied({ mode: 'fooks', target, output: fooksPath, model, timeoutMs, keepWorkdir });
     pairs.push({ pairIndex, vanillaPath, fooksPath });
 
-    const interim = summarizeRepeatedPairs({ requiredAcceptedPairs, pairs });
+    const interim = summarizeRepeatedPairs({
+      runId,
+      taskIdentity,
+      model,
+      setupIdentity: resolvedSetupIdentity,
+      requiredAcceptedPairs,
+      pairs,
+    });
     writeSummary(output, interim);
     if (interim.acceptedPairCount >= requiredAcceptedPairs) break;
   }
 
-  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs, pairs });
+  const summary = summarizeRepeatedPairs({
+    runId,
+    taskIdentity,
+    model,
+    setupIdentity: resolvedSetupIdentity,
+    requiredAcceptedPairs,
+    pairs,
+  });
   writeSummary(output, summary);
-  console.log(JSON.stringify({ output, classification: summary.classification, acceptedPairCount: summary.acceptedPairCount, attemptedPairCount: summary.attemptedPairCount }, null, 2));
+  console.log(JSON.stringify({
+    output,
+    runId,
+    classification: summary.classification,
+    candidateStatus: summary.candidate.status,
+    acceptedPairCount: summary.acceptedPairCount,
+    attemptedPairCount: summary.attemptedPairCount,
+  }, null, 2));
   if (summary.acceptedPairCount < requiredAcceptedPairs) process.exit(2);
 }
 

--- a/benchmarks/layer2-frontend-task/runner-direct.js
+++ b/benchmarks/layer2-frontend-task/runner-direct.js
@@ -3,7 +3,7 @@
  * Layer 2 Direct Execution Runner - Provider-Agnostic
  * 
  * Interface:
- *   Input:  --mode=vanilla|fooks --target=<file> --output=<json> [--provider=openai|anthropic] [--model=gpt-4o|claude-sonnet-4]
+ *   Input:  --mode=vanilla|fooks --target=<file> --output=<json> [--provider=openai|anthropic] [--model=<model-id>]
  *   Output: JSON artifact with metrics, validation, and comparison data
  * 
  * First Success Criteria:
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const { resolveOpenAIModel } = require('./model-resolution.js');
 
 // Parse arguments
 const args = process.argv.slice(2).reduce((acc, arg) => {
@@ -30,7 +31,13 @@ const mode = args.mode || 'vanilla';
 const targetFile = args.target;
 const outputPath = args.output;
 const provider = args.provider || 'openai';
-const model = args.model || 'gpt-4o';
+const openAIModel = resolveOpenAIModel({ modelArg: args.model });
+const model = provider === 'openai'
+  ? openAIModel.model
+  : args.model || process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || 'model-unspecified';
+const modelSource = provider === 'openai'
+  ? openAIModel.modelSource
+  : args.model ? 'cli --model' : 'provider env/default';
 
 // Validate inputs
 if (!targetFile || !outputPath) {
@@ -38,7 +45,7 @@ if (!targetFile || !outputPath) {
   process.exit(1);
 }
 
-console.log(`[Direct Runner] Mode: ${mode}, Provider: ${provider}, Model: ${model}`);
+console.log(`[Direct Runner] Mode: ${mode}, Provider: ${provider}, Model: ${model} (${modelSource})`);
 console.log(`[Direct Runner] Target: ${targetFile}`);
 console.log(`[Direct Runner] Output: ${outputPath}`);
 
@@ -136,6 +143,7 @@ const placeholderArtifact = {
   status: 'implementation-in-progress',
   provider,
   model,
+  modelSource,
   inputTokens,
   outputTokens: 0,
   latencyMs: 0,

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -59,6 +59,261 @@ medians were intentionally absent because there were no comparable accepted
 pairs. Treat this as additional negative diagnostic evidence, not as a win or a
 replacement for a later multi-task applied-code benchmark.
 
+### L2 provider usage estimated-cost evidence, 2026-04-22
+
+The L2 evidence tier is an OpenAI direct benchmark pipeline that converts
+provider API usage-token artifacts into **estimated API cost deltas** under an
+explicit pricing assumption. This tier is designed to answer whether a matched
+baseline/fooks pair used fewer OpenAI API input/output tokens and what that
+would mean under a dated pricing table.
+
+Model selection is not hardcoded to an older OpenAI model. Direct OpenAI runs
+resolve the request model as `--model` first, then `OPENAI_MODEL`, then the
+current default `gpt-5.4`; the recorded evidence still uses the provider
+response model when available. Cost estimation is similarly decoupled from the
+runner model: pricing must come from explicit rates or from a LiteLLM-shaped
+pricing catalog (`--pricing-catalog`, `--pricing-catalog-url`, or
+`--fetch-pricing`), following the same broad pattern as ccusage: usage logs
+carry the model, a pricing catalog resolves that model, and missing pricing
+keeps the result inconclusive.
+
+Generated local evidence defaults to the project-local `.fooks/evidence/`
+namespace rather than temporary directories:
+
+- `.fooks/evidence/provider-cost/<run-id>/` stores provider usage
+  estimated-cost JSON/Markdown artifacts.
+- `.fooks/evidence/runtime/<run-id>/` stores repeated matched-pair
+  runtime-token/time summaries.
+- `.fooks/evidence/billing-import/<run-id>/` stores the first-pass manual
+  billing import schema/readme. This is only a future reconciliation lane; it
+  does not collect credentials or prove invoice savings by itself.
+
+This remains estimate-only evidence: it is not an invoice, provider dashboard,
+charge, or billing-grade savings proof. It also does not establish stable
+runtime-token or wall-clock wins. Public summaries must label this tier as
+`estimated-api-cost-only` until a separate billing-grade validation lane exists.
+
+The repeated provider-cost campaign runner is the path for making a positive
+estimated API cost claim true. It writes campaign summaries to
+`.fooks/evidence/provider-cost/<run-id>/summary.json` and keeps a
+`campaign-ledger.json` beside the summary. Launch-grade estimated API cost
+evidence requires all of the following:
+
+- at least three predeclared task classes;
+- at least five accepted matched baseline/fooks pairs per task class;
+- matching model, endpoint, service tier, reasoning, and setup identity inside
+  each comparable group;
+- `validated-provider-import` or `live-openai-usage` provenance, not
+  fixture-only mechanics;
+- a positive median estimated total API cost reduction per task and overall;
+- task-class quality gates that are not `usage-smoke`;
+- a campaign manifest and attempted-pair ledger preserving planned, attempted,
+  accepted, failed, missing-usage, neutral, regressed, and omitted pair counts;
+- explicit pricing assumptions including input, cached-input, output,
+  endpoint/service-tier, long-context, and regional/data-residency treatment.
+
+Fixture-only runs can reach `fixture-launch-grade-mechanics` to prove the
+threshold logic in CI, but they do not unlock public positive claimability.
+Default capped live batches (`$5` / `10` matched pairs) are smoke or
+`narrow-estimated-cost-candidate` evidence unless an explicitly budgeted
+campaign reaches the full threshold.
+
+A launch-grade live template is available at
+`benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json`.
+It predeclares three task classes with five matched pairs each. Running it
+without a resolved OpenAI credential writes a local blocker artifact under
+`.fooks/` and does not make a provider request; running it with credentials
+still requires explicit spend caps. Auth resolution is `--auth-mode=auto` by
+default: environment API key first, then Codex OAuth from
+`$FOOKS_CODEX_HOME/auth.json`, `$CODEX_HOME/auth.json`, or `~/.codex/auth.json`.
+Use `--auth-mode=codex-oauth --transport=codex-exec` to force the common
+Codex/ChatGPT sign-in path. That transport shells out to `codex exec --json`
+and parses the `turn.completed.usage` event instead of requiring a platform API
+key:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --task-manifest=benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15 \
+  --run-id=provider-cost-live-campaign
+```
+
+The first Codex OAuth campaign using that synthetic template completed the
+intended 3 × 5 denominator, but it was classified as diagnostic-only: 15/15
+pairs were accepted for usage, 14/15 regressed on estimated API cost, and the
+overall median estimated API cost reduction was negative. That run is useful
+because it prevents cherry-picking the earlier one-pair smoke, but it must not
+be used as a product-mechanism proof: the `fooks` side used a prompt that said
+"compact prepared context" without injecting a real `fooks extract` payload, and
+Codex agentic workspace/tool activity dominated the provider usage tokens.
+
+For the next proof attempt, use the corrected real-payload campaign builder. It
+writes a task manifest with actual full-source baseline payloads and actual
+`fooks extract --model-payload` JSON payloads, preserves prompt payload-size
+stats, and recommends isolated Codex workdirs plus AB/BA order:
+
+```bash
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --run-id=provider-cost-corrected-real-payload \
+  --target-pair-count=5
+```
+
+Then dry-run or execute the generated manifest with no-tool enforcement:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --live-openai \
+  --auth-mode=codex-oauth \
+  --transport=codex-exec \
+  --codex-workdir=isolated \
+  --pair-order=abba \
+  --require-no-tool-use=true \
+  --task-manifest=.fooks/evidence/provider-cost/provider-cost-corrected-real-payload/corrected-task-manifest.json \
+  --model="${OPENAI_MODEL:-gpt-5.4}" \
+  --fetch-pricing \
+  --max-matched-pairs=15 \
+  --max-estimated-usd=5 \
+  --campaign-max-estimated-usd=15 \
+  --run-id=provider-cost-corrected-real-payload
+```
+
+If `codex exec` emits command execution events in this corrected lane, the
+pair-side quality gate fails. That protects the evidence from claiming a
+payload-only/no-tool result when workspace inspection was actually used.
+
+Cost/pricing is deliberately not part of corrected manifest generation. The
+builder only writes prompt contexts and payload-size stats. Pricing assumptions
+are resolved later by the repeated evidence runner (`--fetch-pricing` or
+explicit pricing args) and are recorded on the pair evidence/summary. This keeps
+the cost layer from changing extraction behavior or prompt construction.
+
+The corrected Codex OAuth campaign run
+`provider-cost-corrected-real-payload-campaign-20260422` passed this estimated
+API-cost threshold:
+
+- status: `launch-grade-estimated-cost-evidence`;
+- denominator: 3 task classes × 5 accepted matched pairs = 15/15 accepted;
+- no-tool gate: 0 `command_execution` events on every baseline/fooks side;
+- overall median estimated API cost delta: `+0.001362` USD;
+- overall median estimated API cost reduction: `+4.171%`;
+- aggregate estimated API cost: baseline `$0.588855` vs fooks `$0.5547775`
+  (`$0.0340775`, 5.787% lower under the recorded pricing assumption);
+- aggregate provider-reported usage tokens in the campaign: baseline `376,104` vs fooks `372,065`
+  (`4,039` fewer total tokens);
+- task medians were positive for all three task classes, while 4/15 individual
+  pairs still regressed.
+
+This result unlocks only the estimate-scoped statement:
+
+> In this corrected 2026-04-22 Codex OAuth benchmark campaign, fooks reduced
+> estimated OpenAI API cost under explicit pricing assumptions.
+
+It still does **not** prove provider invoice/dashboard savings, actual charged
+cost savings, provider billing-token savings, stable runtime-token savings, or
+stable wall-clock/latency savings.
+
+Larger public-code profiles are available for checking whether the observed
+effect scales beyond the small fixture lane:
+
+```bash
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --profile=nextjs-large \
+  --nextjs-root=~/Workspace/fooks-test-repos/nextjs \
+  --run-id=provider-cost-nextjs-large-real-payload \
+  --target-pair-count=5
+
+npm run bench:layer2:provider-cost:corrected-manifest -- \
+  --profile=tailwind-large \
+  --tailwindcss-root=~/Workspace/fooks-test-repos/tailwindcss \
+  --run-id=provider-cost-tailwind-large-real-payload \
+  --target-pair-count=5
+```
+
+Known 2026-04-22 large-profile Codex OAuth outcomes, both using `gpt-5.4`,
+Codex OAuth, isolated workdirs, AB/BA pair order, real full-source baseline
+payloads, real fooks model-facing payloads, no-tool enforcement, and LiteLLM
+catalog pricing:
+
+- `provider-cost-nextjs-large-real-payload-campaign-20260422`
+  - status: `launch-grade-estimated-cost-evidence`;
+  - denominator: 15/15 accepted, 0 regressions, 0 `command_execution` events;
+  - median estimated API cost reduction: `26.492%`;
+  - aggregate provider-reported usage tokens in the campaign: baseline `446,275` vs fooks `382,139`
+    (`14.371%` fewer total usage tokens);
+  - aggregate estimated API cost: baseline `$0.88386` vs fooks `$0.64497`
+    (`$0.23889`, `27.028%` lower under the recorded pricing assumption);
+  - task median reductions: App Router summary `30.681%`, Layout Router
+    refactor plan `28.699%`, Error Boundary test strategy `19.447%`.
+- `provider-cost-tailwind-large-real-payload-campaign-20260422`
+  - status: `launch-grade-estimated-cost-evidence`;
+  - denominator: 15/15 accepted, 0 regressions, 0 `command_execution` events;
+  - median estimated API cost reduction: `38.238%`;
+  - aggregate provider-reported usage tokens in the campaign: baseline `718,616` vs fooks `381,583`
+    (`46.9%` fewer total usage tokens);
+  - aggregate estimated API cost: baseline `$1.598875` vs fooks `$0.64853`
+    (`$0.950345`, `59.438%` lower under the recorded pricing assumption);
+  - task median reductions: Utilities summary `78.992%`, Variants refactor
+    plan `38.238%`, CSS Parser test strategy `33.582%`.
+
+These larger-profile runs explain why the small fixture lane had only a weak
+cost signal: Codex requests include a fixed wrapper/system overhead, so a small
+local prompt reduction can be diluted. On larger Next.js/Tailwind payloads, the
+payload reduction is large enough to dominate that fixed overhead and produces
+repeatable provider usage-token and estimated API-cost wins. The claim boundary
+remains estimate-scoped; these runs still do not prove invoice/dashboard
+savings or stable runtime latency.
+
+An import validation kit is available at
+`benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/`, with the
+runbook `benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md`.
+It supports a non-live mechanics check:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json \
+  --run-id=provider-cost-import-kit-smoke
+```
+
+This sample must report `fixture-launch-grade-mechanics`; real launch-grade
+estimated-cost evidence requires replacing the fixture pair evidence with
+real `validated-provider-import` or `live-openai-usage` artifacts and preserving
+the attempted-pair ledger.
+
+### Runtime repeated candidate evidence lane
+
+The `.fooks/evidence/runtime/<run-id>/` tier is for internal repeated local
+telemetry only. A useful first-pass run must keep the same task, model, and
+setup identity across at least five accepted vanilla/fooks matched pairs. The
+summary should keep failed, missing, mixed-identity, and regressed pairs visible
+instead of cherry-picking favorable comparisons.
+
+Candidate evidence uses resolved identity, not a claim that every raw artifact
+carried every metadata field. Artifact-level identity, pair-level identity, and
+run-level identity supplied by the repeated runner are all valid identity
+sources. When a pair inherits task/model/setup identity from pair or run
+defaults, the summary records inherited identity source reasons for auditability;
+unresolved identity still blocks candidate evidence.
+
+This tier separates three concepts:
+
+1. telemetry availability — whether CLI runtime-token/latency fields are
+   present and comparable;
+2. candidate evidence — whether the local repeated-pair threshold was met; and
+3. product claimability — which remains false for stable runtime-token/time and
+   provider billing claims.
+
+A positive runtime candidate summary may be used as internal follow-up evidence,
+but it is still **not** provider billing-token evidence, actual cost-savings
+evidence, stable runtime-token savings evidence, or stable latency/time savings
+evidence. Stable/public claims require a later higher-N and likely multi-task
+validation lane.
+
 ## Reproducing or extending evidence
 
 The benchmark harness source remains in `benchmarks/`. Generated outputs under

--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
     "bench:gate": "npm run build && node benchmarks/scripts/gate.mjs",
     "lint": "npm run typecheck -- --pretty false",
     "smoke:claude": "npm run build && node scripts/smoke-claude-hook.mjs",
-    "release:smoke": "npm run build && node scripts/release-smoke.mjs"
+    "release:smoke": "npm run build && node scripts/release-smoke.mjs",
+    "bench:layer2:r4:repeated": "npm run build && node benchmarks/layer2-frontend-task/run-r4-repeated.js",
+    "bench:layer2:provider-cost": "node benchmarks/layer2-frontend-task/run-provider-cost-evidence.js",
+    "bench:layer2:provider-cost:repeated": "node benchmarks/layer2-frontend-task/run-provider-cost-repeated.js",
+    "bench:layer2:provider-cost:corrected-manifest": "npm run build && node benchmarks/layer2-frontend-task/build-provider-cost-corrected-manifest.js",
+    "bench:layer2:billing-import": "node benchmarks/layer2-frontend-task/billing-import-evidence.js"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/test/layer2-applied-validation.test.mjs
+++ b/test/layer2-applied-validation.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const repoRoot = process.cwd();
@@ -22,10 +23,26 @@ function copyDir(src, dest) {
   }
 }
 
-function runArtifact({ prompt = 1000, runtime = 1000, latency = 1000, status = "applied-code-run-validated", validation = "applied-acceptance-validated" } = {}) {
+function runArtifact({
+  prompt = 1000,
+  runtime = 1000,
+  latency = 1000,
+  status = "applied-code-run-validated",
+  validation = "applied-acceptance-validated",
+  taskIdentity,
+  targetIdentity,
+  model,
+  setupIdentity,
+  targetFile,
+} = {}) {
   return {
     status,
     validation: { status: validation },
+    taskIdentity,
+    targetIdentity,
+    targetFile,
+    model,
+    setupIdentity,
     metrics: {
       promptTokensApprox: prompt,
       runtimeTokensTotal: runtime,
@@ -140,18 +157,27 @@ test("Codex runtime-token parser extracts CLI tokens used without billing semant
 test("R4 repeated summary can classify a narrow L1 candidate", () => {
   const pairs = Array.from({ length: 5 }, (_, index) => ({
     pairIndex: index + 1,
-    vanillaArtifact: runArtifact({ prompt: 10000, runtime: 1000 + index * 10, latency: 1000 + index * 10 }),
-    fooksArtifact: runArtifact({ prompt: 1200, runtime: 700 + index * 10, latency: 800 + index * 10 }),
+    vanillaArtifact: runArtifact({ prompt: 10000, runtime: 1000 + index * 10, latency: 1000 + index * 10, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
+    fooksArtifact: runArtifact({ prompt: 1200, runtime: 700 + index * 10, latency: 800 + index * 10, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
   }));
 
   const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
 
   assert.equal(summary.classification, "narrow-l1-candidate");
+  assert.equal(summary.candidate.status, "candidate-evidence");
+  assert.equal(summary.candidate.achieved, true);
   assert.equal(summary.acceptedPairCount, 5);
+  assert.equal(summary.distributions.runtimeTokenReductionPct.length, 5);
   assert.equal(summary.medians.promptReductionPct, 88);
   assert.ok(summary.medians.runtimeTokenReductionPct > 0);
   assert.ok(summary.medians.latencyReductionPct > 0);
+  assert.equal(summary.identity.inherited, false);
+  assert.equal(Object.hasOwn(summary.pairs[0].vanilla, "runtimeTokenClaimAvailable"), false);
+  assert.equal(summary.pairs[0].vanilla.runtimeTokenTelemetryAvailable, true);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+  assert.equal(summary.claimability.stableTimeOrLatencySavings, false);
   assert.match(summary.claimBoundary.join("\n"), /not provider billing tokens or costs/);
+  assert.match(summary.claimBoundary.join("\n"), /not product claimability/i);
 });
 
 test("R4 repeated summary blocks claims when accepted pairs are insufficient or regress", () => {
@@ -173,9 +199,12 @@ test("R4 repeated summary blocks claims when accepted pairs are insufficient or 
   const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
 
   assert.equal(summary.classification, "insufficient-accepted-pairs");
+  assert.equal(summary.candidate.status, "insufficient-accepted-pairs");
   assert.equal(summary.acceptedPairCount, 2);
   assert.equal(summary.outliers.runtimeTokenRegressionCount, 1);
   assert.equal(summary.outliers.latencyRegressionCount, 1);
+  assert.equal(summary.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
 });
 
 test("R4 repeated summary treats missing artifacts as failed pairs", () => {
@@ -186,8 +215,311 @@ test("R4 repeated summary treats missing artifacts as failed pairs", () => {
   });
 
   assert.equal(summary.classification, "insufficient-accepted-pairs");
+  assert.equal(summary.candidate.status, "insufficient-accepted-pairs");
   assert.equal(summary.acceptedPairCount, 0);
   assert.equal(summary.failedPairCount, 1);
   assert.equal(summary.pairs[0].vanilla.validationStatus, "artifact-unavailable");
   assert.match(summary.pairs[0].vanilla.artifactError, /ENOENT/);
+});
+
+test("R4 repeated summary downgrades mixed model/setup identity instead of cherry-picking candidate evidence", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({
+      prompt: 10000,
+      runtime: 1000 + index,
+      latency: 1000 + index,
+      taskIdentity: index === 4 ? "r4-combobox-alt" : "r4-combobox",
+      model: index === 4 ? "gpt-5.4-mini-alt" : "gpt-5.4-mini",
+      setupIdentity: index === 4 ? "setup-alt" : "setup-main",
+    }),
+    fooksArtifact: runArtifact({
+      prompt: 1200,
+      runtime: 700 + index,
+      latency: 800 + index,
+      taskIdentity: index === 4 ? "r4-combobox-alt" : "r4-combobox",
+      model: index === 4 ? "gpt-5.4-mini-alt" : "gpt-5.4-mini",
+      setupIdentity: index === 4 ? "setup-alt" : "setup-main",
+    }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "mixed-identity");
+  assert.equal(summary.candidate.status, "mixed-identity");
+  assert.equal(summary.identity.mixed, true);
+  assert.deepEqual(summary.identity.mixedReasons.sort(), ["mixed-model", "mixed-setup-identity", "mixed-task-identity"].sort());
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+  assert.equal(summary.claimability.stableTimeOrLatencySavings, false);
+});
+
+test("R4 repeated summary refuses candidate evidence when identity is missing", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({ runtime: 1000 + index, latency: 1000 + index }),
+    fooksArtifact: runArtifact({ runtime: 700 + index, latency: 800 + index }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "missing-identity");
+  assert.equal(summary.candidate.status, "missing-identity");
+  assert.deepEqual(summary.identity.missingReasons.sort(), ["missing-model", "missing-setup-identity", "missing-task-identity"].sort());
+  assert.equal(summary.candidate.achieved, false);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+});
+
+test("R4 repeated summary allows run-level identity defaults but reports inherited identity sources", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({ runtime: 1000 + index, latency: 1000 + index }),
+    fooksArtifact: runArtifact({ runtime: 700 + index, latency: 800 + index }),
+  }));
+
+  const summary = summarizeRepeatedPairs({
+    requiredAcceptedPairs: 5,
+    taskIdentity: "r4-combobox",
+    model: "gpt-5.4-mini",
+    setupIdentity: "setup-main",
+    pairs,
+  });
+
+  assert.equal(summary.classification, "narrow-l1-candidate");
+  assert.equal(summary.candidate.status, "candidate-evidence");
+  assert.equal(summary.identity.missing, false);
+  assert.equal(summary.identity.inherited, true);
+  assert.ok(summary.identity.inheritedReasons.includes("vanilla-taskIdentity-from-run.taskIdentity"));
+  assert.ok(summary.identity.inheritedReasons.includes("fooks-model-from-run.model"));
+  assert.ok(summary.identity.inheritedReasons.includes("vanilla-setupIdentity-from-run.setupIdentity"));
+  assert.equal(summary.pairs[4].vanilla.identity.sources.taskIdentity, "run.taskIdentity");
+  assert.equal(summary.pairs[4].vanilla.identity.sources.model, "run.model");
+  assert.equal(summary.pairs[4].vanilla.identity.sources.setupIdentity, "run.setupIdentity");
+  assert.match(summary.identity.sourcePolicy, /resolved/);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+});
+
+test("R4 repeated summary requires explicit setup identity before candidate evidence", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({ runtime: 1000 + index, latency: 1000 + index, taskIdentity: "r4-combobox", model: "gpt-5.4-mini" }),
+    fooksArtifact: runArtifact({ runtime: 700 + index, latency: 800 + index, taskIdentity: "r4-combobox", model: "gpt-5.4-mini" }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "missing-identity");
+  assert.equal(summary.candidate.status, "missing-identity");
+  assert.deepEqual(summary.identity.missingReasons, ["missing-setup-identity"]);
+  assert.equal(summary.taskIdentity, "r4-combobox");
+  assert.equal(summary.model, "gpt-5.4-mini");
+  assert.equal(summary.setupIdentity, null);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+});
+
+test("R4 repeated summary rejects partial missing identity among accepted pairs", () => {
+  const cases = [
+    {
+      name: "task",
+      missingReason: "missing-task-identity",
+      mutate: (identity, index) => (index === 4 ? { ...identity, taskIdentity: undefined } : identity),
+    },
+    {
+      name: "model",
+      missingReason: "missing-model",
+      mutate: (identity, index) => (index === 4 ? { ...identity, model: undefined } : identity),
+    },
+    {
+      name: "setup",
+      missingReason: "missing-setup-identity",
+      mutate: (identity, index) => (index === 4 ? { ...identity, setupIdentity: undefined } : identity),
+    },
+  ];
+
+  for (const testCase of cases) {
+    const baseIdentity = { taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" };
+    const pairs = Array.from({ length: 5 }, (_, index) => {
+      const identity = testCase.mutate(baseIdentity, index);
+      return {
+        pairIndex: index + 1,
+        vanillaArtifact: runArtifact({ runtime: 1000 + index, latency: 1000 + index, ...identity }),
+        fooksArtifact: runArtifact({ runtime: 700 + index, latency: 800 + index, ...identity }),
+      };
+    });
+
+    const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+    assert.equal(summary.classification, "missing-identity", testCase.name);
+    assert.equal(summary.candidate.status, "missing-identity", testCase.name);
+    assert.ok(summary.identity.missingReasons.includes(testCase.missingReason), testCase.name);
+    assert.equal(summary.candidate.achieved, false, testCase.name);
+  }
+});
+
+test("R4 repeated summary does not collapse different same-basename targets", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({
+      runtime: 1000 + index,
+      latency: 1000 + index,
+      targetFile: index === 4 ? "/repo/a/Component.tsx" : "/repo/b/Component.tsx",
+      model: "gpt-5.4-mini",
+      setupIdentity: "setup-main",
+    }),
+    fooksArtifact: runArtifact({
+      runtime: 700 + index,
+      latency: 800 + index,
+      targetFile: index === 4 ? "/repo/a/Component.tsx" : "/repo/b/Component.tsx",
+      model: "gpt-5.4-mini",
+      setupIdentity: "setup-main",
+    }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "mixed-identity");
+  assert.equal(summary.candidate.status, "mixed-identity");
+  assert.ok(summary.identity.acceptedTaskIdentities.some((value) => value.includes("/a/Component.tsx")));
+  assert.ok(summary.identity.acceptedTaskIdentities.some((value) => value.includes("/b/Component.tsx")));
+  assert.ok(summary.identity.mixedReasons.includes("mixed-task-identity"));
+});
+
+test("R4 repeated summary marks accepted pairs without runtime telemetry unavailable", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({ runtime: null, latency: 1000 + index, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
+    fooksArtifact: runArtifact({ runtime: null, latency: 800 + index, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "runtime-token-unavailable");
+  assert.equal(summary.candidate.status, "runtime-token-unavailable");
+  assert.equal(summary.runtimeTokenComparablePairCount, 0);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+});
+
+test("R4 repeated summary reports diagnostic candidate status when accepted pairs regress", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({ runtime: 1000, latency: 1000, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
+    fooksArtifact: runArtifact({ runtime: 1400 + index, latency: 1200 + index, taskIdentity: "r4-combobox", model: "gpt-5.4-mini", setupIdentity: "setup-main" }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "diagnostic-only");
+  assert.equal(summary.candidate.status, "diagnostic-only");
+  assert.equal(summary.candidate.achieved, false);
+  assert.equal(summary.outliers.runtimeTokenRegressionCount, 5);
+  assert.equal(summary.distributions.runtimeTokenReductionPct.length, 5);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+});
+
+test("R4 repeated runner defaults summary output into project-local .fooks evidence with seed pairs", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-r4-default-"));
+  try {
+    const seedArgs = [];
+    for (let index = 1; index <= 5; index += 1) {
+      const vanillaPath = path.join(tempRoot, `vanilla-${index}.json`);
+      const fooksPath = path.join(tempRoot, `fooks-${index}.json`);
+      fs.writeFileSync(vanillaPath, JSON.stringify(runArtifact({ prompt: 10_000, runtime: 1_000 + index, latency: 1_000 + index })));
+      fs.writeFileSync(fooksPath, JSON.stringify(runArtifact({ prompt: 1_200, runtime: 800 + index, latency: 850 + index })));
+      seedArgs.push(`--seed-pair=${vanillaPath}:${fooksPath}`);
+    }
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-r4-repeated.js"),
+      "--run-id=runtime-smoke",
+      "--task-id=runtime-smoke-task",
+      "--required-accepted=5",
+      "--max-pairs=5",
+      ...seedArgs,
+    ], { cwd: tempRoot, encoding: "utf8" });
+
+    const summaryLine = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "runtime", "runtime-smoke", "summary.json");
+    const pairsDir = path.join(tempRoot, ".fooks", "evidence", "runtime", "runtime-smoke", "pairs");
+    assert.equal(path.resolve(summaryLine.output), fs.realpathSync(summaryPath));
+    assert.equal(summaryLine.runId, "runtime-smoke");
+    assert.equal(summaryLine.candidateStatus, "candidate-evidence");
+    assert.equal(fs.existsSync(summaryPath), true);
+    assert.equal(fs.existsSync(pairsDir), true);
+
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    assert.equal(summary.classification, "narrow-l1-candidate");
+    assert.equal(summary.candidate.status, "candidate-evidence");
+    assert.equal(summary.taskIdentity, "runtime-smoke-task");
+    assert.equal(summary.model, "gpt-5.4-mini");
+    assert.match(summary.setupIdentity, /requiredAccepted=5/);
+    assert.equal(summary.claimability.providerInvoiceOrBillingSavings, false);
+    assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+    assert.equal(summary.claimability.stableTimeOrLatencySavings, false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("R4 repeated runner explicit output override avoids default .fooks evidence", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-r4-explicit-"));
+  try {
+    const seedArgs = [];
+    for (let index = 1; index <= 5; index += 1) {
+      const vanillaPath = path.join(tempRoot, `vanilla-${index}.json`);
+      const fooksPath = path.join(tempRoot, `fooks-${index}.json`);
+      fs.writeFileSync(vanillaPath, JSON.stringify(runArtifact({ runtime: 1_000 + index, latency: 1_000 + index })));
+      fs.writeFileSync(fooksPath, JSON.stringify(runArtifact({ runtime: 800 + index, latency: 850 + index })));
+      seedArgs.push(`--seed-pair=${vanillaPath}:${fooksPath}`);
+    }
+    const explicitOutput = path.join(tempRoot, "explicit", "summary.json");
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-r4-repeated.js"),
+      "--run-id=runtime-explicit",
+      `--output=${explicitOutput}`,
+      "--required-accepted=5",
+      "--max-pairs=5",
+      ...seedArgs,
+    ], { cwd: tempRoot, encoding: "utf8" });
+
+    const summaryLine = JSON.parse(stdout);
+    assert.equal(path.resolve(summaryLine.output), explicitOutput);
+    assert.equal(fs.existsSync(explicitOutput), true);
+    assert.equal(fs.existsSync(path.join(tempRoot, ".fooks")), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("R4 repeated runner success still requires verifier to inspect candidate status", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-r4-diagnostic-"));
+  try {
+    const seedArgs = [];
+    for (let index = 1; index <= 5; index += 1) {
+      const vanillaPath = path.join(tempRoot, `vanilla-${index}.json`);
+      const fooksPath = path.join(tempRoot, `fooks-${index}.json`);
+      fs.writeFileSync(vanillaPath, JSON.stringify(runArtifact({ runtime: 1_000, latency: 1_000 })));
+      fs.writeFileSync(fooksPath, JSON.stringify(runArtifact({ runtime: 1_400 + index, latency: 1_200 + index })));
+      seedArgs.push(`--seed-pair=${vanillaPath}:${fooksPath}`);
+    }
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-r4-repeated.js"),
+      "--run-id=runtime-diagnostic",
+      "--task-id=runtime-diagnostic-task",
+      "--required-accepted=5",
+      "--max-pairs=5",
+      ...seedArgs,
+    ], { cwd: tempRoot, encoding: "utf8" });
+
+    const summaryLine = JSON.parse(stdout);
+    assert.equal(summaryLine.acceptedPairCount, 5);
+    assert.equal(summaryLine.candidateStatus, "diagnostic-only");
+
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "runtime", "runtime-diagnostic", "summary.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    assert.equal(summary.candidate.achieved, false);
+    assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/test/provider-cost-evidence.test.mjs
+++ b/test/provider-cost-evidence.test.mjs
@@ -1,0 +1,1305 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const {
+  buildProviderCostEvidence,
+  normalizeUsageArtifact,
+  renderProviderCostEvidenceMarkdown,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-cost-evidence.js"));
+const {
+  summarizeProviderCostCampaign,
+  shouldStartNextPair,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-cost-repeated-summary.js"));
+const {
+  findPricingEntry,
+  pricingAssumptionFromLiteLLMCatalog,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-pricing.js"));
+const {
+  DEFAULT_OPENAI_MODEL,
+  resolveOpenAIModel,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "model-resolution.js"));
+const {
+  resolveOpenAILiveAuth,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "openai-live-auth.js"));
+const {
+  writeBillingImportArtifacts,
+} = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "billing-import-evidence.js"));
+
+const pricing = {
+  provider: "openai",
+  model: "test-model",
+  currency: "USD",
+  inputPer1MTokens: 2.5,
+  outputPer1MTokens: 10,
+  sourceUrl: "https://openai.com/api/pricing/",
+  checkedDate: "2026-04-22",
+};
+
+function sampleEvidence(overrides = {}) {
+  return buildProviderCostEvidence({
+    baselineArtifact: {
+      provider: "openai",
+      model: "test-model",
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+      timestamp: "2026-04-22T00:00:00.000Z",
+    },
+    fooksArtifact: {
+      provider: "openai",
+      model: "test-model",
+      inputTokens: 40_000,
+      outputTokens: 8_000,
+      timestamp: "2026-04-22T00:01:00.000Z",
+    },
+    pricing,
+    sourceKind: "fixture",
+    ...overrides,
+  });
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, keys);
+    return keys;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(child, keys);
+    }
+  }
+  return keys;
+}
+
+test("provider cost evidence computes usage-token and estimated API cost deltas", () => {
+  const evidence = sampleEvidence();
+
+  assert.equal(evidence.schemaVersion, "provider-cost-evidence.v1");
+  assert.equal(evidence.evidenceTier, "L2-provider-usage-estimated-cost");
+  assert.equal(evidence.claimBoundary, "estimated-api-cost-only");
+  assert.equal(evidence.sourceKind, "fixture");
+  assert.equal(evidence.status, "estimated-cost-reduction");
+  assert.equal(evidence.deltas.inputTokens.absolute, 60_000);
+  assert.equal(evidence.deltas.inputTokens.reductionPct, 60);
+  assert.equal(evidence.deltas.outputTokens.absolute, 2_000);
+  assert.equal(evidence.deltas.outputTokens.reductionPct, 20);
+  assert.equal(evidence.deltas.totalTokens.absolute, 62_000);
+  assert.equal(evidence.deltas.estimatedApiCostInput.absolute, 0.15);
+  assert.equal(evidence.deltas.estimatedApiCostOutput.absolute, 0.02);
+  assert.equal(evidence.deltas.estimatedApiCostTotal.absolute, 0.17);
+  assert.equal(evidence.deltas.estimatedApiCostTotal.reductionPct, 48.571);
+  assert.equal(evidence.pricingAssumption.sourceUrl, "https://openai.com/api/pricing/");
+  assert.equal(evidence.pricingAssumption.checkedDate, "2026-04-22");
+});
+
+
+
+test("provider cost evidence uses artifact model and requires explicit pricing rates", () => {
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact: { provider: "openai", model: "actual-model", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "actual-model", inputTokens: 40_000, outputTokens: 8_000 },
+    pricing: {
+      inputPer1MTokens: 1.23,
+      outputPer1MTokens: 4.56,
+      sourceUrl: "https://example.test/pricing",
+      checkedDate: "2026-04-22",
+    },
+  });
+
+  assert.equal(evidence.model, "actual-model");
+  assert.equal(evidence.provider, "openai");
+  assert.equal(evidence.status, "estimated-cost-reduction");
+});
+
+test("provider cost evidence is inconclusive without explicit pricing rates", () => {
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact: { provider: "openai", model: "actual-model", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "actual-model", inputTokens: 40_000, outputTokens: 8_000 },
+  });
+
+  assert.equal(evidence.model, "actual-model");
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /pricing input rate is missing/);
+  assert.match(evidence.statusReasons.join("\n"), /pricing output rate is missing/);
+});
+
+test("OpenAI model resolution prioritizes CLI, then OPENAI_MODEL, then the current default", () => {
+  assert.equal(DEFAULT_OPENAI_MODEL, "gpt-5.4");
+  assert.deepEqual(resolveOpenAIModel({ modelArg: "gpt-custom", env: { OPENAI_MODEL: "gpt-env" } }), {
+    provider: "openai",
+    model: "gpt-custom",
+    modelSource: "cli --model",
+    defaultModel: "gpt-5.4",
+  });
+  assert.equal(resolveOpenAIModel({ env: { OPENAI_MODEL: "gpt-env" } }).model, "gpt-env");
+  assert.equal(resolveOpenAIModel({ env: {} }).model, "gpt-5.4");
+});
+
+test("OpenAI live auth resolution prefers env API key before Codex OAuth in auto mode", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-auth-"));
+  try {
+    const authJson = path.join(tempRoot, "auth.json");
+    fs.writeFileSync(authJson, JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    const auth = resolveOpenAILiveAuth({
+      args: { "codex-auth-json": authJson },
+      env: { OPENAI_API_KEY: "sk-test", CODEX_HOME: tempRoot },
+    });
+
+    assert.equal(auth.ok, true);
+    assert.equal(auth.credentialKind, "openai-api-key");
+    assert.equal(auth.source, "env:OPENAI_API_KEY");
+    assert.equal(auth.headers.Authorization, "Bearer sk-test");
+    assert.equal(auth.headers["chatgpt-account-id"], undefined);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("OpenAI live auth resolution reads Codex OAuth auth.json with account header", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-oauth-"));
+  try {
+    fs.writeFileSync(path.join(tempRoot, "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    const auth = resolveOpenAILiveAuth({
+      args: { "auth-mode": "codex-oauth" },
+      env: { CODEX_HOME: tempRoot, OPENAI_API_KEY: "sk-ignored" },
+    });
+
+    assert.equal(auth.ok, true);
+    assert.equal(auth.credentialKind, "codex-oauth");
+    assert.equal(auth.source, "codex-auth-json");
+    assert.equal(auth.accountId, "account-1");
+    assert.equal(auth.authMode, "chatgpt");
+    assert.equal(auth.headers.Authorization, "Bearer oauth-token");
+    assert.equal(auth.headers["chatgpt-account-id"], "account-1");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("LiteLLM-shaped pricing catalog resolves current OpenAI model rates without hardcoded runner pricing", () => {
+  const catalog = {
+    "openai/gpt-5.4": {
+      input_cost_per_token: 2.5e-6,
+      output_cost_per_token: 15e-6,
+      cache_read_input_token_cost: 0.25e-6,
+    },
+  };
+
+  const entry = findPricingEntry(catalog, { provider: "openai", model: "gpt-5.4" });
+  assert.equal(entry.modelKey, "openai/gpt-5.4");
+
+  const resolved = pricingAssumptionFromLiteLLMCatalog({
+    dataset: catalog,
+    provider: "openai",
+    model: "gpt-5.4",
+    sourceUrl: "https://example.test/litellm-pricing.json",
+    checkedDate: "2026-04-22",
+  });
+
+  assert.deepEqual(resolved.reasons, []);
+  assert.equal(resolved.pricing.inputPer1MTokens, 2.5);
+  assert.equal(resolved.pricing.outputPer1MTokens, 15);
+  assert.equal(resolved.pricing.cachedInputPer1MTokens, 0.25);
+
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact: { provider: "openai", model: "gpt-5.4", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "gpt-5.4", inputTokens: 40_000, outputTokens: 8_000 },
+    pricing: resolved.pricing,
+  });
+
+  assert.equal(evidence.status, "estimated-cost-reduction");
+  assert.equal(evidence.model, "gpt-5.4");
+  assert.equal(evidence.pricingAssumption.catalogModelKey, "openai/gpt-5.4");
+  assert.equal(evidence.deltas.estimatedApiCostTotal.absolute, 0.18);
+});
+
+test("provider cost evidence keeps input, output, and total cost separate", () => {
+  const evidence = sampleEvidence({
+    baselineArtifact: { provider: "openai", model: "test-model", inputTokens: 100_000, outputTokens: 1_000 },
+    fooksArtifact: { provider: "openai", model: "test-model", inputTokens: 20_000, outputTokens: 50_000 },
+  });
+
+  assert.equal(evidence.status, "estimated-cost-regression");
+  assert.equal(evidence.deltas.estimatedApiCostInput.absolute, 0.2);
+  assert.equal(evidence.deltas.estimatedApiCostOutput.absolute, -0.49);
+  assert.equal(evidence.deltas.estimatedApiCostTotal.absolute, -0.29);
+  assert.equal(evidence.deltas.inputTokens.reductionPct, 80);
+  assert.ok(evidence.deltas.estimatedApiCostTotal.reductionPct < 0);
+});
+
+test("provider cost evidence is inconclusive for zero or missing token data", () => {
+  const zeroBaseline = sampleEvidence({
+    baselineArtifact: { provider: "openai", model: "test-model", inputTokens: 0, outputTokens: 0 },
+    fooksArtifact: { provider: "openai", model: "test-model", inputTokens: 0, outputTokens: 0 },
+  });
+  assert.equal(zeroBaseline.status, "inconclusive");
+  assert.equal(zeroBaseline.deltas.estimatedApiCostTotal.reductionPct, null);
+  assert.match(zeroBaseline.statusReasons.join("\n"), /baseline usage tokens are zero/);
+
+  const missing = sampleEvidence({
+    baselineArtifact: { provider: "openai", model: "test-model", inputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "test-model", inputTokens: 5_000, outputTokens: 100 },
+  });
+  assert.equal(missing.status, "inconclusive");
+  assert.match(missing.statusReasons.join("\n"), /baseline output tokens are missing/);
+});
+
+test("provider cost evidence normalizes direct OpenAI usage-shaped artifacts", () => {
+  const normalized = normalizeUsageArtifact({
+    usage: {
+      prompt_tokens: 12_345,
+      completion_tokens: 678,
+      total_tokens: 13_023,
+    },
+    model: "test-model",
+    provider: "openai",
+  }, "baseline");
+
+  assert.equal(normalized.status, "usage-available");
+  assert.equal(normalized.inputTokens, 12_345);
+  assert.equal(normalized.outputTokens, 678);
+  assert.equal(normalized.totalTokens, 13_023);
+  assert.equal(normalized.model, "test-model");
+});
+
+test("provider cost evidence exposes estimate-only claimability and avoids misleading cost field names", () => {
+  const evidence = sampleEvidence();
+  const keys = collectKeys(evidence);
+
+  assert.equal(evidence.claimability.estimatedApiCostDelta, true);
+  assert.equal(evidence.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(evidence.claimability.providerBillingTokenSavings, false);
+  assert.equal(evidence.claimability.stableRuntimeTokenSavings, false);
+  assert.equal(evidence.claimability.stableTimeOrLatencySavings, false);
+  for (const forbidden of ["billingSavings", "invoiceSavings", "chargedCostSavings", "billingCost", "invoiceCost", "chargedCost"]) {
+    assert.equal(keys.includes(forbidden), false, `${forbidden} should not appear as an evidence field name`);
+  }
+});
+
+
+
+test("provider cost evidence treats live artifacts with missing usage as inconclusive", () => {
+  const evidence = sampleEvidence({
+    baselineArtifact: { provider: "openai", model: "test-model", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: {
+      provider: "openai",
+      model: "test-model",
+      usageSource: "live-openai-usage",
+      status: "usage-unavailable",
+      inputTokens: null,
+      outputTokens: null,
+    },
+    sourceKind: "live-openai-usage",
+  });
+
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /fooks input tokens are missing/);
+  assert.match(evidence.statusReasons.join("\n"), /fooks output tokens are missing/);
+  assert.equal(evidence.deltas.estimatedApiCostTotal.reductionPct, null);
+});
+
+test("provider cost evidence bounds sourceKind to the L2 schema enum", () => {
+  const evidence = sampleEvidence({ sourceKind: "dashboard-export" });
+
+  assert.equal(evidence.sourceKind, "invalid-source-kind");
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /sourceKind must be one of/);
+});
+
+test("provider cost evidence CLI writes JSON and Markdown without requiring credentials", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-cost-"));
+  try {
+    const baselinePath = path.join(tempRoot, "baseline.json");
+    const fooksPath = path.join(tempRoot, "fooks.json");
+    const outputPath = path.join(tempRoot, "evidence.json");
+    const markdownPath = path.join(tempRoot, "evidence.md");
+    fs.writeFileSync(baselinePath, JSON.stringify({ provider: "openai", model: "test-model", inputTokens: 100_000, outputTokens: 10_000 }));
+    fs.writeFileSync(fooksPath, JSON.stringify({ provider: "openai", model: "test-model", inputTokens: 40_000, outputTokens: 8_000 }));
+
+    execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-evidence.js"),
+      `--baseline=${baselinePath}`,
+      `--fooks=${fooksPath}`,
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+      "--provider=openai",
+      "--model=test-model",
+      "--input-rate-per-1m=2.5",
+      "--output-rate-per-1m=10",
+      "--pricing-source-url=https://openai.com/api/pricing/",
+      "--pricing-checked-date=2026-04-22",
+    ], { cwd: repoRoot, env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    const markdown = fs.readFileSync(markdownPath, "utf8");
+    assert.equal(evidence.status, "estimated-cost-reduction");
+    assert.equal(evidence.claimBoundary, "estimated-api-cost-only");
+    assert.match(markdown, /estimated API cost evidence only/i);
+    assert.match(markdown, /not provider invoice\/billing savings/i);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost evidence CLI defaults generated evidence into project-local .fooks", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-default-"));
+  try {
+    const baselinePath = path.join(tempRoot, "baseline.json");
+    const fooksPath = path.join(tempRoot, "fooks.json");
+    const catalogPath = path.join(tempRoot, "pricing.json");
+    fs.writeFileSync(baselinePath, JSON.stringify({ provider: "openai", model: "gpt-5.4", inputTokens: 100_000, outputTokens: 10_000 }));
+    fs.writeFileSync(fooksPath, JSON.stringify({ provider: "openai", model: "gpt-5.4", inputTokens: 40_000, outputTokens: 8_000 }));
+    fs.writeFileSync(catalogPath, JSON.stringify({
+      "gpt-5.4": {
+        input_cost_per_token: 2.5e-6,
+        output_cost_per_token: 15e-6,
+      },
+    }));
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-evidence.js"),
+      `--baseline=${baselinePath}`,
+      `--fooks=${fooksPath}`,
+      `--pricing-catalog=${catalogPath}`,
+      "--run-id=default-path-smoke",
+      "--source-kind=fixture",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const summary = JSON.parse(stdout);
+    const outputPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "default-path-smoke", "evidence.json");
+    const markdownPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "default-path-smoke", "evidence.md");
+    assert.equal(summary.output, ".fooks/evidence/provider-cost/default-path-smoke/evidence.json");
+    assert.equal(summary.markdownOutput, ".fooks/evidence/provider-cost/default-path-smoke/evidence.md");
+    assert.equal(fs.existsSync(outputPath), true);
+    assert.equal(fs.existsSync(markdownPath), true);
+
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    assert.equal(evidence.status, "estimated-cost-reduction");
+    assert.equal(evidence.claimability.providerInvoiceOrBillingSavings, false);
+    assert.equal(evidence.claimability.providerBillingTokenSavings, false);
+    assert.equal(evidence.claimability.stableRuntimeTokenSavings, false);
+    assert.equal(evidence.claimability.stableTimeOrLatencySavings, false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost evidence explicit output does not create default .fooks evidence", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-explicit-"));
+  try {
+    const baselinePath = path.join(tempRoot, "baseline.json");
+    const fooksPath = path.join(tempRoot, "fooks.json");
+    const outputPath = path.join(tempRoot, "custom", "evidence.json");
+    fs.writeFileSync(baselinePath, JSON.stringify({ provider: "openai", model: "test-model", inputTokens: 100_000, outputTokens: 10_000 }));
+    fs.writeFileSync(fooksPath, JSON.stringify({ provider: "openai", model: "test-model", inputTokens: 40_000, outputTokens: 8_000 }));
+
+    execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-evidence.js"),
+      `--baseline=${baselinePath}`,
+      `--fooks=${fooksPath}`,
+      `--output=${outputPath}`,
+      "--input-rate-per-1m=2.5",
+      "--output-rate-per-1m=10",
+      "--run-id=explicit-path-smoke",
+    ], { cwd: tempRoot, env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    assert.equal(fs.existsSync(outputPath), true);
+    assert.equal(fs.existsSync(path.join(tempRoot, ".fooks")), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("billing manual import artifacts stay local and do not unlock billing claims", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-billing-import-"));
+  try {
+    const result = writeBillingImportArtifacts({ cwd: tempRoot, runId: "billing-smoke" });
+    assert.equal(result.schemaPath, path.join(tempRoot, ".fooks", "evidence", "billing-import", "billing-smoke", "import.schema.json"));
+    assert.equal(result.readmePath, path.join(tempRoot, ".fooks", "evidence", "billing-import", "billing-smoke", "README.md"));
+    assert.equal(result.claimability.providerInvoiceOrBillingSavings, false);
+
+    const schema = JSON.parse(fs.readFileSync(result.schemaPath, "utf8"));
+    assert.equal(schema.properties.claimability.properties.providerInvoiceOrBillingSavings.const, false);
+    assert.deepEqual(schema.properties.source.properties.type.enum, ["invoice", "dashboard-export", "usage-export", "manual-entry"]);
+    assert.match(fs.readFileSync(result.readmePath, "utf8"), /does not prove provider invoice or billing savings/i);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost evidence CLI can read a LiteLLM-shaped pricing catalog", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-catalog-"));
+  try {
+    const baselinePath = path.join(tempRoot, "baseline.json");
+    const fooksPath = path.join(tempRoot, "fooks.json");
+    const catalogPath = path.join(tempRoot, "pricing.json");
+    const outputPath = path.join(tempRoot, "evidence.json");
+    fs.writeFileSync(baselinePath, JSON.stringify({ provider: "openai", model: "gpt-5.4", inputTokens: 100_000, outputTokens: 10_000 }));
+    fs.writeFileSync(fooksPath, JSON.stringify({ provider: "openai", model: "gpt-5.4", inputTokens: 40_000, outputTokens: 8_000 }));
+    fs.writeFileSync(catalogPath, JSON.stringify({
+      "openai/gpt-5.4": {
+        input_cost_per_token: 2.5e-6,
+        output_cost_per_token: 15e-6,
+      },
+    }));
+
+    execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-evidence.js"),
+      `--baseline=${baselinePath}`,
+      `--fooks=${fooksPath}`,
+      `--output=${outputPath}`,
+      `--pricing-catalog=${catalogPath}`,
+      "--pricing-checked-date=2026-04-22",
+    ], { cwd: repoRoot, env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    assert.equal(evidence.status, "estimated-cost-reduction");
+    assert.equal(evidence.provider, "openai");
+    assert.equal(evidence.model, "gpt-5.4");
+    assert.equal(evidence.pricingAssumption.catalogModelKey, "openai/gpt-5.4");
+    assert.equal(evidence.pricingAssumption.pricingSourceKind, "litellm-pricing-catalog");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+
+test("provider cost evidence rejects placeholder artifacts as inconclusive", () => {
+  const placeholder = {
+    provider: "openai",
+    model: "test-model",
+    status: "implementation-in-progress",
+    inputTokens: 1_000,
+    outputTokens: 0,
+  };
+  const evidence = sampleEvidence({ baselineArtifact: placeholder, fooksArtifact: placeholder });
+
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /implementation-in-progress/);
+});
+
+test("provider cost evidence requires live provider usage provenance for live sourceKind", () => {
+  const evidence = sampleEvidence({
+    baselineArtifact: { provider: "openai", model: "test-model", status: "success", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "test-model", status: "success", inputTokens: 40_000, outputTokens: 8_000 },
+    sourceKind: "live-openai-usage",
+  });
+
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /lacks live provider usage provenance/);
+});
+
+test("provider cost evidence ignores local prompt approximations for live sourceKind", () => {
+  const evidence = sampleEvidence({
+    baselineArtifact: {
+      provider: "openai",
+      model: "test-model",
+      status: "success",
+      metrics: { promptTokensApprox: 100_000, outputTokens: 10_000 },
+    },
+    fooksArtifact: {
+      provider: "openai",
+      model: "test-model",
+      status: "success",
+      metrics: { promptTokensApprox: 40_000, outputTokens: 8_000 },
+    },
+    sourceKind: "live-openai-usage",
+  });
+
+  assert.equal(evidence.status, "inconclusive");
+  assert.match(evidence.statusReasons.join("\n"), /input tokens are missing/);
+});
+
+test("provider cost evidence accepts successful live usage artifacts", () => {
+  const evidence = sampleEvidence({
+    baselineArtifact: {
+      provider: "openai",
+      model: "test-model",
+      status: "success",
+      usageSource: "live-openai-usage",
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+    },
+    fooksArtifact: {
+      provider: "openai",
+      model: "test-model",
+      status: "success",
+      usageSource: "live-openai-usage",
+      inputTokens: 40_000,
+      outputTokens: 8_000,
+    },
+    sourceKind: "live-openai-usage",
+  });
+
+  assert.equal(evidence.status, "estimated-cost-reduction");
+  assert.equal(evidence.sourceKind, "live-openai-usage");
+});
+
+test("provider cost evidence markdown keeps billing and runtime claims blocked", () => {
+  const markdown = renderProviderCostEvidenceMarkdown(sampleEvidence());
+
+  assert.match(markdown, /not provider invoice\/billing savings evidence/i);
+  assert.match(markdown, /not stable runtime-token, wall-clock, or latency savings evidence/i);
+  assert.doesNotMatch(markdown, /reduces provider billing cost/i);
+  assert.doesNotMatch(markdown, /invoice savings proven/i);
+});
+
+function campaignPricing(overrides = {}) {
+  return {
+    provider: "openai",
+    model: "gpt-5.4",
+    currency: "USD",
+    inputPer1MTokens: 2.5,
+    outputPer1MTokens: 15,
+    cachedInputPer1MTokens: 0.25,
+    sourceUrl: "https://openai.com/api/pricing/",
+    checkedDate: "2026-04-22",
+    endpoint: "chat.completions",
+    serviceTier: "standard",
+    pricingTreatment: {
+      longContextApplies: false,
+      regionalProcessingApplies: false,
+    },
+    ...overrides,
+  };
+}
+
+function taskManifest(taskClasses = ["extract", "refactor", "summarize"]) {
+  return {
+    campaignId: "campaign-positive",
+    model: "gpt-5.4",
+    endpoint: "chat.completions",
+    serviceTier: "standard",
+    pricingSourceUrl: "https://openai.com/api/pricing/",
+    pricingCheckedDate: "2026-04-22",
+    taskClasses: taskClasses.map((id) => ({
+      id,
+      targetPairCount: 5,
+      qualityGate: { id: "applied-validation", version: "v1", command: "node validate.js" },
+    })),
+    caps: { maxEstimatedUsd: 5, campaignMaxEstimatedUsd: 15, maxMatchedPairs: 20, maxBatches: 3 },
+  };
+}
+
+function providerPair({ taskClass, index = 1, sourceKind = "validated-provider-import", baselineInput = 100_000, fooksInput = 50_000, baselineOutput = 10_000, fooksOutput = 8_000, pricing: pricingOverride = campaignPricing(), qualityGate = { id: "applied-validation", status: "passed" } } = {}) {
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact: {
+      provider: "openai",
+      model: "gpt-5.4",
+      usageSource: sourceKind,
+      usage: { prompt_tokens: baselineInput, completion_tokens: baselineOutput, total_tokens: baselineInput + baselineOutput },
+      taskClass,
+      setupIdentity: "same-setup",
+      endpoint: "chat.completions",
+      serviceTier: "standard",
+      qualityGate,
+    },
+    fooksArtifact: {
+      provider: "openai",
+      model: "gpt-5.4",
+      usageSource: sourceKind,
+      usage: { prompt_tokens: fooksInput, completion_tokens: fooksOutput, total_tokens: fooksInput + fooksOutput },
+      taskClass,
+      setupIdentity: "same-setup",
+      endpoint: "chat.completions",
+      serviceTier: "standard",
+      qualityGate,
+    },
+    pricing: pricingOverride,
+    sourceKind,
+    runId: `${taskClass}-${index}`,
+  });
+  return { pairId: `${taskClass}-${index}`, taskClass, evidence, qualityGate };
+}
+
+function positiveCampaignPairs(sourceKind = "validated-provider-import") {
+  return ["extract", "refactor", "summarize"].flatMap((taskClass) => (
+    Array.from({ length: 5 }, (_, index) => providerPair({ taskClass, index: index + 1, sourceKind }))
+  ));
+}
+
+function ledgerForPairs(pairs, overrides = {}) {
+  return {
+    plannedPairCount: pairs.length,
+    attemptedPairCount: pairs.length,
+    acceptedPairCount: pairs.length,
+    failedPairCount: 0,
+    rejectedPairCount: 0,
+    missingUsagePairCount: 0,
+    neutralPairCount: 0,
+    regressedPairCount: pairs.filter((pair) => pair.evidence.deltas.estimatedApiCostTotal.absolute < 0).length,
+    omittedPairs: [],
+    attemptedPairs: pairs.map((pair) => ({ pairId: pair.pairId, taskClass: pair.taskClass, status: pair.evidence.status })),
+    ...overrides,
+  };
+}
+
+test("provider cost repeated summary reaches launch-grade from validated provider import campaign", () => {
+  const pairs = positiveCampaignPairs("validated-provider-import");
+  const summary = summarizeProviderCostCampaign({
+    runId: "positive-import",
+    campaignManifest: taskManifest(),
+    attemptedPairLedger: ledgerForPairs(pairs),
+    pairEvidence: pairs,
+  });
+
+  assert.equal(summary.status, "launch-grade-estimated-cost-evidence");
+  assert.equal(summary.claimability.estimatedApiCostPositiveEvidence, true);
+  assert.equal(summary.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(summary.claimability.providerBillingTokenSavings, false);
+  assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+  assert.equal(summary.claimability.stableTimeOrLatencySavings, false);
+  assert.equal(summary.counts.acceptedPairCount, 15);
+  assert.equal(summary.taskSummaries.length, 3);
+  assert.ok(summary.medians.estimatedApiCostDelta > 0);
+});
+
+test("provider cost repeated summary classifies one positive task as narrow candidate", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => providerPair({ taskClass: "extract", index: index + 1 }));
+  const summary = summarizeProviderCostCampaign({
+    runId: "narrow",
+    campaignManifest: taskManifest(["extract"]),
+    attemptedPairLedger: ledgerForPairs(pairs),
+    pairEvidence: pairs,
+  });
+
+  assert.equal(summary.status, "narrow-estimated-cost-candidate");
+  assert.equal(summary.claimability.estimatedApiCostPositiveEvidence, false);
+  assert.match(summary.statusReasons.join("\n"), /accepted task classes 1\/3/);
+});
+
+test("provider cost repeated summary keeps fixture mechanics out of public launch-grade claimability", () => {
+  const pairs = positiveCampaignPairs("fixture-mechanics");
+  const summary = summarizeProviderCostCampaign({
+    runId: "fixture-mechanics",
+    campaignManifest: taskManifest(),
+    attemptedPairLedger: ledgerForPairs(pairs),
+    pairEvidence: pairs,
+  });
+
+  assert.equal(summary.status, "fixture-launch-grade-mechanics");
+  assert.equal(summary.claimability.estimatedApiCostPositiveEvidence, false);
+  assert.equal(summary.claimability.providerInvoiceOrBillingSavings, false);
+});
+
+test("provider cost repeated summary rejects mixed identity", () => {
+  const pairs = positiveCampaignPairs("validated-provider-import");
+  pairs[0] = providerPair({ taskClass: "extract", index: 99, sourceKind: "validated-provider-import", pricing: campaignPricing({ model: "gpt-5.4-mini" }) });
+  pairs[0].evidence.model = "gpt-5.4-mini";
+
+  const summary = summarizeProviderCostCampaign({
+    runId: "mixed",
+    campaignManifest: taskManifest(),
+    attemptedPairLedger: ledgerForPairs(pairs),
+    pairEvidence: pairs,
+  });
+
+  assert.equal(summary.status, "mixed-identity");
+  assert.match(summary.statusReasons.join("\n"), /mixed identity/);
+});
+
+test("provider cost repeated summary blocks cherry-picked imports without a ledger", () => {
+  const pairs = positiveCampaignPairs("validated-provider-import");
+  const summary = summarizeProviderCostCampaign({
+    runId: "missing-ledger",
+    campaignManifest: taskManifest(),
+    pairEvidence: pairs,
+  });
+
+  assert.equal(summary.status, "narrow-estimated-cost-candidate");
+  assert.equal(summary.claimability.estimatedApiCostPositiveEvidence, false);
+  assert.match(summary.statusReasons.join("\n"), /ledger is missing/);
+});
+
+test("provider cost repeated summary preserves regression and diagnostic visibility", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => providerPair({
+    taskClass: "extract",
+    index: index + 1,
+    baselineInput: 50_000,
+    fooksInput: 90_000,
+    baselineOutput: 8_000,
+    fooksOutput: 12_000,
+  }));
+  const summary = summarizeProviderCostCampaign({
+    runId: "regression",
+    campaignManifest: taskManifest(["extract"]),
+    attemptedPairLedger: ledgerForPairs(pairs, { regressedPairCount: 5 }),
+    pairEvidence: pairs,
+  });
+
+  assert.notEqual(summary.status, "launch-grade-estimated-cost-evidence");
+  assert.equal(summary.counts.regressedPairCount, 5);
+  assert.match(summary.diagnostics.join("\n"), /negative|neutral|median/i);
+});
+
+test("provider cost repeated cap enforcement stops before exceeding pair or spend caps", () => {
+  const spendGate = shouldStartNextPair({
+    currentBatchEstimatedUsd: 4.75,
+    currentCampaignEstimatedUsd: 4.75,
+    nextWorstCaseEstimatedUsd: 0.5,
+    maxEstimatedUsd: 5,
+    campaignMaxEstimatedUsd: 5,
+    attemptedMatchedPairs: 4,
+    maxMatchedPairs: 10,
+  });
+  assert.equal(spendGate.allowed, false);
+  assert.match(spendGate.reasons.join("\n"), /batch estimated spend cap/);
+
+  const pairGate = shouldStartNextPair({ attemptedMatchedPairs: 10, maxMatchedPairs: 10, nextWorstCaseEstimatedUsd: 0.01 });
+  assert.equal(pairGate.allowed, false);
+  assert.match(pairGate.reasons.join("\n"), /matched pair cap/);
+});
+
+test("provider cost evidence prices cached input tokens with cached input rate", () => {
+  const evidence = buildProviderCostEvidence({
+    baselineArtifact: {
+      provider: "openai",
+      model: "gpt-5.4",
+      usageSource: "validated-provider-import",
+      usage: {
+        prompt_tokens: 100_000,
+        completion_tokens: 10_000,
+        total_tokens: 110_000,
+        input_tokens_details: { cached_tokens: 40_000 },
+      },
+    },
+    fooksArtifact: {
+      provider: "openai",
+      model: "gpt-5.4",
+      usageSource: "validated-provider-import",
+      usage: {
+        prompt_tokens: 50_000,
+        completion_tokens: 8_000,
+        total_tokens: 58_000,
+        input_tokens_details: { cached_tokens: 10_000 },
+      },
+    },
+    pricing: campaignPricing(),
+    sourceKind: "validated-provider-import",
+  });
+
+  assert.equal(evidence.status, "estimated-cost-reduction");
+  assert.equal(evidence.runs.baseline.cachedInputTokens, 40_000);
+  assert.equal(evidence.runs.baseline.estimatedApiCost.inputStandard, 0.15);
+  assert.equal(evidence.runs.baseline.estimatedApiCost.inputCached, 0.01);
+  assert.equal(evidence.runs.baseline.estimatedApiCost.input, 0.16);
+});
+
+test("provider cost repeated summary blocks launch-grade when cached pricing treatment is unknown", () => {
+  const pairs = positiveCampaignPairs("validated-provider-import");
+  pairs[0] = providerPair({
+    taskClass: "extract",
+    index: 1,
+    sourceKind: "validated-provider-import",
+    pricing: campaignPricing({ cachedInputPer1MTokens: undefined }),
+  });
+  pairs[0].evidence.runs.baseline.cachedInputTokens = 10_000;
+  pairs[0].evidence.pricingAssumption.cachedInputPer1MTokens = null;
+
+  const summary = summarizeProviderCostCampaign({
+    runId: "cached-unknown",
+    campaignManifest: taskManifest(),
+    attemptedPairLedger: ledgerForPairs(pairs),
+    pairEvidence: pairs,
+  });
+
+  assert.notEqual(summary.status, "launch-grade-estimated-cost-evidence");
+  assert.match(summary.statusReasons.join("\n"), /cached input rate missing/);
+});
+
+test("provider cost repeated CLI writes import-only summary and ledger into project-local .fooks", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-"));
+  try {
+    const pairPath = path.join(tempRoot, "pair.json");
+    const pair = providerPair({ taskClass: "extract", sourceKind: "validated-provider-import" });
+    fs.writeFileSync(pairPath, JSON.stringify(pair.evidence));
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      `--pair-evidence=${pairPath}`,
+      "--run-id=repeated-smoke",
+      "--required-task-classes=1",
+      "--required-accepted-pairs-per-task=1",
+      "--quality-gate-id=applied-validation",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "repeated-smoke", "summary.json");
+    const markdownPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "repeated-smoke", "summary.md");
+    const ledgerPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "repeated-smoke", "campaign-ledger.json");
+    assert.equal(result.output, ".fooks/evidence/provider-cost/repeated-smoke/summary.json");
+    assert.equal(fs.existsSync(summaryPath), true);
+    assert.equal(fs.existsSync(markdownPath), true);
+    assert.equal(fs.existsSync(ledgerPath), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI explicit output avoids default .fooks", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-explicit-"));
+  try {
+    const pairPath = path.join(tempRoot, "pair.json");
+    const outputPath = path.join(tempRoot, "custom", "summary.json");
+    const pair = providerPair({ taskClass: "extract", sourceKind: "validated-provider-import" });
+    fs.writeFileSync(pairPath, JSON.stringify(pair.evidence));
+
+    execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      `--pair-evidence=${pairPath}`,
+      `--output=${outputPath}`,
+      "--required-task-classes=1",
+      "--required-accepted-pairs-per-task=1",
+    ], { cwd: tempRoot, env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    assert.equal(fs.existsSync(outputPath), true);
+    assert.equal(fs.existsSync(path.join(tempRoot, ".fooks")), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI dry-run live mode does not require credentials or write requests", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-dry-"));
+  try {
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--dry-run-live",
+      "--auth-mode=api-key",
+      "--run-id=dry-live",
+      "--max-estimated-usd=5",
+      "--max-matched-pairs=10",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+    const result = JSON.parse(stdout);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.requestMade, false);
+    assert.equal(result.capPlan.maxEstimatedUsd, 5);
+    assert.equal(fs.existsSync(path.join(tempRoot, ".fooks")), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI dry-run reports Codex OAuth auth plan without making requests", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-oauth-dry-"));
+  try {
+    fs.writeFileSync(path.join(tempRoot, "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--dry-run-live",
+      "--auth-mode=codex-oauth",
+      "--run-id=dry-live-oauth",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, CODEX_HOME: tempRoot, OPENAI_API_KEY: "" } });
+    const result = JSON.parse(stdout);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.requestMade, false);
+    assert.equal(result.authPlan.ok, true);
+    assert.equal(result.authPlan.credentialKind, "codex-oauth");
+    assert.equal(result.authPlan.hasAccountId, true);
+    assert.deepEqual(result.authPlan.headerNames.sort(), ["Authorization", "chatgpt-account-id"].sort());
+    assert.equal(fs.existsSync(path.join(tempRoot, ".fooks")), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI can collect Codex OAuth exec usage through codex transport", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-codex-"));
+  try {
+    const binDir = path.join(tempRoot, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeCodex = path.join(binDir, "codex");
+    fs.writeFileSync(fakeCodex, `#!/usr/bin/env node
+const argv = process.argv.join(" ");
+const isFooks = argv.includes("compact prepared context");
+const usage = isFooks
+  ? { input_tokens: 500, cached_input_tokens: 100, output_tokens: 40 }
+  : { input_tokens: 1000, cached_input_tokens: 100, output_tokens: 50 };
+console.log(JSON.stringify({ type: "thread.started", thread_id: "test-thread" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "OK" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage }));
+`);
+    fs.chmodSync(fakeCodex, 0o755);
+    fs.writeFileSync(path.join(tempRoot, "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    const taskManifestPath = path.join(tempRoot, "tasks.json");
+    fs.writeFileSync(taskManifestPath, JSON.stringify({
+      tasks: [{
+        id: "component",
+        targetPairCount: 1,
+        qualityGate: { id: "applied-validation", status: "passed", command: "fake" },
+        baselinePrompt: "baseline full context",
+        fooksPrompt: "compact prepared context",
+      }],
+    }));
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--auth-mode=codex-oauth",
+      "--transport=codex-exec",
+      `--task-manifest=${taskManifestPath}`,
+      "--run-id=codex-transport",
+      "--model=gpt-5.4",
+      "--input-rate-per-1m=1",
+      "--output-rate-per-1m=1",
+      "--cached-input-rate-per-1m=0.1",
+      "--required-task-classes=1",
+      "--required-accepted-pairs-per-task=1",
+    ], {
+      cwd: tempRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+        CODEX_HOME: tempRoot,
+        OPENAI_API_KEY: "",
+      },
+    });
+
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "codex-transport", "summary.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    assert.equal(result.requestMade, true);
+    assert.equal(result.auth.credentialKind, "codex-oauth");
+    assert.equal(summary.status, "launch-grade-estimated-cost-evidence");
+    assert.equal(summary.counts.acceptedPairCount, 1);
+    assert.equal(summary.pairs[0].evidencePath.includes("pairs/component-1.json"), true);
+    assert.ok(summary.medians.estimatedApiCostDelta > 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI hydrates corrected payload manifests with ABBA order and isolated Codex workdirs", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-corrected-abba-"));
+  try {
+    const binDir = path.join(tempRoot, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeCodex = path.join(binDir, "codex");
+    fs.writeFileSync(fakeCodex, `#!/usr/bin/env node
+const fs = require("fs");
+const argv = process.argv;
+const prompt = argv[argv.length - 1] || "";
+const isFooks = prompt.includes("PAYLOAD_KIND: fooks-model-facing-payload");
+fs.appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify({ cwd: process.cwd(), isFooks }) + "\\n");
+const usage = isFooks
+  ? { input_tokens: 400, cached_input_tokens: 0, output_tokens: 25 }
+  : { input_tokens: 900, cached_input_tokens: 0, output_tokens: 30 };
+console.log(JSON.stringify({ type: "thread.started", thread_id: "test-thread" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "OK" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage }));
+`);
+    fs.chmodSync(fakeCodex, 0o755);
+    fs.writeFileSync(path.join(tempRoot, "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    const baselineContextPath = path.join(tempRoot, "baseline.txt");
+    const fooksContextPath = path.join(tempRoot, "fooks.json");
+    fs.writeFileSync(baselineContextPath, "export function Example() { return <button>Full source</button>; }");
+    fs.writeFileSync(fooksContextPath, JSON.stringify({ mode: "compressed", componentName: "Example" }));
+    const taskManifestPath = path.join(tempRoot, "corrected-tasks.json");
+    fs.writeFileSync(taskManifestPath, JSON.stringify({
+      tasks: [{
+        id: "corrected-component",
+        targetPairCount: 2,
+        targetFile: "src/Example.tsx",
+        instruction: "Summarize the supplied component.",
+        baselineContextPath: "baseline.txt",
+        fooksContextPath: "fooks.json",
+        pairOrder: "abba",
+        setupIdentity: "corrected-real-payload-no-tool",
+        qualityGate: { id: "corrected-payload-validation", status: "passed", command: "fake" },
+      }],
+    }));
+    const logPath = path.join(tempRoot, "codex-log.jsonl");
+    const isolatedRoot = path.join(tempRoot, "isolated");
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--auth-mode=codex-oauth",
+      "--transport=codex-exec",
+      "--codex-workdir=isolated",
+      `--codex-workdir-root=${isolatedRoot}`,
+      "--require-no-tool-use=true",
+      `--task-manifest=${taskManifestPath}`,
+      "--run-id=corrected-abba",
+      "--model=gpt-5.4",
+      "--input-rate-per-1m=1",
+      "--output-rate-per-1m=1",
+      "--cached-input-rate-per-1m=0.1",
+      "--required-task-classes=1",
+      "--required-accepted-pairs-per-task=2",
+    ], {
+      cwd: tempRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+        CODEX_HOME: tempRoot,
+        OPENAI_API_KEY: "",
+        FAKE_CODEX_LOG: logPath,
+      },
+    });
+
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "corrected-abba", "summary.json");
+    const ledgerPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "corrected-abba", "campaign-ledger.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    const ledger = JSON.parse(fs.readFileSync(ledgerPath, "utf8"));
+    const fakeRuns = fs.readFileSync(logPath, "utf8").trim().split(/\n/).map((line) => JSON.parse(line));
+
+    assert.equal(result.requestMade, true);
+    assert.equal(summary.status, "launch-grade-estimated-cost-evidence");
+    assert.equal(summary.counts.acceptedPairCount, 2);
+    assert.deepEqual(ledger.attemptedPairs[0].executionOrder, ["baseline", "fooks"]);
+    assert.deepEqual(ledger.attemptedPairs[1].executionOrder, ["fooks", "baseline"]);
+    const realIsolatedRoot = fs.realpathSync(isolatedRoot);
+    assert.equal(fakeRuns.every((run) => fs.realpathSync(run.cwd).startsWith(realIsolatedRoot)), true);
+    assert.equal(summary.campaignManifest.taskClasses[0].qualityGate.id, "corrected-payload-validation");
+    assert.ok(summary.medians.estimatedApiCostDelta > 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI can fail corrected no-tool quality gate on Codex command events", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-corrected-tools-"));
+  try {
+    const binDir = path.join(tempRoot, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeCodex = path.join(binDir, "codex");
+    fs.writeFileSync(fakeCodex, `#!/usr/bin/env node
+const usage = { input_tokens: 400, cached_input_tokens: 0, output_tokens: 25 };
+console.log(JSON.stringify({ type: "thread.started", thread_id: "test-thread" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "ls" } }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "OK" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage }));
+`);
+    fs.chmodSync(fakeCodex, 0o755);
+    fs.writeFileSync(path.join(tempRoot, "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    fs.writeFileSync(path.join(tempRoot, "baseline.txt"), "full source");
+    fs.writeFileSync(path.join(tempRoot, "fooks.json"), "{}");
+    const taskManifestPath = path.join(tempRoot, "corrected-tasks.json");
+    fs.writeFileSync(taskManifestPath, JSON.stringify({
+      tasks: [{
+        id: "corrected-component",
+        targetPairCount: 1,
+        instruction: "Summarize.",
+        baselineContextPath: "baseline.txt",
+        fooksContextPath: "fooks.json",
+        qualityGate: { id: "corrected-payload-validation", status: "passed", command: "fake" },
+      }],
+    }));
+
+    execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--auth-mode=codex-oauth",
+      "--transport=codex-exec",
+      "--require-no-tool-use=true",
+      `--task-manifest=${taskManifestPath}`,
+      "--run-id=corrected-tool-gate",
+      "--model=gpt-5.4",
+      "--input-rate-per-1m=1",
+      "--output-rate-per-1m=1",
+      "--required-task-classes=1",
+      "--required-accepted-pairs-per-task=1",
+    ], {
+      cwd: tempRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+        CODEX_HOME: tempRoot,
+        OPENAI_API_KEY: "",
+      },
+    });
+
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "corrected-tool-gate", "summary.json");
+    const pairPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "corrected-tool-gate", "pairs", "corrected-component-1.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    const pair = JSON.parse(fs.readFileSync(pairPath, "utf8"));
+    assert.equal(summary.counts.acceptedPairCount, 0);
+    assert.equal(summary.pairs[0].qualityGate.passed, false);
+    assert.equal(summary.taskSummaries[0].pairs[0].qualityGatePassed, false);
+    assert.match(pair.runs.baseline.qualityGate.command, /commandExecutionCount:1/);
+    assert.equal(pair.runs.baseline.qualityGate.status, "failed");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("corrected provider cost manifest builder writes real source and fooks payload contexts", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-corrected-builder-"));
+  try {
+    const outputPath = path.join(tempRoot, "corrected-task-manifest.json");
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "build-provider-cost-corrected-manifest.js"),
+      `--output=${outputPath}`,
+      "--target-pair-count=1",
+    ], { cwd: repoRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+    const result = JSON.parse(stdout);
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    assert.equal(result.taskCount, 3);
+    assert.equal(manifest.tasks.length, 3);
+    assert.equal(manifest.recommendedRunnerArgs.codexWorkdir, "isolated");
+    assert.equal(manifest.tasks.every((task) => fs.existsSync(path.join(tempRoot, task.baselineContextPath))), true);
+    assert.equal(manifest.tasks.every((task) => fs.existsSync(path.join(tempRoot, task.fooksContextPath))), true);
+    assert.equal(manifest.tasks.every((task) => task.payloadStats.promptPayloadReductionPct > 0), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("corrected provider cost manifest builder supports large external profiles without pricing fields", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-large-builder-"));
+  try {
+    const nextRoot = path.join(tempRoot, "nextjs");
+    const tailwindRoot = path.join(tempRoot, "tailwindcss");
+    const nextComponents = path.join(nextRoot, "packages", "next", "src", "client", "components");
+    const tailwindSrc = path.join(tailwindRoot, "packages", "tailwindcss", "src");
+    fs.mkdirSync(nextComponents, { recursive: true });
+    fs.mkdirSync(tailwindSrc, { recursive: true });
+
+    fs.writeFileSync(path.join(nextComponents, "app-router.tsx"), `
+      import React from "react";
+      export function AppRouter({ tree, cache, navigate }) {
+        const [state, setState] = React.useState(tree);
+        React.useEffect(() => {
+          if (cache?.pendingPush) navigate(cache.pendingPush);
+        }, [cache, navigate]);
+        return <main data-tree={JSON.stringify(state)}>{state?.children}</main>;
+      }
+    `);
+    fs.writeFileSync(path.join(nextComponents, "layout-router.tsx"), `
+      import React from "react";
+      export function LayoutRouter({ segmentPath, loading, error, template }) {
+        if (error) return <section role="alert">{error.message}</section>;
+        if (loading) return <section aria-busy="true">loading</section>;
+        return <section data-segment={segmentPath.join("/")}>{template}</section>;
+      }
+    `);
+    fs.writeFileSync(path.join(tailwindSrc, "utilities.ts"), `
+      export function createUtilities(theme) {
+        const utilities = new Map();
+        utilities.set("flex", () => ({ display: "flex" }));
+        utilities.set("text", (value) => ({ color: theme.resolve(value) }));
+        return utilities;
+      }
+    `);
+
+    const outputPath = path.join(tempRoot, "large", "corrected-task-manifest.json");
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "build-provider-cost-corrected-manifest.js"),
+      "--profile=nextjs-tailwind-large",
+      `--nextjs-root=${nextRoot}`,
+      `--tailwindcss-root=${tailwindRoot}`,
+      `--output=${outputPath}`,
+      "--target-pair-count=1",
+    ], { cwd: repoRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const result = JSON.parse(stdout);
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    assert.equal(result.profile, "nextjs-tailwind-large");
+    assert.equal(manifest.profile, "nextjs-tailwind-large");
+    assert.equal(manifest.tasks.length, 3);
+    assert.deepEqual(manifest.tasks.map((task) => task.sourceRootLabel), ["nextjs", "nextjs", "tailwindcss"]);
+    assert.equal(manifest.tasks.every((task) => fs.existsSync(path.join(path.dirname(outputPath), task.baselineContextPath))), true);
+    assert.equal(manifest.tasks.every((task) => fs.existsSync(path.join(path.dirname(outputPath), task.fooksContextPath))), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(manifest, "pricing"), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(manifest, "inputPer1MTokens"), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(manifest, "outputPer1MTokens"), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost repeated CLI live mode without credentials writes controlled blocker", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-nokey-"));
+  try {
+    const taskManifestPath = path.join(tempRoot, "live-campaign-tasks.json");
+    fs.writeFileSync(taskManifestPath, JSON.stringify({
+      tasks: ["component", "refactor", "tests"].map((id) => ({
+        id,
+        targetPairCount: 5,
+        qualityGate: { id: "applied-validation", version: "v1", command: "manual review" },
+      })),
+    }));
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--auth-mode=api-key",
+      `--task-manifest=${taskManifestPath}`,
+      "--run-id=no-key",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, CODEX_HOME: tempRoot, OPENAI_API_KEY: "" } });
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "no-key", "summary.json");
+    const ledgerPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "no-key", "campaign-ledger.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    const ledger = JSON.parse(fs.readFileSync(ledgerPath, "utf8"));
+    assert.equal(result.status, "live-openai-credentials-missing");
+    assert.equal(result.requestMade, false);
+    assert.equal(result.auth.ok, false);
+    assert.equal(result.auth.credentialKind, null);
+    assert.equal(summary.status, "live-openai-credentials-missing");
+    assert.match(summary.statusReasons.join("\n"), /OpenAI live auth is required/);
+    assert.equal(summary.campaignManifest.taskClasses.length, 3);
+    assert.equal(summary.counts.plannedPairCount, 15);
+    assert.equal(summary.counts.attemptedPairCount, 0);
+    assert.equal(ledger.plannedPairCount, 15);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost import manifest fixture kit runs as mechanics-only evidence", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-import-kit-"));
+  try {
+    const fixtureRoot = path.join(repoRoot, "benchmarks", "layer2-frontend-task", "fixtures", "provider-cost-import-kit");
+    const localFixtureRoot = path.join(tempRoot, "kit");
+    fs.cpSync(fixtureRoot, localFixtureRoot, { recursive: true });
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      `--import-manifest=${path.join(localFixtureRoot, "import-manifest.json")}`,
+      "--run-id=import-kit-smoke",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, OPENAI_API_KEY: "" } });
+
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "import-kit-smoke", "summary.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    assert.equal(result.status, "fixture-launch-grade-mechanics");
+    assert.equal(summary.status, "fixture-launch-grade-mechanics");
+    assert.equal(summary.claimability.estimatedApiCostPositiveEvidence, false);
+    assert.equal(summary.claimability.providerInvoiceOrBillingSavings, false);
+    assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
+    assert.equal(summary.counts.acceptedPairCount, 15);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add an estimate-scoped provider usage/API cost evidence lane for Layer 2 benchmark campaigns
- support current model resolution (`--model` → `OPENAI_MODEL` → `gpt-5.4`) plus LiteLLM-shaped pricing catalog lookup
- support OpenAI env credentials and Codex OAuth / `codex exec --json` usage collection without requiring a platform API key
- add corrected real-payload campaign manifest generation, no-tool gates, ABBA pair ordering, isolated Codex workdirs, import fixtures, and billing-import scaffolding
- document the 2026-04-22 corrected small/Next.js/Tailwind outcomes while keeping invoice billing and runtime latency claims blocked

## Claim boundary
This PR intentionally proves only **provider-reported usage-token and estimated API cost evidence under explicit pricing assumptions**.

It does **not** claim:
- actual provider invoice/dashboard savings
- actual charged-cost savings
- provider billing-token savings
- stable runtime-token savings
- stable wall-clock / latency savings

## Evidence captured in docs
- small corrected Codex OAuth campaign: 15/15 accepted, median estimated API cost reduction 4.171%
- Next.js large corrected Codex OAuth campaign: 15/15 accepted, 0 regressions, median estimated API cost reduction 26.492%
- Tailwind large corrected Codex OAuth campaign: 15/15 accepted, 0 regressions, median estimated API cost reduction 38.238%

## Verification
- [x] `node --test test/provider-cost-evidence.test.mjs`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run release:smoke`
- [x] `git diff --cached --check && git diff --check`
- [x] local invariant check for Next.js/Tailwind large-profile launch-grade summaries
