### PR TITLE
Define validation path for token reduction claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Frontend context compression for Codex and Claude Code.
 Public npm package: `oh-my-fooks`
 CLI command: `fooks`
 
-`fooks` helps Codex and Claude Code reduce frontend code context for React component work. In an attached Codex project or a Claude project-local context-hook flow, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time, lowering estimated input-token load and creating a path to lower usage cost.
+`fooks` helps Codex and Claude Code reduce frontend code context for React component work. In an attached Codex project or a Claude project-local context-hook flow, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time, lowering estimated input-token load. Provider billing-token savings, billed-cost savings, and stable runtime-token/time wins remain separate validation tracks and are not claimed by default.
 
 ## Quick start
 

--- a/benchmarks/layer2-frontend-task/codex-wrapper.js
+++ b/benchmarks/layer2-frontend-task/codex-wrapper.js
@@ -2,6 +2,7 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { parseCodexRuntimeUsage } = require('./runtime-token-metrics');
 
 /**
  * Codex CLI Wrapper
@@ -73,6 +74,7 @@ class CodexWrapper {
         const lastMessage = fs.existsSync(lastMessagePath)
           ? fs.readFileSync(lastMessagePath, 'utf8')
           : '';
+        const runtimeUsage = parseCodexRuntimeUsage(stdout, stderr, lastMessage);
 
         fs.rmSync(tempDir, { recursive: true, force: true });
 
@@ -83,6 +85,7 @@ class CodexWrapper {
           stdout,
           stderr,
           lastMessage,
+          runtimeUsage,
           latencyMs,
           timestamp,
           metadata: {

--- a/benchmarks/layer2-frontend-task/r4-repeated-summary.js
+++ b/benchmarks/layer2-frontend-task/r4-repeated-summary.js
@@ -123,8 +123,12 @@ function artifactStatus(artifactPath, artifact, defaults) {
     validationStatus: artifact.validation?.status || null,
     identity: artifactIdentity(artifact, defaults),
     promptTokensApprox: Number.isFinite(metrics.promptTokensApprox) ? metrics.promptTokensApprox : null,
+    runtimeTokensInput: Number.isFinite(metrics.runtimeTokensInput) ? metrics.runtimeTokensInput : null,
+    runtimeTokensOutput: Number.isFinite(metrics.runtimeTokensOutput) ? metrics.runtimeTokensOutput : null,
     runtimeTokensTotal: Number.isFinite(metrics.runtimeTokensTotal) ? metrics.runtimeTokensTotal : null,
     runtimeTokenTelemetryAvailable,
+    runtimeTokenSource: typeof metrics.runtimeTokenSource === 'string' ? metrics.runtimeTokenSource : null,
+    runtimeTokenClaimBoundary: typeof metrics.runtimeTokenClaimBoundary === 'string' ? metrics.runtimeTokenClaimBoundary : null,
     latencyMs: Number.isFinite(metrics.latencyMs) ? metrics.latencyMs : null,
     artifactError: artifact.artifactError || null,
   };

--- a/benchmarks/layer2-frontend-task/run-r4-applied.js
+++ b/benchmarks/layer2-frontend-task/run-r4-applied.js
@@ -14,7 +14,7 @@ const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 const { validate } = require('./validate-r4-applied');
-const { parseCodexRuntimeTokens } = require('./runtime-token-metrics');
+const { parseCodexRuntimeUsage } = require('./runtime-token-metrics');
 
 function parseArgs(argv) {
   return argv.reduce((acc, arg) => {
@@ -114,6 +114,7 @@ function runCodex(prompt, workdir, model, timeoutMs) {
     child.on('error', reject);
     child.on('close', (exitCode, signal) => {
       const lastMessage = fs.existsSync(lastMessagePath) ? fs.readFileSync(lastMessagePath, 'utf8') : '';
+      const runtimeUsage = parseCodexRuntimeUsage(stdout, stderr, lastMessage);
       resolve({
         exitCode,
         signal,
@@ -121,7 +122,7 @@ function runCodex(prompt, workdir, model, timeoutMs) {
         stdout,
         stderr,
         lastMessage,
-        runtimeTokensTotal: parseCodexRuntimeTokens(stdout, stderr, lastMessage),
+        runtimeUsage,
         latencyMs: Date.now() - startedAt,
       });
     });
@@ -179,10 +180,13 @@ async function main() {
       latencyMs: codexResult.latencyMs,
       retryCount: 0,
       outputChars: codexResult.lastMessage.length || codexResult.stdout.length,
-      runtimeTokensTotal: codexResult.runtimeTokensTotal,
-      runtimeTokenSource: codexResult.runtimeTokensTotal === null ? null : 'codex-cli-output',
-      runtimeTokenClaimAvailable: codexResult.runtimeTokensTotal !== null,
-      runtimeTokenClaimBoundary: 'Runtime-reported CLI tokens are not provider billing tokens or costs.',
+      runtimeTokensInput: codexResult.runtimeUsage.inputTokens,
+      runtimeTokensOutput: codexResult.runtimeUsage.outputTokens,
+      runtimeTokensTotal: codexResult.runtimeUsage.totalTokens,
+      runtimeTokenSource: codexResult.runtimeUsage.source,
+      runtimeTokenTelemetryAvailable: codexResult.runtimeUsage.totalTokens !== null,
+      runtimeTokenClaimAvailable: codexResult.runtimeUsage.totalTokens !== null,
+      runtimeTokenClaimBoundary: codexResult.runtimeUsage.claimBoundary,
     },
     codexResult: {
       exitCode: codexResult.exitCode,

--- a/benchmarks/layer2-frontend-task/runner.js
+++ b/benchmarks/layer2-frontend-task/runner.js
@@ -77,6 +77,12 @@ async function main() {
       latencyMs: result.latencyMs,
       retryCount: 0,
       outputChars: result.lastMessage?.length || result.stdout.length,
+      runtimeTokensInput: result.runtimeUsage.inputTokens,
+      runtimeTokensOutput: result.runtimeUsage.outputTokens,
+      runtimeTokensTotal: result.runtimeUsage.totalTokens,
+      runtimeTokenSource: result.runtimeUsage.source,
+      runtimeTokenTelemetryAvailable: result.runtimeUsage.totalTokens !== null,
+      runtimeTokenClaimBoundary: result.runtimeUsage.claimBoundary,
     }
   };
   

--- a/benchmarks/layer2-frontend-task/runtime-token-metrics.js
+++ b/benchmarks/layer2-frontend-task/runtime-token-metrics.js
@@ -7,16 +7,61 @@
  * not a provider cost source, and not sufficient for public billing-token claims.
  */
 function parseCodexRuntimeTokens(...chunks) {
-  const text = chunks.filter((chunk) => typeof chunk === 'string' && chunk.length > 0).join('\n');
-  if (!text) return null;
+  const usage = parseCodexRuntimeUsage(...chunks);
+  return usage.totalTokens;
+}
 
