### PR TITLE
Add worktree status parser for dirty-change separation

### DIFF
--- a/src/core/worktree-status.ts
+++ b/src/core/worktree-status.ts
@@ -1,0 +1,165 @@
+export type GitPorcelainStatusCode =
+  | " "
+  | "M"
+  | "A"
+  | "D"
+  | "R"
+  | "C"
+  | "T"
+  | "U"
+  | "?"
+  | "!";
+
+export type WorktreeChangeKind =
+  | "modified"
+  | "added"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "type-changed"
+  | "untracked"
+  | "ignored"
+  | "unmerged"
+  | "unknown";
+
+export type WorktreeStatusEntry = {
+  path: string;
+  originalPath?: string;
+  indexStatus: GitPorcelainStatusCode;
+  worktreeStatus: GitPorcelainStatusCode;
+  kind: WorktreeChangeKind;
+  tracked: boolean;
+  conflicted: boolean;
+  raw: string;
+};
+
+export type WorktreeStatusSummary = {
+  clean: boolean;
+  entries: WorktreeStatusEntry[];
+  changedPaths: string[];
+  trackedPaths: string[];
+  untrackedPaths: string[];
+  ignoredPaths: string[];
+  conflictedPaths: string[];
+};
+
+export type ParseWorktreeStatusOptions = {
+  nulTerminated?: boolean;
+};
+
+const CONFLICT_STATUS_PAIRS = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
+function normalizeStatusCode(value: string | undefined): GitPorcelainStatusCode {
+  switch (value) {
+    case " ":
+    case "M":
+    case "A":
+    case "D":
+    case "R":
+    case "C":
+    case "T":
+    case "U":
+    case "?":
+    case "!":
+      return value;
+    default:
+      return " ";
+  }
+}
+
+function classifyEntry(indexStatus: GitPorcelainStatusCode, worktreeStatus: GitPorcelainStatusCode): WorktreeChangeKind {
+  const pair = `${indexStatus}${worktreeStatus}`;
+  if (CONFLICT_STATUS_PAIRS.has(pair) || indexStatus === "U" || worktreeStatus === "U") {
+    return "unmerged";
+  }
+  if (pair === "??") return "untracked";
+  if (pair === "!!") return "ignored";
+  if (indexStatus === "R" || worktreeStatus === "R") return "renamed";
+  if (indexStatus === "C" || worktreeStatus === "C") return "copied";
+  if (indexStatus === "T" || worktreeStatus === "T") return "type-changed";
+  if (indexStatus === "A" || worktreeStatus === "A") return "added";
+  if (indexStatus === "D" || worktreeStatus === "D") return "deleted";
+  if (indexStatus === "M" || worktreeStatus === "M") return "modified";
+  return "unknown";
+}
+
+function parsePorcelainLine(line: string): WorktreeStatusEntry | undefined {
+  if (!line) return undefined;
+  const indexStatus = normalizeStatusCode(line[0]);
+  const worktreeStatus = normalizeStatusCode(line[1]);
+  const pathSpec = line.slice(3);
+  if (!pathSpec) return undefined;
+
+  let filePath = pathSpec;
+  let originalPath: string | undefined;
+  const renameSeparator = " -> ";
+  const separatorIndex = pathSpec.indexOf(renameSeparator);
+  if (separatorIndex >= 0) {
+    originalPath = pathSpec.slice(0, separatorIndex);
+    filePath = pathSpec.slice(separatorIndex + renameSeparator.length);
+  }
+
+  const kind = classifyEntry(indexStatus, worktreeStatus);
+  return {
+    path: filePath,
+    originalPath,
+    indexStatus,
+    worktreeStatus,
+    kind,
+    tracked: kind !== "untracked" && kind !== "ignored",
+    conflicted: kind === "unmerged",
+    raw: line,
+  };
+}
+
+function parseNulTerminatedPorcelain(output: string): WorktreeStatusEntry[] {
+  const fields = output.split("\0").filter((field) => field.length > 0);
+  const entries: WorktreeStatusEntry[] = [];
+
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index];
+    const entry = parsePorcelainLine(field);
+    if (!entry) continue;
+
+    if ((entry.indexStatus === "R" || entry.indexStatus === "C") && index + 1 < fields.length) {
+      entry.originalPath = fields[index + 1];
+      entry.raw = `${field}\0${fields[index + 1]}`;
+      index += 1;
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+export function parseWorktreeStatus(output: string, options: ParseWorktreeStatusOptions = {}): WorktreeStatusEntry[] {
+  if (!output.trim()) return [];
+  if (options.nulTerminated || output.includes("\0")) {
+    return parseNulTerminatedPorcelain(output);
+  }
+  return output
+    .split(/\r?\n/)
+    .map((line) => parsePorcelainLine(line))
+    .filter((entry): entry is WorktreeStatusEntry => Boolean(entry));
+}
+
+export function summarizeWorktreeStatus(entries: WorktreeStatusEntry[]): WorktreeStatusSummary {
+  const changedEntries = entries.filter((entry) => entry.kind !== "ignored");
+  return {
+    clean: changedEntries.length === 0,
+    entries,
+    changedPaths: changedEntries.map((entry) => entry.path),
+    trackedPaths: changedEntries.filter((entry) => entry.tracked).map((entry) => entry.path),
+    untrackedPaths: entries.filter((entry) => entry.kind === "untracked").map((entry) => entry.path),
+    ignoredPaths: entries.filter((entry) => entry.kind === "ignored").map((entry) => entry.path),
+    conflictedPaths: entries.filter((entry) => entry.conflicted).map((entry) => entry.path),
+  };
+}
+
+export function parseAndSummarizeWorktreeStatus(
+  output: string,
+  options: ParseWorktreeStatusOptions = {},
+): WorktreeStatusSummary {
+  return summarizeWorktreeStatus(parseWorktreeStatus(output, options));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,11 @@ export { handleCodexNativeHookPayload } from "./adapters/codex-native-hook";
 export { installCodexHookPreset } from "./adapters/codex-hook-preset";
 
 export { readCodexTrustStatus } from "./adapters/codex-runtime-trust";
+export { parseWorktreeStatus, summarizeWorktreeStatus, parseAndSummarizeWorktreeStatus } from "./core/worktree-status";
+export type {
+  GitPorcelainStatusCode,
+  ParseWorktreeStatusOptions,
+  WorktreeChangeKind,
+  WorktreeStatusEntry,
+  WorktreeStatusSummary,
+} from "./core/worktree-status";

--- a/test/worktree-status.test.mjs
+++ b/test/worktree-status.test.mjs
@@ -1,0 +1,73 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+
+const {
+  parseWorktreeStatus,
+  summarizeWorktreeStatus,
+  parseAndSummarizeWorktreeStatus,
+} = require(path.join(repoRoot, "dist", "core", "worktree-status.js"));
+
+test("parseWorktreeStatus parses modified, staged, deleted, and untracked porcelain entries", () => {
+  const entries = parseWorktreeStatus(" M README.md\nA  src/new.ts\n D old.txt\n?? scratch.log\n");
+
+  assert.deepEqual(entries.map((entry) => [entry.path, entry.indexStatus, entry.worktreeStatus, entry.kind, entry.tracked]), [
+    ["README.md", " ", "M", "modified", true],
+    ["src/new.ts", "A", " ", "added", true],
+    ["old.txt", " ", "D", "deleted", true],
+    ["scratch.log", "?", "?", "untracked", false],
+  ]);
+});
+
+test("parseWorktreeStatus preserves staged and worktree type-change status", () => {
+  const entries = parseWorktreeStatus("T  scripts/run.sh\n T docs/link.md\nMT src/mixed.ts\n");
+
+  assert.deepEqual(entries.map((entry) => [entry.path, entry.indexStatus, entry.worktreeStatus, entry.kind, entry.tracked]), [
+    ["scripts/run.sh", "T", " ", "type-changed", true],
+    ["docs/link.md", " ", "T", "type-changed", true],
+    ["src/mixed.ts", "M", "T", "type-changed", true],
+  ]);
+});
+
+test("parseWorktreeStatus preserves rename source and destination for line porcelain", () => {
+  const entries = parseWorktreeStatus("R  src/old.ts -> src/new.ts\n");
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, "renamed");
+  assert.equal(entries[0].originalPath, "src/old.ts");
+  assert.equal(entries[0].path, "src/new.ts");
+});
+
+test("parseWorktreeStatus parses nul-terminated porcelain rename fields", () => {
+  const entries = parseWorktreeStatus("R  src/new.ts\0src/old.ts\0?? notes.md\0", { nulTerminated: true });
+
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].kind, "renamed");
+  assert.equal(entries[0].path, "src/new.ts");
+  assert.equal(entries[0].originalPath, "src/old.ts");
+  assert.equal(entries[1].kind, "untracked");
+  assert.equal(entries[1].path, "notes.md");
+});
+
+test("summarizeWorktreeStatus separates tracked, untracked, ignored, and conflicted paths", () => {
+  const summary = summarizeWorktreeStatus(parseWorktreeStatus(" M README.md\n?? scratch.log\n!! dist/index.js\nUU src/conflict.ts\n"));
+
+  assert.equal(summary.clean, false);
+  assert.deepEqual(summary.changedPaths, ["README.md", "scratch.log", "src/conflict.ts"]);
+  assert.deepEqual(summary.trackedPaths, ["README.md", "src/conflict.ts"]);
+  assert.deepEqual(summary.untrackedPaths, ["scratch.log"]);
+  assert.deepEqual(summary.ignoredPaths, ["dist/index.js"]);
+  assert.deepEqual(summary.conflictedPaths, ["src/conflict.ts"]);
+});
+
+test("parseAndSummarizeWorktreeStatus treats empty or ignored-only output as clean", () => {
+  assert.equal(parseAndSummarizeWorktreeStatus("\n").clean, true);
+  assert.equal(parseAndSummarizeWorktreeStatus("!! dist/index.js\n").clean, true);
+});


### PR DESCRIPTION
## Summary\n- Add a pure Git porcelain worktree status parser and summary helper.\n- Export parser functions and types from the package entrypoint.\n- Cover tracked, untracked, ignored, conflicted, rename, NUL-terminated rename, and type-change status cases.\n\n## Scope\nPrimary lane: feature foundation.\nAllowed support: focused parser tests and verification.\nDeferred: runtime/cache/session wiring, CLI consumer integration, and unrelated Claude adapter worktree changes.\n\n## Verification\n- npm run build\n- node --test test/worktree-status.test.mjs\n- npm run lint\n- npm test (226/226)\n- git diff --check\n\n## Notes\nExisting unrelated dirty local files were preserved and are not part of this branch/PR.