### PR TITLE
Preserve edit-guidance evidence boundaries

### DIFF
--- a/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
+++ b/benchmarks/frontend-harness/v2-runner/src/dry-run.mjs
@@ -15,7 +15,7 @@ import { BucketClassifier, DEFAULT_BUCKETS } from './bucket-classifier.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY =
-  'local/dry-run edit targeting evidence only; not provider billing/cost proof and not LSP semantic safety';
+  'local/dry-run edit targeting evidence only; not provider tokenizer proof, not provider billing/cost proof, and not LSP semantic safety';
 const WITH_GUIDANCE_LOCALIZATION_STEPS = Object.freeze([
   'read-model-payload',
   'verify-sourceFingerprint',
@@ -110,7 +110,9 @@ function buildEditGuidanceEvidenceVariant(editGuidanceEnabled, patchTargetsCount
 export function buildEditGuidanceEvidencePair(options = {}) {
   const targetFile = options.targetFile || 'unresolved-frontend-target.tsx';
   const componentName = options.componentName || 'UnresolvedComponent';
-  const patchTargetsCount = normalizePatchTargetsCount(options.patchTargetsCount ?? 1) || 1;
+  const patchTargetsCount = options.patchTargetsCount === undefined
+    ? 1
+    : normalizePatchTargetsCount(options.patchTargetsCount);
 
   return {
     schemaVersion: 'fooks-edit-guidance-evidence.v1',

--- a/docs/edit-guidance-evidence.md
+++ b/docs/edit-guidance-evidence.md
@@ -27,7 +27,7 @@ Required fields:
   "patchTargetsCount": 1,
   "freshnessChecked": true,
   "targetLocalizationSteps": ["read-model-payload", "verify-sourceFingerprint", "select-patchTarget"],
-  "claimBoundary": "local/dry-run edit targeting evidence only; not provider billing/cost proof and not LSP semantic safety"
+  "claimBoundary": "local/dry-run edit targeting evidence only; not provider tokenizer proof, not provider billing/cost proof, and not LSP semantic safety"
 }
 ```
 
@@ -38,8 +38,8 @@ not a prose summary or a subjective model-quality score.
 
 - Line ranges are AST-derived edit aids, not LSP-backed semantic rename/reference
   locations.
-- This evidence lane is not provider tokenizer, billing-token, or provider-cost
-  proof.
+- This evidence lane is not provider tokenizer behavior/proof, billing-token
+  proof, or provider-cost proof.
 - A positive dry-run report is not by itself a claim that automatic Codex runtime
   editing improved; runtime integration still requires an explicit opt-in path and
   tests that preserve compact default payload behavior.

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -335,8 +335,8 @@ const claudeLocalSettings = path.join(project, ".claude", "settings.local.json")
 assert(fs.existsSync(claudeLocalSettings), "Claude project-local hooks should be installed under the project");
 const claudeSettings = JSON.parse(fs.readFileSync(claudeLocalSettings, "utf8"));
 assert(
-  JSON.stringify(Object.keys(claudeSettings.hooks ?? {}).sort()) === JSON.stringify(["SessionStart", "UserPromptSubmit"]),
-  "Claude smoke hooks should be limited to SessionStart and UserPromptSubmit",
+  JSON.stringify(Object.keys(claudeSettings.hooks ?? {}).sort()) === JSON.stringify(["SessionStart", "Stop", "UserPromptSubmit"]),
+  "Claude smoke hooks should be limited to SessionStart, UserPromptSubmit, and Stop",
 );
 assert(
   claudeSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
@@ -345,6 +345,10 @@ assert(
 assert(
   claudeSettings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
   "Claude UserPromptSubmit smoke hook should use the canonical fooks command",
+);
+assert(
+  claudeSettings.hooks?.Stop?.[0]?.hooks?.[0]?.command === "fooks claude-runtime-hook --native-hook",
+  "Claude Stop smoke hook should use the canonical fooks command",
 );
 const hookEnv = {
   ...process.env,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -545,7 +545,7 @@ Everyday commands:
   ${displayCliName} status cache
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
-  ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit> [--session-id <id>] [--prompt <text>] [--json]
+  ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} claude-runtime-hook --native-hook
 
 Install: npm install -g oh-my-fooks
@@ -679,12 +679,12 @@ function parseCodexRuntimeHookArgs(args: string[]): {
 
 function parseClaudeRuntimeHookArgs(args: string[]): {
   nativeHook: boolean;
-  event: "SessionStart" | "UserPromptSubmit";
+  event: "SessionStart" | "UserPromptSubmit" | "Stop";
   prompt?: string;
   sessionId?: string;
 } {
   let nativeHook = false;
-  let event: "SessionStart" | "UserPromptSubmit" | undefined;
+  let event: "SessionStart" | "UserPromptSubmit" | "Stop" | undefined;
   let prompt: string | undefined;
   let sessionId: string | undefined;
 
@@ -717,8 +717,8 @@ function parseClaudeRuntimeHookArgs(args: string[]): {
     return { nativeHook, event: "SessionStart", prompt, sessionId };
   }
 
-  if (event !== "SessionStart" && event !== "UserPromptSubmit") {
-    throw new Error("claude-runtime-hook requires --event <SessionStart|UserPromptSubmit>");
+  if (event !== "SessionStart" && event !== "UserPromptSubmit" && event !== "Stop") {
+    throw new Error("claude-runtime-hook requires --event <SessionStart|UserPromptSubmit|Stop>");
   }
 
   return { nativeHook, event, prompt, sessionId };

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2457,6 +2457,11 @@ test("cli claude-runtime-hook handles native JSON and malformed JSON", () => {
   );
   assert.equal(unsupportedOutput, "");
 
+  const stopOutput = run(["claude-runtime-hook", "--event", "Stop", "--session-id", "cli-claude-native"], attachedDir);
+  assert.equal(stopOutput.hookEventName, "Stop");
+  assert.equal(stopOutput.action, "noop");
+  assert.ok(stopOutput.reasons.includes("session-stop"));
+
   let failure = "";
   try {
     runTextWithInput(["claude-runtime-hook", "--native-hook"], "{not-json", attachedDir);

--- a/test/frontend-v2-runner.test.mjs
+++ b/test/frontend-v2-runner.test.mjs
@@ -216,6 +216,7 @@ test('edit guidance evidence pair keeps variants matched and claim-bounded', () 
 
   for (const variant of [evidence.withGuidance, evidence.withoutGuidance]) {
     assert.equal(variant.claimBoundary, EDIT_GUIDANCE_EVIDENCE_CLAIM_BOUNDARY);
+    assert.match(variant.claimBoundary, /not provider tokenizer proof/);
     assert.match(variant.claimBoundary, /not provider billing\/cost proof/);
     assert.match(variant.claimBoundary, /not LSP semantic safety/);
     assert.equal(


### PR DESCRIPTION
## Summary
- tighten edit-guidance dry-run evidence boundaries to explicitly exclude provider tokenizer proof
- keep patch target count defaulting precise so invalid explicit counts do not silently become one target
- align release smoke and CLI direct Stop handling with the Claude Stop hook installed by latest main

## Verification
- git diff --cached --check
- node --test test/frontend-v2-runner.test.mjs
- npm run build
- npm run typecheck
- npm run lint
- npm test (201 pass)
- npm run release:smoke (ok true)
- Ralph architect review: APPROVE

## Boundaries
- local/dry-run edit targeting evidence only
- not provider tokenizer proof
- not provider billing/cost proof
- not LSP semantic safety
- not live Codex/Claude model outcome proof