### PR TITLE
Harden Claude runtime state handling

### DIFF
--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -142,8 +142,13 @@ function noopDecision(input: ClaudeRuntimeHookInput, reasons: string[], policy?:
   };
 }
 
+const VALID_CLAUDE_HOOK_EVENTS = new Set<ClaudeRuntimeHookEvent>(["SessionStart", "UserPromptSubmit", "Stop"]);
+
 export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = process.cwd()): ClaudeRuntimeHookDecision {
   const hookEventName = input.hookEventName;
+  if (!VALID_CLAUDE_HOOK_EVENTS.has(hookEventName)) {
+    return noopDecision({ ...input, hookEventName: "UserPromptSubmit" }, ["unrecognized-hook-event"]);
+  }
   const sessionKey = resolveClaudeRuntimeSessionKey(input.sessionId);
 
   if (hookEventName === "SessionStart") {

--- a/src/adapters/claude-runtime-session.ts
+++ b/src/adapters/claude-runtime-session.ts
@@ -91,10 +91,24 @@ export function markClaudeRuntimeSeenFile(cwd: string, sessionKey: string, fileP
   };
 }
 
+function removeEmptyDirs(dir: string, stopAt: string): void {
+  let current = dir;
+  while (current !== stopAt && fs.existsSync(current)) {
+    const entries = fs.readdirSync(current);
+    if (entries.length === 0) {
+      fs.rmdirSync(current);
+      current = path.dirname(current);
+    } else {
+      break;
+    }
+  }
+}
+
 export function clearClaudeRuntimeSession(cwd: string, sessionKey: string): string {
   const file = claudeRuntimeSessionPath(cwd, sessionKey);
   if (fs.existsSync(file)) {
     fs.rmSync(file);
+    removeEmptyDirs(path.dirname(file), cwd);
   }
   return file;
 }

--- a/src/adapters/claude-runtime-trust.ts
+++ b/src/adapters/claude-runtime-trust.ts
@@ -24,13 +24,26 @@ export function readClaudeTrustStatus(cwd = process.cwd()): ClaudeTrustStatus {
       updatedAt: now(),
     };
   }
-  return JSON.parse(fs.readFileSync(file, "utf8")) as ClaudeTrustStatus;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as ClaudeTrustStatus;
+  } catch {
+    return {
+      runtime: "claude",
+      connectionState: "disconnected",
+      lifecycleState: "disconnected",
+      updatedAt: now(),
+    };
+  }
 }
 
 export function writeClaudeTrustStatus(status: ClaudeTrustStatus, cwd = process.cwd()): ClaudeTrustStatus {
   const file = statusFile(cwd);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(status, null, 2));
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(status, null, 2));
+  } catch {
+    // swallow write failures to avoid crashing the hook pipeline
+  }
   return status;
 }
 
@@ -104,6 +117,5 @@ export function ensureFreshClaudeContextForTarget(target: string, cwd = process.
     return { refreshed: true, scannedAt: refreshed.scannedAt };
   }
 
-  patchClaudeTrustStatus({ connectionState: "connected", lifecycleState: "ready" }, cwd);
   return { refreshed: false, scannedAt: index.scannedAt };
 }

--- a/src/adapters/claude-runtime-trust.ts
+++ b/src/adapters/claude-runtime-trust.ts
@@ -83,11 +83,15 @@ export function markClaudeReady(cwd = process.cwd()): ClaudeTrustStatus {
 }
 
 export function markClaudeAttachPrepared(activeFile: ClaudeActiveFileContext, cwd = process.cwd()): ClaudeTrustStatus {
+  const previous = readClaudeTrustStatus(cwd);
+  if (previous.activeFile?.filePath === activeFile.filePath && previous.lifecycleState === "attach-prepared") {
+    return previous;
+  }
   return patchClaudeTrustStatus({
     connectionState: "connected",
     lifecycleState: "attach-prepared",
     activeFile,
-    lastAttachPreparedAt: now(),
+    lastAttachPreparedAt: previous.lastAttachPreparedAt ?? now(),
   }, cwd);
 }
 

