### PR TITLE
Add evidence readiness lanes for billing, Claude, and edit guidance

### DIFF
--- a/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
+++ b/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
@@ -14,6 +14,17 @@ import { ManifestLoader } from './manifest-loader.mjs';
 import { BucketClassifier, DEFAULT_BUCKETS } from './bucket-classifier.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+export const EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY =
+  'local/dry-run edit targeting evidence only; not provider billing/cost proof and not LSP semantic safety';
+const WITH_GUIDANCE_LOCALIZATION_STEPS = Object.freeze([
+  'read-model-payload',
+  'verify-sourceFingerprint',
+  'select-patchTarget',
+]);
+const WITHOUT_GUIDANCE_LOCALIZATION_STEPS = Object.freeze([
+  'read-source-or-search',
+  'locate-edit-anchor-manually',
+]);
 
 function computeSeed(repoName, bucketId, globalSeed) {
   const hash = createHash('sha256');
@@ -76,6 +87,41 @@ function selectSamples(files, targetSize, seed) {
   }
   
   return selected;
+}
+
+function normalizePatchTargetsCount(value) {
+  return Number.isInteger(value) && value > 0 ? value : 0;
+}
+
+function buildEditGuidanceEvidenceVariant(editGuidanceEnabled, patchTargetsCount) {
+  const normalizedPatchTargetsCount = editGuidanceEnabled ? normalizePatchTargetsCount(patchTargetsCount) : 0;
+
+  return {
+    editGuidanceEnabled,
+    patchTargetsCount: normalizedPatchTargetsCount,
+    freshnessChecked: editGuidanceEnabled && normalizedPatchTargetsCount > 0,
+    targetLocalizationSteps: editGuidanceEnabled
+      ? [...WITH_GUIDANCE_LOCALIZATION_STEPS]
+      : [...WITHOUT_GUIDANCE_LOCALIZATION_STEPS],
+    claimBoundary: EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY,
+  };
+}
+
+export function buildEditGuidanceEvidencePair(options = {}) {
+  const targetFile = options.targetFile || 'unresolved-frontend-target.tsx';
+  const componentName = options.componentName || 'UnresolvedComponent';
+  const patchTargetsCount = normalizePatchTargetsCount(options.patchTargetsCount ?? 1) || 1;
+
+  return {
+    schemaVersion: 'fooks-edit-guidance-evidence.v1',
+    pairedTarget: {
+      filePath: targetFile,
+      componentName,
+    },
+    comparisonInvariant: 'with-guidance and without-guidance variants must use this same target file and component',
+    withGuidance: buildEditGuidanceEvidenceVariant(true, patchTargetsCount),
+    withoutGuidance: buildEditGuidanceEvidenceVariant(false, 0),
+  };
 }
 
 export class DryRunCommand {
@@ -148,6 +194,16 @@ export class DryRunCommand {
       };
     }
 
+    const selectedFiles = Object.values(bucketResults).flatMap(bucket => bucket.selectedFiles);
+    const editGuidanceTarget = options.editGuidanceTarget || {};
+    const editGuidanceEvidence = options.editGuidanceEvidence
+      ? buildEditGuidanceEvidencePair({
+          targetFile: editGuidanceTarget.filePath || selectedFiles[0]?.path,
+          componentName: editGuidanceTarget.componentName,
+          patchTargetsCount: options.editGuidancePatchTargetsCount,
+        })
+      : undefined;
+
     const report = {
       schemaVersion: 'fooks-benchmark.v2-dry-run',
       timestamp: new Date().toISOString(),
@@ -165,6 +221,7 @@ export class DryRunCommand {
       },
       buckets: bucketResults,
       discovery: classifier.lastDiscovery,
+      ...(editGuidanceEvidence ? { editGuidanceEvidence } : {}),
       coverageStatus: criticalDeficits > 0 ? 'insufficient' : 
                       Object.values(bucketResults).some(b => b.status === 'undersampled') ? 'partial' : 'full'
     };

--- a/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
+++ b/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
@@ -43,6 +43,15 @@ npm run bench:layer2:billing-import -- \
   --run-id=billing-reconciliation-review
 ```
 
+A synthetic redacted example import is available for local mechanics checks:
+
+```bash
+npm run bench:layer2:billing-import -- \
+  --import=benchmarks/layer2-frontend-task/fixtures/billing-import/redacted-openai-dashboard-export.example.json \
+  --estimated-evidence=.fooks/evidence/provider-cost/<run-id>/evidence.json \
+  --run-id=billing-reconciliation-example
+```
+
 Campaign summaries can be passed with `--summary` or `--provider-cost`:
 
 ```bash

--- a/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
+++ b/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
@@ -19,6 +19,66 @@ Launch-grade estimated API cost evidence requires:
 
 Fixture samples only prove mechanics. They should classify as `fixture-launch-grade-mechanics`, not public positive evidence.
 
+## Offline billing import reconciliation
+
+The billing-import tier is the safe, non-live bridge from existing estimated API
+cost evidence to future billing review. It validates a redacted/local billing
+artifact and writes a side-by-side reconciliation beside a provider-cost
+`evidence.json` or campaign `summary.json`.
+
+Generate only the local import schema/readme:
+
+```bash
+npm run bench:layer2:billing-import -- \
+  --run-id=billing-import-schema-smoke
+```
+
+Reconcile a redacted billing/dashboard/export/manual artifact with an existing
+estimated-cost artifact:
+
+```bash
+npm run bench:layer2:billing-import -- \
+  --import=/path/to/redacted-billing-import.json \
+  --estimated-evidence=.fooks/evidence/provider-cost/<run-id>/evidence.json \
+  --run-id=billing-reconciliation-review
+```
+
+Campaign summaries can be passed with `--summary` or `--provider-cost`:
+
+```bash
+npm run bench:layer2:billing-import -- \
+  --import=/path/to/redacted-billing-import.json \
+  --summary=.fooks/evidence/provider-cost/<run-id>/summary.json \
+  --run-id=billing-campaign-reconciliation-review
+```
+
+Generated output:
+
+- `.fooks/evidence/billing-import/<run-id>/import.schema.json`
+- `.fooks/evidence/billing-import/<run-id>/README.md`
+- `.fooks/evidence/billing-import/<run-id>/reconciliation.json` when both
+  `--import` and estimated evidence are provided
+- `.fooks/evidence/billing-import/<run-id>/reconciliation.md` when both
+  `--import` and estimated evidence are provided
+
+The reconciliation status is intentionally narrow:
+
+- `reconciliation-ready`: required billing fields, provider/model matching,
+  usage tokens, billed amount, and estimate-scoped provider-cost evidence are
+  present for side-by-side review.
+- `inconclusive`: non-fatal data is missing, such as model, billed amount,
+  usage tokens, redaction metadata, or estimated aggregate cost.
+- `mismatch`: provider/model/period contract checks block linking the import
+  to the estimated evidence.
+- `invalid`: required import or estimated-evidence fields are absent or the
+  estimated evidence is not `estimated-api-cost-only`.
+
+Claim boundary: this is still **not** provider invoice/dashboard savings proof,
+actual charged-cost savings proof, or provider billing-token savings proof. The
+artifact always keeps `providerInvoiceOrBillingSavings=false` and
+`providerBillingTokenSavings=false`; it only makes the future billing review
+lane auditable without collecting credentials or calling billing APIs.
+
 ## Files in the import kit
 
 Fixture mechanics kit:

--- a/benchmarks/layer2-frontend-task/billing-import-evidence.js
+++ b/benchmarks/layer2-frontend-task/billing-import-evidence.js
@@ -6,6 +6,52 @@ const path = require('path');
 const { ensureEvidenceDir, evidencePaths, timestampRunId } = require('./evidence-paths');
 
 const BILLING_IMPORT_SCHEMA_VERSION = 'billing-import-evidence.v1';
