### PR TITLE
Implement deterministic edit-guidance fixture replay

### DIFF
--- a/benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js
+++ b/benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js
@@ -2,12 +2,12 @@
 'use strict';
 
 /**
- * Design/scaffold-only contract for future deterministic outcome benchmarks.
+ * Design/scaffold-only and fixture-replay contracts for deterministic outcome
+ * benchmark lanes.
  *
  * This file deliberately does not run Codex/Claude, does not price provider
  * usage, does not tokenize provider payloads, and does not change runtime
- * defaults. It only emits/validates the benchmark contract that later lanes can
- * build on after release-safe runtime guardrails land.
+ * defaults. Fixture replay is local/offline target-localization evidence only.
  */
 
 const fs = require('fs');
@@ -15,6 +15,23 @@ const path = require('path');
 
 const SCHEMA_VERSION = 'layer2-deterministic-outcome-scaffold.v1';
 const STATUS = 'design-scaffold-only';
+const FIXTURE_REPLAY_SCHEMA_VERSION = 'layer2-deterministic-outcome-fixture-replay.v1';
+const FIXTURE_REPLAY_STATUS = 'fixture-replay-only';
+const DEFAULT_FIXTURE_TARGET = 'fixtures/compressed/HookEffectPanel.tsx';
+const DEFAULT_TASK_IDENTITY = 'edit-guidance-target-localization';
+const DEFAULT_FIXTURE_REVISION = 'repo-fixture-current';
+const SOURCE_IDENTITY_REF = 'sourceIdentity';
+const COMPARISON_INVARIANT =
+  'with-guidance and without-guidance variants must use this same target file and component';
+const FIXTURE_REPLAY_CLAIM_BOUNDARY = [
+  'local deterministic target-localization evidence only',
+  'not live Codex/Claude model outcome proof',
+  'not provider tokenizer proof',
+  'not provider billing/cost proof',
+  'not LSP semantic safety',
+  'not runtime-token/latency proof',
+  'not a public edit-win claim',
+].join('; ');
 
 const CLAIM_BOUNDARY = [
   'This scaffold is a design contract only, not live Codex or Claude outcome evidence.',
@@ -44,10 +61,65 @@ const FORBIDDEN_UNTIL_NEXT_PHASE = [
   'lsp-dependency',
 ];
 
+const REQUIRED_FIXTURE_REPLAY_CLAIMABILITY = {
+  liveCodexOutcome: false,
+  liveClaudeOutcome: false,
+  providerTokenizerParity: false,
+  providerBillingTokenSavings: false,
+  providerInvoiceOrCostSavings: false,
+  stableRuntimeTokenSavings: false,
+  stableLatencySavings: false,
+  lspSemanticSafety: false,
+  publicEditWin: false,
+};
+
+const WITHOUT_GUIDANCE_LOCALIZATION_STEPS = [
+  'read-model-payload',
+  'fallback-search-or-read',
+];
+
+const WITH_GUIDANCE_LOCALIZATION_STEPS = [
+  'read-model-payload',
+  'verify-sourceFingerprint',
+  'select-patchTarget',
+];
+
 function normalizeList(value) {
   if (!value) return [];
   if (Array.isArray(value)) return value.map(String).filter(Boolean);
   return String(value).split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function sameFingerprint(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.fileHash === right.fileHash &&
+      left.lineCount === right.lineCount,
+  );
+}
+
+function targetKey(target) {
+  if (!target || !target.loc) return '';
+  return [
+    target.kind,
+    target.label,
+    target.loc.startLine,
+    target.loc.endLine,
+    target.reason,
+  ].map((item) => String(item ?? '')).join('\u0000');
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object || {}, key);
+}
+
+function buildClaimability() {
+  return { ...REQUIRED_FIXTURE_REPLAY_CLAIMABILITY };
 }
 
 function buildDeterministicOutcomeScaffold(options = {}) {
@@ -176,6 +248,353 @@ function markdownForScaffold(scaffold, validation = validateDeterministicOutcome
   ].join('\n');
 }
 
