### PR TITLE
Fence deterministic outcome benchmarking before live evidence work

### DIFF
--- a/benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js
+++ b/benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Design/scaffold-only contract for future deterministic outcome benchmarks.
+ *
+ * This file deliberately does not run Codex/Claude, does not price provider
+ * usage, does not tokenize provider payloads, and does not change runtime
+ * defaults. It only emits/validates the benchmark contract that later lanes can
+ * build on after release-safe runtime guardrails land.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SCHEMA_VERSION = 'layer2-deterministic-outcome-scaffold.v1';
+const STATUS = 'design-scaffold-only';
+
+const CLAIM_BOUNDARY = [
+  'This scaffold is a design contract only, not live Codex or Claude outcome evidence.',
+  'This scaffold does not claim provider billing-token savings, provider tokenizer parity, provider invoice savings, or provider costs.',
+  'This scaffold does not change automatic runtime defaults or editGuidance.patchTargets default behavior.',
+  'Future live smoke or provider-cost evidence must run in separate lanes after release-safe guardrails land.',
+];
+
+const REQUIRED_CONTROLS = [
+  'fixed-task-identity',
+  'fixed-fixture-revision',
+  'isolated-workdir-per-attempt',
+  'deterministic-validator-command',
+  'explicit-seed-and-order-metadata',
+  'source-fingerprint-recorded',
+  'claim-boundary-recorded',
+];
+
+const FORBIDDEN_UNTIL_NEXT_PHASE = [
+  'runtime-default-change',
+  'edit-guidance-default-change',
+  'provider-tokenizer-claim',
+  'provider-billing-token-claim',
+  'provider-cost-claim',
+  'live-codex-outcome-claim',
+  'live-claude-outcome-claim',
+  'lsp-dependency',
+];
+
+function normalizeList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map(String).filter(Boolean);
+  return String(value).split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function buildDeterministicOutcomeScaffold(options = {}) {
+  const runId = options.runId || `deterministic-outcome-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+  const tasks = normalizeList(options.tasks);
+  const validators = normalizeList(options.validators);
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    status: STATUS,
+    runId,
+    generatedAt: options.generatedAt || new Date().toISOString(),
+    scope: {
+      lane: 'priority-3-deterministic-outcome-benchmark',
+      phase: 'scaffold',
+      allowedWork: [
+        'contract-docs',
+        'local-scaffold-emission',
+        'claim-boundary-tests',
+      ],
+      nonGoals: FORBIDDEN_UNTIL_NEXT_PHASE,
+    },
+    plannedInputs: {
+      tasks,
+      validators,
+      minimumAcceptedPairs: Number.isFinite(Number(options.minimumAcceptedPairs))
+        ? Number(options.minimumAcceptedPairs)
+        : 0,
+      liveModelExecution: false,
+      providerBillingImport: false,
+      lspRequired: false,
+    },
+    deterministicControls: REQUIRED_CONTROLS,
+    artifactContract: {
+      requiredIdentityFields: [
+        'taskIdentity',
+        'fixtureRevision',
+        'setupIdentity',
+        'validatorIdentity',
+      ],
+      requiredOutcomeFields: [
+        'accepted',
+        'validatorStatus',
+        'diagnosticReasons',
+      ],
+      requiredAuditFields: [
+        'sourceFingerprint',
+        'seed',
+        'attemptOrder',
+        'claimBoundary',
+      ],
+    },
+    claimability: {
+      liveCodexOutcome: false,
+      liveClaudeOutcome: false,
+      providerTokenizerParity: false,
+      providerBillingTokenSavings: false,
+      providerInvoiceOrCostSavings: false,
+      stableRuntimeTokenSavings: false,
+      stableLatencySavings: false,
+    },
+    claimBoundary: CLAIM_BOUNDARY,
+    nextPhaseRequires: [
+      'release-safe-runtime-opt-in-guardrails-merged',
+      'fixture-replay-manifest-reviewed',
+      'no-live-model-claim-wording-approved',
+    ],
+  };
+}
+
+function validateDeterministicOutcomeScaffold(scaffold) {
+  const blockers = [];
+  if (!scaffold || typeof scaffold !== 'object') blockers.push('missing-scaffold-object');
+  if (scaffold?.schemaVersion !== SCHEMA_VERSION) blockers.push('unexpected-schema-version');
+  if (scaffold?.status !== STATUS) blockers.push('status-must-remain-design-scaffold-only');
+
+  for (const [key, value] of Object.entries(scaffold?.claimability || {})) {
+    if (value !== false) blockers.push(`claimability-${key}-must-be-false`);
+  }
+
+  const controls = new Set(scaffold?.deterministicControls || []);
+  for (const control of REQUIRED_CONTROLS) {
+    if (!controls.has(control)) blockers.push(`missing-control:${control}`);
+  }
+
+  const nonGoals = new Set(scaffold?.scope?.nonGoals || []);
+  for (const forbidden of FORBIDDEN_UNTIL_NEXT_PHASE) {
+    if (!nonGoals.has(forbidden)) blockers.push(`missing-non-goal:${forbidden}`);
+  }
+
+  const boundary = (scaffold?.claimBoundary || []).join(' ').toLowerCase();
+  for (const phrase of ['design contract only', 'provider billing-token', 'automatic runtime defaults', 'separate lanes']) {
+    if (!boundary.includes(phrase)) blockers.push(`missing-claim-boundary:${phrase}`);
+  }
+
+  return {
+    valid: blockers.length === 0,
+    blockers,
+  };
+}
+
+function markdownForScaffold(scaffold, validation = validateDeterministicOutcomeScaffold(scaffold)) {
+  return [
+    '# Deterministic Outcome Benchmark Scaffold',
+    '',
+    `- Schema: ${scaffold.schemaVersion}`,
+    `- Status: ${scaffold.status}`,
+    `- Run ID: ${scaffold.runId}`,
+    `- Valid: ${validation.valid}`,
+    '',
+    '## Claim boundary',
+    '',
+    ...scaffold.claimBoundary.map((item) => `- ${item}`),
+    '',
+    '## Deterministic controls',
+    '',
+    ...scaffold.deterministicControls.map((item) => `- ${item}`),
+    '',
+    '## Non-goals for this phase',
+    '',
+    ...scaffold.scope.nonGoals.map((item) => `- ${item}`),
+    '',
+    '## Validation blockers',
+    '',
+    ...(validation.blockers.length > 0 ? validation.blockers.map((item) => `- ${item}`) : ['- none']),
+    '',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  return argv.reduce((acc, arg) => {
+    const [key, ...rest] = arg.split('=');
+    if (key.startsWith('--')) {
+      acc[key.slice(2)] = rest.length > 0 ? rest.join('=') : true;
+    }
+    return acc;
+  }, {});
+}
+
+function writeIfRequested(filePath, content) {
+  if (!filePath) return;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function usage() {
+  return [
+    'Usage: node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js [--output=<json>] [--markdown=<md>] [--run-id=<id>] [--tasks=a,b] [--validators=a,b] [--minimum-accepted-pairs=5]',
+    'Emits a design/scaffold-only deterministic outcome benchmark contract. It does not run live models or provider-cost evidence.',
+  ].join('\n');
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return 0;
+  }
+  const scaffold = buildDeterministicOutcomeScaffold({
+    runId: args['run-id'],
+    tasks: args.tasks,
+    validators: args.validators,
+    minimumAcceptedPairs: args['minimum-accepted-pairs'],
+  });
+  const validation = validateDeterministicOutcomeScaffold(scaffold);
+  const json = `${JSON.stringify({ ...scaffold, validation }, null, 2)}\n`;
+  writeIfRequested(args.output, json);
+  writeIfRequested(args.markdown, markdownForScaffold(scaffold, validation));
+  if (!args.output) process.stdout.write(json);
+  return validation.valid ? 0 : 2;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  STATUS,
+  CLAIM_BOUNDARY,
+  REQUIRED_CONTROLS,
+  FORBIDDEN_UNTIL_NEXT_PHASE,
+  buildDeterministicOutcomeScaffold,
+  validateDeterministicOutcomeScaffold,
+  markdownForScaffold,
+};

--- a/docs/deterministic-outcome-benchmark.md
+++ b/docs/deterministic-outcome-benchmark.md
@@ -1,0 +1,74 @@
+# Deterministic Outcome Benchmark Plan
+
+This is a **design/scaffold-only** lane for a future deterministic outcome benchmark. It is intentionally separated from the release-safe runtime opt-in work so that it can run in a parallel worktree without changing runtime defaults, provider billing claims, or live model outcome claims.
+
+## Scope
+
+The first pass may add only:
+
+- deterministic benchmark plan/spec artifacts;
+- local scaffold code that emits or validates the benchmark contract;
+- tests proving the scaffold stays claim-bounded.
+
+The first pass must not modify runtime adapter behavior, public win claims, provider-cost logic, or LSP dependencies.
+
+## Non-goals
+
+- No default runtime behavior change.
+- No automatic `editGuidance.patchTargets` behavior change; patch targets remain opt-in.
+- No provider tokenizer, provider billing-token, provider invoice, or provider cost claim.
+- No live Codex/Claude model outcome claim.
+- No LSP implementation and no new dependency.
+- No edits to existing public claim surfaces until the runtime opt-in guardrail work lands.
+
+## Why this exists
+
+The existing R4 repeated benchmark lane can classify narrow local telemetry candidates, but a future deterministic outcome benchmark needs a separate contract before any live smoke or provider-cost work starts. The contract should make outcome comparability deterministic enough for internal evidence without accidentally becoming a public runtime-token, billing, cost, or live-model claim.
+
+## Deterministic controls
+
+A future implementation should require all accepted comparisons to share:
+
+1. fixed task identity;
+2. fixed fixture/source revision;
+3. fixed model/setup identity when a model is involved;
+4. isolated workdirs per attempt;
+5. deterministic validator command and acceptance rubric;
+6. explicit seed/order metadata;
+7. stored source fingerprints for every target input;
+8. claim-boundary metadata on every emitted artifact.
+
+## Phase gates
+
+| Phase | Allowed output | Still forbidden |
+| --- | --- | --- |
+| Scaffold | Contract JSON/Markdown and local validator tests | Live model claims, provider billing/cost claims, runtime default changes |
+| Fixture replay | Deterministic local fixture acceptance deltas | Public outcome wins, provider billing/cost claims |
+| Live smoke | Internal Codex/Claude smoke artifacts | Public win claims unless later repeated evidence gates pass |
+| Provider proof | Imported/provider-backed evidence under explicit billing lanes | Any unqualified runtime-token or cost claim |
+
+## Merge-fence guidance
+
+Safe parallel files for this lane:
+
+- `docs/deterministic-outcome-benchmark.md`
+- `benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js`
+- `test/deterministic-outcome-scaffold.test.mjs`
+
+Avoid while release-safe runtime opt-in work is active:
+
+- `README.md`
+- `docs/release.md`
+- `docs/benchmark-evidence.md`
+- `docs/edit-guidance-evidence.md`
+- `src/core/payload/model-facing.ts`
+- `src/adapters/codex-runtime-hook.ts`
+- `src/adapters/claude-runtime-hook.ts`
+- `test/fooks.test.mjs`
+- `test/frontend-v2-runner.test.mjs`
+- `test/provider-cost-evidence.test.mjs`
+- existing provider-cost and billing-import scripts
+
+## Claim boundary
+
+This lane can only say that a deterministic outcome benchmark contract/scaffold exists. It cannot say that fooks improves live Codex/Claude outcomes, reduces provider billing tokens, reduces provider costs, or provides stable runtime-token/time savings.

--- a/test/deterministic-outcome-scaffold.test.mjs
+++ b/test/deterministic-outcome-scaffold.test.mjs
@@ -1,0 +1,103 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const scaffoldPath = path.join(repoRoot, 'benchmarks', 'layer2-frontend-task', 'deterministic-outcome-scaffold.js');
+const {
+  buildDeterministicOutcomeScaffold,
+  validateDeterministicOutcomeScaffold,
+  markdownForScaffold,
+} = require(scaffoldPath);
+
+test('deterministic outcome scaffold stays design-only and claim-bounded', () => {
+  const scaffold = buildDeterministicOutcomeScaffold({
+    runId: 'deterministic-outcome-test',
+    tasks: ['R4-feature-module-split'],
+    validators: ['validate-r4-applied'],
+    minimumAcceptedPairs: 5,
+    generatedAt: '2026-04-23T00:00:00.000Z',
+  });
+
+  assert.equal(scaffold.status, 'design-scaffold-only');
+  assert.equal(scaffold.plannedInputs.liveModelExecution, false);
+  assert.equal(scaffold.plannedInputs.providerBillingImport, false);
+  assert.equal(scaffold.plannedInputs.lspRequired, false);
+  assert.equal(scaffold.claimability.liveCodexOutcome, false);
+  assert.equal(scaffold.claimability.liveClaudeOutcome, false);
+  assert.equal(scaffold.claimability.providerTokenizerParity, false);
+  assert.equal(scaffold.claimability.providerBillingTokenSavings, false);
+  assert.equal(scaffold.claimability.providerInvoiceOrCostSavings, false);
+  assert.ok(scaffold.scope.nonGoals.includes('runtime-default-change'));
+  assert.ok(scaffold.scope.nonGoals.includes('edit-guidance-default-change'));
+  assert.ok(scaffold.deterministicControls.includes('source-fingerprint-recorded'));
+
+  const validation = validateDeterministicOutcomeScaffold(scaffold);
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.blockers, []);
+
+  const combined = JSON.stringify(scaffold).toLowerCase();
+  assert.match(combined, /design contract only/);
+  assert.match(combined, /provider billing-token/);
+  assert.match(combined, /automatic runtime defaults/);
+  assert.doesNotMatch(combined, /provider billing-token savings are proven/);
+  assert.doesNotMatch(combined, /live codex outcome win/);
+});
+
+test('deterministic outcome scaffold validation rejects premature claimability', () => {
+  const scaffold = buildDeterministicOutcomeScaffold({ runId: 'invalid-claimability' });
+  scaffold.claimability.providerBillingTokenSavings = true;
+  scaffold.scope.nonGoals = scaffold.scope.nonGoals.filter((item) => item !== 'provider-billing-token-claim');
+
+  const validation = validateDeterministicOutcomeScaffold(scaffold);
+  assert.equal(validation.valid, false);
+  assert.ok(validation.blockers.includes('claimability-providerBillingTokenSavings-must-be-false'));
+  assert.ok(validation.blockers.includes('missing-non-goal:provider-billing-token-claim'));
+});
+
+test('deterministic outcome scaffold CLI writes JSON and Markdown without live execution', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fooks-deterministic-outcome-'));
+  const output = path.join(tempDir, 'scaffold.json');
+  const markdown = path.join(tempDir, 'scaffold.md');
+
+  execFileSync(process.execPath, [
+    scaffoldPath,
+    `--output=${output}`,
+    `--markdown=${markdown}`,
+    '--run-id=cli-scaffold',
+    '--tasks=R4-feature-module-split',
+    '--validators=validate-r4-applied',
+    '--minimum-accepted-pairs=5',
+  ], { cwd: repoRoot, encoding: 'utf8' });
+
+  const result = JSON.parse(fs.readFileSync(output, 'utf8'));
+  assert.equal(result.validation.valid, true);
+  assert.equal(result.plannedInputs.liveModelExecution, false);
+  assert.equal(result.plannedInputs.providerBillingImport, false);
+  assert.equal(result.plannedInputs.minimumAcceptedPairs, 5);
+  assert.deepEqual(result.plannedInputs.tasks, ['R4-feature-module-split']);
+
+  const md = fs.readFileSync(markdown, 'utf8');
+  assert.match(md, /Design.*Scaffold/i);
+  assert.match(md, /does not run live models|design contract only/i);
+  assert.match(md, /provider billing-token/i);
+  assert.doesNotMatch(md, /provider billing-token savings are proven/i);
+});
+
+test('deterministic outcome scaffold markdown reports validation blockers', () => {
+  const scaffold = buildDeterministicOutcomeScaffold({ runId: 'markdown-invalid' });
+  scaffold.deterministicControls = scaffold.deterministicControls.filter((item) => item !== 'source-fingerprint-recorded');
+
+  const validation = validateDeterministicOutcomeScaffold(scaffold);
+  const markdown = markdownForScaffold(scaffold, validation);
+  assert.equal(validation.valid, false);
+  assert.match(markdown, /missing-control:source-fingerprint-recorded/);
+});


### PR DESCRIPTION
## Summary
- Add a design/scaffold-only deterministic outcome benchmark plan that is safe to run in parallel with priority 1-2 runtime guardrail work.
- Add an isolated scaffold/validator script for the deterministic outcome contract without touching runtime defaults, provider-cost logic, or shared public claim docs.
- Add focused tests proving the scaffold keeps live model, provider tokenizer/billing/cost, runtime-token, latency, LSP, and edit-guidance-default claims blocked.

## Claim boundaries
- Does not change automatic runtime defaults.
- Does not change `editGuidance.patchTargets` default behavior; patch targets remain opt-in.
- Does not run live Codex/Claude model outcome smoke.
- Does not add provider tokenizer, provider billing-token, provider invoice, or provider cost proof.
- Does not add LSP dependencies or implementation.

## Verification
- `node --test test/deterministic-outcome-scaffold.test.mjs`
- `npm test`