+const BILLING_RECONCILIATION_SCHEMA_VERSION = 'billing-import-reconciliation.v1';
+const CLAIM_BOUNDARY = 'billing-import-reconciliation-only';
+const ALLOWED_SOURCE_TYPES = ['invoice', 'dashboard-export', 'usage-export', 'manual-entry'];
+const BILLING_CLAIMABILITY = Object.freeze({
+  providerInvoiceOrBillingSavings: false,
+  providerBillingTokenSavings: false,
+});
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNonNegativeNumber(value) {
+  if (typeof value === 'string' && value.trim() !== '') value = Number(value);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function firstFiniteNonNegative(...values) {
+  for (const value of values) {
+    const normalized = finiteNonNegativeNumber(value);
+    if (normalized !== null) return normalized;
+  }
+  return null;
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function normalizeComparableString(value) {
+  const normalized = nonEmptyString(value);
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+function usageTotal(usage) {
+  if (!isObject(usage)) return null;
+  return firstFiniteNonNegative(
+    usage.totalTokens,
+    usage.total_tokens,
+    usage.inputTokens !== null && usage.outputTokens !== null ? usage.inputTokens + usage.outputTokens : null,
+  );
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
 
 function billingImportSchema() {
   return {
@@ -54,7 +100,7 @@ function billingImportSchema() {
         required: ['type', 'timestamp'],
         properties: {
           type: {
-            enum: ['invoice', 'dashboard-export', 'usage-export', 'manual-entry'],
+            enum: ALLOWED_SOURCE_TYPES,
           },
           timestamp: { type: 'string' },
           redacted: { type: 'boolean' },
@@ -74,24 +120,418 @@ function billingImportSchema() {
   };
 }
 
+function normalizeBillingUsage(usageInput) {
+  const usage = isObject(usageInput) ? usageInput : {};
+  const normalized = {
+    inputTokens: firstFiniteNonNegative(usage.inputTokens, usage.input_tokens, usage.prompt_tokens),
+    outputTokens: firstFiniteNonNegative(usage.outputTokens, usage.output_tokens, usage.completion_tokens),
+    cachedInputTokens: firstFiniteNonNegative(usage.cachedInputTokens, usage.cached_input_tokens),
+    cacheCreationInputTokens: firstFiniteNonNegative(usage.cacheCreationInputTokens, usage.cache_creation_input_tokens),
+  };
+  normalized.totalTokens = usageTotal({ ...usage, ...normalized });
+  return normalized;
+}
+
+function normalizeBillingImportArtifact(artifact) {
+  const errors = [];
+  const warnings = [];
+
+  if (!isObject(artifact)) {
+    return {
+      schemaVersion: BILLING_IMPORT_SCHEMA_VERSION,
+      status: 'invalid',
+      provider: null,
+      account: null,
+      period: { start: null, end: null },
+      model: null,
+      currency: null,
+      usage: normalizeBillingUsage(null),
+      billedAmount: null,
+      source: { type: null, timestamp: null, redacted: null, note: null },
+      claimability: { ...BILLING_CLAIMABILITY },
+      errors: ['billing import artifact is not an object'],
+      warnings,
+    };
+  }
+
+  const period = isObject(artifact.period) ? artifact.period : {};
+  const source = isObject(artifact.source) ? artifact.source : {};
+  const usage = normalizeBillingUsage(artifact.usage);
+  const provider = nonEmptyString(artifact.provider);
+  const model = nonEmptyString(artifact.model);
+  const sourceType = nonEmptyString(source.type);
+  const sourceTimestamp = nonEmptyString(source.timestamp);
+  const claimability = isObject(artifact.claimability) ? artifact.claimability : {};
+
+  if (artifact.schemaVersion && artifact.schemaVersion !== BILLING_IMPORT_SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${BILLING_IMPORT_SCHEMA_VERSION}`);
+  }
+  if (!provider) errors.push('provider is required');
+  if (!nonEmptyString(period.start)) errors.push('period.start is required');
+  if (!nonEmptyString(period.end)) errors.push('period.end is required');
+  if (!sourceType) errors.push('source.type is required');
+  else if (!ALLOWED_SOURCE_TYPES.includes(sourceType)) {
+    errors.push(`source.type must be one of: ${ALLOWED_SOURCE_TYPES.join(', ')}`);
+  }
+  if (!sourceTimestamp) errors.push('source.timestamp is required');
+  if (!model) warnings.push('model is missing; reconciliation can only compare provider-level evidence');
+  if (usage.inputTokens === null && usage.outputTokens === null && usage.totalTokens === null) {
+    warnings.push('billing usage tokens are missing; charged amount can be recorded but usage-token reconciliation is inconclusive');
+  }
+  if (finiteNonNegativeNumber(artifact.billedAmount) === null) {
+    warnings.push('billedAmount is missing; actual charged amount cannot be reviewed beside estimated evidence');
+  }
+  if (claimability.providerInvoiceOrBillingSavings === true || claimability.providerBillingTokenSavings === true) {
+    warnings.push('billing import claimability was force-disabled; imports do not prove savings by themselves');
+  }
+
+  return {
+    schemaVersion: BILLING_IMPORT_SCHEMA_VERSION,
+    status: errors.length ? 'invalid' : 'valid',
+    provider,
+    account: isObject(artifact.account) ? {
+      id: nonEmptyString(artifact.account.id),
+      projectId: nonEmptyString(artifact.account.projectId),
+      redacted: artifact.account.redacted === true,
+    } : null,
+    period: {
+      start: nonEmptyString(period.start),
+      end: nonEmptyString(period.end),
+    },
+    model,
+    currency: nonEmptyString(artifact.currency)?.toUpperCase() || null,
+    usage,
+    billedAmount: finiteNonNegativeNumber(artifact.billedAmount),
+    source: {
+      type: sourceType,
+      timestamp: sourceTimestamp,
+      redacted: source.redacted === true,
+      note: nonEmptyString(source.note),
+    },
+    claimability: { ...BILLING_CLAIMABILITY },
+    errors,
+    warnings,
+  };
+}
+
+function firstPair(summary) {
+  return Array.isArray(summary?.pairs) && summary.pairs.length > 0 ? summary.pairs[0] : null;
+}
+
+function firstPairIdentity(summary) {
+  const pair = firstPair(summary);
+  return isObject(pair?.identity) ? pair.identity : {};
+}
+
+function normalizeEstimatedEvidence(evidence) {
+  const errors = [];
+  const warnings = [];
+  if (!isObject(evidence)) {
+    return {
+      status: 'invalid',
+      schemaVersion: null,
+      evidenceKind: 'unknown',
+      runId: null,
+      provider: null,
+      model: null,
+      claimBoundary: null,
+      evidenceStatus: null,
+      sourceKind: null,
+      pricingAssumption: null,
+      estimatedApiCost: null,
+      deltas: null,
+      errors: ['estimated provider-cost evidence is not an object'],
+      warnings,
+    };
+  }
+
+  const identity = firstPairIdentity(evidence);
+  const pricing = isObject(evidence.pricingAssumption)
+    ? evidence.pricingAssumption
+    : isObject(firstPair(evidence)?.pricingAssumption)
+      ? firstPair(evidence).pricingAssumption
+      : {};
+  const manifest = isObject(evidence.campaignManifest) ? evidence.campaignManifest : {};
+  const schemaVersion = nonEmptyString(evidence.schemaVersion);
+  const evidenceKind = schemaVersion === 'provider-cost-repeated-summary.v1'
+    ? 'campaign-summary'
+    : schemaVersion === 'provider-cost-evidence.v1'
+      ? 'pair-evidence'
+      : 'unknown';
+  const provider = nonEmptyString(evidence.provider || pricing.provider || identity.provider);
+  const model = nonEmptyString(evidence.model || pricing.model || manifest.model || identity.model);
+  const claimBoundary = nonEmptyString(evidence.claimBoundary);
+  const sourceKinds = Array.isArray(evidence.pairs)
+    ? Array.from(new Set(evidence.pairs.map((pair) => pair.sourceKind).filter(Boolean)))
+    : [];
+
+  if (!schemaVersion) errors.push('estimated evidence schemaVersion is missing');
+  if (!provider) errors.push('estimated evidence provider is missing');
+  if (!model) errors.push('estimated evidence model is missing');
+  if (claimBoundary !== 'estimated-api-cost-only') {
+    errors.push('estimated evidence must have estimated-api-cost-only claim boundary');
+  }
+
+  let estimatedApiCost = null;
+  let deltas = null;
+  if (evidenceKind === 'pair-evidence') {
+    estimatedApiCost = {
+      baseline: evidence.runs?.baseline?.estimatedApiCost?.total ?? null,
+      fooks: evidence.runs?.fooks?.estimatedApiCost?.total ?? null,
+      currency: evidence.pricingAssumption?.currency || null,
+    };
+    deltas = evidence.deltas?.estimatedApiCostTotal || null;
+  } else if (evidenceKind === 'campaign-summary') {
+    estimatedApiCost = {
+      baseline: evidence.aggregate?.estimatedApiCost?.baseline ?? evidence.aggregate?.estimatedApiCostBaseline ?? null,
+      fooks: evidence.aggregate?.estimatedApiCost?.fooks ?? evidence.aggregate?.estimatedApiCostFooks ?? null,
+      currency: pricing.currency || null,
+    };
+    deltas = {
+      absolute: evidence.medians?.estimatedApiCostDelta ?? null,
+      reductionPct: evidence.medians?.estimatedApiCostReductionPct ?? null,
+      aggregation: 'median',
+    };
+  } else {
+    warnings.push('estimated evidence schema is not a recognized provider-cost pair or campaign summary schema');
+  }
+
+  if (!deltas || deltas.absolute === null || deltas.absolute === undefined || !Number.isFinite(Number(deltas.absolute))) {
+    warnings.push('estimated API cost delta is missing or not numeric');
+  }
+  if (evidenceKind === 'campaign-summary' && estimatedApiCost.baseline === null && estimatedApiCost.fooks === null) {
+    warnings.push('campaign summary does not include aggregate estimated baseline/fooks costs; median deltas remain reviewable');
+  }
+
+  return {
+    status: errors.length ? 'invalid' : 'valid',
+    schemaVersion,
+    evidenceKind,
+    runId: nonEmptyString(evidence.runId),
+    provider,
+    model,
+    claimBoundary,
+    evidenceStatus: nonEmptyString(evidence.status),
+    sourceKind: nonEmptyString(evidence.sourceKind) || (sourceKinds.length ? sourceKinds.join(',') : null),
+    pricingAssumption: {
+      provider: nonEmptyString(pricing.provider),
+      model: nonEmptyString(pricing.model),
+      currency: nonEmptyString(pricing.currency),
+      sourceUrl: nonEmptyString(pricing.sourceUrl || pricing.source_url || manifest.pricingSourceUrl),
+      checkedDate: nonEmptyString(pricing.checkedDate || pricing.checked_date || manifest.pricingCheckedDate),
+    },
+    estimatedApiCost,
+    deltas,
+    errors,
+    warnings,
+  };
+}
+
+function check(id, label, status, detail) {
+  return { id, label, status, detail };
+}
+
+function hasNumericEstimatedDelta(estimated) {
+  return estimated.deltas
+    && estimated.deltas.absolute !== null
+    && estimated.deltas.absolute !== undefined
+    && Number.isFinite(Number(estimated.deltas.absolute));
+}
+
+function buildBillingImportReconciliation({
+  billingImportArtifact,
+  estimatedEvidence,
+  generatedAt = new Date().toISOString(),
+  runId = null,
+} = {}) {
+  const billingImport = normalizeBillingImportArtifact(billingImportArtifact);
+  const estimated = normalizeEstimatedEvidence(estimatedEvidence);
+  const checks = [];
+
+  checks.push(check(
+    'billing-import-valid',
+    'Billing import validates against the local import contract',
+    billingImport.status === 'valid' ? 'pass' : 'fail',
+    billingImport.errors.length ? billingImport.errors.join('; ') : 'required provider, period, source, and claimability fields are present',
+  ));
+  checks.push(check(
+    'estimated-evidence-valid',
+    'Estimated provider-cost evidence is recognized and estimate-scoped',
+    estimated.status === 'valid' ? 'pass' : 'fail',
+    estimated.errors.length ? estimated.errors.join('; ') : `${estimated.schemaVersion} / ${estimated.evidenceKind}`,
+  ));
+
+  const providerMatchable = billingImport.provider && estimated.provider;
+  const providerMatches = providerMatchable && normalizeComparableString(billingImport.provider) === normalizeComparableString(estimated.provider);
+  checks.push(check(
+    'provider-match',
+    'Billing provider matches estimated evidence provider',
+    providerMatchable ? (providerMatches ? 'pass' : 'fail') : 'warn',
+    providerMatchable ? `${billingImport.provider} vs ${estimated.provider}` : 'provider missing on one side',
+  ));
+
+  const modelMatchable = billingImport.model && estimated.model;
+  const modelMatches = modelMatchable && normalizeComparableString(billingImport.model) === normalizeComparableString(estimated.model);
+  checks.push(check(
+    'model-match',
+    'Billing model matches estimated evidence model',
+    modelMatchable ? (modelMatches ? 'pass' : 'fail') : 'warn',
+    modelMatchable ? `${billingImport.model} vs ${estimated.model}` : 'model missing on one side',
+  ));
+
+  const periodPresent = Boolean(billingImport.period.start && billingImport.period.end);
+  checks.push(check(
+    'billing-period-present',
+    'Billing period is present',
+    periodPresent ? 'pass' : 'fail',
+    periodPresent ? `${billingImport.period.start} → ${billingImport.period.end}` : 'period.start and period.end are required',
+  ));
+
+  const billingUsagePresent = billingImport.usage.inputTokens !== null
+    || billingImport.usage.outputTokens !== null
+    || billingImport.usage.totalTokens !== null;
+  checks.push(check(
+    'billing-usage-present',
+    'Billing import includes provider usage tokens',
+    billingUsagePresent ? 'pass' : 'warn',
+    billingUsagePresent ? `${billingImport.usage.totalTokens ?? 'n/a'} total tokens` : 'usage tokens missing',
+  ));
+
+  checks.push(check(
+    'billed-amount-present',
+    'Billing import includes actual billed amount',
+    billingImport.billedAmount !== null ? 'pass' : 'warn',
+    billingImport.billedAmount !== null ? `${billingImport.billedAmount} ${billingImport.currency || ''}`.trim() : 'billedAmount missing',
+  ));
+
+  checks.push(check(
+    'redaction-recorded',
+    'Source redaction state is recorded',
+    billingImport.source.redacted === true || billingImport.account?.redacted === true ? 'info' : 'warn',
+    billingImport.source.redacted === true || billingImport.account?.redacted === true
+      ? 'source/account marked redacted'
+      : 'artifact does not mark source/account as redacted',
+  ));
+
+  checks.push(check(
+    'estimated-delta-present',
+    'Estimated API cost delta remains available for side-by-side review',
+    hasNumericEstimatedDelta(estimated) ? 'pass' : 'warn',
+    estimated.deltas ? `${estimated.deltas.absolute} ${estimated.pricingAssumption.currency || ''}`.trim() : 'estimated delta missing',
+  ));
+
+  checks.push(check(
+    'billing-claimability-blocked',
+    'Billing/import claimability remains disabled',
+    'pass',
+    'providerInvoiceOrBillingSavings=false; providerBillingTokenSavings=false',
+  ));
+
+  const failed = checks.filter((item) => item.status === 'fail');
+  const warned = checks.filter((item) => item.status === 'warn');
+  let status = 'reconciliation-ready';
+  if (billingImport.status === 'invalid' || estimated.status === 'invalid') status = 'invalid';
+  else if (failed.length > 0) status = 'mismatch';
+  else if (warned.length > 0) status = 'inconclusive';
+
+  return {
+    schemaVersion: BILLING_RECONCILIATION_SCHEMA_VERSION,
+    claimBoundary: CLAIM_BOUNDARY,
+    generatedAt,
+    runId,
+    status,
+    statusReasons: failed.map((item) => item.detail),
+    warnings: [
+      ...billingImport.warnings,
+      ...estimated.warnings,
+      ...warned.map((item) => item.detail),
+    ],
+    billingImport,
+    estimatedEvidence: estimated,
+    checks,
+    claimability: {
+      ...BILLING_CLAIMABILITY,
+      estimatedApiCostDelta: estimated.status === 'valid' && hasNumericEstimatedDelta(estimated),
+    },
+    claimBoundaryNotes: [
+      'This artifact reconciles a local/redacted billing import with existing estimated API cost evidence for review only.',
+      'It does not prove provider invoice/dashboard savings or actual charged-cost savings.',
+      'It does not prove provider billing-token savings.',
+      'It does not collect provider credentials or call billing dashboards/APIs.',
+    ],
+  };
+}
+
+function formatValue(value, fallback = 'n/a') {
+  return value === null || value === undefined || value === '' ? fallback : String(value);
+}
+
+function renderBillingReconciliationMarkdown(reconciliation) {
+  const billing = reconciliation.billingImport;
+  const estimated = reconciliation.estimatedEvidence;
+  return [
+    '# Billing import reconciliation evidence',
+    '',
+    `- Schema: \`${reconciliation.schemaVersion}\``,
+    `- Status: \`${reconciliation.status}\``,
+    `- Claim boundary: \`${reconciliation.claimBoundary}\``,
+    `- Billing source: \`${formatValue(billing.source.type)}\` at \`${formatValue(billing.source.timestamp)}\``,
+    `- Provider/model: billing \`${formatValue(billing.provider)}/${formatValue(billing.model)}\` vs estimated \`${formatValue(estimated.provider)}/${formatValue(estimated.model)}\``,
+    `- Billing period: \`${formatValue(billing.period.start)}\` → \`${formatValue(billing.period.end)}\``,
+    `- Billing amount: \`${formatValue(billing.billedAmount)} ${formatValue(billing.currency, '')}\``,
+    `- Estimated evidence: \`${formatValue(estimated.schemaVersion)}\` / \`${formatValue(estimated.evidenceStatus)}\``,
+    '',
+    '## Reconciliation checks',
+    '',
+    '| Check | Status | Detail |',
+    '| --- | --- | --- |',
+    ...reconciliation.checks.map((item) => `| ${item.label} | \`${item.status}\` | ${item.detail || ''} |`),
+    '',
+    '## Claim boundary',
+    '',
+    '- This is a local billing import reconciliation artifact only.',
+    '- This is not provider invoice/billing savings proof and does not prove actual charged-cost savings.',
+    '- This does not unlock provider billing-token savings claims.',
+    '- This does not collect credentials or call provider billing APIs.',
+    '',
+  ].join('\n');
+}
+
 function renderBillingImportReadme(runId) {
   return [
     '# Billing manual-import evidence tier',
     '',
     `Run ID: \`${runId}\``,
     '',
-    'This directory is a placeholder for future manual provider billing imports.',
+    'This directory stores the offline billing-import contract and, when provided, a local reconciliation artifact that links redacted provider billing/dashboard/export data beside existing provider usage estimated-cost evidence.',
     '',
     '## Claim boundary',
     '',
     '- This schema does not prove provider invoice or billing savings.',
     '- This tier does not collect provider credentials or call billing dashboards/APIs.',
-    '- Actual billing savings require a later reconciliation step against invoice/dashboard/export data.',
+    '- Reconciliation artifacts keep `providerInvoiceOrBillingSavings=false` and `providerBillingTokenSavings=false` until a separate billing-grade proof lane is authorized and completed.',
     '',
   ].join('\n');
 }
 
-function writeBillingImportArtifacts({ cwd = process.cwd(), runId = timestampRunId('billing-import') } = {}) {
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value);
+}
+
+function writeBillingImportArtifacts({
+  cwd = process.cwd(),
+  runId = timestampRunId('billing-import'),
+  billingImportArtifact = null,
+  estimatedEvidence = null,
+  outputPath = null,
+  markdownOutputPath = null,
+} = {}) {
   const paths = evidencePaths({
     cwd,
     tier: 'billing-import',
@@ -100,17 +540,32 @@ function writeBillingImportArtifacts({ cwd = process.cwd(), runId = timestampRun
     markdownName: 'README.md',
   });
   ensureEvidenceDir({ cwd, tier: 'billing-import', runId });
-  fs.writeFileSync(paths.json, `${JSON.stringify(billingImportSchema(), null, 2)}\n`);
-  fs.writeFileSync(paths.markdown, renderBillingImportReadme(paths.runId));
-  return {
+  writeJson(paths.json, billingImportSchema());
+  writeText(paths.markdown, renderBillingImportReadme(paths.runId));
+
+  const result = {
     runId: paths.runId,
     schemaPath: paths.json,
     readmePath: paths.markdown,
-    claimability: {
-      providerInvoiceOrBillingSavings: false,
-      providerBillingTokenSavings: false,
-    },
+    claimability: { ...BILLING_CLAIMABILITY },
   };
+
+  if (billingImportArtifact && estimatedEvidence) {
+    const reconciliation = buildBillingImportReconciliation({
+      billingImportArtifact,
+      estimatedEvidence,
+      runId: paths.runId,
+    });
+    const reconciliationPath = outputPath || path.join(paths.dir, 'reconciliation.json');
+    const reconciliationMarkdownPath = markdownOutputPath || path.join(paths.dir, 'reconciliation.md');
+    writeJson(reconciliationPath, reconciliation);
+    writeText(reconciliationMarkdownPath, renderBillingReconciliationMarkdown(reconciliation));
+    result.reconciliationPath = reconciliationPath;
+    result.reconciliationMarkdownPath = reconciliationMarkdownPath;
+    result.reconciliation = reconciliation;
+  }
+
+  return result;
 }
 
 function parseArgs(argv) {
@@ -130,17 +585,40 @@ function relativePath(filePath) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || args.h) {
-    console.log('Usage: node benchmarks/layer2-frontend-task/billing-import-evidence.js [--run-id=<id>]');
+    console.log([
+      'Usage: node benchmarks/layer2-frontend-task/billing-import-evidence.js [--run-id=<id>]',
+      '       node benchmarks/layer2-frontend-task/billing-import-evidence.js --import=<billing.json> --estimated-evidence=<evidence.json> [--run-id=<id>]',
+      '',
+      'Aliases: --provider-cost=<evidence.json>, --summary=<summary.json>',
+    ].join('\n'));
     return;
   }
 
-  const result = writeBillingImportArtifacts({ runId: args['run-id'] });
-  console.log(JSON.stringify({
+  const estimatedPath = args['estimated-evidence'] || args['provider-cost'] || args.summary;
+  if ((args.import && !estimatedPath) || (!args.import && estimatedPath)) {
+    throw new Error('Both --import and --estimated-evidence/--provider-cost/--summary are required for reconciliation');
+  }
+  const billingImportArtifact = args.import ? readJson(args.import) : null;
+  const estimatedEvidence = estimatedPath ? readJson(estimatedPath) : null;
+  const result = writeBillingImportArtifacts({
+    runId: args['run-id'],
+    billingImportArtifact,
+    estimatedEvidence,
+    outputPath: args.output,
+    markdownOutputPath: args['markdown-output'],
+  });
+  const summary = {
     runId: result.runId,
     schemaPath: relativePath(result.schemaPath),
     readmePath: relativePath(result.readmePath),
     claimability: result.claimability,
-  }, null, 2));
+  };
+  if (result.reconciliationPath) {
+    summary.reconciliationPath = relativePath(result.reconciliationPath);
+    summary.reconciliationMarkdownPath = relativePath(result.reconciliationMarkdownPath);
+    summary.reconciliationStatus = result.reconciliation.status;
+  }
+  console.log(JSON.stringify(summary, null, 2));
 }
 
 if (require.main === module) {
@@ -154,7 +632,13 @@ if (require.main === module) {
 
 module.exports = {
   BILLING_IMPORT_SCHEMA_VERSION,
+  BILLING_RECONCILIATION_SCHEMA_VERSION,
+  CLAIM_BOUNDARY,
   billingImportSchema,
+  normalizeBillingImportArtifact,
+  normalizeEstimatedEvidence,
+  buildBillingImportReconciliation,
   renderBillingImportReadme,
+  renderBillingReconciliationMarkdown,
   writeBillingImportArtifacts,
 };

--- a/benchmarks/layer2-frontend-task/fixtures/billing-import/redacted-openai-dashboard-export.example.json
+++ b/benchmarks/layer2-frontend-task/fixtures/billing-import/redacted-openai-dashboard-export.example.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "billing-import-evidence.v1",
+  "provider": "openai",
+  "account": {
+    "id": "acct_redacted_example",
+    "projectId": "proj_redacted_example",
+    "redacted": true
+  },
+  "period": {
+    "start": "2026-04-22T00:00:00.000Z",
+    "end": "2026-04-23T00:00:00.000Z"
+  },
+  "model": "gpt-5.4",
+  "currency": "USD",
+  "usage": {
+    "inputTokens": 140000,
+    "outputTokens": 18000,
+    "cachedInputTokens": 0,
+    "cacheCreationInputTokens": 0
+  },
+  "billedAmount": 0.42,
+  "source": {
+    "type": "dashboard-export",
+    "timestamp": "2026-04-23T00:00:00.000Z",
+    "redacted": true,
+    "note": "Synthetic redacted example for exercising the local billing-import reconciliation lane; not a real invoice or dashboard export."
+  },
+  "claimability": {
+    "providerInvoiceOrBillingSavings": false,
+    "providerBillingTokenSavings": false
+  }
+}

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -108,6 +108,9 @@ npm run bench:layer2:billing-import -- \
   --run-id=billing-reconciliation-review
 ```
 
+For mechanics-only local checks, use the synthetic redacted example at
+`benchmarks/layer2-frontend-task/fixtures/billing-import/redacted-openai-dashboard-export.example.json`.
+
 This closes the previous tooling gap around provider billing/cost connection,
 but it does not change public claimability by itself. Reconciliation artifacts
 keep `providerInvoiceOrBillingSavings=false` and

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -84,14 +84,35 @@ namespace rather than temporary directories:
   estimated-cost JSON/Markdown artifacts.
 - `.fooks/evidence/runtime/<run-id>/` stores repeated matched-pair
   runtime-token/time summaries.
-- `.fooks/evidence/billing-import/<run-id>/` stores the first-pass manual
-  billing import schema/readme. This is only a future reconciliation lane; it
-  does not collect credentials or prove invoice savings by itself.
+- `.fooks/evidence/billing-import/<run-id>/` stores the manual billing import
+  schema/readme and, when a redacted billing import plus estimated-cost evidence
+  are provided, `reconciliation.json` / `reconciliation.md` side-by-side review
+  artifacts.
 
 This remains estimate-only evidence: it is not an invoice, provider dashboard,
 charge, or billing-grade savings proof. It also does not establish stable
 runtime-token or wall-clock wins. Public summaries must label this tier as
 `estimated-api-cost-only` until a separate billing-grade validation lane exists.
+
+The billing import reconciliation lane is intentionally offline and local. It
+accepts provider invoice/dashboard/export/manual data that has already been
+redacted by the operator, compares provider/model/period/source/usage/billed
+amount fields against existing provider-cost `evidence.json` or campaign
+`summary.json`, and records whether the link is `reconciliation-ready`,
+`inconclusive`, `mismatch`, or `invalid`:
+
+```bash
+npm run bench:layer2:billing-import -- \
+  --import=/path/to/redacted-billing-import.json \
+  --estimated-evidence=.fooks/evidence/provider-cost/<run-id>/evidence.json \
+  --run-id=billing-reconciliation-review
+```
+
+This closes the previous tooling gap around provider billing/cost connection,
+but it does not change public claimability by itself. Reconciliation artifacts
+keep `providerInvoiceOrBillingSavings=false` and
+`providerBillingTokenSavings=false`; they are a review bridge, not billing-grade
+savings proof.
 
 The repeated provider-cost campaign runner is the path for making a positive
 estimated API cost claim true. It writes campaign summaries to

--- a/docs/edit-guidance-evidence.md
+++ b/docs/edit-guidance-evidence.md
@@ -1,0 +1,45 @@
+# Edit guidance evidence boundary
+
+`editGuidance.patchTargets` are line-aware edit hints for frontend work. They are
+useful for steering an agent toward likely patch anchors, but they are not proof
+that automatic Codex frontend edits are faster or more accurate by default.
+
+## Current reflection level
+
+| Layer | Status | Safe claim |
+| --- | --- | --- |
+| Typed source ranges and patch targets | Implemented | fooks can represent line-aware edit anchors. |
+| `fooks extract <file> --model-payload` | Opts in to edit guidance | A user or agent can explicitly request patch targets for a file. |
+| Automatic Codex pre-read/runtime path | Compact by default | Do not claim it receives edit guidance unless a future opt-in path is implemented and tested. |
+| Frontend edit outcome evidence | Not proven yet | Do not claim fewer cold-call/read/search steps until a deterministic benchmark or runtime integration proves it. |
+
+## Evidence-lane report contract
+
+Dry-run frontend edit-guidance evidence is local and deterministic. It may compare
+a with-guidance variant against a without-guidance variant only when both variants
+use the same target file and component.
+
+Required fields:
+
+```json
+{
+  "editGuidanceEnabled": true,
+  "patchTargetsCount": 1,
+  "freshnessChecked": true,
+  "targetLocalizationSteps": ["read-model-payload", "verify-sourceFingerprint", "select-patchTarget"],
+  "claimBoundary": "local/dry-run edit targeting evidence only; not provider billing/cost proof and not LSP semantic safety"
+}
+```
+
+`targetLocalizationSteps` must be a deterministic array of named workflow steps,
+not a prose summary or a subjective model-quality score.
+
+## Boundaries that must remain explicit
+
+- Line ranges are AST-derived edit aids, not LSP-backed semantic rename/reference
+  locations.
+- This evidence lane is not provider tokenizer, billing-token, or provider-cost
+  proof.
+- A positive dry-run report is not by itself a claim that automatic Codex runtime
+  editing improved; runtime integration still requires an explicit opt-in path and
+  tests that preserve compact default payload behavior.

--- a/src/adapters/claude-hook-preset.ts
+++ b/src/adapters/claude-hook-preset.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export const CLAUDE_HOOK_EVENTS = ["SessionStart", "UserPromptSubmit"] as const;
+export const CLAUDE_HOOK_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop"] as const;
 const CLAUDE_HOOK_SUFFIX = "claude-runtime-hook --native-hook";
 
 export type ClaudeHookEvent = (typeof CLAUDE_HOOK_EVENTS)[number];

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { decidePreRead } from "./pre-read";
-import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, readClaudeRuntimeSession, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
+import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
+import { ensureFreshClaudeContextForTarget } from "./claude-runtime-trust";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
 import {
@@ -229,12 +230,11 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     return runtimeDecision;
   }
 
-  const currentMtime = fs.statSync(resolvedTarget).mtimeMs;
-  const priorMtime = readClaudeRuntimeSession(cwd, sessionKey).seenFiles[target]?.lastModifiedAtMs;
-  const refreshed = priorMtime !== undefined && priorMtime !== currentMtime;
-
   const { statePath, seenCount } = markClaudeRuntimeSeenFile(cwd, sessionKey, target);
   const repeatedFile = seenCount >= 2;
+
+  const freshness = repeatedFile ? ensureFreshClaudeContextForTarget(target, cwd) : { refreshed: false };
+  const refreshed = freshness.refreshed;
 
   if (!repeatedFile) {
     const decision: ClaudeRuntimeHookDecision = {

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -65,13 +65,34 @@ function payloadContextMode(payload: NonNullable<ReturnType<typeof decidePreRead
   return payload.useOriginal ? "light-minimal" : "light";
 }
 
-function buildPayloadContext(filePath: string, payload: NonNullable<ReturnType<typeof decidePreRead>["payload"]>, contextMode: ContextMode): string {
-  return clampAdditionalContext([
+function buildPayloadContext(
+  filePath: string,
+  payload: NonNullable<ReturnType<typeof decidePreRead>["payload"]>,
+  contextMode: ContextMode,
+): { context: string; truncated: boolean; removedSections: string[] } {
+  const prefix = [
     `fooks: Claude context hook · file: ${filePath} · context-mode: ${contextMode}`,
     "fooks does not intercept Claude Read or claim runtime-token savings.",
     "",
-    JSON.stringify(payload, null, 2),
-  ].join("\n"));
+  ].join("\n");
+  const maxPayloadChars = CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - prefix.length;
+  const removedSections: string[] = [];
+  const workingPayload = { ...payload } as Record<string, unknown>;
+  const sectionsToRemove = ["style", "snippets", "structure", "behavior"];
+
+  let json = JSON.stringify(workingPayload, null, 2);
+  while (json.length > maxPayloadChars && sectionsToRemove.length > 0) {
+    const section = sectionsToRemove.shift()!;
+    if (workingPayload[section] !== undefined) {
+      delete workingPayload[section];
+      removedSections.push(section);
+      json = JSON.stringify(workingPayload, null, 2);
+    }
+  }
+
+  const truncated = removedSections.length > 0;
+  const context = clampAdditionalContext(`${prefix}${json}`);
+  return { context, truncated, removedSections };
 }
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
@@ -237,6 +258,49 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
   const refreshed = freshness.refreshed;
 
   if (!repeatedFile) {
+    if (process.env.FOOKS_CLAUDE_FIRST_SEEN_INJECT === "1") {
+      let preRead: ReturnType<typeof decidePreRead> | undefined;
+      try {
+        preRead = decidePreRead(resolvedTarget, cwd);
+      } catch {
+        // fall through to default record behavior
+      }
+      if (preRead?.decision === "payload" && preRead.payload) {
+        const contextMode = payloadContextMode(preRead.payload);
+        const { context: additionalContext, truncated, removedSections } = buildPayloadContext(target, preRead.payload, contextMode);
+        const reasons = ["first-seen-file", "first-seen-inject"];
+        if (truncated) {
+          reasons.push(`truncated: ${removedSections.join(", ")}`);
+        }
+        const decision: ClaudeRuntimeHookDecision = {
+          runtime: "claude",
+          hookEventName,
+          action: "inject",
+          filePath: target,
+          reasons,
+          additionalContext,
+          statePath,
+          contextMode,
+          contextModeReason: contextMode === "light-minimal" ? "first-seen-exact-file-tiny-raw-original" : "first-seen-exact-file-payload",
+          contextBudget: policy.contextBudget,
+          promptSpecificity: policy.promptSpecificity,
+          contextPolicyVersion: policy.contextPolicyVersion,
+          debug: {
+            repeatedFile: false,
+            eligible: true,
+            bounded: true,
+            escapeHatchUsed: false,
+          },
+        };
+        recordClaudeMetric(cwd, sessionKey, decision, {
+          originalEstimatedBytes: targetEstimatedBytes(cwd, target),
+          actualEstimatedBytes: estimateTextBytes(additionalContext),
+          comparableForSavings: true,
+        });
+        return decision;
+      }
+    }
+
     const decision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
@@ -301,13 +365,17 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    const additionalContext = buildPayloadContext(target, decision.payload, contextMode);
+    const { context: additionalContext, truncated, removedSections } = buildPayloadContext(target, decision.payload, contextMode);
+    const reasons = refreshed ? ["repeated-file", "refreshed-before-inject"] : ["repeated-file"];
+    if (truncated) {
+      reasons.push(`truncated: ${removedSections.join(", ")}`);
+    }
     const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
       hookEventName,
       action: "inject",
       filePath: target,
-      reasons: refreshed ? ["repeated-file", "refreshed-before-inject"] : ["repeated-file"],
+      reasons,
       additionalContext,
       statePath,
       contextMode,

--- a/src/adapters/claude-runtime-trust.ts
+++ b/src/adapters/claude-runtime-trust.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { hashText } from "../core/hash";
+import { readScanIndex } from "../core/cache";
+import { runtimeStatusPath } from "../core/paths";
+import { scanProject } from "../core/scan";
+import type { ClaudeActiveFileContext, ClaudeTrustStatus } from "../core/schema";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function statusFile(cwd: string): string {
+  return runtimeStatusPath("claude", cwd);
+}
+
+export function readClaudeTrustStatus(cwd = process.cwd()): ClaudeTrustStatus {
+  const file = statusFile(cwd);
+  if (!fs.existsSync(file)) {
+    return {
+      runtime: "claude",
+      connectionState: "disconnected",
+      lifecycleState: "disconnected",
+      updatedAt: now(),
+    };
+  }
+  return JSON.parse(fs.readFileSync(file, "utf8")) as ClaudeTrustStatus;
+}
+
+export function writeClaudeTrustStatus(status: ClaudeTrustStatus, cwd = process.cwd()): ClaudeTrustStatus {
+  const file = statusFile(cwd);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(status, null, 2));
+  return status;
+}
+
+export function patchClaudeTrustStatus(
+  partial: Partial<ClaudeTrustStatus>,
+  cwd = process.cwd(),
+): ClaudeTrustStatus {
+  const previous = readClaudeTrustStatus(cwd);
+  const next: ClaudeTrustStatus = {
+    ...previous,
+    ...partial,
+    runtime: "claude",
+    updatedAt: now(),
+  };
+  if (partial.activeFile === undefined && Object.prototype.hasOwnProperty.call(partial, "activeFile")) {
+    delete next.activeFile;
+  }
+  return writeClaudeTrustStatus(next, cwd);
+}
+
+export function initializeClaudeTrustStatus(cwd = process.cwd()): ClaudeTrustStatus {
+  return patchClaudeTrustStatus({ connectionState: "connected", lifecycleState: "indexing" }, cwd);
+}
+
+export function completeClaudeInitialScan(scannedAt: string, cwd = process.cwd()): ClaudeTrustStatus {
+  return patchClaudeTrustStatus({
+    connectionState: "connected",
+    lifecycleState: "ready",
+    attachedAt: scannedAt,
+    lastScanAt: scannedAt,
+    lastRefreshAt: scannedAt,
+  }, cwd);
+}
+
+export function markClaudeReady(cwd = process.cwd()): ClaudeTrustStatus {
+  return patchClaudeTrustStatus({ connectionState: "connected", lifecycleState: "ready" }, cwd);
+}
+
+export function markClaudeAttachPrepared(activeFile: ClaudeActiveFileContext, cwd = process.cwd()): ClaudeTrustStatus {
+  return patchClaudeTrustStatus({
+    connectionState: "connected",
+    lifecycleState: "attach-prepared",
+    activeFile,
+    lastAttachPreparedAt: now(),
+  }, cwd);
+}
+
+export function clearClaudeActiveFile(cwd = process.cwd()): ClaudeTrustStatus {
+  return patchClaudeTrustStatus({ activeFile: undefined, lifecycleState: "ready" }, cwd);
+}
+
+export function ensureFreshClaudeContextForTarget(target: string, cwd = process.cwd()): { refreshed: boolean; scannedAt?: string } {
+  const absolute = path.join(cwd, target);
+  if (!fs.existsSync(absolute)) {
+    patchClaudeTrustStatus({ lifecycleState: "stale" }, cwd);
+    return { refreshed: false };
+  }
+
+  const index = readScanIndex(cwd);
+  const currentHash = hashText(fs.readFileSync(absolute, "utf8"));
+  const indexed = index?.files.find((entry) => entry.filePath === target);
+  if (!index || !indexed || indexed.fileHash !== currentHash) {
+    patchClaudeTrustStatus({ connectionState: "connected", lifecycleState: "refreshing" }, cwd);
+    const refreshed = scanProject(cwd);
+    patchClaudeTrustStatus({
+      connectionState: "connected",
+      lifecycleState: "ready",
+      lastScanAt: refreshed.scannedAt,
+      lastRefreshAt: refreshed.scannedAt,
+    }, cwd);
+    return { refreshed: true, scannedAt: refreshed.scannedAt };
+  }
+
+  patchClaudeTrustStatus({ connectionState: "connected", lifecycleState: "ready" }, cwd);
+  return { refreshed: false, scannedAt: index.scannedAt };
+}

--- a/src/adapters/claude-status.ts
+++ b/src/adapters/claude-status.ts
@@ -268,7 +268,7 @@ export function readClaudeRuntimeStatus(cwd = process.cwd()): ClaudeRuntimeStatu
           ],
     notes: [
       "Claude P0 uses project-local context hooks in .claude/settings.local.json only; fooks does not mutate ~/.claude/settings.json.",
-      "Claude P0 supports project-local SessionStart/UserPromptSubmit context hooks only: first eligible frontend-file prompts are recorded/prepared, repeated same-file prompts may inject bounded context, and fooks does not intercept Read/tool calls or claim runtime-token savings.",
+      "Claude P0 supports project-local SessionStart/UserPromptSubmit/Stop context hooks: first eligible frontend-file prompts are recorded/prepared, repeated same-file prompts may inject bounded context, Stop cleans up session state, and fooks does not intercept Read/tool calls or claim runtime-token savings.",
     ],
   };
 }

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,8 +1,13 @@
+import { scanProject } from "../core/scan";
 import { extractFile } from "../core/extract";
 import { detectAccountContext, finalizeAttach, installRuntimeManifest } from "./shared";
+import { completeClaudeInitialScan, initializeClaudeTrustStatus } from "./claude-runtime-trust";
 import type { AttachResult } from "../core/schema";
 
 export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachResult {
+  initializeClaudeTrustStatus(cwd);
+  const scan = scanProject(cwd);
+  const trustStatus = completeClaudeInitialScan(scan.scannedAt, cwd);
   const sample = extractFile(sampleFile);
   const account = detectAccountContext(cwd);
   const attemptedAt = new Date().toISOString();
@@ -41,5 +46,5 @@ export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachRes
       blocker: "Claude runtime home not detected",
     };
   })();
-  return finalizeAttach("claude", sample, runtimeProof, cwd);
+  return finalizeAttach("claude", sample, runtimeProof, cwd, trustStatus);
 }

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { adapterDir, canonicalProjectDataDir, ensureProjectDataDirs } from "../core/paths";
-import type { AttachResult, CodexTrustStatus, ExtractionResult } from "../core/schema";
+import type { AttachResult, ClaudeTrustStatus, CodexTrustStatus, ExtractionResult } from "../core/schema";
 
 type AccountDetection = {
   account: string;
@@ -176,7 +176,7 @@ export function finalizeAttach(
   sample: ExtractionResult,
   runtimeProof: AttachResult["runtimeProof"],
   cwd = process.cwd(),
-  trustStatus?: CodexTrustStatus,
+  trustStatus?: CodexTrustStatus | ClaudeTrustStatus,
 ): AttachResult {
   return {
     runtime,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -353,6 +353,21 @@ export type CodexTrustStatus = {
   updatedAt: string;
 };
 
+export type ClaudeActiveFileContext = CodexActiveFileContext;
+export type ClaudeTrustLifecycleState = CodexTrustLifecycleState;
+
+export type ClaudeTrustStatus = {
+  runtime: "claude";
+  connectionState: "connected" | "disconnected";
+  lifecycleState: ClaudeTrustLifecycleState;
+  attachedAt?: string;
+  lastScanAt?: string;
+  lastRefreshAt?: string;
+  lastAttachPreparedAt?: string;
+  activeFile?: ClaudeActiveFileContext;
+  updatedAt: string;
+};
+
 export type AttachResult = {
   runtime: "codex" | "claude";
   accountContext: string;
@@ -370,5 +385,5 @@ export type AttachResult = {
     artifactPath?: string;
     blocker?: string;
   };
-  trustStatus?: CodexTrustStatus;
+  trustStatus?: CodexTrustStatus | ClaudeTrustStatus;
 };

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2035,7 +2035,7 @@ test("status claude reports handoff-ready artifacts when project-local hooks are
   assert.equal(status.manifest.valid, true);
   assert.equal(status.hooks.exists, false);
   assert.equal(status.hooks.ready, false);
-  assert.deepEqual(status.hooks.missingEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.deepEqual(status.hooks.missingEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
 
   const text = collectStrings(status).join("\n");
   assert.match(text, /manual-shared-handoff/);
@@ -2055,29 +2055,29 @@ test("install claude-hooks creates local settings and status reports context-hoo
   assert.equal(result.runtime, "claude");
   assert.equal(result.created, true);
   assert.equal(result.modified, true);
-  assert.deepEqual(result.installedEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.deepEqual(result.installedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
   assert.equal(result.settingsPath, path.join(fs.realpathSync(tempDir), ".claude", "settings.local.json"));
 
   const settings = JSON.parse(fs.readFileSync(path.join(tempDir, ".claude", "settings.local.json"), "utf8"));
   assert.equal(settings.hooks.SessionStart[0].hooks[0].command, "fooks claude-runtime-hook --native-hook");
   assert.equal(settings.hooks.UserPromptSubmit[0].hooks[0].command, "fooks claude-runtime-hook --native-hook");
+  assert.equal(settings.hooks.Stop[0].hooks[0].command, "fooks claude-runtime-hook --native-hook");
   assert.equal(settings.hooks.Read, undefined);
   assert.equal(settings.hooks.PreToolUse, undefined);
   assert.equal(settings.hooks.PostToolUse, undefined);
-  assert.equal(settings.hooks.Stop, undefined);
   assert.equal(settings.hooks.SubagentStop, undefined);
   assert.equal(fs.existsSync(path.join(tempDir, ".claude", "settings.json")), false);
 
   const second = run(["install", "claude-hooks"], tempDir, env);
   assert.equal(second.modified, false);
-  assert.deepEqual(second.skippedEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.deepEqual(second.skippedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
 
   const status = run(["status", "claude"], tempDir, env);
   assert.equal(status.state, "context-hook-ready");
   assert.equal(status.mode, "automatic-context-hook");
   assert.equal(status.ready, true);
   assert.equal(status.hooks.ready, true);
-  assert.deepEqual(status.hooks.installedEvents, ["SessionStart", "UserPromptSubmit"]);
+  assert.deepEqual(status.hooks.installedEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
   assert.deepEqual(status.hooks.missingEvents, []);
   assert.deepEqual(status.hooks.unexpectedFooksEvents, []);
 });

--- a/test/frontend-v2-runner.test.mjs
+++ b/test/frontend-v2-runner.test.mjs
@@ -4,7 +4,11 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { BucketClassifier, DEFAULT_BUCKETS, _test } from '../benchmarks/frontend-harness/v2-runner/src/bucket-classifier.mjs';
-import { DryRunCommand } from '../benchmarks/frontend-harness/v2-runner/src/dry-run.mjs';
+import {
+  EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY,
+  DryRunCommand,
+  buildEditGuidanceEvidencePair,
+} from '../benchmarks/frontend-harness/v2-runner/src/dry-run.mjs';
 
 function writeFile(path, content) {
   mkdirSync(dirname(path), { recursive: true });
@@ -174,6 +178,84 @@ test('DryRunCommand reports additive discovery metadata and source-root traceabi
 
     assert.equal(report.coverageStatus, 'insufficient');
     assert.equal(exitCode, 1);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('edit guidance evidence pair keeps variants matched and claim-bounded', () => {
+  const evidence = buildEditGuidanceEvidencePair({
+    targetFile: 'apps/web/components/Button.tsx',
+    componentName: 'Button',
+    patchTargetsCount: 2
+  });
+
+  assert.equal(evidence.schemaVersion, 'fooks-edit-guidance-evidence.v1');
+  assert.deepEqual(evidence.pairedTarget, {
+    filePath: 'apps/web/components/Button.tsx',
+    componentName: 'Button'
+  });
+  assert.match(evidence.comparisonInvariant, /same target file and component/);
+
+  assert.equal(evidence.withGuidance.editGuidanceEnabled, true);
+  assert.equal(evidence.withGuidance.patchTargetsCount, 2);
+  assert.equal(evidence.withGuidance.freshnessChecked, true);
+  assert.deepEqual(evidence.withGuidance.targetLocalizationSteps, [
+    'read-model-payload',
+    'verify-sourceFingerprint',
+    'select-patchTarget'
+  ]);
+
+  assert.equal(evidence.withoutGuidance.editGuidanceEnabled, false);
+  assert.equal(evidence.withoutGuidance.patchTargetsCount, 0);
+  assert.equal(evidence.withoutGuidance.freshnessChecked, false);
+  assert.deepEqual(evidence.withoutGuidance.targetLocalizationSteps, [
+    'read-source-or-search',
+    'locate-edit-anchor-manually'
+  ]);
+
+  for (const variant of [evidence.withGuidance, evidence.withoutGuidance]) {
+    assert.equal(variant.claimBoundary, EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY);
+    assert.match(variant.claimBoundary, /not provider billing\/cost proof/);
+    assert.match(variant.claimBoundary, /not LSP semantic safety/);
+    assert.equal(
+      variant.targetLocalizationSteps.every(step => typeof step === 'string' && step.length > 0),
+      true
+    );
+  }
+});
+
+test('DryRunCommand can attach opt-in edit guidance evidence without changing default reports', async () => {
+  const fixture = createFixture();
+  try {
+    const defaultOutputPath = join(fixture.root, 'dry-run-default.json');
+    const evidenceOutputPath = join(fixture.root, 'dry-run-evidence.json');
+    const command = new DryRunCommand(fixture.manifestPath, fixture.reposBaseDir);
+
+    const defaultRun = await command.execute('fixture', { output: defaultOutputPath });
+    assert.equal(Object.hasOwn(defaultRun.report, 'editGuidanceEvidence'), false);
+
+    const evidenceRun = await command.execute('fixture', {
+      output: evidenceOutputPath,
+      editGuidanceEvidence: true,
+      editGuidanceTarget: {
+        filePath: 'apps/web/components/Button.tsx',
+        componentName: 'Button'
+      },
+      editGuidancePatchTargetsCount: 1
+    });
+    const written = JSON.parse(readFileSync(evidenceOutputPath, 'utf-8'));
+    const evidence = written.editGuidanceEvidence;
+
+    assert.equal(evidence.withGuidance.editGuidanceEnabled, true);
+    assert.equal(evidence.withoutGuidance.editGuidanceEnabled, false);
+    assert.deepEqual(evidence.pairedTarget, {
+      filePath: 'apps/web/components/Button.tsx',
+      componentName: 'Button'
+    });
+    assert.deepEqual(evidenceRun.report.editGuidanceEvidence, evidence);
+    assert.equal(Array.isArray(evidence.withGuidance.targetLocalizationSteps), true);
+    assert.equal(Array.isArray(evidence.withoutGuidance.targetLocalizationSteps), true);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/test/provider-cost-evidence.test.mjs
+++ b/test/provider-cost-evidence.test.mjs
@@ -606,6 +606,32 @@ test("billing import CLI writes reconciliation JSON and Markdown under project-l
   }
 });
 
+test("billing import example fixture reconciles against matching estimated evidence", () => {
+  const fixturePath = path.join(
+    repoRoot,
+    "benchmarks",
+    "layer2-frontend-task",
+    "fixtures",
+    "billing-import",
+    "redacted-openai-dashboard-export.example.json",
+  );
+  const billingImportArtifact = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+  const estimatedEvidence = buildProviderCostEvidence({
+    baselineArtifact: { provider: "openai", model: "gpt-5.4", inputTokens: 100_000, outputTokens: 10_000 },
+    fooksArtifact: { provider: "openai", model: "gpt-5.4", inputTokens: 40_000, outputTokens: 8_000 },
+    pricing: {
+      ...pricing,
+      model: "gpt-5.4",
+    },
+  });
+
+  const reconciliation = buildBillingImportReconciliation({ billingImportArtifact, estimatedEvidence });
+  assert.equal(reconciliation.status, "reconciliation-ready");
+  assert.equal(reconciliation.billingImport.source.redacted, true);
+  assert.equal(reconciliation.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(reconciliation.claimability.providerBillingTokenSavings, false);
+});
+
 test("provider cost evidence CLI can read a LiteLLM-shaped pricing catalog", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-catalog-"));
   try {

--- a/test/provider-cost-evidence.test.mjs
+++ b/test/provider-cost-evidence.test.mjs
@@ -29,6 +29,8 @@ const {
   resolveOpenAILiveAuth,
 } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "openai-live-auth.js"));
 const {
+  buildBillingImportReconciliation,
+  renderBillingReconciliationMarkdown,
   writeBillingImportArtifacts,
 } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "billing-import-evidence.js"));
 
@@ -435,6 +437,170 @@ test("billing manual import artifacts stay local and do not unlock billing claim
     assert.equal(schema.properties.claimability.properties.providerInvoiceOrBillingSavings.const, false);
     assert.deepEqual(schema.properties.source.properties.type.enum, ["invoice", "dashboard-export", "usage-export", "manual-entry"]);
     assert.match(fs.readFileSync(result.readmePath, "utf8"), /does not prove provider invoice or billing savings/i);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("billing import reconciliation links redacted billing data beside estimated evidence without unlocking billing claims", () => {
+  const reconciliation = buildBillingImportReconciliation({
+    runId: "billing-reconciliation-smoke",
+    billingImportArtifact: {
+      schemaVersion: "billing-import-evidence.v1",
+      provider: "openai",
+      account: { id: "acct-redacted", redacted: true },
+      period: { start: "2026-04-22", end: "2026-04-23" },
+      model: "test-model",
+      currency: "USD",
+      usage: { inputTokens: 140_000, outputTokens: 18_000 },
+      billedAmount: 0.42,
+      source: { type: "dashboard-export", timestamp: "2026-04-23T00:00:00.000Z", redacted: true },
+      claimability: {
+        providerInvoiceOrBillingSavings: false,
+        providerBillingTokenSavings: false,
+      },
+    },
+    estimatedEvidence: sampleEvidence(),
+  });
+
+  assert.equal(reconciliation.schemaVersion, "billing-import-reconciliation.v1");
+  assert.equal(reconciliation.status, "reconciliation-ready");
+  assert.equal(reconciliation.claimBoundary, "billing-import-reconciliation-only");
+  assert.equal(reconciliation.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(reconciliation.claimability.providerBillingTokenSavings, false);
+  assert.equal(reconciliation.claimability.estimatedApiCostDelta, true);
+  assert.equal(reconciliation.billingImport.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(reconciliation.estimatedEvidence.claimBoundary, "estimated-api-cost-only");
+
+  const checks = Object.fromEntries(reconciliation.checks.map((item) => [item.id, item.status]));
+  assert.equal(checks["provider-match"], "pass");
+  assert.equal(checks["model-match"], "pass");
+  assert.equal(checks["billed-amount-present"], "pass");
+  assert.equal(checks["billing-claimability-blocked"], "pass");
+
+  const markdown = renderBillingReconciliationMarkdown(reconciliation);
+  assert.match(markdown, /Billing import reconciliation evidence/i);
+  assert.match(markdown, /not provider invoice\/billing savings proof/i);
+  assert.match(markdown, /does not unlock provider billing-token savings claims/i);
+});
+
+test("billing import reconciliation reports provider/model mismatches as non-claimable blockers", () => {
+  const reconciliation = buildBillingImportReconciliation({
+    billingImportArtifact: {
+      schemaVersion: "billing-import-evidence.v1",
+      provider: "anthropic",
+      period: { start: "2026-04-22", end: "2026-04-23" },
+      model: "claude-test",
+      currency: "USD",
+      usage: { inputTokens: 10_000, outputTokens: 1_000 },
+      billedAmount: 0.10,
+      source: { type: "manual-entry", timestamp: "2026-04-23T00:00:00.000Z", redacted: true },
+      claimability: {
+        providerInvoiceOrBillingSavings: true,
+        providerBillingTokenSavings: true,
+      },
+    },
+    estimatedEvidence: sampleEvidence(),
+  });
+
+  assert.equal(reconciliation.status, "mismatch");
+  assert.equal(reconciliation.claimability.providerInvoiceOrBillingSavings, false);
+  assert.equal(reconciliation.claimability.providerBillingTokenSavings, false);
+  assert.match(reconciliation.statusReasons.join("\n"), /anthropic vs openai/);
+  assert.match(reconciliation.statusReasons.join("\n"), /claude-test vs test-model/);
+  assert.match(reconciliation.warnings.join("\n"), /force-disabled/);
+});
+
+test("billing import reconciliation accepts provider-cost campaign summaries", () => {
+  const reconciliation = buildBillingImportReconciliation({
+    billingImportArtifact: {
+      schemaVersion: "billing-import-evidence.v1",
+      provider: "openai",
+      account: { redacted: true },
+      period: { start: "2026-04-22", end: "2026-04-23" },
+      model: "gpt-5.4",
+      currency: "USD",
+      usage: { inputTokens: 376_104, outputTokens: 40_000 },
+      billedAmount: 0.59,
+      source: { type: "invoice", timestamp: "2026-04-23T00:00:00.000Z", redacted: true },
+      claimability: {
+        providerInvoiceOrBillingSavings: false,
+        providerBillingTokenSavings: false,
+      },
+    },
+    estimatedEvidence: {
+      schemaVersion: "provider-cost-repeated-summary.v1",
+      claimBoundary: "estimated-api-cost-only",
+      runId: "campaign-summary-smoke",
+      status: "launch-grade-estimated-cost-evidence",
+      campaignManifest: {
+        model: "gpt-5.4",
+        pricingSourceUrl: "https://openai.com/api/pricing/",
+        pricingCheckedDate: "2026-04-22",
+      },
+      medians: {
+        estimatedApiCostDelta: 0.001362,
+        estimatedApiCostReductionPct: 4.171,
+      },
+      pairs: [{
+        sourceKind: "live-openai-usage",
+        identity: { provider: "openai", model: "gpt-5.4" },
+        pricingAssumption: { provider: "openai", model: "gpt-5.4", currency: "USD" },
+      }],
+      claimability: {
+        estimatedApiCostPositiveEvidence: true,
+        providerInvoiceOrBillingSavings: false,
+        providerBillingTokenSavings: false,
+      },
+    },
+  });
+
+  assert.equal(reconciliation.status, "reconciliation-ready");
+  assert.equal(reconciliation.estimatedEvidence.evidenceKind, "campaign-summary");
+  assert.equal(reconciliation.estimatedEvidence.deltas.aggregation, "median");
+  assert.equal(reconciliation.claimability.providerInvoiceOrBillingSavings, false);
+});
+
+test("billing import CLI writes reconciliation JSON and Markdown under project-local .fooks", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-billing-reconcile-"));
+  try {
+    const importPath = path.join(tempRoot, "billing-import.json");
+    const evidencePath = path.join(tempRoot, "estimated-evidence.json");
+    fs.writeFileSync(importPath, JSON.stringify({
+      schemaVersion: "billing-import-evidence.v1",
+      provider: "openai",
+      account: { redacted: true },
+      period: { start: "2026-04-22", end: "2026-04-23" },
+      model: "test-model",
+      currency: "USD",
+      usage: { inputTokens: 140_000, outputTokens: 18_000 },
+      billedAmount: 0.42,
+      source: { type: "usage-export", timestamp: "2026-04-23T00:00:00.000Z", redacted: true },
+      claimability: {
+        providerInvoiceOrBillingSavings: false,
+        providerBillingTokenSavings: false,
+      },
+    }));
+    fs.writeFileSync(evidencePath, JSON.stringify(sampleEvidence()));
+
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "billing-import-evidence.js"),
+      `--import=${importPath}`,
+      `--estimated-evidence=${evidencePath}`,
+      "--run-id=billing-reconcile-smoke",
+    ], { cwd: tempRoot, encoding: "utf8" });
+
+    const summary = JSON.parse(stdout);
+    assert.equal(summary.reconciliationStatus, "reconciliation-ready");
+    assert.equal(summary.reconciliationPath, ".fooks/evidence/billing-import/billing-reconcile-smoke/reconciliation.json");
+    assert.equal(summary.reconciliationMarkdownPath, ".fooks/evidence/billing-import/billing-reconcile-smoke/reconciliation.md");
+
+    const reconciliationPath = path.join(tempRoot, summary.reconciliationPath);
+    const markdownPath = path.join(tempRoot, summary.reconciliationMarkdownPath);
+    const reconciliation = JSON.parse(fs.readFileSync(reconciliationPath, "utf8"));
+    assert.equal(reconciliation.claimability.providerInvoiceOrBillingSavings, false);
+    assert.equal(reconciliation.status, "reconciliation-ready");
+    assert.match(fs.readFileSync(markdownPath, "utf8"), /not provider invoice\/billing savings proof/i);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- add a synthetic redacted billing-import example and tests so provider-cost reconciliation can be reviewed without real billing data
- bound Claude hook additional context by trimming lower-priority payload sections, keep first-seen injection behind an explicit env flag, and align Stop hook expectations
- add an opt-in frontend dry-run edit-guidance evidence lane with explicit claim boundaries and unchanged default reports

## Claim boundaries

- Billing import reconciliation remains local/offline review support only; it does not prove provider invoice/dashboard savings or provider billing-token savings.
- Claude remains project-local context-hook support only; it does not intercept Claude Read/tool calls or claim runtime-token savings.
- Edit-guidance evidence remains local dry-run targeting evidence only; it is not provider billing/cost proof and not LSP semantic safety.

## Verification

- `npm test` → 201 tests passed
- `node --test test/provider-cost-evidence.test.mjs` → 48 tests passed
- `node --test --test-name-pattern='claude.*hooks|status claude reports handoff-ready' test/fooks.test.mjs` → 4 tests passed
- `npm run typecheck -- --pretty false` → passed
- `git diff --check` → passed

## Notes

The branch intentionally keeps these as separate logical commits for review:

1. billing reconciliation example fixture/docs/tests
2. Claude hook context bounding and Stop hook test expectations
3. opt-in dry-run edit-guidance evidence
