### PR TITLE
Clarify public positioning before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@
 
 Smaller model-facing context for repeated React component work in Codex.
 
-Broad category: Frontend context compression for Codex and Claude Code. Current strongest path: Codex repeated React component work.
+Broad category: Frontend context compression for Codex and Claude Code. Current strongest path: Codex repeated React component work; Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
+
+`fooks` is for Codex users who repeatedly work on the same React `.tsx` / `.jsx` file. On the first eligible mention, fooks records the component context; on later same-file prompts, it can send a compact model-facing payload instead of the full source when safe.
 
 - Public npm package: `oh-my-fooks`
 - CLI command: `fooks`
 
-`fooks` helps Codex users avoid resending the same full `.tsx` / `.jsx` component context during iterative frontend work. In the Codex repeated-file hook path, the first eligible file mention records context and later same-file prompts may reuse a compact fooks payload when safe.
+## 30-second version
 
-The core claim is deliberately narrow: **lower model-facing input/context load for supported repeated frontend work**. That is not provider billing/cost proof, not provider billing-token proof, not stable runtime-token or latency proof, and not a `ccusage` replacement.
+Use fooks when you are iterating on the same large React component in Codex and want to avoid repeatedly sending the full file context.
+
+- **Best today:** Codex + repeated same-file `.tsx` / `.jsx` work.
+- **Local proof:** `fooks compare` shows the original source size versus the compact fooks model-facing payload for one supported file.
+- **Evidence boundary:** fooks supports prompt-size/context-load estimates and estimate-scoped API-cost evidence under explicit assumptions; it does not prove provider invoices, billing-grade charges, stable runtime-token wins, or Claude/opencode automatic savings.
 
 ## Quick start and local proof
 
@@ -24,13 +30,26 @@ Then open Codex in that repo and work normally. `fooks compare` gives an immedia
 
 `fooks setup` is explicit by design. Installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files.
 
-## What fooks is / is not
+## Best today / not today
 
-| fooks is | fooks is not |
+| Best today | Not today |
 | --- | --- |
-| A focused context-reduction helper for repeated React `.tsx` / `.jsx` work, strongest today in Codex. | A universal file-read interceptor for every language, framework, runtime, or file type. |
-| A way to inspect local model-facing payload estimates with `fooks compare` and local session estimates with `fooks status`. | Provider billing telemetry, provider tokenizer behavior, provider invoice/dashboard proof, or a `ccusage` replacement. |
-| A project setup tool that prepares Codex hooks plus narrower Claude/opencode helper paths when available. | A claim that Claude or opencode has Codex-equivalent automatic runtime-token savings. |
+| Repeated same-file React `.tsx` / `.jsx` work in Codex. | Universal file-read interception for every language, framework, runtime, or file type. |
+| Local model-facing payload estimates with `fooks compare` and local session estimates with `fooks status`. | Provider billing telemetry, provider tokenizer behavior, provider invoice/dashboard proof, or a `ccusage` replacement. |
+| Project setup that prepares Codex hooks plus narrower Claude/opencode helper paths when available. | A claim that Claude or opencode has Codex-equivalent automatic runtime-token behavior. |
+
+## Not supported yet
+
+These are useful future directions, but they are not required for the current Codex repeated React workflow:
+
+- Vue, Svelte, or non-React framework support.
+- General `.ts` / backend-file context compression.
+- Multi-file refactor context compression.
+- Universal runtime file-read interception.
+- LSP-backed semantic rename/reference safety.
+- Provider invoice/dashboard or billing-grade charge proof.
+
+See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stronger support or stronger evidence claims.
 
 ## Runtime support at a glance
 
@@ -87,9 +106,18 @@ The command compares the original source bytes with the compact base fooks model
 
 ## Benchmark and evidence boundaries
 
-The shortest evidence summary is:
+The evidence ladder is intentionally split so public wording does not collapse prompt-size, runtime telemetry, and billing-grade proof into one claim:
 