--- a/test/claude-adapter-resilience.test.mjs
+++ b/test/claude-adapter-resilience.test.mjs
@@ -1,0 +1,90 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+
+const { handleClaudeRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+const { readClaudeTrustStatus, ensureFreshClaudeContextForTarget, initializeClaudeTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
+const { clearClaudeRuntimeSession, claudeRuntimeSessionPath } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-session.js"));
+const { scanProject } = require(path.join(repoRoot, "dist", "core", "scan.js"));
+
+function makeTempProject() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-claude-resilience-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "src", "components", "FormSection.tsx"),
+    "export function FormSection() { return <div>Form</div>; }\n",
+  );
+  fs.writeFileSync(
+    path.join(tempDir, "package.json"),
+    JSON.stringify({ name: "temp-project", version: "1.0.0" }),
+  );
+  return tempDir;
+}
+
+test("claude runtime hook defends against corrupt trust status file", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "claude-corrupt-trust";
+  const target = path.join("src", "components", "FormSection.tsx");
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const trustFile = path.join(tempDir, ".fooks", "state", "claude-runtime", "trust.json");
+  fs.writeFileSync(trustFile, "{not-json");
+
+  const afterCorrupt = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, review ${target}` }, tempDir);
+  assert.equal(afterCorrupt.action, "inject");
+  assert.equal(afterCorrupt.filePath, target);
+
+  const status = readClaudeTrustStatus(tempDir);
+  assert.equal(status.connectionState, "connected");
+  assert.equal(status.lifecycleState, "attach-prepared");
+});
+
+test("claude runtime hook no-ops unrecognized event names", () => {
+  const tempDir = makeTempProject();
+  const decision = handleClaudeRuntimeHook({ hookEventName: "UnknownEvent", prompt: "Explain src/components/FormSection.tsx" }, tempDir);
+  assert.equal(decision.action, "noop");
+  assert.ok(decision.reasons.includes("unrecognized-hook-event"));
+  assert.equal(decision.filePath, undefined);
+});
+
+test("claude runtime session clear removes empty parent directories", () => {
+  const tempDir = makeTempProject();
+  const sessionKey = "claude-cleanup-test";
+  const statePath = claudeRuntimeSessionPath(tempDir, sessionKey);
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: sessionKey }, tempDir);
+  assert.ok(fs.existsSync(statePath));
+
+  clearClaudeRuntimeSession(tempDir, sessionKey);
+  assert.equal(fs.existsSync(statePath), false);
+  assert.equal(fs.existsSync(path.join(tempDir, ".fooks", "state", "claude-runtime")), false);
+});
+
+test("claude ensureFreshClaudeContextForTarget non-stale path does not rewrite trust status", () => {
+  const tempDir = makeTempProject();
+  const target = path.join("src", "components", "FormSection.tsx");
+
+  scanProject(tempDir);
+  // Seed trust status so the file exists before the non-stale check
+  initializeClaudeTrustStatus(tempDir);
+
+  const before = readClaudeTrustStatus(tempDir);
+  const beforeUpdatedAt = before.updatedAt;
+
+  const result = ensureFreshClaudeContextForTarget(target, tempDir);
+  assert.equal(result.refreshed, false);
+
+  const after = readClaudeTrustStatus(tempDir);
+  assert.equal(after.updatedAt, beforeUpdatedAt);
+});

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -48,7 +48,8 @@ const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
 const { installClaudeHookPreset, claudeLocalSettingsPath } = require(path.join(repoRoot, "dist", "adapters", "claude-hook-preset.js"));
 const { handleClaudeRuntimeHook, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
-const { readClaudeTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
+const { readClaudeTrustStatus, ensureFreshClaudeContextForTarget } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
+const { clearClaudeRuntimeSession, claudeRuntimeSessionPath } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-session.js"));
 const { handleClaudeNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "claude-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 const ts = require("typescript");
@@ -2461,6 +2462,65 @@ test("codex and claude estimated metrics are runtime/source-qualified without se
   assert.equal(Object.keys(summaryFile.sessions).length, 2);
   assert.ok(summaryFile.sessions[codexSummary.sanitizedSessionKey]);
   assert.ok(summaryFile.sessions[claudeSummary.sanitizedSessionKey]);
+});
+
+test("claude runtime hook defends against corrupt trust status file", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "claude-corrupt-trust";
+  const target = path.join("src", "components", "FormSection.tsx");
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const trustFile = path.join(tempDir, ".fooks", "state", "claude-runtime", "trust.json");
+  fs.writeFileSync(trustFile, "{not-json");
+
+  const afterCorrupt = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, review ${target}` }, tempDir);
+  assert.equal(afterCorrupt.action, "inject");
+  assert.equal(afterCorrupt.filePath, target);
+
+  const status = readClaudeTrustStatus(tempDir);
+  assert.equal(status.connectionState, "connected");
+  assert.equal(status.lifecycleState, "attach-prepared");
+});
+
+test("claude runtime hook no-ops unrecognized event names", () => {
+  const tempDir = makeTempProject();
+  const decision = handleClaudeRuntimeHook({ hookEventName: "UnknownEvent", prompt: "Explain src/components/FormSection.tsx" }, tempDir);
+  assert.equal(decision.action, "noop");
+  assert.ok(decision.reasons.includes("unrecognized-hook-event"));
+  assert.equal(decision.filePath, undefined);
+});
+
+test("claude runtime session clear removes empty parent directories", () => {
+  const tempDir = makeTempProject();
+  const sessionKey = "claude-cleanup-test";
+  const statePath = claudeRuntimeSessionPath(tempDir, sessionKey);
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: sessionKey }, tempDir);
+  assert.ok(fs.existsSync(statePath));
+
+  clearClaudeRuntimeSession(tempDir, sessionKey);
+  assert.equal(fs.existsSync(statePath), false);
+  assert.equal(fs.existsSync(path.join(tempDir, ".fooks", "state", "claude-runtime")), false);
+});
+
+test("claude trust status non-stale path does not overwrite on repeated file", () => {
+  const tempDir = makeTempProject();
+  const sessionId = "claude-non-stale-repeat";
+  const target = path.join("src", "components", "FormSection.tsx");
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+
+  const beforeRepeat = readClaudeTrustStatus(tempDir);
+  const lastAttachPreparedAt = beforeRepeat.lastAttachPreparedAt;
+
+  const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, review ${target}` }, tempDir);
+  assert.equal(second.action, "inject");
+
+  const afterRepeat = readClaudeTrustStatus(tempDir);
+  assert.equal(afterRepeat.lastAttachPreparedAt, lastAttachPreparedAt);
 });
 
 test("claude fallback metrics record zero savings and telemetry failures are non-fatal", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2511,10 +2511,15 @@ test("claude trust status non-stale path does not overwrite on repeated file", (
   const target = path.join("src", "components", "FormSection.tsx");
 
   handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  // establish lastAttachPreparedAt baseline via first-seen-inject
+  process.env.FOOKS_CLAUDE_FIRST_SEEN_INJECT = "1";
   handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Review ${target}` }, tempDir);
+  delete process.env.FOOKS_CLAUDE_FIRST_SEEN_INJECT;
 
   const beforeRepeat = readClaudeTrustStatus(tempDir);
   const lastAttachPreparedAt = beforeRepeat.lastAttachPreparedAt;
+  assert.ok(lastAttachPreparedAt, "baseline lastAttachPreparedAt should be set");
 
   const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, review ${target}` }, tempDir);
   assert.equal(second.action, "inject");


### PR DESCRIPTION
## Summary
- No-op unknown Claude hook event names instead of flowing them through normal prompt handling.
- Treat corrupt Claude trust status as disconnected local state and make trust-status writes non-fatal.
- Clean empty Claude runtime session directories after session clear/Stop.
- Add regression tests for corrupt trust files, unknown events, session cleanup, and repeated non-stale trust state.

## Verification
- npm test
- npm run release:smoke

## Claim boundaries
- This keeps Claude support in the project-local context-hook lane only.
- It does not add Claude Read interception or runtime-token savings claims.