### PR TITLE
Align runtime trust state across shared pre-read hooks

### DIFF
--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { decidePreRead } from "./pre-read";
 import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
-import { ensureFreshClaudeContextForTarget } from "./claude-runtime-trust";
+import { clearClaudeActiveFile, ensureFreshClaudeContextForTarget, markClaudeAttachPrepared } from "./claude-runtime-trust";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
 import {
@@ -14,6 +14,8 @@ import {
 } from "../core/session-metrics";
 
 export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
+const CLAUDE_CONTEXT_TRUNCATION_SUFFIX =
+  "\n\n[fooks: context truncated to stay within Claude hook additionalContext cap. Read the full source file if exact code is required.]";
 
 export type ClaudeRuntimeHookEvent = "SessionStart" | "UserPromptSubmit" | "Stop";
 
@@ -51,7 +53,7 @@ export type ClaudeRuntimeHookDecision = {
 
 function clampAdditionalContext(value: string): string {
   if (value.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS) return value;
-  return `${value.slice(0, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - 126).trimEnd()}\n\n[fooks: context truncated to stay within Claude hook additionalContext cap. Read the full source file if exact code is required.]`;
+  return `${value.slice(0, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - CLAUDE_CONTEXT_TRUNCATION_SUFFIX.length).trimEnd()}${CLAUDE_CONTEXT_TRUNCATION_SUFFIX}`;
 }
 
 function boundedFallbackContext(filePath: string | undefined, reason: string): string {
@@ -181,6 +183,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (hookEventName === "Stop") {
     const statePath = clearClaudeRuntimeSession(cwd, sessionKey);
+    clearClaudeActiveFile(cwd);
     finalizeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
     return {
       runtime: "claude",
@@ -243,6 +246,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         reason: "escape-hatch-full-read",
       },
     };
+    markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
       actualEstimatedBytes: originalEstimatedBytes,
@@ -261,7 +265,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     if (process.env.FOOKS_CLAUDE_FIRST_SEEN_INJECT === "1") {
       let preRead: ReturnType<typeof decidePreRead> | undefined;
       try {
-        preRead = decidePreRead(resolvedTarget, cwd);
+        preRead = decidePreRead(resolvedTarget, cwd, "claude");
       } catch {
         // fall through to default record behavior
       }
@@ -292,6 +296,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
             escapeHatchUsed: false,
           },
         };
+        markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
         recordClaudeMetric(cwd, sessionKey, decision, {
           originalEstimatedBytes: targetEstimatedBytes(cwd, target),
           actualEstimatedBytes: estimateTextBytes(additionalContext),
@@ -328,8 +333,9 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   let decision: ReturnType<typeof decidePreRead>;
   try {
-    decision = decidePreRead(resolvedTarget, cwd);
+    decision = decidePreRead(resolvedTarget, cwd, "claude");
   } catch (error) {
+    markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
     const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
@@ -390,6 +396,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         escapeHatchUsed: false,
       },
     };
+    markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
     recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
@@ -399,6 +406,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     return runtimeDecision;
   }
 
+  markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
   const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
   const runtimeDecision: ClaudeRuntimeHookDecision = {
     runtime: "claude",

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { decideCodexPreRead } from "./codex-pre-read";
-import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./codex-runtime-prompt";
+import { decidePreRead } from "./pre-read";
+import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import { buildPreReadReuseStatus } from "./codex-runtime-status";
 import { clearCodexActiveFile, ensureFreshCodexContextForTarget, markCodexAttachPrepared, markCodexReady } from "./codex-runtime-trust";
 import {
@@ -71,7 +71,7 @@ function fallbackDecision(
   escapeHatchUsed: boolean,
   fallbackReason: string,
   policy?: ReturnType<typeof resolvePromptFileContext>["policy"],
-  decision?: ReturnType<typeof decideCodexPreRead>,
+  decision?: ReturnType<typeof decidePreRead>,
 ): CodexRuntimeHookDecision {
   return {
     runtime: "codex",
@@ -222,9 +222,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     return runtimeDecision;
   }
 
-  let decision: ReturnType<typeof decideCodexPreRead>;
+  let decision: ReturnType<typeof decidePreRead>;
   try {
-    decision = decideCodexPreRead(path.join(cwd, target), cwd);
+    decision = decidePreRead(path.join(cwd, target), cwd);
   } catch {
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const originalEstimatedBytes = targetEstimatedBytes(cwd, target);

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { extractFile } from "../core/extract";
 import { toModelFacingPayload } from "../core/payload/model-facing";
 import { assessPayloadReadiness } from "../core/payload/readiness";
-import type { CodexPreReadDecision } from "../core/schema";
+import type { PreReadDecision } from "../core/schema";
 
 const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 
@@ -11,14 +11,14 @@ function relativePath(filePath: string, cwd: string): string {
   return relative || path.basename(filePath);
 }
 
-export function decidePreRead(filePath: string, cwd = process.cwd()): CodexPreReadDecision {
+export function decidePreRead(filePath: string, cwd = process.cwd(), runtime: PreReadDecision["runtime"] = "codex"): PreReadDecision {
   const resolvedPath = path.resolve(filePath);
   const outputPath = relativePath(resolvedPath, cwd);
   const extension = path.extname(resolvedPath);
 
   if (!ELIGIBLE_EXTENSIONS.has(extension)) {
     return {
-      runtime: "codex",
+      runtime,
       filePath: outputPath,
       eligible: false,
       decision: "fallback",
@@ -44,7 +44,7 @@ export function decidePreRead(filePath: string, cwd = process.cwd()): CodexPreRe
 
   if (readiness.ready) {
     return {
-      runtime: "codex",
+      runtime,
       filePath: outputPath,
       eligible: true,
       decision: "payload",
@@ -56,7 +56,7 @@ export function decidePreRead(filePath: string, cwd = process.cwd()): CodexPreRe
   }
 
   return {
-    runtime: "codex",
+    runtime,
     filePath: outputPath,
     eligible: true,
     decision: "fallback",

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -191,8 +191,8 @@ export type PayloadReadiness = {
   };
 };
 
-export type CodexPreReadDecision = {
-  runtime: "codex";
+export type PreReadDecision = {
+  runtime: "codex" | "claude";
   filePath: string;
   eligible: boolean;
   decision: "payload" | "fallback";
@@ -211,6 +211,9 @@ export type CodexPreReadDecision = {
     reason: string;
   };
 };
+
+/** @deprecated Use PreReadDecision instead. Kept for backward compatibility. */
+export type CodexPreReadDecision = PreReadDecision;
 
 
 export type PromptSpecificity = "exact-file" | "file-hinted" | "ambiguous";
@@ -251,7 +254,7 @@ export type CodexRuntimeHookDecision = {
     repeatedFile: boolean;
     eligible: boolean;
     escapeHatchUsed: boolean;
-    decision?: CodexPreReadDecision;
+    decision?: PreReadDecision;
   };
   fallback?: {
     action: "full-read";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -23,6 +23,7 @@ const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "pa
 const { assessPayloadReadiness } = require(path.join(repoRoot, "dist", "core", "payload", "readiness.js"));
 const codexPreReadModule = require(path.join(repoRoot, "dist", "adapters", "codex-pre-read.js"));
 const { decideCodexPreRead } = codexPreReadModule;
+const preReadModule = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
 const {
   extractPromptTarget,
   hasFullReadEscapeHatch,
@@ -47,6 +48,7 @@ const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
 const { installClaudeHookPreset, claudeLocalSettingsPath } = require(path.join(repoRoot, "dist", "adapters", "claude-hook-preset.js"));
 const { handleClaudeRuntimeHook, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+const { readClaudeTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
 const { handleClaudeNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "claude-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 const ts = require("typescript");
@@ -131,14 +133,18 @@ function patchTargetKeys(targets) {
 
 function withThrowingCodexPreRead(callback) {
   const originalDecideCodexPreRead = codexPreReadModule.decideCodexPreRead;
-  codexPreReadModule.decideCodexPreRead = () => {
+  const originalDecidePreRead = preReadModule.decidePreRead;
+  const throwingFn = () => {
     throw new Error("synthetic payload build failure");
   };
+  codexPreReadModule.decideCodexPreRead = throwingFn;
+  preReadModule.decidePreRead = throwingFn;
 
   try {
     return callback();
   } finally {
     codexPreReadModule.decideCodexPreRead = originalDecideCodexPreRead;
+    preReadModule.decidePreRead = originalDecidePreRead;
   }
 }
 
@@ -2237,6 +2243,55 @@ test("claude runtime hook records first eligible prompt, injects repeated same-f
   assert.equal(linkedTs.action, "noop");
   const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
   assert.equal(missing.action, "noop");
+});
+
+test("claude runtime hook refreshes stale target state and clears active file on stop", () => {
+  const tempDir = makeTempProject();
+  const claudeHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-home-"));
+  run(["attach", "claude"], tempDir, { FOOKS_CLAUDE_HOME: claudeHome });
+
+  const sessionId = `claude-hook-refresh-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Review ${target}`,
+    },
+    tempDir,
+  );
+
+  appendMarker(path.join(tempDir, target), "// claude-trust-refresh-marker");
+
+  const second = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, review ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.equal(second.filePath, target);
+  assert.ok(second.reasons.includes("refreshed-before-inject"));
+  assert.match(second.additionalContext, /fooks does not intercept Claude Read/);
+
+  const prepared = readClaudeTrustStatus(tempDir);
+  assert.equal(prepared.connectionState, "connected");
+  assert.equal(prepared.lifecycleState, "attach-prepared");
+  assert.equal(prepared.activeFile.filePath, target);
+  assert.equal(prepared.activeFile.source, "prompt-target");
+  assert.ok(prepared.lastRefreshAt);
+  assert.ok(prepared.lastAttachPreparedAt);
+
+  handleClaudeRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+
+  const afterStop = readClaudeTrustStatus(tempDir);
+  assert.equal(afterStop.connectionState, "connected");
+  assert.equal(afterStop.lifecycleState, "ready");
+  assert.equal("activeFile" in afterStop, false);
 });
 
 test("codex and claude estimated metrics are runtime/source-qualified without session collisions", () => {


### PR DESCRIPTION
## Summary
- Share the pre-read decision type/seam across Codex and Claude while keeping the default Codex runtime behavior backward compatible.
- Mark Claude attach-prepared trust state when the Claude context hook injects or falls back for an explicit frontend target, then clear the active file on Stop.
- Replace the Claude additionalContext truncation magic number with a suffix-length calculation and add regression coverage for stale refresh + Stop cleanup.

## Claim boundaries
- This PR does **not** claim Claude Read/tool-call interception.
- This PR does **not** claim provider billing/runtime-token savings for Claude.
- Claude evidence remains project-local context-hook evidence; provider billing/cost evidence must come through the billing/provider-cost lanes.

## Verification
- `npm run typecheck -- --pretty false`
- `node --test --test-name-pattern='(runtime hook refreshes stale target|stop clears active file|claude runtime hook refreshes stale target|claude runtime hook records first eligible|codex and claude estimated metrics|runtime hook falls back)' test/fooks.test.mjs`
- `npm test`
