### PR TITLE
Preserve compact runtime defaults while opening edit-guidance opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Frontend context compression for Codex and Claude Code.
 Public npm package: `oh-my-fooks`
 CLI command: `fooks`
 
-`fooks` helps Codex and Claude Code reduce frontend code context for React component work. In an attached Codex project or a Claude project-local context-hook flow, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time, lowering estimated input-token load. Provider billing-token savings, billed-cost savings, and stable runtime-token/time wins remain separate validation tracks and are not claimed by default.
+`fooks` helps Codex and Claude Code reduce frontend code context for React component work. In an attached Codex project or a Claude project-local context-hook flow, repeated work on the same `.tsx` / `.jsx` file can reuse a smaller model-facing payload instead of pushing the full file context every time, lowering estimated input-token load. Provider-side billing telemetry, billed-cost evidence, and stable runtime-token/time win evidence remain separate validation tracks and are not claimed by default.
 
 ## Quick start
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,6 +62,8 @@ Bare `fooks status` reports local estimated context-size telemetry from `.fooks/
 
 `fooks extract <file> --model-payload` may expose `editGuidance.patchTargets` when source ranges are available. Public wording may describe those patch targets as compact, AST-derived line-aware edit anchors for components, props, effects, callbacks, event handlers, form controls, submit handlers, validation anchors, and representative snippets. Public wording must also state the freshness rule: use the targets only while `sourceFingerprint.fileHash` and `sourceFingerprint.lineCount` match the current source, otherwise rerun extraction or read the file before editing. Do not describe this guidance as LSP-backed semantic rename/reference resolution, provider tokenizer behavior, provider billing-token proof, provider-cost proof, or a `ccusage` replacement.
 
+Automatic runtime pre-read payloads stay compact by default: Codex repeated-file injection may include `sourceFingerprint` when available, but it must not include `editGuidance` unless a future explicit opt-in path proves exact-file frontend edit intent, positive freshness, fingerprint equality, and payload-budget safety with tests. Until that gated runtime opt-in exists, public wording must not claim automatic Codex runtime editing is improved by default.
+
 Codex setup/attach/status readiness is also local state only. It may show that
 Codex hooks, manifests, and trust metadata were prepared, but it is not live
 Codex runtime telemetry and must not be described as proof of runtime-token

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -1,17 +1,24 @@
 import path from "node:path";
 import { extractFile } from "../core/extract";
-import { toModelFacingPayload } from "../core/payload/model-facing";
+import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/payload/model-facing";
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import type { PreReadDecision } from "../core/schema";
 
 const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+
+export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance">;
 
 function relativePath(filePath: string, cwd: string): string {
   const relative = path.relative(cwd, filePath);
   return relative || path.basename(filePath);
 }
 
-export function decidePreRead(filePath: string, cwd = process.cwd(), runtime: PreReadDecision["runtime"] = "codex"): PreReadDecision {
+export function decidePreRead(
+  filePath: string,
+  cwd = process.cwd(),
+  runtime: PreReadDecision["runtime"] = "codex",
+  options: PreReadOptions = {},
+): PreReadDecision {
   const resolvedPath = path.resolve(filePath);
   const outputPath = relativePath(resolvedPath, cwd);
   const extension = path.extname(resolvedPath);
@@ -32,7 +39,9 @@ export function decidePreRead(filePath: string, cwd = process.cwd(), runtime: Pr
   }
 
   const result = extractFile(resolvedPath);
-  const payload = toModelFacingPayload(result, cwd);
+  const payload = toModelFacingPayload(result, cwd, {
+    includeEditGuidance: options.includeEditGuidance === true,
+  });
   const readiness = assessPayloadReadiness(result, payload);
   const debug = {
     mode: result.mode,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -323,6 +323,13 @@ test("extract can return model-facing payload without engine metadata", () => {
 test("extract adds source ranges and hook intent signals to frontend payloads", () => {
   const samplePath = path.join(repoRoot, "fixtures", "compressed", "HookEffectPanel.tsx");
   const result = extractFile(samplePath);
+  const defaultPayload = toModelFacingPayload(result, repoRoot);
+  assert.deepEqual(defaultPayload.sourceFingerprint, {
+    fileHash: result.fileHash,
+    lineCount: result.meta.lineCount,
+  });
+  assert.equal("editGuidance" in defaultPayload, false);
+
   const payload = toModelFacingPayload(result, repoRoot, { includeEditGuidance: true });
 
   assert.deepEqual(payload.componentLoc, {
@@ -536,11 +543,22 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.equal(compressed.decision, "payload");
   assert.equal(compressed.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
   assert.ok(compressed.payload);
+  assert.ok(compressed.payload.sourceFingerprint);
+  assert.equal("editGuidance" in compressed.payload, false);
   assert.ok(["low", "medium", "high"].includes(compressed.debug.decideConfidence));
+
+  const compressedOptIn = preReadModule.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
+    includeEditGuidance: true,
+  });
+  assert.equal(compressedOptIn.decision, "payload");
+  assert.ok(compressedOptIn.payload.editGuidance);
+  assert.deepEqual(compressedOptIn.payload.editGuidance.freshness, compressedOptIn.payload.sourceFingerprint);
+  assert.ok(compressedOptIn.payload.editGuidance.patchTargets.length <= 12);
 
   const hybrid = decideCodexPreRead(path.join(repoRoot, "fixtures", "hybrid", "DashboardPanel.tsx"), repoRoot);
   assert.equal(hybrid.decision, "payload");
   assert.ok(hybrid.payload.snippets?.length);
+  assert.equal("editGuidance" in hybrid.payload, false);
   assert.ok(["medium", "high"].includes(hybrid.debug.decideConfidence));
 
   const jsx = decideCodexPreRead(path.join(repoRoot, "fixtures", "jsx", "SimpleWidget.jsx"), repoRoot);
@@ -548,6 +566,7 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.equal(jsx.decision, "payload");
   assert.equal(jsx.filePath, path.join("fixtures", "jsx", "SimpleWidget.jsx"));
   assert.ok(jsx.payload.contract);
+  assert.equal("editGuidance" in jsx.payload, false);
 
   const raw = decideCodexPreRead(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), repoRoot);
   assert.equal(raw.eligible, true);
@@ -559,6 +578,7 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   const linkedTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-linked", "Button.types.ts"), repoRoot);
   assert.equal(linkedTs.eligible, false);
   assert.equal(linkedTs.decision, "fallback");
+  assert.equal("payload" in linkedTs, false);
   assert.ok(linkedTs.reasons.includes("ineligible-extension"));
   assert.equal(linkedTs.filePath, path.join("fixtures", "ts-linked", "Button.types.ts"));
 });
@@ -858,7 +878,9 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   );
   assert.equal(second.additionalContext.includes("#fooks-full-read"), false);
   assert.equal(second.additionalContext.includes("#fooks-disable-pre-read"), false);
+  assert.equal(second.additionalContext.includes("\"editGuidance\""), false);
   assert.equal(second.debug.repeatedFile, true);
+  assert.equal("editGuidance" in second.debug.decision.payload, false);
 
   fs.writeFileSync(second.statePath, "{not-json");
   const afterCorruptState = handleCodexRuntimeHook(

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -62,6 +62,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(firstInject.action, "record");
   assert.equal(secondInject.action, "inject");
   assert.match(secondInject.additionalContext, /^fooks: reused pre-read \(compressed\)/);
+  assert.equal(secondInject.additionalContext.includes("\"editGuidance\""), false);
+  assert.equal("editGuidance" in secondInject.debug.decision.payload, false);
 
   const smallRawSession = `bridge-contract-small-raw-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: smallRawSession }, repoRoot);


### PR DESCRIPTION
## Summary

- add a narrow `decidePreRead(..., options?)` seam for explicit `includeEditGuidance` opt-in
- lock default model-facing/pre-read/Codex runtime behavior so automatic paths continue omitting `editGuidance`
- document release claim boundaries for runtime edit guidance and provider-side billing/cost evidence
- update the 3rd-priority provider proof lane in #108 instead of bundling provider proof here

## Scope boundary

This PR intentionally does **not** wire runtime hooks to auto-include `editGuidance`. Runtime opt-in remains blocked until exact-file frontend edit intent, positive freshness, fingerprint equality, and payload-budget safety are implemented with positive/negative tests.

This PR also does **not** implement provider tokenizer proof, provider billing-token proof, provider-cost proof, LSP semantics, or live Codex/Claude outcome claims.

## Verification

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `node --test test/fooks.test.mjs test/runtime-bridge-contract.test.mjs`
- [x] `npm test`
- [x] `npm run release:smoke`
- [x] Architect verification: APPROVE

## Related

- Updates/deferred 3rd-priority lane: #108