-  const candidates = [];
-  const patterns = [
+/**
+ * Parse the strongest structured Codex CLI runtime-token telemetry available.
+ *
+ * `totalTokens` is the only comparable runtime-token aggregate used by the
+ * repeated L1 gate. `inputTokens` and `outputTokens` are retained when the CLI
+ * prints them, but they are optional because older/terser Codex output may only
+ * include "tokens used".
+ */
+function parseCodexRuntimeUsage(...chunks) {
+  const text = chunks.filter((chunk) => typeof chunk === 'string' && chunk.length > 0).join('\n');
+  const empty = {
+    inputTokens: null,
+    outputTokens: null,
+    totalTokens: null,
+    source: null,
+    claimBoundary: 'Codex CLI runtime-reported tokens are not provider billing tokens or costs.',
+  };
+  if (!text) return empty;
+
+  const inputTokens = lastNumber([
+    /(?:input|prompt)\s+tokens\s*:?\s*([0-9][0-9,]*)/gi,
+    /(?:input|prompt)_tokens["']?\s*[:=]\s*([0-9][0-9,]*)/gi,
+  ], text);
+  const outputTokens = lastNumber([
+    /(?:output|completion)\s+tokens\s*:?\s*([0-9][0-9,]*)/gi,
+    /(?:output|completion)_tokens["']?\s*[:=]\s*([0-9][0-9,]*)/gi,
+  ], text);
+  const explicitTotalTokens = lastNumber([
     /tokens\s+used\s*:?\s*\n\s*([0-9][0-9,]*)/gi,
     /tokens\s+used\s*:?\s*([0-9][0-9,]*)/gi,
     /total\s+tokens\s*:?\s*([0-9][0-9,]*)/gi,
-  ];
+    /total_tokens["']?\s*[:=]\s*([0-9][0-9,]*)/gi,
+  ], text);
 
+  const totalTokens = explicitTotalTokens !== null
+    ? explicitTotalTokens
+    : inputTokens !== null && outputTokens !== null
+      ? inputTokens + outputTokens
+      : null;
+
+  return {
+    ...empty,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    source: totalTokens === null ? null : 'codex-cli-output',
+  };
+}
+
+function lastNumber(patterns, text) {
+  const candidates = [];
   for (const pattern of patterns) {
     let match;
     while ((match = pattern.exec(text)) !== null) {
@@ -24,8 +69,7 @@ function parseCodexRuntimeTokens(...chunks) {
       if (Number.isFinite(value)) candidates.push(value);
     }
   }
-
   return candidates.length > 0 ? candidates[candidates.length - 1] : null;
 }
 
-module.exports = { parseCodexRuntimeTokens };
+module.exports = { parseCodexRuntimeTokens, parseCodexRuntimeUsage };

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -22,6 +22,51 @@ benchmark harness.
 - Automatic Claude or opencode runtime-token savings.
 - Universal file-read interception outside the documented Codex hook path.
 
+## Validation ladder
+
+The repo now treats token/cost evidence as four distinct layers with separate
+claim boundaries:
+
+| Level | Evidence source | What it can support | What it cannot support yet |
+| --- | --- | --- | --- |
+| L0 | Local prompt/context-size estimates such as `promptTokensApprox`, `fooks status`, `fooks compare`, and prepared-context benchmark payload accounting | Prepared-context / prompt-size reduction wording | Provider billing tokens, billed costs, or stable runtime-token/time wins |
+| L1 | Codex CLI runtime-reported telemetry parsed from matched run artifacts | Narrow internal runtime-token candidate evidence for one task/model/setup identity when accepted-pair gates pass | Provider billing-token/cost claims or stable public runtime-win wording |
+| L2a | Provider usage-token artifacts converted into estimated API cost under explicit pricing assumptions | Estimate-scoped provider-usage / estimated API-cost wording with pricing caveats | Invoice/dashboard/billed-cost claims |
+| L2b | Provider invoice, billing export, dashboard, or matched billed-usage telemetry | Billing-grade provider token/cost wording | Any broader product win beyond the measured scope |
+
+### L1 runtime-token candidate gate
+
+Before even internal L1 runtime-token wording is considered, the repeated
+Codex-applied lane must keep all of the following true:
+
+- matched vanilla/fooks pairs for one task identity, model, and setup identity;
+- both sides pass applied-code acceptance for each included pair;
+- at least five accepted pairs remain after failures and mixed-identity runs are
+  excluded;
+- runtime-token telemetry is present for every accepted pair used in the
+  aggregate;
+- median runtime-token reduction is positive, severe regressions are absent, and
+  regressions remain visible in the summary instead of being cherry-picked away.
+
+Even when this gate passes, public stable runtime-token/time claimability stays
+false until a later broader repeated lane exists.
+
+### L2b billing-grade gate
+
+Billing/cost wording requires a stricter lane than L1 or L2a:
+
+- L1/L2a methodology must already be stable enough to define the matched pair;
+- provider-side billing or billed-usage artifacts must exist;
+- baseline/fooks runs must be linkable by run ID, timestamp, or another
+  auditable join key;
+- the provider source must expose billed input/output/cache tokens and/or billed
+  cost, not only local estimates or CLI output;
+- model, account/org, cache policy, retries, parallelism, and environment must
+  be recorded well enough to explain deltas.
+
+This repo has L0, L1, and L2a machinery today. Billing-grade L2b remains a
+separate validation lane.
+
 ## Latest summarized evidence
 
 ### Initial Codex-oriented proxy snapshot, 2026-04-14

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,6 +45,15 @@ context-compression mechanics and targeted-file behavior, but must not claim
 stable direct runtime-token/time wins until a future multi-task benchmark class
 proves them.
 
+Use the evidence ladder in [`docs/benchmark-evidence.md`](benchmark-evidence.md)
+when reviewing release copy: L0 is local prompt/context-size evidence, L1 is
+Codex CLI runtime-reported telemetry from quality-gated matched pairs, L2a is
+provider usage-token / estimated API-cost evidence under explicit pricing
+assumptions, and L2b is provider invoice/dashboard/billed-usage evidence.
+Release copy must keep L1 runtime-token wording separate from L2a estimated API
+cost wording, and must not use either of them as L2b billing-grade cost or
+billing-token proof.
+
 Bare `fooks status` reports local estimated context-size telemetry from `.fooks/sessions`, including runtime/source breakdowns for Codex automatic hooks and Claude project-local context hooks. Its CLI output omits per-session details, is for maintainer/user inspection only, and must not be treated as provider billing tokens, provider costs, or a `ccusage` replacement.
 
 `fooks doctor [codex|claude] [--json]` reports read-only local setup and hook-readiness diagnostics. It may say whether local artifacts such as hooks, manifests, adapter files, Codex trust state, cache health, supported source files, and warning-only optional Claude TypeScript language server host tooling are present. It must not be described as live provider health proof. It is not a ccusage replacement and not provider billing telemetry or provider costs.

--- a/test/layer2-applied-validation.test.mjs
+++ b/test/layer2-applied-validation.test.mjs
@@ -9,8 +9,9 @@ import { createRequire } from "node:module";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { validate } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "validate-r4-applied.js"));
-const { parseCodexRuntimeTokens } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "runtime-token-metrics.js"));
+const { parseCodexRuntimeTokens, parseCodexRuntimeUsage } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "runtime-token-metrics.js"));
 const { summarizeRepeatedPairs } = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "r4-repeated-summary.js"));