-- Local commands such as `fooks compare` and `fooks status` support **model-facing context / prompt-size estimate** wording.
+| Level | Evidence | Supports | Does not support |
+| --- | --- | --- | --- |
+| Local estimate | `fooks compare`, `fooks status`, prepared payload accounting | Model-facing context / prompt-size estimate wording | Provider tokenizer, billing, or invoice wording |
+| Runtime telemetry | Codex CLI-reported matched-run diagnostics | Narrow internal runtime candidate evidence when quality gates pass | Stable public runtime-token or latency claims |
+| Estimated API cost | Provider usage tokens converted under explicit pricing assumptions | Estimate-scoped API-cost wording with caveats | Invoice/dashboard or actual charged-cost proof |
+| Billing-grade proof | Provider invoice, dashboard, or billed-usage exports | Future billing-grade wording for the measured scope | Not claimed today |
+
+Current public summary:
+
+- Local commands support **model-facing context / prompt-size estimate** wording.
 - The 2026-04-14 Codex-oriented proxy snapshot showed a prepared-context estimate reduction from roughly 2.1M to 450K estimated context tokens in a 5-task sample, with no success-rate regression in that sample.
 - Later benchmark lanes include estimate-scoped API-cost evidence, but that wording must stay qualified as **estimated API cost under explicit pricing assumptions**.
 - Direct runtime-token/time evidence remains unstable or negative in some diagnostics, so fooks does not claim stable runtime-token, wall-clock, or latency wins.
@@ -97,6 +125,24 @@ The shortest evidence summary is:
 Detailed evidence and current claim boundaries are maintained in the curated benchmark evidence page: https://github.com/minislively/fooks/blob/main/docs/benchmark-evidence.md
 
 The benchmark evidence is not provider invoice/dashboard proof, not actual charged-cost proof, not provider billing-token proof, and not a Claude or opencode automatic savings claim.
+
+## Common questions
+
+### Does this prove my provider bill will be lower?
+
+No. fooks can reduce model-facing prompt/context size in supported cases, and the benchmark docs include estimate-scoped API-cost evidence under explicit pricing assumptions. That is not provider invoice, dashboard, actual charged-cost, or billing-grade proof.
+
+### Is Claude automatic too?
+
+Not at Codex parity. Claude support uses project-local `SessionStart` / `UserPromptSubmit` context hooks plus handoff artifacts. fooks does not intercept Claude `Read` tool calls.
+
+### Does opencode get automatic read interception?
+
+No. opencode support is a project-local `fooks_extract` tool and `/fooks-extract` slash command. It steers explicit tool use; it does not replace opencode's built-in `read` behavior.
+
+### Which files are supported?
+
+The strongest path today is repeated same-file React `.tsx` / `.jsx` work in Codex. Unsupported or unsafe cases fall back to normal full-source behavior.
 
 ## Everyday commands
 
@@ -186,6 +232,7 @@ Useful public docs:
 - Setup details: [`docs/setup.md`](docs/setup.md)
 - opencode support boundary: [`docs/opencode-read-interception.md`](docs/opencode-read-interception.md)
 - Release checklist: [`docs/release.md`](docs/release.md)
+- Roadmap / future evidence lanes: [`docs/roadmap.md`](docs/roadmap.md)
 - Benchmark evidence and claim boundaries: https://github.com/minislively/fooks/blob/main/docs/benchmark-evidence.md
 
 Benchmark harness internals and generated reports live in the source repository, but are intentionally not part of the npm package payload.

--- a/benchmarks/BENCHMARK_ARCHITECTURE.md
+++ b/benchmarks/BENCHMARK_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Benchmark Architecture: Two-Layer System
 
