### PR TITLE
feat: Claude Runtime Status Module + Preset Status Parity

### DIFF
--- a/src/adapters/claude-hook-preset.ts
+++ b/src/adapters/claude-hook-preset.ts
@@ -23,6 +23,18 @@ type ClaudeSettingsFile = {
   [key: string]: unknown;
 };
 
+export type ClaudeHookPresetStatus = {
+  settingsPath: string;
+  exists: boolean;
+  valid?: boolean;
+  installedEvents: ClaudeHookEvent[];
+  missingEvents: ClaudeHookEvent[];
+  unexpectedFooksEvents: string[];
+  commandMatches?: boolean;
+  disabledByLocalSettings?: boolean;
+  blocker?: string;
+};
+
 export type ClaudeHookPresetInstallResult = {
   settingsPath: string;
   backupPath?: string;
@@ -71,6 +83,73 @@ function readSettingsFile(filePath: string): ClaudeSettingsFile {
   if (!fs.existsSync(filePath)) return {};
   const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as ClaudeSettingsFile;
   return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+function hookCommandsForEvent(settings: ClaudeSettingsFile, event: string): string[] {
+  const matchers = settings.hooks?.[event] ?? [];
+  if (!Array.isArray(matchers)) return [];
+  return matchers.flatMap((matcher) => {
+    if (!Array.isArray(matcher?.hooks)) return [];
+    return (matcher.hooks as HookCommand[])
+      .filter((hook) => hook?.type === "command" && typeof hook.command === "string")
+      .map((hook) => hook.command as string);
+  });
+}
+
+export function readClaudeHookPresetStatus(cwd = process.cwd(), cliName = "fooks"): ClaudeHookPresetStatus {
+  const filePath = claudeLocalSettingsPath(cwd);
+  if (!fs.existsSync(filePath)) {
+    return {
+      settingsPath: filePath,
+      exists: false,
+      installedEvents: [],
+      missingEvents: [...CLAUDE_HOOK_EVENTS],
+      unexpectedFooksEvents: [],
+      commandMatches: false,
+    };
+  }
+
+  let settings: ClaudeSettingsFile;
+  try {
+    settings = readSettingsFile(filePath);
+  } catch (error) {
+    return {
+      settingsPath: filePath,
+      exists: true,
+      valid: false,
+      installedEvents: [],
+      missingEvents: [...CLAUDE_HOOK_EVENTS],
+      unexpectedFooksEvents: [],
+      commandMatches: false,
+      blocker: `Claude local settings are not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const command = defaultClaudeHookCommand(cliName);
+  const installedEvents = CLAUDE_HOOK_EVENTS.filter((event) => hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, cliName)));
+  const missingEvents = CLAUDE_HOOK_EVENTS.filter((event) => !installedEvents.includes(event));
+  const unexpectedFooksEvents = Object.keys(settings.hooks ?? {}).filter(
+    (event) => !CLAUDE_HOOK_EVENTS.includes(event as ClaudeHookEvent) && hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, cliName)),
+  );
+  const disabledByLocalSettings = settings.disableAllHooks === true;
+  const commandMatches = installedEvents.every((event) => hookCommandsForEvent(settings, event).some((item) => item === command));
+  const blocker = disabledByLocalSettings
+    ? "Claude hooks are disabled by local settings"
+    : unexpectedFooksEvents.length > 0
+      ? `Unsupported fooks Claude hook events are installed: ${unexpectedFooksEvents.join(", ")}`
+      : undefined;
+
+  return {
+    settingsPath: filePath,
+    exists: true,
+    valid: true,
+    installedEvents,
+    missingEvents,
+    unexpectedFooksEvents,
+    commandMatches,
+    disabledByLocalSettings,
+    blocker,
+  };
 }
 
 function ensureEventHook(settingsFile: ClaudeSettingsFile, event: ClaudeHookEvent, command: string): boolean {

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -4,6 +4,12 @@ import { decidePreRead } from "./pre-read";
 import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { clearClaudeActiveFile, ensureFreshClaudeContextForTarget, markClaudeAttachPrepared } from "./claude-runtime-trust";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
+import {
+  clampAdditionalContext,
+  boundedFallbackContext,
+  sessionStartContext,
+  CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS,
+} from "./claude-runtime-status";
 import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
 import {
   estimateFileBytes,
@@ -13,9 +19,7 @@ import {
   recordFooksSessionMetricEventSafe,
 } from "../core/session-metrics";
 
-export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
-const CLAUDE_CONTEXT_TRUNCATION_SUFFIX =
-  "\n\n[fooks: context truncated to stay within Claude hook additionalContext cap. Read the full source file if exact code is required.]";
+export { CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS };
 
 export type ClaudeRuntimeHookEvent = "SessionStart" | "UserPromptSubmit" | "Stop";
 
@@ -50,18 +54,6 @@ export type ClaudeRuntimeHookDecision = {
     reason: string;
   };
 };
-
-function clampAdditionalContext(value: string): string {
-  if (value.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS) return value;
-  return `${value.slice(0, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - CLAUDE_CONTEXT_TRUNCATION_SUFFIX.length).trimEnd()}${CLAUDE_CONTEXT_TRUNCATION_SUFFIX}`;
-}
-
-function boundedFallbackContext(filePath: string | undefined, reason: string): string {
-  const target = filePath ?? "requested frontend file";
-  return clampAdditionalContext(
-    `fooks: Claude context hook fallback · file: ${target} · reason: ${reason} · Read the full source file for this turn. No Claude Read interception or runtime-token savings is claimed.`,
-  );
-}
 
 function payloadContextMode(payload: NonNullable<ReturnType<typeof decidePreRead>["payload"]>): ContextMode {
   return payload.useOriginal ? "light-minimal" : "light";
@@ -128,12 +120,6 @@ function recordClaudeMetric(
     comparableForSavings: options.comparableForSavings,
     observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
   });
-}
-
-function sessionStartContext(): string {
-  return clampAdditionalContext(
-    "fooks: active · no Read interception · first prompt triggers context.",
-  );
 }
 
 function noopDecision(input: ClaudeRuntimeHookInput, reasons: string[], policy?: ReturnType<typeof resolvePromptFileContext>["policy"]): ClaudeRuntimeHookDecision {

--- a/src/adapters/claude-runtime-status.ts
+++ b/src/adapters/claude-runtime-status.ts
@@ -1,0 +1,21 @@
+export const CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS = 9000;
+const CLAUDE_CONTEXT_TRUNCATION_SUFFIX =
+  "\n\n[fooks: context truncated to stay within Claude hook additionalContext cap. Read the full source file if exact code is required.]";
+
+export function clampAdditionalContext(value: string): string {
+  if (value.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS) return value;
+  return `${value.slice(0, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS - CLAUDE_CONTEXT_TRUNCATION_SUFFIX.length).trimEnd()}${CLAUDE_CONTEXT_TRUNCATION_SUFFIX}`;
+}
+
+export function sessionStartContext(): string {
+  return clampAdditionalContext(
+    "fooks: active · no Read interception · first prompt triggers context.",
+  );
+}
+
+export function boundedFallbackContext(filePath: string | undefined, reason: string): string {
+  const target = filePath ?? "requested frontend file";
+  return clampAdditionalContext(
+    `fooks: Claude context hook fallback · file: ${target} · reason: ${reason} · Read the full source file for this turn. No Claude Read interception or runtime-token savings is claimed.`,
+  );
+}

--- a/src/adapters/claude-status.ts
+++ b/src/adapters/claude-status.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { adapterDir } from "../core/paths";
-import { claudeLocalSettingsPath, CLAUDE_HOOK_EVENTS, defaultClaudeHookCommand, isCompatibleClaudeHookCommand, type ClaudeHookEvent } from "./claude-hook-preset";
+import { readClaudeHookPresetStatus, type ClaudeHookEvent } from "./claude-hook-preset";
 import { runtimeManifestPath } from "./shared";
 
 type ClaudeStatusState = "context-hook-ready" | "handoff-ready" | "blocked";
@@ -23,20 +23,6 @@ type ClaudeManifestStatus = {
   runtimeMatches?: boolean;
   projectRootMatches?: boolean;
   blocker?: string;
-};
-
-type HookCommand = {
-  type?: unknown;
-  command?: unknown;
-};
-
-type HookMatcher = {
-  hooks?: unknown;
-};
-
-type ClaudeSettingsFile = {
-  hooks?: Record<string, HookMatcher[]>;
-  disableAllHooks?: unknown;
 };
 
 export type ClaudeHookStatus = {
@@ -152,73 +138,21 @@ function manifestStatus(cwd: string): ClaudeManifestStatus {
   }
 }
 
-function hookCommandsForEvent(settings: ClaudeSettingsFile, event: string): string[] {
-  const matchers = settings.hooks?.[event] ?? [];
-  if (!Array.isArray(matchers)) return [];
-  return matchers.flatMap((matcher) => {
-    if (!Array.isArray(matcher?.hooks)) return [];
-    return (matcher.hooks as HookCommand[])
-      .filter((hook) => hook?.type === "command" && typeof hook.command === "string")
-      .map((hook) => hook.command as string);
-  });
-}
-
 function hookStatus(cwd: string): ClaudeHookStatus {
-  const filePath = claudeLocalSettingsPath(cwd);
-  if (!fs.existsSync(filePath)) {
-    return {
-      path: filePath,
-      exists: false,
-      ready: false,
-      installedEvents: [],
-      missingEvents: [...CLAUDE_HOOK_EVENTS],
-      unexpectedFooksEvents: [],
-      commandMatches: false,
-    };
-  }
-
-  let settings: ClaudeSettingsFile;
-  try {
-    settings = readJson(filePath) as ClaudeSettingsFile;
-  } catch (error) {
-    return {
-      path: filePath,
-      exists: true,
-      ready: false,
-      valid: false,
-      installedEvents: [],
-      missingEvents: [...CLAUDE_HOOK_EVENTS],
-      unexpectedFooksEvents: [],
-      commandMatches: false,
-      blocker: `Claude local settings are not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
-
-  const command = defaultClaudeHookCommand("fooks");
-  const installedEvents = CLAUDE_HOOK_EVENTS.filter((event) => hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, "fooks"))) as ClaudeHookEvent[];
-  const missingEvents = CLAUDE_HOOK_EVENTS.filter((event) => !installedEvents.includes(event)) as ClaudeHookEvent[];
-  const unexpectedFooksEvents = Object.keys(settings.hooks ?? {}).filter(
-    (event) => !CLAUDE_HOOK_EVENTS.includes(event as ClaudeHookEvent) && hookCommandsForEvent(settings, event).some((item) => isCompatibleClaudeHookCommand(item, "fooks")),
-  );
-  const disabledByLocalSettings = settings.disableAllHooks === true;
-  const commandMatches = installedEvents.every((event) => hookCommandsForEvent(settings, event).some((item) => item === command));
-  const blocker = disabledByLocalSettings
-    ? "Claude hooks are disabled by local settings"
-    : unexpectedFooksEvents.length > 0
-      ? `Unsupported fooks Claude hook events are installed: ${unexpectedFooksEvents.join(", ")}`
-      : undefined;
+  const preset = readClaudeHookPresetStatus(cwd);
+  const ready = preset.missingEvents.length === 0 && preset.unexpectedFooksEvents.length === 0 && !preset.disabledByLocalSettings;
 
   return {
-    path: filePath,
-    exists: true,
-    ready: missingEvents.length === 0 && unexpectedFooksEvents.length === 0 && !disabledByLocalSettings,
-    valid: true,
-    installedEvents,
-    missingEvents,
-    unexpectedFooksEvents,
-    commandMatches,
-    disabledByLocalSettings,
-    blocker,
+    path: preset.settingsPath,
+    exists: preset.exists,
+    ready,
+    valid: preset.valid,
+    installedEvents: preset.installedEvents,
+    missingEvents: preset.missingEvents,
+    unexpectedFooksEvents: preset.unexpectedFooksEvents,
+    commandMatches: preset.commandMatches,
+    disabledByLocalSettings: preset.disabledByLocalSettings,
+    blocker: preset.blocker,
   };
 }
 


### PR DESCRIPTION
## Summary
Extract true status-string builders into `claude-runtime-status.ts` and add `readClaudeHookPresetStatus()` to achieve structural parity with the Codex adapter.

## Changes
- **Create `src/adapters/claude-runtime-status.ts`**
  - `CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS` constant (moved from hook file)
  - `clampAdditionalContext()` — 9000-char cap utility
  - `sessionStartContext()` — SessionStart context string
  - `boundedFallbackContext()` — fallback guidance string

- **Refactor `src/adapters/claude-runtime-hook.ts`**
  - Imports status utilities from `./claude-runtime-status`
  - Re-exports `CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS` for backward-compatible test imports
  - Keeps `buildPayloadContext()` in place (payload assembly stays in hook file)

- **Add `readClaudeHookPresetStatus()` to `src/adapters/claude-hook-preset.ts`**
  - Returns `ClaudeHookPresetStatus` with `installedEvents`, `missingEvents`, `unexpectedFooksEvents`, `disabledByLocalSettings`
  - Wraps file reading in try/catch; returns `valid: false` + `blocker` on parse failure
  - Migrates `hookCommandsForEvent` helper into preset module

- **Refactor `src/adapters/claude-status.ts`**
  - `hookStatus()` delegates core preset validation to `readClaudeHookPresetStatus()`
  - Keeps manifest/adapter JSON checks as enrichment layer
  - Removes ~60 lines of duplicated preset-reading logic, types, and helpers

## Principles
1. Honest module boundaries — `*-runtime-status.ts` mirrors Codex: simple string builders only
2. Zero behavior change — pure refactoring, no functional differences
3. Preserve public APIs — `ClaudeRuntimeHookDecision` and exports remain stable
4. Deduplicate, don't duplicate — `readClaudeHookPresetStatus()` becomes source of truth

## Verification
- `npm run build` passes with zero TypeScript errors
- `npm test` passes (209 tests, 0 failures)
- Architect reviewer verified module boundaries and backward compatibility

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Spot-check: SessionStart, escape-hatch, first-seen, repeated-file, fallback context strings are byte-identical before/after refactor