+const CodexWrapper = require(path.join(repoRoot, "benchmarks", "layer2-frontend-task", "codex-wrapper.js"));
 const fixtureRoot = path.join(repoRoot, "benchmarks", "layer2-frontend-task", "fixtures", "r4-applied-pass", "combobox");
 
 function copyDir(src, dest) {
@@ -34,6 +35,9 @@ function runArtifact({
   model,
   setupIdentity,
   targetFile,
+  runtimeTokensInput,
+  runtimeTokensOutput,
+  runtimeTokenSource,
 } = {}) {
   return {
     status,
@@ -45,7 +49,10 @@ function runArtifact({
     setupIdentity,
     metrics: {
       promptTokensApprox: prompt,
+      runtimeTokensInput: runtimeTokensInput ?? null,
+      runtimeTokensOutput: runtimeTokensOutput ?? null,
       runtimeTokensTotal: runtime,
+      runtimeTokenSource: runtimeTokenSource ?? (runtime !== null ? "codex-cli-output" : null),
       runtimeTokenClaimAvailable: runtime !== null,
       latencyMs: latency,
     },
@@ -152,6 +159,23 @@ test("Codex runtime-token parser extracts CLI tokens used without billing semant
   assert.equal(parseCodexRuntimeTokens("tokens used\n52,485\n"), 52485);
   assert.equal(parseCodexRuntimeTokens("debug", "tokens used: 1,234"), 1234);
   assert.equal(parseCodexRuntimeTokens("no usage here"), null);
+
+  const usage = parseCodexRuntimeUsage("Input tokens: 1,000\nOutput tokens: 234\nTotal tokens: 1,234");
+  assert.deepEqual(
+    {
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens: usage.totalTokens,
+      source: usage.source,
+    },
+    {
+      inputTokens: 1000,
+      outputTokens: 234,
+      totalTokens: 1234,
+      source: "codex-cli-output",
+    },
+  );
+  assert.match(usage.claimBoundary, /not provider billing tokens or costs/);
 });
 
 test("R4 repeated summary can classify a narrow L1 candidate", () => {
@@ -174,6 +198,7 @@ test("R4 repeated summary can classify a narrow L1 candidate", () => {
   assert.equal(summary.identity.inherited, false);
   assert.equal(Object.hasOwn(summary.pairs[0].vanilla, "runtimeTokenClaimAvailable"), false);
   assert.equal(summary.pairs[0].vanilla.runtimeTokenTelemetryAvailable, true);
+  assert.equal(summary.pairs[0].vanilla.runtimeTokenSource, "codex-cli-output");
   assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
   assert.equal(summary.claimability.stableTimeOrLatencySavings, false);
   assert.match(summary.claimBoundary.join("\n"), /not provider billing tokens or costs/);
@@ -398,6 +423,40 @@ test("R4 repeated summary marks accepted pairs without runtime telemetry unavail
   assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
 });
 
+test("R4 repeated summary preserves structured runtime-token fields when available", () => {
+  const pairs = Array.from({ length: 5 }, (_, index) => ({
+    pairIndex: index + 1,
+    vanillaArtifact: runArtifact({
+      runtimeTokensInput: 800 + index,
+      runtimeTokensOutput: 200,
+      runtime: 1000 + index,
+      latency: 1000 + index,
+      taskIdentity: "r4-combobox",
+      model: "gpt-5.4-mini",
+      setupIdentity: "setup-main",
+    }),
+    fooksArtifact: runArtifact({
+      runtimeTokensInput: 500 + index,
+      runtimeTokensOutput: 200,
+      runtime: 700 + index,
+      latency: 800 + index,
+      taskIdentity: "r4-combobox",
+      model: "gpt-5.4-mini",
+      setupIdentity: "setup-main",
+    }),
+  }));
+
+  const summary = summarizeRepeatedPairs({ requiredAcceptedPairs: 5, pairs });
+
+  assert.equal(summary.classification, "narrow-l1-candidate");
+  assert.equal(summary.pairs[0].vanilla.runtimeTokensInput, 800);
+  assert.equal(summary.pairs[0].vanilla.runtimeTokensOutput, 200);
+  assert.equal(summary.pairs[0].vanilla.runtimeTokensTotal, 1000);
+  assert.equal(summary.pairs[0].fooks.runtimeTokensInput, 500);
+  assert.equal(summary.pairs[0].fooks.runtimeTokensOutput, 200);
+  assert.equal(summary.claimability.providerBillingTokenSavings, false);
+});
+
 test("R4 repeated summary reports diagnostic candidate status when accepted pairs regress", () => {
   const pairs = Array.from({ length: 5 }, (_, index) => ({
     pairIndex: index + 1,
@@ -521,5 +580,50 @@ test("R4 repeated runner success still requires verifier to inspect candidate st
     assert.equal(summary.claimability.stableRuntimeTokenSavings, false);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("Codex wrapper artifacts include structured runtime usage without billing semantics", async () => {
+  const tempBin = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-bin-"));
+  const realPath = process.env.PATH;
+  const codexPath = path.join(tempBin, "codex");
+  try {
+    fs.writeFileSync(
+      codexPath,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('fs');",
+        "const outIndex = process.argv.indexOf('-o');",
+        "if (outIndex !== -1) fs.writeFileSync(process.argv[outIndex + 1], 'ok');",
+        "console.error('Input tokens: 1,000');",
+        "console.error('Output tokens: 234');",
+        "console.error('Total tokens: 1,234');",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${tempBin}${path.delimiter}${realPath}`;
+
+    const wrapper = new CodexWrapper({ model: "test-model", timeoutMs: 1000 });
+    const result = await wrapper.run("context", "task");
+
+    assert.equal(result.success, true);
+    assert.deepEqual(
+      {
+        inputTokens: result.runtimeUsage.inputTokens,
+        outputTokens: result.runtimeUsage.outputTokens,
+        totalTokens: result.runtimeUsage.totalTokens,
+        source: result.runtimeUsage.source,
+      },
+      {
+        inputTokens: 1000,
+        outputTokens: 234,
+        totalTokens: 1234,
+        source: "codex-cli-output",
+      },
+    );
+    assert.match(result.runtimeUsage.claimBoundary, /not provider billing tokens or costs/);
+  } finally {
+    process.env.PATH = realPath;
+    fs.rmSync(tempBin, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- define the L0/L1/L2a/L2b token and cost evidence ladder for Issue #93
- capture structured Codex CLI runtime-token fields in Layer 2 runner artifacts
- keep runtime-token, estimated API-cost, and billing-grade provider claims explicitly separated in docs and tests

## Verification
- npm run lint
- npm test

Closes #93