-> Extraction Benchmark vs Frontend Task Benchmark
+> Historical benchmark planning note. For current public claim boundaries, use [`docs/benchmark-evidence.md`](../docs/benchmark-evidence.md) and [`benchmarks/layer2-frontend-task/STATUS.md`](layer2-frontend-task/STATUS.md). This file explains the benchmark direction, but older `TBD` / phase language below should not be read as the current release claim surface.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,34 @@
+# Roadmap and future evidence lanes
+
+This page frames common "does fooks support X?" questions as future support or evidence lanes. These items are **not required** for the current strongest workflow: Codex repeated same-file React `.tsx` / `.jsx` context reduction.
+
+## Current strongest workflow
+
+- Runtime: Codex hooks prepared by `fooks setup`.
+- Files: React `.tsx` / `.jsx` components.
+- Pattern: repeated same-file work in one Codex session.
+- Evidence: local model-facing prompt/context estimates, plus estimate-scoped API-cost evidence where the benchmark docs say the assumptions hold.
+
+## Future support lanes
+
+| Lane | Why it matters | Current boundary |
+| --- | --- | --- |
+| Vue / Svelte / broader frontend frameworks | Would expand the component extraction model beyond React. | Not part of the current automatic path. |
+| General `.ts` / backend files | Would make fooks useful outside React component loops. | Current extraction and public wording stay frontend-focused. |
+| Multi-file refactor context compression | Would support broader agentic refactors where several files must stay in view. | Current strongest path is repeated same-file work. |
+| Universal read interception | Would make runtime behavior broader than Codex repeated-file hooks. | Not claimed; unsupported cases should fall back to normal source reading. |
+| LSP-backed semantic locations | Would strengthen rename/reference/edit safety beyond line-aware hints. | Current source ranges and patch targets are AST-derived edit aids, not LSP semantic proof. |
+
+## Future evidence lanes
+
+| Lane | Stronger claim it could unlock | Current boundary |
+| --- | --- | --- |
+| Provider tokenizer parity | Better provider-tokenized prompt accounting. | `fooks compare` remains a local model-facing estimate, not provider tokenizer behavior. |
+| Billing/dashboard reconciliation | Billing-grade wording for a measured scope. | Current benchmark evidence is not provider invoice/dashboard or actual charged-cost proof. |
+| ccusage-style usage-log import boundaries | Better review bridges between local estimates, provider usage logs, and billing exports. | `fooks status` is local context-size telemetry only and is not a `ccusage` replacement. |
+| Stable runtime-token/time benchmark class | Public runtime-token or latency wording if repeated quality-gated runs support it. | Existing direct runtime-token/time evidence is unstable or negative in documented diagnostics. |
+| Applied-code quality benchmark | Stronger claims about edit outcomes, not just context size. | Current edit-guidance evidence is local/dry-run unless benchmark docs say otherwise. |
+
+## How to read open issues
+
+Open issues in these lanes should be treated as enhancement or stronger-evidence work unless they contradict the current documented Codex repeated React workflow. They should not be used as shorthand for "the core product is unproven" without checking the current claim boundary in [`benchmark-evidence.md`](benchmark-evidence.md) and [`release.md`](release.md).

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dist",
     "docs/setup.md",
     "docs/release.md",
+    "docs/roadmap.md",
     "docs/runtime-bridge-contract.md",
     "docs/codex-live-feedback-checklist.md",
     "docs/opencode-read-interception.md",

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -122,6 +122,7 @@ function assertPackedFiles(packEntry) {
     "dist/adapters/opencode-tool-preset.js",
     "docs/setup.md",
     "docs/release.md",
+    "docs/roadmap.md",
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",
@@ -172,6 +173,7 @@ assertPublicSurfaceClaimBoundaries({
   "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
   "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
   "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "docs/roadmap.md": fs.readFileSync(path.join(repoRoot, "docs", "roadmap.md"), "utf8"),
   "docs/internal/live-hook-smoke-checklist.md": fs.existsSync(path.join(repoRoot, "docs", "internal", "live-hook-smoke-checklist.md"))
     ? fs.readFileSync(path.join(repoRoot, "docs", "internal", "live-hook-smoke-checklist.md"), "utf8")
     : "",


### PR DESCRIPTION
## Summary
- Tighten the README first screen around the current strongest workflow: Codex repeated React component context reduction.
- Add a public roadmap that frames broader framework, tokenizer, billing, ccusage-style, LSP, and applied-code work as future support/evidence lanes rather than launch blockers.
- Mark the older benchmark architecture note as historical and include the roadmap in the package/release-smoke public surface checks.

## Verification
- npm test
- npm run release:smoke

## Claim boundaries
- Does not claim provider billing savings, stable runtime-token wins, Claude/opencode automatic savings, or LSP semantic proof.
- Does not run npm publish.