### PR TITLE
Share pre-read seams across runtime adapters

### DIFF
--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { decideCodexPreRead } from "./codex-pre-read";
+import { decidePreRead } from "./pre-read";
 import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, readClaudeRuntimeSession, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
-import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./codex-runtime-prompt";
+import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
 import {
   estimateFileBytes,
@@ -60,11 +60,11 @@ function boundedFallbackContext(filePath: string | undefined, reason: string): s
   );
 }
 
-function payloadContextMode(payload: NonNullable<ReturnType<typeof decideCodexPreRead>["payload"]>): ContextMode {
+function payloadContextMode(payload: NonNullable<ReturnType<typeof decidePreRead>["payload"]>): ContextMode {
   return payload.useOriginal ? "light-minimal" : "light";
 }
 
-function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<typeof decideCodexPreRead>["payload"]>, contextMode: ContextMode): string {
+function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<typeof decidePreRead>["payload"]>, contextMode: ContextMode): string {
   return clampAdditionalContext([
     `fooks: Claude context hook · file: ${filePath} · context-mode: ${contextMode}`,
     "fooks does not intercept Claude Read or claim runtime-token savings.",
@@ -262,9 +262,9 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     return decision;
   }
 
-  let decision: ReturnType<typeof decideCodexPreRead>;
+  let decision: ReturnType<typeof decidePreRead>;
   try {
-    decision = decideCodexPreRead(resolvedTarget, cwd);
+    decision = decidePreRead(resolvedTarget, cwd);
   } catch (error) {
     const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
     const runtimeDecision: ClaudeRuntimeHookDecision = {

--- a/src/adapters/codex-pre-read.ts
+++ b/src/adapters/codex-pre-read.ts
@@ -1,71 +1,7 @@
-import path from "node:path";
-import { extractFile } from "../core/extract";
-import { toModelFacingPayload } from "../core/payload/model-facing";
-import { assessPayloadReadiness } from "../core/payload/readiness";
-import type { CodexPreReadDecision } from "../core/schema";
+import { decidePreRead } from "./pre-read";
 
-const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+export { decidePreRead };
 
-function relativePath(filePath: string, cwd: string): string {
-  const relative = path.relative(cwd, filePath);
-  return relative || path.basename(filePath);
-}
-
-export function decideCodexPreRead(filePath: string, cwd = process.cwd()): CodexPreReadDecision {
-  const resolvedPath = path.resolve(filePath);
-  const outputPath = relativePath(resolvedPath, cwd);
-  const extension = path.extname(resolvedPath);
-
-  if (!ELIGIBLE_EXTENSIONS.has(extension)) {
-    return {
-      runtime: "codex",
-      filePath: outputPath,
-      eligible: false,
-      decision: "fallback",
-      reasons: ["ineligible-extension"],
-      debug: {},
-      fallback: {
-        action: "full-read",
-        reason: "ineligible-extension",
-      },
-    };
-  }
-
-  const result = extractFile(resolvedPath);
-  const payload = toModelFacingPayload(result, cwd);
-  const readiness = assessPayloadReadiness(result, payload);
-  const debug = {
-    mode: result.mode,
-    complexityScore: result.meta.complexityScore,
-    decideReason: result.meta.decideReason,
-    decideConfidence: result.meta.decideConfidence,
-    language: result.language,
-  };
-
-  if (readiness.ready) {
-    return {
-      runtime: "codex",
-      filePath: outputPath,
-      eligible: true,
-      decision: "payload",
-      reasons: [],
-      payload,
-      readiness,
-      debug,
-    };
-  }
-
-  return {
-    runtime: "codex",
-    filePath: outputPath,
-    eligible: true,
-    decision: "fallback",
-    reasons: readiness.reasons,
-    readiness,
-    debug,
-    fallback: {
-      action: "full-read",
-      reason: readiness.reasons[0] ?? "missing-structure",
-    },
-  };
+export function decideCodexPreRead(filePath: string, cwd = process.cwd()) {
+  return decidePreRead(filePath, cwd);
 }

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -1,0 +1,71 @@
+import path from "node:path";
+import { extractFile } from "../core/extract";
+import { toModelFacingPayload } from "../core/payload/model-facing";
+import { assessPayloadReadiness } from "../core/payload/readiness";
+import type { CodexPreReadDecision } from "../core/schema";
+
+const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+
+function relativePath(filePath: string, cwd: string): string {
+  const relative = path.relative(cwd, filePath);
+  return relative || path.basename(filePath);
+}
+
+export function decidePreRead(filePath: string, cwd = process.cwd()): CodexPreReadDecision {
+  const resolvedPath = path.resolve(filePath);
+  const outputPath = relativePath(resolvedPath, cwd);
+  const extension = path.extname(resolvedPath);
+
+  if (!ELIGIBLE_EXTENSIONS.has(extension)) {
+    return {
+      runtime: "codex",
+      filePath: outputPath,
+      eligible: false,
+      decision: "fallback",
+      reasons: ["ineligible-extension"],
+      debug: {},
+      fallback: {
+        action: "full-read",
+        reason: "ineligible-extension",
+      },
+    };
+  }
+
+  const result = extractFile(resolvedPath);
+  const payload = toModelFacingPayload(result, cwd);
+  const readiness = assessPayloadReadiness(result, payload);
+  const debug = {
+    mode: result.mode,
+    complexityScore: result.meta.complexityScore,
+    decideReason: result.meta.decideReason,
+    decideConfidence: result.meta.decideConfidence,
+    language: result.language,
+  };
+
+  if (readiness.ready) {
+    return {
+      runtime: "codex",
+      filePath: outputPath,
+      eligible: true,
+      decision: "payload",
+      reasons: [],
+      payload,
+      readiness,
+      debug,
+    };
+  }
+
+  return {
+    runtime: "codex",
+    filePath: outputPath,
+    eligible: true,
+    decision: "fallback",
+    reasons: readiness.reasons,
+    readiness,
+    debug,
+    fallback: {
+      action: "full-read",
+      reason: readiness.reasons[0] ?? "missing-structure",
+    },
+  };
+}

--- a/src/adapters/prompt-context.ts
+++ b/src/adapters/prompt-context.ts
@@ -1,0 +1,10 @@
+export {
+  hasFullReadEscapeHatch,
+  resolvePromptFileContext,
+} from "../core/context-policy";
+
+export type {
+  ContextBudget,
+  ContextMode,
+  PromptSpecificity,
+} from "../core/context-policy";


### PR DESCRIPTION
## Summary
- Move shared pre-read decision logic into a neutral `pre-read` adapter module.
- Keep `codex-pre-read` as the Codex compatibility boundary so existing CLI/tests continue to patch `decideCodexPreRead`.
- Add a neutral `prompt-context` adapter export and point Claude runtime hook at neutral shared seams instead of Codex-named modules.

## Verification
- `npm run lint`
- `node --test --test-name-pattern "runtime hook falls back when repeated-file payload build throws|native hook bridge maps payload-build failures|install claude-hooks creates local settings|status claude reports handoff-ready" test/fooks.test.mjs`
- `npm test` (194/194)
- `npm run release:smoke`

## Notes
- This is intentionally separate from the merged doctor work on `main`.
- No Claude Stop hook install behavior is included in this PR.