+function resolveRepoRoot() {
+  return path.resolve(__dirname, '..', '..');
+}
+
+function loadFooksExtractors(repoRoot = resolveRepoRoot()) {
+  const extractModule = require(path.join(repoRoot, 'dist', 'core', 'extract.js'));
+  const payloadModule = require(path.join(repoRoot, 'dist', 'core', 'payload', 'model-facing.js'));
+  return {
+    extractFile: extractModule.extractFile,
+    toModelFacingPayload: payloadModule.toModelFacingPayload,
+  };
+}
+
+function normalizeFixtureTarget(targetFile, repoRoot) {
+  const resolved = path.resolve(repoRoot, targetFile || DEFAULT_FIXTURE_TARGET);
+  return {
+    absoluteTarget: resolved,
+    relativeTarget: path.relative(repoRoot, resolved).split(path.sep).join('/'),
+  };
+}
+
+function selectPatchTarget(patchTargets = [], options = {}) {
+  const targets = Array.isArray(patchTargets) ? patchTargets : [];
+  if (options.targetKind || options.targetLabel) {
+    const matched = targets.find((target) => {
+      const kindMatches = options.targetKind ? target.kind === options.targetKind : true;
+      const labelMatches = options.targetLabel ? target.label === options.targetLabel : true;
+      return kindMatches && labelMatches;
+    });
+    if (matched) return matched;
+  }
+  return targets[0];
+}
+
+function countFallbackSteps(variant) {
+  const steps = Array.isArray(variant?.targetLocalizationSteps) ? variant.targetLocalizationSteps : [];
+  let count = steps.filter((step) => /fallback|search|full-read|read-full/i.test(String(step))).length;
+  if (variant?.fallbackFullReadOrSearchRequired === true) count += 1;
+  return count;
+}
+
+function classifyFixtureReplayArtifact(artifact) {
+  const blockers = validateDeterministicFixtureReplay(artifact).blockers;
+  const identityBlockers = blockers.filter((item) =>
+    /source-identity|paired-target|missing-sourceIdentity|missing-pairedTarget/i.test(item),
+  );
+  if (identityBlockers.length > 0) {
+    return {
+      classification: 'inconclusive',
+      classificationReasons: identityBlockers,
+    };
+  }
+
+  const withGuidance = artifact?.variants?.withEditGuidance;
+  const withoutGuidance = artifact?.variants?.withoutEditGuidance;
+  if (!withGuidance?.selectedPatchTarget || !withGuidance.selectedPatchTarget.loc) {
+    return {
+      classification: 'inconclusive',
+      classificationReasons: ['missing-selected-patch-target'],
+    };
+  }
+
+  const withFallbackCount = countFallbackSteps(withGuidance);
+  const withoutFallbackCount = countFallbackSteps(withoutGuidance);
+  if (withFallbackCount < withoutFallbackCount) {
+    return {
+      classification: 'pass',
+      classificationReasons: ['with-guidance-reduces-fallback-target-localization'],
+    };
+  }
+
+  return {
+    classification: 'fail',
+    classificationReasons: ['with-guidance-does-not-reduce-fallback-target-localization'],
+  };
+}
+
+function buildDeterministicFixtureReplay(options = {}) {
+  const repoRoot = path.resolve(options.repoRoot || process.cwd());
+  const { absoluteTarget, relativeTarget } = normalizeFixtureTarget(options.targetFile, repoRoot);
+  const extractFile = options.extractFile;
+  const toModelFacingPayload = options.toModelFacingPayload;
+  if (typeof extractFile !== 'function' || typeof toModelFacingPayload !== 'function') {
+    throw new Error('buildDeterministicFixtureReplay requires extractFile and toModelFacingPayload dependencies');
+  }
+
+  const extraction = extractFile(absoluteTarget);
+  const withoutPayload = toModelFacingPayload(extraction, repoRoot);
+  const withPayload = toModelFacingPayload(extraction, repoRoot, { includeEditGuidance: true });
+  const patchTargets = clone(withPayload.editGuidance?.patchTargets || []);
+  const selectedPatchTarget = clone(selectPatchTarget(patchTargets, options));
+  const sourceFingerprint = clone(withPayload.sourceFingerprint || withoutPayload.sourceFingerprint);
+  const sourceIdentity = {
+    sourceFingerprint,
+    defaultPayloadFingerprint: clone(withoutPayload.sourceFingerprint),
+    withGuidancePayloadFingerprint: clone(withPayload.sourceFingerprint),
+    editGuidanceFreshness: clone(withPayload.editGuidance?.freshness),
+    freshnessSource: 'extractFile + toModelFacingPayload(..., { includeEditGuidance: true })',
+  };
+
+  const artifact = {
+    schemaVersion: FIXTURE_REPLAY_SCHEMA_VERSION,
+    status: FIXTURE_REPLAY_STATUS,
+    runId: options.runId || `deterministic-fixture-replay-${new Date().toISOString().replace(/[:.]/g, '-')}`,
+    generatedAt: options.generatedAt || new Date().toISOString(),
+    taskIdentity: options.taskIdentity || DEFAULT_TASK_IDENTITY,
+    fixtureRevision: options.fixtureRevision || DEFAULT_FIXTURE_REVISION,
+    pairedTarget: {
+      filePath: relativeTarget,
+      componentName: withPayload.componentName || withoutPayload.componentName || extraction.componentName || 'UnknownComponent',
+    },
+    comparisonInvariant: COMPARISON_INVARIANT,
+    comparisonInputs: {
+      withoutEditGuidance: {
+        filePath: withoutPayload.filePath,
+        componentName: withoutPayload.componentName,
+      },
+      withEditGuidance: {
+        filePath: withPayload.filePath,
+        componentName: withPayload.componentName,
+      },
+    },
+    sourceIdentity,
+    claimBoundary: FIXTURE_REPLAY_CLAIM_BOUNDARY,
+    claimability: buildClaimability(),
+    variants: {
+      withoutEditGuidance: {
+        editGuidanceEnabled: false,
+        sourceIdentityRef: SOURCE_IDENTITY_REF,
+        targetLocalizationSteps: [...WITHOUT_GUIDANCE_LOCALIZATION_STEPS],
+        fallbackFullReadOrSearchRequired: true,
+        diagnosticReasons: [],
+      },
+      withEditGuidance: {
+        editGuidanceEnabled: true,
+        sourceIdentityRef: SOURCE_IDENTITY_REF,
+        freshnessChecked: sameFingerprint(sourceFingerprint, withPayload.editGuidance?.freshness),
+        availablePatchTargets: patchTargets,
+        patchTargetsCount: patchTargets.length,
+        targetLocalizationSteps: selectedPatchTarget
+          ? [...WITH_GUIDANCE_LOCALIZATION_STEPS]
+          : ['read-model-payload', 'verify-sourceFingerprint', 'fallback-search-or-read'],
+        fallbackFullReadOrSearchRequired: !selectedPatchTarget,
+        ...(selectedPatchTarget ? { selectedPatchTarget } : {}),
+        diagnosticReasons: selectedPatchTarget ? [] : ['missing-patch-target'],
+      },
+    },
+  };
+
+  const classification = classifyFixtureReplayArtifact(artifact);
+  return {
+    ...artifact,
+    ...classification,
+  };
+}
+
+function validateClaimability(claimability, blockers, prefix = 'claimability') {
+  if (!claimability || typeof claimability !== 'object') {
+    blockers.push(`missing-${prefix}`);
+    return;
+  }
+  for (const key of Object.keys(REQUIRED_FIXTURE_REPLAY_CLAIMABILITY)) {
+    if (!hasOwn(claimability, key)) {
+      blockers.push(`missing-${prefix}:${key}`);
+    } else if (typeof claimability[key] !== 'boolean') {
+      blockers.push(`${prefix}-${key}-must-be-boolean-false`);
+    } else if (claimability[key] !== false) {
+      blockers.push(`${prefix}-${key}-must-be-false`);
+    }
+  }
+  for (const key of Object.keys(claimability)) {
+    if (!hasOwn(REQUIRED_FIXTURE_REPLAY_CLAIMABILITY, key)) {
+      blockers.push(`unexpected-${prefix}:${key}`);
+    }
+  }
+}
+
+function validatePairedTarget(artifact, blockers) {
+  const pairedTarget = artifact?.pairedTarget;
+  if (!pairedTarget || typeof pairedTarget !== 'object') {
+    blockers.push('missing-pairedTarget');
+    return;
+  }
+  if (!pairedTarget.filePath) blockers.push('missing-pairedTarget.filePath');
+  if (!pairedTarget.componentName) blockers.push('missing-pairedTarget.componentName');
+  if (!String(artifact?.comparisonInvariant || '').includes('same target file and component')) {
+    blockers.push('missing-comparisonInvariant:same target file and component');
+  }
+
+  const withoutIdentity = artifact?.comparisonInputs?.withoutEditGuidance || {};
+  const withIdentity = artifact?.comparisonInputs?.withEditGuidance || {};
+  if (withoutIdentity.filePath !== withIdentity.filePath || withoutIdentity.filePath !== pairedTarget.filePath) {
+    blockers.push('paired-target-filePath-mismatch');
+  }
+  if (withoutIdentity.componentName !== withIdentity.componentName || withoutIdentity.componentName !== pairedTarget.componentName) {
+    blockers.push('paired-target-componentName-mismatch');
+  }
+}
+
+function validateSourceIdentity(artifact, blockers) {
+  const sourceIdentity = artifact?.sourceIdentity;
+  if (!sourceIdentity || typeof sourceIdentity !== 'object') {
+    blockers.push('missing-sourceIdentity');
+    return;
+  }
+  const fingerprint = sourceIdentity.sourceFingerprint;
+  if (!fingerprint) blockers.push('missing-sourceIdentity.sourceFingerprint');
+  const checks = [
+    ['defaultPayloadFingerprint', sourceIdentity.defaultPayloadFingerprint],
+    ['withGuidancePayloadFingerprint', sourceIdentity.withGuidancePayloadFingerprint],
+    ['editGuidanceFreshness', sourceIdentity.editGuidanceFreshness],
+  ];
+  for (const [label, value] of checks) {
+    if (!sameFingerprint(fingerprint, value)) {
+      blockers.push(`source-identity-mismatch:${label}`);
+    }
+  }
+  if (artifact?.variants?.withoutEditGuidance?.sourceIdentityRef !== SOURCE_IDENTITY_REF) {
+    blockers.push('without-guidance-sourceIdentityRef-mismatch');
+  }
+  if (artifact?.variants?.withEditGuidance?.sourceIdentityRef !== SOURCE_IDENTITY_REF) {
+    blockers.push('with-guidance-sourceIdentityRef-mismatch');
+  }
+  if (hasOwn(artifact?.variants?.withoutEditGuidance, 'sourceFingerprint')) {
+    blockers.push('without-guidance-must-not-duplicate-sourceFingerprint');
+  }
+  if (hasOwn(artifact?.variants?.withEditGuidance, 'sourceFingerprint')) {
+    blockers.push('with-guidance-must-not-duplicate-sourceFingerprint');
+  }
+}
+
+function validateWithoutGuidance(variant, blockers) {
+  if (!variant || typeof variant !== 'object') {
+    blockers.push('missing-withoutEditGuidance');
+    return;
+  }
+  if (variant.editGuidanceEnabled !== false) blockers.push('without-guidance-editGuidanceEnabled-must-be-false');
+  for (const forbidden of ['editGuidance', 'patchTargets', 'selectedPatchTarget']) {
+    if (hasOwn(variant, forbidden)) blockers.push(`without-guidance-forbidden-field:${forbidden}`);
+  }
+  if (variant.freshnessChecked === true) blockers.push('without-guidance-freshnessChecked-must-not-be-true');
+  const steps = Array.isArray(variant.targetLocalizationSteps) ? variant.targetLocalizationSteps : [];
+  if (steps.includes('select-patchTarget')) blockers.push('without-guidance-must-not-select-patchTarget');
+}
+
+function validateWithGuidance(variant, blockers) {
+  if (!variant || typeof variant !== 'object') {
+    blockers.push('missing-withEditGuidance');
+    return;
+  }
+  if (variant.editGuidanceEnabled !== true) blockers.push('with-guidance-editGuidanceEnabled-must-be-true');
+  if (variant.freshnessChecked !== true) blockers.push('with-guidance-freshnessChecked-must-be-true');
+  const availableTargets = Array.isArray(variant.availablePatchTargets) ? variant.availablePatchTargets : [];
+  if (!Number.isFinite(Number(variant.patchTargetsCount)) || Number(variant.patchTargetsCount) !== availableTargets.length) {
+    blockers.push('with-guidance-patchTargetsCount-mismatch');
+  }
+  const selected = variant.selectedPatchTarget;
+  if (selected) {
+    if (!selected.loc || !Number.isFinite(Number(selected.loc.startLine)) || !Number.isFinite(Number(selected.loc.endLine))) {
+      blockers.push('with-guidance-selectedPatchTarget-missing-loc');
+    }
+    const selectedKey = targetKey(selected);
+    const availableKeys = new Set(availableTargets.map(targetKey));
+    if (!availableKeys.has(selectedKey)) {
+      blockers.push('with-guidance-selectedPatchTarget-not-in-production-patchTargets');
+    }
+  }
+}
+
+function validateDeterministicFixtureReplay(artifact) {
+  const blockers = [];
+  if (!artifact || typeof artifact !== 'object') blockers.push('missing-fixture-replay-object');
+  if (artifact?.schemaVersion !== FIXTURE_REPLAY_SCHEMA_VERSION) blockers.push('unexpected-fixture-replay-schema-version');
+  if (artifact?.status !== FIXTURE_REPLAY_STATUS) blockers.push('fixture-replay-status-must-remain-fixture-replay-only');
+  if (!String(artifact?.claimBoundary || '').toLowerCase().includes('local deterministic target-localization evidence only')) {
+    blockers.push('missing-fixture-replay-claim-boundary');
+  }
+  const boundary = String(artifact?.claimBoundary || '').toLowerCase();
+  const requiredBoundaryPhrases = [
+    'not live codex/claude',
+    'not provider tokenizer',
+    'not provider billing/cost',
+    'not lsp',
+    'not runtime-token/latency',
+    'not a public edit-win claim',
+  ];
+  for (const phrase of requiredBoundaryPhrases) {
+    if (!boundary.includes(phrase)) blockers.push(`missing-fixture-replay-boundary:${phrase}`);
+  }
+
+  validateClaimability(artifact?.claimability, blockers);
+  validatePairedTarget(artifact, blockers);
+  validateSourceIdentity(artifact, blockers);
+  validateWithoutGuidance(artifact?.variants?.withoutEditGuidance, blockers);
+  validateWithGuidance(artifact?.variants?.withEditGuidance, blockers);
+
+  if (!['pass', 'fail', 'inconclusive'].includes(artifact?.classification)) {
+    blockers.push('invalid-fixture-replay-classification');
+  }
+  if (artifact?.classification === 'pass') {
+    const selected = artifact?.variants?.withEditGuidance?.selectedPatchTarget;
+    if (!selected?.loc) blockers.push('pass-requires-selected-patch-target-with-loc');
+    const withFallbackCount = countFallbackSteps(artifact?.variants?.withEditGuidance);
+    const withoutFallbackCount = countFallbackSteps(artifact?.variants?.withoutEditGuidance);
+    if (!(withFallbackCount < withoutFallbackCount)) {
+      blockers.push('pass-requires-reduced-fallback-target-localization');
+    }
+  }
+
+  return {
+    valid: blockers.length === 0,
+    blockers,
+  };
+}
+
+function markdownForFixtureReplay(artifact, validation = validateDeterministicFixtureReplay(artifact)) {
+  const claimabilityLines = Object.entries(artifact.claimability || {}).map(([key, value]) => `- ${key}: ${value}`);
+  return [
+    '# Deterministic Edit-Guidance Fixture Replay',
+    '',
+    `- Schema: ${artifact.schemaVersion}`,
+    `- Status: ${artifact.status}`,
+    `- Run ID: ${artifact.runId}`,
+    `- Valid: ${validation.valid}`,
+    `- Classification: ${artifact.classification}`,
+    `- Target: ${artifact.pairedTarget?.filePath ?? 'unknown'}#${artifact.pairedTarget?.componentName ?? 'unknown'}`,
+    '',
+    '## Claim boundary',
+    '',
+    `- ${artifact.claimBoundary}`,
+    '',
+    '## Claimability',
+    '',
+    ...claimabilityLines,
+    '',
+    '## Target-localization steps',
+    '',
+    `- Without guidance: ${(artifact.variants?.withoutEditGuidance?.targetLocalizationSteps || []).join(' -> ')}`,
+    `- With guidance: ${(artifact.variants?.withEditGuidance?.targetLocalizationSteps || []).join(' -> ')}`,
+    '',
+    '## Validation blockers',
+    '',
+    ...(validation.blockers.length > 0 ? validation.blockers.map((item) => `- ${item}`) : ['- none']),
+    '',
+  ].join('\n');
+}
+
 function parseArgs(argv) {
   return argv.reduce((acc, arg) => {
     const [key, ...rest] = arg.split('=');
@@ -194,8 +613,17 @@ function writeIfRequested(filePath, content) {
 
 function usage() {
   return [
-    'Usage: node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js [--output=<json>] [--markdown=<md>] [--run-id=<id>] [--tasks=a,b] [--validators=a,b] [--minimum-accepted-pairs=5]',
-    'Emits a design/scaffold-only deterministic outcome benchmark contract. It does not run live models or provider-cost evidence.',
+    [
+      'Usage: node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js',
+      '[--output=<json>] [--markdown=<md>] [--run-id=<id>]',
+      '[--tasks=a,b] [--validators=a,b] [--minimum-accepted-pairs=5]',
+    ].join(' '),
+    [
+      '       node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js --fixture-replay',
+      '[--target-file=fixtures/compressed/HookEffectPanel.tsx]',
+      '[--output=<json>] [--markdown=<md>] [--run-id=<id>]',
+    ].join(' '),
+    'Emits local deterministic benchmark contracts. Fixture replay does not run live models or provider-cost evidence.',
   ].join('\n');
 }
 
@@ -205,6 +633,28 @@ function main(argv = process.argv.slice(2)) {
     console.log(usage());
     return 0;
   }
+
+  if (args['fixture-replay']) {
+    const repoRoot = resolveRepoRoot();
+    const deps = loadFooksExtractors(repoRoot);
+    const replay = buildDeterministicFixtureReplay({
+      ...deps,
+      repoRoot,
+      runId: args['run-id'],
+      targetFile: args['target-file'],
+      taskIdentity: args['task-identity'],
+      fixtureRevision: args['fixture-revision'],
+      targetKind: args['target-kind'],
+      targetLabel: args['target-label'],
+    });
+    const validation = validateDeterministicFixtureReplay(replay);
+    const json = `${JSON.stringify({ ...replay, validation }, null, 2)}\n`;
+    writeIfRequested(args.output, json);
+    writeIfRequested(args.markdown, markdownForFixtureReplay(replay, validation));
+    if (!args.output) process.stdout.write(json);
+    return validation.valid ? 0 : 2;
+  }
+
   const scaffold = buildDeterministicOutcomeScaffold({
     runId: args['run-id'],
     tasks: args.tasks,
@@ -231,10 +681,17 @@ if (require.main === module) {
 module.exports = {
   SCHEMA_VERSION,
   STATUS,
+  FIXTURE_REPLAY_SCHEMA_VERSION,
+  FIXTURE_REPLAY_STATUS,
+  FIXTURE_REPLAY_CLAIM_BOUNDARY,
+  REQUIRED_FIXTURE_REPLAY_CLAIMABILITY,
   CLAIM_BOUNDARY,
   REQUIRED_CONTROLS,
   FORBIDDEN_UNTIL_NEXT_PHASE,
   buildDeterministicOutcomeScaffold,
   validateDeterministicOutcomeScaffold,
   markdownForScaffold,
+  buildDeterministicFixtureReplay,
+  validateDeterministicFixtureReplay,
+  markdownForFixtureReplay,
 };

--- a/docs/deterministic-outcome-benchmark.md
+++ b/docs/deterministic-outcome-benchmark.md
@@ -1,16 +1,24 @@
 # Deterministic Outcome Benchmark Plan
 
-This is a **design/scaffold-only** lane for a future deterministic outcome benchmark. It is intentionally separated from the release-safe runtime opt-in work so that it can run in a parallel worktree without changing runtime defaults, provider billing claims, or live model outcome claims.
+This is a **claim-bounded deterministic evidence** lane for outcome benchmark work. It is
+intentionally separated from the release-safe runtime opt-in work so that it can run in a
+parallel worktree without changing runtime defaults, provider billing claims, or live model
+outcome claims.
 
 ## Scope
 
-The first pass may add only:
+The scaffold pass may add only:
 
 - deterministic benchmark plan/spec artifacts;
 - local scaffold code that emits or validates the benchmark contract;
 - tests proving the scaffold stays claim-bounded.
 
-The first pass must not modify runtime adapter behavior, public win claims, provider-cost logic, or LSP dependencies.
+The fixture-replay pass may add only local/offline with-guidance vs without-guidance
+target-localization artifacts. It must use the same target file and component for both
+variants, record source identity/freshness, and stay aligned with
+[`docs/edit-guidance-evidence.md`](edit-guidance-evidence.md).
+
+Neither pass may modify runtime adapter behavior, public win claims, provider-cost logic, or LSP dependencies.
 
 ## Non-goals
 
@@ -23,7 +31,11 @@ The first pass must not modify runtime adapter behavior, public win claims, prov
 
 ## Why this exists
 
-The existing R4 repeated benchmark lane can classify narrow local telemetry candidates, but a future deterministic outcome benchmark needs a separate contract before any live smoke or provider-cost work starts. The contract should make outcome comparability deterministic enough for internal evidence without accidentally becoming a public runtime-token, billing, cost, or live-model claim.
+The existing R4 repeated benchmark lane can classify narrow local telemetry candidates, but a
+future deterministic outcome benchmark needs a separate contract before any live smoke or
+provider-cost work starts. The contract should make outcome comparability deterministic enough
+for internal evidence without accidentally becoming a public runtime-token, billing, cost, or
+live-model claim.
 
 ## Deterministic controls
 
@@ -38,12 +50,51 @@ A future implementation should require all accepted comparisons to share:
 7. stored source fingerprints for every target input;
 8. claim-boundary metadata on every emitted artifact.
 
+## Fixture replay contract
+
+`node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js --fixture-replay`
+emits local deterministic target-localization evidence for one fixed fixture. The default
+fixture is `fixtures/compressed/HookEffectPanel.tsx`.
+
+The replay compares two variants:
+
+- `withoutEditGuidance`: built from default `toModelFacingPayload(extractFile(file), repoRoot)`
+  and forbidden from using `editGuidance`, `patchTargets`, `selectedPatchTarget`, or
+  `select-patchTarget` localization steps.
+- `withEditGuidance`: built from
+  `toModelFacingPayload(extractFile(file), repoRoot, { includeEditGuidance: true })`, with
+  freshness/source identity checked before selecting a patch target.
+
+Both variants share a replay-level `pairedTarget.filePath`, `pairedTarget.componentName`,
+`comparisonInvariant`, and `sourceIdentity`. This follows the dry-run evidence boundary that
+with-guidance and without-guidance comparisons must use the same target file and component.
+
+The emitted `claimability` fields must all remain `false`:
+
+- `liveCodexOutcome`
+- `liveClaudeOutcome`
+- `providerTokenizerParity`
+- `providerBillingTokenSavings`
+- `providerInvoiceOrCostSavings`
+- `stableRuntimeTokenSavings`
+- `stableLatencySavings`
+- `lspSemanticSafety`
+- `publicEditWin`
+
+The only supported classification is local deterministic target-localization evidence:
+
+- `pass`: with-guidance has matching freshness/source identity, selects a production patch
+  target with `loc`, and reduces fallback read/search requirement versus without-guidance.
+- `fail`: guidance is available but does not reduce deterministic fallback target-localization work.
+- `inconclusive`: source identity is missing/mismatched, patch targets are unavailable,
+  extraction fails, or the task needs live/model judgment.
+
 ## Phase gates
 
 | Phase | Allowed output | Still forbidden |
 | --- | --- | --- |
 | Scaffold | Contract JSON/Markdown and local validator tests | Live model claims, provider billing/cost claims, runtime default changes |
-| Fixture replay | Deterministic local fixture acceptance deltas | Public outcome wins, provider billing/cost claims |
+| Fixture replay | Deterministic local target-localization deltas for the same file/component | Public outcome wins, provider billing/cost claims |
 | Live smoke | Internal Codex/Claude smoke artifacts | Public win claims unless later repeated evidence gates pass |
 | Provider proof | Imported/provider-backed evidence under explicit billing lanes | Any unqualified runtime-token or cost claim |
 
@@ -71,4 +122,7 @@ Avoid while release-safe runtime opt-in work is active:
 
 ## Claim boundary
 
-This lane can only say that a deterministic outcome benchmark contract/scaffold exists. It cannot say that fooks improves live Codex/Claude outcomes, reduces provider billing tokens, reduces provider costs, or provides stable runtime-token/time savings.
+This lane can only say that a deterministic outcome benchmark contract/scaffold or local
+fixture-replay target-localization artifact exists. It cannot say that fooks improves live
+Codex/Claude outcomes, reduces provider billing tokens, reduces provider costs, improves edit
+accuracy, or provides stable runtime-token/time savings.

--- a/test/deterministic-outcome-scaffold.test.mjs
+++ b/test/deterministic-outcome-scaffold.test.mjs
@@ -16,6 +16,10 @@ const {
   buildDeterministicOutcomeScaffold,
   validateDeterministicOutcomeScaffold,
   markdownForScaffold,
+  buildDeterministicFixtureReplay,
+  validateDeterministicFixtureReplay,
+  markdownForFixtureReplay,
+  REQUIRED_FIXTURE_REPLAY_CLAIMABILITY,
 } = require(scaffoldPath);
 
 test('deterministic outcome scaffold stays design-only and claim-bounded', () => {
@@ -100,4 +104,214 @@ test('deterministic outcome scaffold markdown reports validation blockers', () =
   const markdown = markdownForScaffold(scaffold, validation);
   assert.equal(validation.valid, false);
   assert.match(markdown, /missing-control:source-fingerprint-recorded/);
+});
+
+
+function loadBuiltExtractors() {
+  const { extractFile } = require(path.join(repoRoot, 'dist', 'core', 'extract.js'));
+  const { toModelFacingPayload } = require(path.join(repoRoot, 'dist', 'core', 'payload', 'model-facing.js'));
+  return { extractFile, toModelFacingPayload };
+}
+
+function buildReplay(overrides = {}) {
+  return buildDeterministicFixtureReplay({
+    repoRoot,
+    runId: 'fixture-replay-test',
+    generatedAt: '2026-04-23T00:00:00.000Z',
+    fixtureRevision: 'test-fixture-revision',
+    ...loadBuiltExtractors(),
+    ...overrides,
+  });
+}
+
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('deterministic fixture replay builds with and without edit guidance from production payloads', () => {
+  const replay = buildReplay();
+  const validation = validateDeterministicFixtureReplay(replay);
+
+  assert.equal(replay.schemaVersion, 'layer2-deterministic-outcome-fixture-replay.v1');
+  assert.equal(replay.status, 'fixture-replay-only');
+  assert.equal(replay.classification, 'pass');
+  assert.equal(replay.pairedTarget.filePath, 'fixtures/compressed/HookEffectPanel.tsx');
+  assert.equal(replay.pairedTarget.componentName, 'HookEffectPanel');
+  assert.match(replay.comparisonInvariant, /same target file and component/);
+  assert.deepEqual(replay.comparisonInputs.withoutEditGuidance, replay.comparisonInputs.withEditGuidance);
+  assert.equal(replay.sourceIdentity.sourceFingerprint.fileHash.length, 64);
+  assert.deepEqual(replay.sourceIdentity.sourceFingerprint, replay.sourceIdentity.defaultPayloadFingerprint);
+  assert.deepEqual(replay.sourceIdentity.sourceFingerprint, replay.sourceIdentity.withGuidancePayloadFingerprint);
+  assert.deepEqual(replay.sourceIdentity.sourceFingerprint, replay.sourceIdentity.editGuidanceFreshness);
+
+  assert.equal(replay.variants.withoutEditGuidance.editGuidanceEnabled, false);
+  assert.equal(replay.variants.withoutEditGuidance.sourceIdentityRef, 'sourceIdentity');
+  assert.equal('selectedPatchTarget' in replay.variants.withoutEditGuidance, false);
+  assert.equal('patchTargets' in replay.variants.withoutEditGuidance, false);
+  assert.equal('editGuidance' in replay.variants.withoutEditGuidance, false);
+  assert.equal(replay.variants.withoutEditGuidance.fallbackFullReadOrSearchRequired, true);
+
+  assert.equal(replay.variants.withEditGuidance.editGuidanceEnabled, true);
+  assert.equal(replay.variants.withEditGuidance.sourceIdentityRef, 'sourceIdentity');
+  assert.equal(replay.variants.withEditGuidance.freshnessChecked, true);
+  assert.ok(replay.variants.withEditGuidance.patchTargetsCount > 0);
+  assert.ok(replay.variants.withEditGuidance.selectedPatchTarget.loc.startLine > 0);
+  assert.equal(replay.variants.withEditGuidance.fallbackFullReadOrSearchRequired, false);
+  assert.deepEqual(validation, { valid: true, blockers: [] });
+});
+
+test('deterministic fixture replay claimability contract rejects every premature claim', () => {
+  const replay = buildReplay();
+
+  for (const key of Object.keys(REQUIRED_FIXTURE_REPLAY_CLAIMABILITY)) {
+    const trueClaim = deepClone(replay);
+    trueClaim.claimability[key] = true;
+    assert.ok(
+      validateDeterministicFixtureReplay(trueClaim).blockers.includes(`claimability-${key}-must-be-false`),
+      `${key} true should fail`,
+    );
+
+    const missingClaim = deepClone(replay);
+    delete missingClaim.claimability[key];
+    assert.ok(
+      validateDeterministicFixtureReplay(missingClaim).blockers.includes(`missing-claimability:${key}`),
+      `${key} missing should fail`,
+    );
+
+    const nonBooleanClaim = deepClone(replay);
+    nonBooleanClaim.claimability[key] = 'false';
+    assert.ok(
+      validateDeterministicFixtureReplay(nonBooleanClaim).blockers.includes(`claimability-${key}-must-be-boolean-false`),
+      `${key} non-boolean should fail`,
+    );
+  }
+
+  const ambiguousClaim = deepClone(replay);
+  ambiguousClaim.claimability.providerBillingSavings = false;
+  assert.ok(validateDeterministicFixtureReplay(ambiguousClaim).blockers.includes('unexpected-claimability:providerBillingSavings'));
+});
+
+test('deterministic fixture replay enforces paired target and source identity equality', () => {
+  const replay = buildReplay();
+
+  const fileMismatch = deepClone(replay);
+  fileMismatch.comparisonInputs.withEditGuidance.filePath = 'fixtures/compressed/FormControls.tsx';
+  assert.ok(validateDeterministicFixtureReplay(fileMismatch).blockers.includes('paired-target-filePath-mismatch'));
+
+  const componentMismatch = deepClone(replay);
+  componentMismatch.comparisonInputs.withoutEditGuidance.componentName = 'OtherComponent';
+  assert.ok(validateDeterministicFixtureReplay(componentMismatch).blockers.includes('paired-target-componentName-mismatch'));
+
+  for (const field of ['defaultPayloadFingerprint', 'withGuidancePayloadFingerprint', 'editGuidanceFreshness']) {
+    const mutated = deepClone(replay);
+    mutated.sourceIdentity[field].fileHash = '0'.repeat(64);
+    const validation = validateDeterministicFixtureReplay(mutated);
+    assert.ok(validation.blockers.includes(`source-identity-mismatch:${field}`), `${field} mismatch should fail`);
+  }
+
+  const replayFingerprintMismatch = deepClone(replay);
+  replayFingerprintMismatch.sourceIdentity.sourceFingerprint.fileHash = '1'.repeat(64);
+  const blockers = validateDeterministicFixtureReplay(replayFingerprintMismatch).blockers.join('\n');
+  assert.match(blockers, /source-identity-mismatch/);
+});
+
+test('deterministic fixture replay rejects invented patch targets and without-guidance leakage', () => {
+  const replay = buildReplay();
+
+  const inventedTarget = deepClone(replay);
+  inventedTarget.variants.withEditGuidance.selectedPatchTarget = {
+    kind: 'effect',
+    label: 'inventedEffect',
+    loc: { startLine: 1, endLine: 1 },
+    reason: 'Invented target should not validate.',
+  };
+  assert.ok(
+    validateDeterministicFixtureReplay(inventedTarget).blockers
+      .includes('with-guidance-selectedPatchTarget-not-in-production-patchTargets'),
+  );
+
+  const missingLoc = deepClone(replay);
+  delete missingLoc.variants.withEditGuidance.selectedPatchTarget.loc;
+  const missingLocBlockers = validateDeterministicFixtureReplay(missingLoc).blockers;
+  assert.ok(missingLocBlockers.includes('with-guidance-selectedPatchTarget-missing-loc'));
+  assert.ok(missingLocBlockers.includes('with-guidance-selectedPatchTarget-not-in-production-patchTargets'));
+
+  const forbiddenFields = {
+    editGuidance: { patchTargets: [] },
+    patchTargets: [],
+    selectedPatchTarget: replay.variants.withEditGuidance.selectedPatchTarget,
+  };
+  for (const [field, value] of Object.entries(forbiddenFields)) {
+    const leaked = deepClone(replay);
+    leaked.variants.withoutEditGuidance[field] = value;
+    assert.ok(
+      validateDeterministicFixtureReplay(leaked).blockers.includes(`without-guidance-forbidden-field:${field}`),
+      `${field} leakage should fail`,
+    );
+  }
+
+  const freshnessLeak = deepClone(replay);
+  freshnessLeak.variants.withoutEditGuidance.freshnessChecked = true;
+  assert.ok(validateDeterministicFixtureReplay(freshnessLeak).blockers.includes('without-guidance-freshnessChecked-must-not-be-true'));
+
+  const stepLeak = deepClone(replay);
+  stepLeak.variants.withoutEditGuidance.targetLocalizationSteps.push('select-patchTarget');
+  assert.ok(validateDeterministicFixtureReplay(stepLeak).blockers.includes('without-guidance-must-not-select-patchTarget'));
+});
+
+test('deterministic fixture replay reports inconclusive when patch targets are unavailable', () => {
+  const replay = buildReplay({
+    toModelFacingPayload(result, cwd, options) {
+      const payload = loadBuiltExtractors().toModelFacingPayload(result, cwd, options);
+      if (options?.includeEditGuidance && payload.editGuidance) {
+        payload.editGuidance.patchTargets = [];
+      }
+      return payload;
+    },
+  });
+
+  assert.equal(replay.classification, 'inconclusive');
+  assert.ok(replay.classificationReasons.includes('missing-selected-patch-target'));
+  assert.equal(replay.variants.withEditGuidance.fallbackFullReadOrSearchRequired, true);
+});
+
+test('deterministic fixture replay CLI writes JSON and Markdown without live execution', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fooks-deterministic-fixture-replay-'));
+  const output = path.join(tempDir, 'fixture-replay.json');
+  const markdown = path.join(tempDir, 'fixture-replay.md');
+
+  execFileSync(process.execPath, [
+    scaffoldPath,
+    '--fixture-replay',
+    `--output=${output}`,
+    `--markdown=${markdown}`,
+    '--run-id=cli-fixture-replay',
+  ], { cwd: repoRoot, encoding: 'utf8' });
+
+  const result = JSON.parse(fs.readFileSync(output, 'utf8'));
+  assert.equal(result.validation.valid, true);
+  assert.equal(result.status, 'fixture-replay-only');
+  assert.equal(result.claimability.liveCodexOutcome, false);
+  assert.equal(result.claimability.providerBillingTokenSavings, false);
+  assert.equal(result.variants.withoutEditGuidance.editGuidanceEnabled, false);
+  assert.equal('selectedPatchTarget' in result.variants.withoutEditGuidance, false);
+
+  const md = fs.readFileSync(markdown, 'utf8');
+  assert.match(md, /local deterministic target-localization evidence only/i);
+  assert.match(md, /not live Codex\/Claude model outcome proof/i);
+  assert.match(md, /providerTokenizerParity: false/);
+  assert.doesNotMatch(md, /provider billing-token savings are proven/i);
+  assert.doesNotMatch(md, /public edit win/i);
+});
+
+test('deterministic fixture replay markdown reports validation blockers and claimability', () => {
+  const replay = buildReplay();
+  replay.claimability.publicEditWin = true;
+  const validation = validateDeterministicFixtureReplay(replay);
+  const markdown = markdownForFixtureReplay(replay, validation);
+
+  assert.equal(validation.valid, false);
+  assert.match(markdown, /publicEditWin: true/);
+  assert.match(markdown, /claimability-publicEditWin-must-be-false/);
+  assert.match(markdown, /not live Codex\/Claude model outcome proof/);
 });


### PR DESCRIPTION
## Summary

- Adds `--fixture-replay` to the deterministic outcome scaffold for local/offline with-vs-without edit-guidance target-localization evidence.
- Records shared `pairedTarget`, `comparisonInvariant`, replay-level `sourceIdentity`, and `sourceIdentityRef` on both variants.
- Enforces strict claim boundaries: no live Codex/Claude outcome proof, no provider tokenizer/billing/cost proof, no LSP semantic safety claim, no runtime token/latency claim, and no public edit-win claim.
- Updates docs to describe the fixture replay contract and phase boundaries.

Closes #129.

## Verification

- `node --check benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js`
- `node --check test/deterministic-outcome-scaffold.test.mjs`
- `node benchmarks/layer2-frontend-task/deterministic-outcome-scaffold.js --fixture-replay --output=<tmp>/fixture.json --markdown=<tmp>/fixture.md --run-id=manual-fixture-replay`
- `npm run build && node --test test/deterministic-outcome-scaffold.test.mjs` → 11/11 pass
- `npm run typecheck`
- `npm run lint`
- `npm test` → 216/216 pass
- `npm run release:smoke` → ok true
- `git diff --check`
- Ralph architect verification → APPROVED, no blockers

## Claim boundary / non-goals

- No runtime default change.
- No live Codex/Claude model edit smoke.
- No provider tokenizer, provider billing-token, invoice, or cost proof.
- No LSP implementation or new dependency.
- No public outcome-win claim.
