### PR TITLE
Add worktree session evidence sidecar

### DIFF
--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -18,6 +18,7 @@ import {
   initializeSessionMetricSummarySafe,
   recordFooksSessionMetricEventSafe,
 } from "../core/session-metrics";
+import { finalizeWorktreeEvidenceSafe, initializeWorktreeEvidenceSafe } from "../core/worktree-evidence";
 
 export { CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS };
 
@@ -154,6 +155,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
   if (hookEventName === "SessionStart") {
     const statePath = initializeClaudeRuntimeSession(cwd, sessionKey);
     initializeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
+    initializeWorktreeEvidenceSafe(cwd, sessionKey);
     return {
       runtime: "claude",
       hookEventName,
@@ -176,6 +178,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     const statePath = clearClaudeRuntimeSession(cwd, sessionKey);
     clearClaudeActiveFile(cwd);
     finalizeSessionMetricSummarySafe(cwd, sessionKey, { runtime: "claude", measurementSource: "project-local-context-hook" });
+    finalizeWorktreeEvidenceSafe(cwd, sessionKey);
     return {
       runtime: "claude",
       hookEventName,

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -18,6 +18,7 @@ import {
   initializeSessionMetricSummarySafe,
   recordFooksSessionMetricEventSafe,
 } from "../core/session-metrics";
+import { finalizeWorktreeEvidenceSafe, initializeWorktreeEvidenceSafe } from "../core/worktree-evidence";
 
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
@@ -154,6 +155,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     const statePath = initializeCodexRuntimeSession(cwd, sessionKey);
     markCodexReady(cwd);
     initializeSessionMetricSummarySafe(cwd, sessionKey);
+    initializeWorktreeEvidenceSafe(cwd, sessionKey);
     return {
       runtime: "codex",
       hookEventName,
@@ -174,6 +176,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     const statePath = clearCodexRuntimeSession(cwd, sessionKey);
     clearCodexActiveFile(cwd);
     finalizeSessionMetricSummarySafe(cwd, sessionKey);
+    finalizeWorktreeEvidenceSafe(cwd, sessionKey);
     return {
       runtime: "codex",
       hookEventName,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -543,6 +543,7 @@ Everyday commands:
   ${displayCliName} status codex
   ${displayCliName} status claude
   ${displayCliName} status cache
+  ${displayCliName} status worktree
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
   ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -913,7 +914,12 @@ async function run(): Promise<void> {
         print(monitor.healthReport());
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', or 'cache'");
+      if (arg1 === "worktree") {
+        const { currentWorktreeEvidenceStatus } = await import("../core/worktree-evidence.js");
+        print(currentWorktreeEvidenceStatus(process.cwd()));
+        return;
+      }
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', or 'worktree'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -56,6 +56,10 @@ export function sessionSummaryPath(cwd: string, sessionKey: string): string {
   return path.join(sessionDir(cwd, sessionKey), "summary.json");
 }
 
+export function sessionWorktreeEvidencePath(cwd: string, sessionKey: string): string {
+  return path.join(sessionDir(cwd, sessionKey), "worktree.json");
+}
+
 export function sessionsSummaryPath(cwd = process.cwd()): string {
   return path.join(sessionsDir(cwd), "summary.json");
 }

--- a/src/core/worktree-evidence.ts
+++ b/src/core/worktree-evidence.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { parseAndSummarizeWorktreeStatus } from "./worktree-status";
+import { sessionWorktreeEvidencePath } from "./paths";
+
+export const WORKTREE_EVIDENCE_SCHEMA_VERSION = 1;
+export const WORKTREE_EVIDENCE_CLAIM_BOUNDARY =
+  "Local git worktree evidence only; does not mutate files or prove provider/runtime savings.";
+export const WORKTREE_STATUS_COMMAND = "git status --porcelain=v1 -z";
+export const DEFAULT_WORKTREE_STATUS_TIMEOUT_MS = 1000;
+
+export type WorktreeStatusRunner = (cwd: string) => string;
+
+export type WorktreeSnapshot = {
+  capturedAt: string;
+  clean: boolean;
+  changedPaths: string[];
+  trackedPaths: string[];
+  untrackedPaths: string[];
+  ignoredPaths: string[];
+  conflictedPaths: string[];
+};
+
+export type WorktreeDelta = {
+  newDirtyPaths: string[];
+  resolvedDirtyPaths: string[];
+  stillDirtyPaths: string[];
+  conflictedPaths: string[];
+};
+
+export type WorktreeEvidenceFile = {
+  schemaVersion: typeof WORKTREE_EVIDENCE_SCHEMA_VERSION;
+  claimBoundary: typeof WORKTREE_EVIDENCE_CLAIM_BOUNDARY;
+  command: typeof WORKTREE_STATUS_COMMAND;
+  baseline?: WorktreeSnapshot;
+  latest?: WorktreeSnapshot;
+  delta?: WorktreeDelta;
+  blockers: string[];
+};
+
+export type WorktreeCaptureResult = {
+  snapshot?: WorktreeSnapshot;
+  blockers: string[];
+};
+
+export type WorktreeEvidenceResult = {
+  path: string;
+  evidence: WorktreeEvidenceFile;
+};
+
+export type WorktreeCurrentStatus = {
+  schemaVersion: typeof WORKTREE_EVIDENCE_SCHEMA_VERSION;
+  claimBoundary: typeof WORKTREE_EVIDENCE_CLAIM_BOUNDARY;
+  command: typeof WORKTREE_STATUS_COMMAND;
+  cwd: string;
+  capturedAt: string;
+  snapshot?: WorktreeSnapshot;
+  blockers: string[];
+};
+
+export type WorktreeEvidenceOptions = {
+  runner?: WorktreeStatusRunner;
+  now?: () => string;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function uniqueSorted(paths: string[]): string[] {
+  return [...new Set(paths)].sort((left, right) => left.localeCompare(right));
+}
+
+function emptyEvidence(blockers: string[] = []): WorktreeEvidenceFile {
+  return {
+    schemaVersion: WORKTREE_EVIDENCE_SCHEMA_VERSION,
+    claimBoundary: WORKTREE_EVIDENCE_CLAIM_BOUNDARY,
+    command: WORKTREE_STATUS_COMMAND,
+    blockers,
+  };
+}
+
+function errorDetail(error: unknown): string {
+  const maybeError = error && typeof error === "object" ? (error as { message?: unknown; stderr?: unknown; signal?: unknown; code?: unknown }) : {};
+  const stderr = maybeError.stderr;
+  const stderrText = Buffer.isBuffer(stderr) ? stderr.toString("utf8").trim() : typeof stderr === "string" ? stderr.trim() : "";
+  const message = typeof maybeError.message === "string" ? maybeError.message.trim() : String(error);
+  const status = maybeError.signal ? `signal ${String(maybeError.signal)}` : maybeError.code !== undefined ? `code ${String(maybeError.code)}` : "";
+  const detail = stderrText || message || "unknown error";
+  return status ? `${detail} (${status})` : detail;
+}
+
+function blockerFromError(error: unknown): string {
+  return `worktree status unavailable: ${errorDetail(error)}`;
+}
+
+export function defaultWorktreeStatusRunner(cwd: string): string {
+  return execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+    cwd,
+    encoding: "utf8",
+    timeout: DEFAULT_WORKTREE_STATUS_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+export function captureWorktreeSnapshot(cwd = process.cwd(), options: WorktreeEvidenceOptions = {}): WorktreeCaptureResult {
+  const capturedAt = options.now?.() ?? nowIso();
+  const runner = options.runner ?? defaultWorktreeStatusRunner;
+
+  try {
+    const output = runner(cwd);
+    const summary = parseAndSummarizeWorktreeStatus(output, { nulTerminated: true });
+    return {
+      snapshot: {
+        capturedAt,
+        clean: summary.clean,
+        changedPaths: uniqueSorted(summary.changedPaths),
+        trackedPaths: uniqueSorted(summary.trackedPaths),
+        untrackedPaths: uniqueSorted(summary.untrackedPaths),
+        ignoredPaths: uniqueSorted(summary.ignoredPaths),
+        conflictedPaths: uniqueSorted(summary.conflictedPaths),
+      },
+      blockers: [],
+    };
+  } catch (error) {
+    return {
+      blockers: [blockerFromError(error)],
+    };
+  }
+}
+
+export function computeWorktreeDelta(baseline: WorktreeSnapshot, latest: WorktreeSnapshot): WorktreeDelta {
+  const baselineDirty = new Set(baseline.changedPaths);
+  const latestDirty = new Set(latest.changedPaths);
+  return {
+    newDirtyPaths: uniqueSorted(latest.changedPaths.filter((filePath) => !baselineDirty.has(filePath))),
+    resolvedDirtyPaths: uniqueSorted(baseline.changedPaths.filter((filePath) => !latestDirty.has(filePath))),
+    stillDirtyPaths: uniqueSorted(latest.changedPaths.filter((filePath) => baselineDirty.has(filePath))),
+    conflictedPaths: uniqueSorted(latest.conflictedPaths),
+  };
+}
+
+export function readWorktreeEvidence(cwd: string, sessionKey: string): WorktreeEvidenceFile | null {
+  const filePath = sessionWorktreeEvidencePath(cwd, sessionKey);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as WorktreeEvidenceFile;
+}
+
+export function writeWorktreeEvidence(cwd: string, sessionKey: string, evidence: WorktreeEvidenceFile): string {
+  const filePath = sessionWorktreeEvidencePath(cwd, sessionKey);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(evidence, null, 2)}\n`);
+  return filePath;
+}
+
+function unwrittenEvidenceResult(cwd: string, sessionKey: string, evidence: WorktreeEvidenceFile, error: unknown): WorktreeEvidenceResult {
+  return {
+    path: sessionWorktreeEvidencePath(cwd, sessionKey),
+    evidence: {
+      ...evidence,
+      blockers: uniqueSorted([...evidence.blockers, `worktree evidence write failed: ${errorDetail(error)}`]),
+    },
+  };
+}
+
+function readExistingEvidenceForUpdate(cwd: string, sessionKey: string): WorktreeEvidenceFile {
+  try {
+    return readWorktreeEvidence(cwd, sessionKey) ?? emptyEvidence();
+  } catch (error) {
+    return emptyEvidence([`existing worktree evidence unreadable: ${errorDetail(error)}`]);
+  }
+}
+
+export function initializeWorktreeEvidenceSafe(
+  cwd: string,
+  sessionKey: string,
+  options: WorktreeEvidenceOptions = {},
+): WorktreeEvidenceResult {
+  const capture = captureWorktreeSnapshot(cwd, options);
+  const evidence = emptyEvidence(capture.blockers);
+  if (capture.snapshot) {
+    evidence.baseline = capture.snapshot;
+  }
+  try {
+    const filePath = writeWorktreeEvidence(cwd, sessionKey, evidence);
+    return { path: filePath, evidence };
+  } catch (error) {
+    return unwrittenEvidenceResult(cwd, sessionKey, evidence, error);
+  }
+}
+
+export function finalizeWorktreeEvidenceSafe(
+  cwd: string,
+  sessionKey: string,
+  options: WorktreeEvidenceOptions = {},
+): WorktreeEvidenceResult {
+  const evidence = readExistingEvidenceForUpdate(cwd, sessionKey);
+  const capture = captureWorktreeSnapshot(cwd, options);
+  evidence.blockers = uniqueSorted([...evidence.blockers, ...capture.blockers]);
+  if (capture.snapshot) {
+    evidence.latest = capture.snapshot;
+  }
+  if (evidence.baseline && evidence.latest) {
+    evidence.delta = computeWorktreeDelta(evidence.baseline, evidence.latest);
+  }
+  try {
+    const filePath = writeWorktreeEvidence(cwd, sessionKey, evidence);
+    return { path: filePath, evidence };
+  } catch (error) {
+    return unwrittenEvidenceResult(cwd, sessionKey, evidence, error);
+  }
+}
+
+export function currentWorktreeEvidenceStatus(cwd = process.cwd(), options: WorktreeEvidenceOptions = {}): WorktreeCurrentStatus {
+  const capturedAt = options.now?.() ?? nowIso();
+  const capture = captureWorktreeSnapshot(cwd, { ...options, now: () => capturedAt });
+  return {
+    schemaVersion: WORKTREE_EVIDENCE_SCHEMA_VERSION,
+    claimBoundary: WORKTREE_EVIDENCE_CLAIM_BOUNDARY,
+    command: WORKTREE_STATUS_COMMAND,
+    cwd,
+    capturedAt,
+    snapshot: capture.snapshot,
+    blockers: capture.blockers,
+  };
+}

--- a/src/core/worktree-status.ts
+++ b/src/core/worktree-status.ts
@@ -1,0 +1,165 @@
+export type GitPorcelainStatusCode =
+  | " "
+  | "M"
+  | "A"
+  | "D"
+  | "R"
+  | "C"
+  | "T"
+  | "U"
+  | "?"
+  | "!";
+
+export type WorktreeChangeKind =
+  | "modified"
+  | "added"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "type-changed"
+  | "untracked"
+  | "ignored"
+  | "unmerged"
+  | "unknown";
+
+export type WorktreeStatusEntry = {
+  path: string;
+  originalPath?: string;
+  indexStatus: GitPorcelainStatusCode;
+  worktreeStatus: GitPorcelainStatusCode;
+  kind: WorktreeChangeKind;
+  tracked: boolean;
+  conflicted: boolean;
+  raw: string;
+};
+
+export type WorktreeStatusSummary = {
+  clean: boolean;
+  entries: WorktreeStatusEntry[];
+  changedPaths: string[];
+  trackedPaths: string[];
+  untrackedPaths: string[];
+  ignoredPaths: string[];
+  conflictedPaths: string[];
+};
+
+export type ParseWorktreeStatusOptions = {
+  nulTerminated?: boolean;
+};
+
+const CONFLICT_STATUS_PAIRS = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
+function normalizeStatusCode(value: string | undefined): GitPorcelainStatusCode {
+  switch (value) {
+    case " ":
+    case "M":
+    case "A":
+    case "D":
+    case "R":
+    case "C":
+    case "T":
+    case "U":
+    case "?":
+    case "!":
+      return value;
+    default:
+      return " ";
+  }
+}
+
+function classifyEntry(indexStatus: GitPorcelainStatusCode, worktreeStatus: GitPorcelainStatusCode): WorktreeChangeKind {
+  const pair = `${indexStatus}${worktreeStatus}`;
+  if (CONFLICT_STATUS_PAIRS.has(pair) || indexStatus === "U" || worktreeStatus === "U") {
+    return "unmerged";
+  }
+  if (pair === "??") return "untracked";
+  if (pair === "!!") return "ignored";
+  if (indexStatus === "R" || worktreeStatus === "R") return "renamed";
+  if (indexStatus === "C" || worktreeStatus === "C") return "copied";
+  if (indexStatus === "T" || worktreeStatus === "T") return "type-changed";
+  if (indexStatus === "A" || worktreeStatus === "A") return "added";
+  if (indexStatus === "D" || worktreeStatus === "D") return "deleted";
+  if (indexStatus === "M" || worktreeStatus === "M") return "modified";
+  return "unknown";
+}
+
+function parsePorcelainLine(line: string): WorktreeStatusEntry | undefined {
+  if (!line) return undefined;
+  const indexStatus = normalizeStatusCode(line[0]);
+  const worktreeStatus = normalizeStatusCode(line[1]);
+  const pathSpec = line.slice(3);
+  if (!pathSpec) return undefined;
+
+  let filePath = pathSpec;
+  let originalPath: string | undefined;
+  const renameSeparator = " -> ";
+  const separatorIndex = pathSpec.indexOf(renameSeparator);
+  if (separatorIndex >= 0) {
+    originalPath = pathSpec.slice(0, separatorIndex);
+    filePath = pathSpec.slice(separatorIndex + renameSeparator.length);
+  }
+
+  const kind = classifyEntry(indexStatus, worktreeStatus);
+  return {
+    path: filePath,
+    originalPath,
+    indexStatus,
+    worktreeStatus,
+    kind,
+    tracked: kind !== "untracked" && kind !== "ignored",
+    conflicted: kind === "unmerged",
+    raw: line,
+  };
+}
+
+function parseNulTerminatedPorcelain(output: string): WorktreeStatusEntry[] {
+  const fields = output.split("\0").filter((field) => field.length > 0);
+  const entries: WorktreeStatusEntry[] = [];
+
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index];
+    const entry = parsePorcelainLine(field);
+    if (!entry) continue;
+
+    if ((entry.indexStatus === "R" || entry.indexStatus === "C") && index + 1 < fields.length) {
+      entry.originalPath = fields[index + 1];
+      entry.raw = `${field}\0${fields[index + 1]}`;
+      index += 1;
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+export function parseWorktreeStatus(output: string, options: ParseWorktreeStatusOptions = {}): WorktreeStatusEntry[] {
+  if (!output.trim()) return [];
+  if (options.nulTerminated || output.includes("\0")) {
+    return parseNulTerminatedPorcelain(output);
+  }
+  return output
+    .split(/\r?\n/)
+    .map((line) => parsePorcelainLine(line))
+    .filter((entry): entry is WorktreeStatusEntry => Boolean(entry));
+}
+
+export function summarizeWorktreeStatus(entries: WorktreeStatusEntry[]): WorktreeStatusSummary {
+  const changedEntries = entries.filter((entry) => entry.kind !== "ignored");
+  return {
+    clean: changedEntries.length === 0,
+    entries,
+    changedPaths: changedEntries.map((entry) => entry.path),
+    trackedPaths: changedEntries.filter((entry) => entry.tracked).map((entry) => entry.path),
+    untrackedPaths: entries.filter((entry) => entry.kind === "untracked").map((entry) => entry.path),
+    ignoredPaths: entries.filter((entry) => entry.kind === "ignored").map((entry) => entry.path),
+    conflictedPaths: entries.filter((entry) => entry.conflicted).map((entry) => entry.path),
+  };
+}
+
+export function parseAndSummarizeWorktreeStatus(
+  output: string,
+  options: ParseWorktreeStatusOptions = {},
+): WorktreeStatusSummary {
+  return summarizeWorktreeStatus(parseWorktreeStatus(output, options));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,11 @@ export { handleCodexNativeHookPayload } from "./adapters/codex-native-hook";
 export { installCodexHookPreset } from "./adapters/codex-hook-preset";
 
 export { readCodexTrustStatus } from "./adapters/codex-runtime-trust";
+export { parseWorktreeStatus, summarizeWorktreeStatus, parseAndSummarizeWorktreeStatus } from "./core/worktree-status";
+export type {
+  GitPorcelainStatusCode,
+  ParseWorktreeStatusOptions,
+  WorktreeChangeKind,
+  WorktreeStatusEntry,
+  WorktreeStatusSummary,
+} from "./core/worktree-status";

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,19 @@ export { installCodexHookPreset } from "./adapters/codex-hook-preset";
 
 export { readCodexTrustStatus } from "./adapters/codex-runtime-trust";
 export { parseWorktreeStatus, summarizeWorktreeStatus, parseAndSummarizeWorktreeStatus } from "./core/worktree-status";
+export {
+  WORKTREE_EVIDENCE_CLAIM_BOUNDARY,
+  WORKTREE_EVIDENCE_SCHEMA_VERSION,
+  WORKTREE_STATUS_COMMAND,
+  captureWorktreeSnapshot,
+  computeWorktreeDelta,
+  currentWorktreeEvidenceStatus,
+  defaultWorktreeStatusRunner,
+  finalizeWorktreeEvidenceSafe,
+  initializeWorktreeEvidenceSafe,
+  readWorktreeEvidence,
+  writeWorktreeEvidence,
+} from "./core/worktree-evidence";
 export type {
   GitPorcelainStatusCode,
   ParseWorktreeStatusOptions,
@@ -30,3 +43,13 @@ export type {
   WorktreeStatusEntry,
   WorktreeStatusSummary,
 } from "./core/worktree-status";
+export type {
+  WorktreeCaptureResult,
+  WorktreeCurrentStatus,
+  WorktreeDelta,
+  WorktreeEvidenceFile,
+  WorktreeEvidenceOptions,
+  WorktreeEvidenceResult,
+  WorktreeSnapshot,
+  WorktreeStatusRunner,
+} from "./core/worktree-evidence";

--- a/test/claude-adapter-resilience.test.mjs
+++ b/test/claude-adapter-resilience.test.mjs
@@ -12,7 +12,11 @@ const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 
 const { handleClaudeRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
-const { readClaudeTrustStatus, ensureFreshClaudeContextForTarget } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
+const {
+  ensureFreshClaudeContextForTarget,
+  readClaudeTrustStatus,
+  writeClaudeTrustStatus,
+} = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
 const { clearClaudeRuntimeSession, claudeRuntimeSessionPath } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-session.js"));
 const { scanProject } = require(path.join(repoRoot, "dist", "core", "scan.js"));
 
@@ -75,8 +79,18 @@ test("claude ensureFreshClaudeContextForTarget non-stale path does not rewrite t
   const tempDir = makeTempProject();
   const target = path.join("src", "components", "FormSection.tsx");
 
-  scanProject(tempDir);
-  const before = readClaudeTrustStatus(tempDir);
+  const scan = scanProject(tempDir);
+  const before = writeClaudeTrustStatus(
+    {
+      runtime: "claude",
+      connectionState: "connected",
+      lifecycleState: "ready",
+      updatedAt: "2026-04-23T00:00:00.000Z",
+      lastScanAt: scan.scannedAt,
+      lastRefreshAt: scan.scannedAt,
+    },
+    tempDir,
+  );
   const beforeUpdatedAt = before.updatedAt;
 
   const result = ensureFreshClaudeContextForTarget(target, tempDir);

--- a/test/worktree-evidence.test.mjs
+++ b/test/worktree-evidence.test.mjs
@@ -1,0 +1,209 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+
+const {
+  WORKTREE_EVIDENCE_CLAIM_BOUNDARY,
+  WORKTREE_STATUS_COMMAND,
+  captureWorktreeSnapshot,
+  currentWorktreeEvidenceStatus,
+  finalizeWorktreeEvidenceSafe,
+  initializeWorktreeEvidenceSafe,
+  readWorktreeEvidence,
+} = require(path.join(repoRoot, "dist", "core", "worktree-evidence.js"));
+const { sessionWorktreeEvidencePath } = require(path.join(repoRoot, "dist", "core", "paths.js"));
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const { handleClaudeRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+
+function makeTempProject() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-worktree-evidence-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, "src", "components", "SimpleButton.tsx"), "export function SimpleButton() { return <button />; }\n");
+  fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify({ name: "temp-project", version: "1.0.0" }, null, 2));
+  return tempDir;
+}
+
+function run(args, cwd) {
+  return JSON.parse(execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8" }));
+}
+
+function outputRunner(output) {
+  return () => output;
+}
+
+test("captureWorktreeSnapshot parses clean, untracked, conflicted, and rename evidence through the shared parser", () => {
+  const clean = captureWorktreeSnapshot("/tmp/project", {
+    runner: outputRunner(""),
+    now: () => "2026-04-23T00:00:00.000Z",
+  });
+  assert.deepEqual(clean.blockers, []);
+  assert.equal(clean.snapshot.clean, true);
+  assert.deepEqual(clean.snapshot.changedPaths, []);
+
+  const dirty = captureWorktreeSnapshot("/tmp/project", {
+    runner: outputRunner(" M src/App.tsx\0?? scratch.log\0UU conflict.ts\0R  src/NewName.tsx\0src/OldName.tsx\0"),
+    now: () => "2026-04-23T00:00:01.000Z",
+  });
+  assert.deepEqual(dirty.blockers, []);
+  assert.equal(dirty.snapshot.clean, false);
+  assert.deepEqual(dirty.snapshot.changedPaths, ["conflict.ts", "scratch.log", "src/App.tsx", "src/NewName.tsx"]);
+  assert.deepEqual(dirty.snapshot.trackedPaths, ["conflict.ts", "src/App.tsx", "src/NewName.tsx"]);
+  assert.deepEqual(dirty.snapshot.untrackedPaths, ["scratch.log"]);
+  assert.deepEqual(dirty.snapshot.conflictedPaths, ["conflict.ts"]);
+});
+
+test("session evidence records baseline/latest and computes dirty deltas with a fake runner", () => {
+  const tempDir = makeTempProject();
+  const sessionKey = "delta-session";
+  const outputs = [
+    " M existing.txt\0?? scratch.log\0",
+    " M existing.txt\0?? new.txt\0UU conflict.ts\0",
+  ];
+  let calls = 0;
+  const runner = () => outputs[calls++] ?? "";
+
+  const initialized = initializeWorktreeEvidenceSafe(tempDir, sessionKey, {
+    runner,
+    now: () => "2026-04-23T00:00:00.000Z",
+  });
+  assert.equal(initialized.path, sessionWorktreeEvidencePath(tempDir, sessionKey));
+  assert.deepEqual(initialized.evidence.baseline.changedPaths, ["existing.txt", "scratch.log"]);
+  assert.deepEqual(initialized.evidence.blockers, []);
+
+  const finalized = finalizeWorktreeEvidenceSafe(tempDir, sessionKey, {
+    runner,
+    now: () => "2026-04-23T00:01:00.000Z",
+  });
+  assert.deepEqual(finalized.evidence.latest.changedPaths, ["conflict.ts", "existing.txt", "new.txt"]);
+  assert.deepEqual(finalized.evidence.delta, {
+    newDirtyPaths: ["conflict.ts", "new.txt"],
+    resolvedDirtyPaths: ["scratch.log"],
+    stillDirtyPaths: ["existing.txt"],
+    conflictedPaths: ["conflict.ts"],
+  });
+
+  const onDisk = readWorktreeEvidence(tempDir, sessionKey);
+  assert.deepEqual(onDisk.delta, finalized.evidence.delta);
+  assert.equal(onDisk.claimBoundary, WORKTREE_EVIDENCE_CLAIM_BOUNDARY);
+  assert.equal(onDisk.command, WORKTREE_STATUS_COMMAND);
+});
+
+test("session evidence keeps clean-to-dirty and dirty-to-clean deltas distinct", () => {
+  const tempDir = makeTempProject();
+  const sessionKey = "clean-dirty-session";
+  const outputs = ["", "?? new.txt\0"];
+  let calls = 0;
+
+  initializeWorktreeEvidenceSafe(tempDir, sessionKey, { runner: () => outputs[calls++] ?? "" });
+  const dirty = finalizeWorktreeEvidenceSafe(tempDir, sessionKey, { runner: () => outputs[calls++] ?? "" });
+  assert.deepEqual(dirty.evidence.delta.newDirtyPaths, ["new.txt"]);
+  assert.deepEqual(dirty.evidence.delta.resolvedDirtyPaths, []);
+  assert.deepEqual(dirty.evidence.delta.stillDirtyPaths, []);
+
+  const secondSession = "dirty-clean-session";
+  let secondCalls = 0;
+  const secondOutputs = [" M fixed.ts\0", ""];
+  initializeWorktreeEvidenceSafe(tempDir, secondSession, { runner: () => secondOutputs[secondCalls++] ?? "" });
+  const clean = finalizeWorktreeEvidenceSafe(tempDir, secondSession, { runner: () => secondOutputs[secondCalls++] ?? "" });
+  assert.deepEqual(clean.evidence.delta.newDirtyPaths, []);
+  assert.deepEqual(clean.evidence.delta.resolvedDirtyPaths, ["fixed.ts"]);
+  assert.deepEqual(clean.evidence.delta.stillDirtyPaths, []);
+});
+
+test("capture and status report blockers without throwing when local status is unavailable", () => {
+  const tempDir = makeTempProject();
+  const runner = () => {
+    throw new Error("synthetic status failure");
+  };
+
+  const captured = captureWorktreeSnapshot(tempDir, { runner });
+  assert.equal(captured.snapshot, undefined);
+  assert.match(captured.blockers[0], /synthetic status failure/);
+
+  const initialized = initializeWorktreeEvidenceSafe(tempDir, "blocked-session", { runner });
+  assert.equal(initialized.evidence.baseline, undefined);
+  assert.match(initialized.evidence.blockers[0], /synthetic status failure/);
+
+  const current = currentWorktreeEvidenceStatus(tempDir, { runner, now: () => "2026-04-23T00:02:00.000Z" });
+  assert.equal(current.snapshot, undefined);
+  assert.equal(current.capturedAt, "2026-04-23T00:02:00.000Z");
+  assert.match(current.blockers[0], /synthetic status failure/);
+});
+
+test("runtime hooks write sidecars only at session boundaries and tolerate unavailable worktree status", () => {
+  const tempDir = makeTempProject();
+  const codexSession = "codex-worktree-sidecar";
+  const claudeSession = "claude-worktree-sidecar";
+  const target = path.join("src", "components", "SimpleButton.tsx");
+
+  const codexPromptOnly = "codex-prompt-only";
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: codexPromptOnly, prompt: `Review ${target}` }, tempDir);
+  assert.equal(fs.existsSync(sessionWorktreeEvidencePath(tempDir, codexPromptOnly)), false);
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: codexSession }, tempDir);
+  const codexStart = readWorktreeEvidence(tempDir, codexSession);
+  assert.ok(codexStart);
+  assert.match(codexStart.blockers.join("\n"), /worktree status unavailable/);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId: codexSession }, tempDir);
+  const codexStop = readWorktreeEvidence(tempDir, codexSession);
+  assert.ok(codexStop.blockers.length >= codexStart.blockers.length);
+
+  const claudePromptOnly = "claude-prompt-only";
+  handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId: claudePromptOnly, prompt: `Review ${target}` }, tempDir);
+  assert.equal(fs.existsSync(sessionWorktreeEvidencePath(tempDir, claudePromptOnly)), false);
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: claudeSession }, tempDir);
+  const claudeStart = readWorktreeEvidence(tempDir, claudeSession);
+  assert.ok(claudeStart);
+  assert.match(claudeStart.blockers.join("\n"), /worktree status unavailable/);
+  handleClaudeRuntimeHook({ hookEventName: "Stop", sessionId: claudeSession }, tempDir);
+  const claudeStop = readWorktreeEvidence(tempDir, claudeSession);
+  assert.ok(claudeStop.blockers.length >= claudeStart.blockers.length);
+});
+
+test("status worktree emits parseable JSON and default status remains metric-shaped", () => {
+  const tempDir = makeTempProject();
+  const worktree = run(["status", "worktree"], tempDir);
+  assert.equal(worktree.schemaVersion, 1);
+  assert.equal(worktree.command, WORKTREE_STATUS_COMMAND);
+  assert.match(worktree.claimBoundary, /Local git worktree evidence only/);
+  assert.ok(Array.isArray(worktree.blockers));
+
+  const status = run(["status"], tempDir);
+  assert.equal(status.schemaVersion, 1);
+  assert.equal(status.metricTier, "estimated");
+  assert.equal("snapshot" in status, false);
+  assert.equal("baseline" in status, false);
+  assert.equal("latest" in status, false);
+
+  assert.throws(
+    () => execFileSync(process.execPath, [cli, "status", "unknown"], { cwd: tempDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+    /worktree/,
+  );
+});
+
+test("worktree evidence implementation is read-only and keeps claim boundaries local", () => {
+  const implementationFiles = [
+    path.join(repoRoot, "src", "core", "worktree-evidence.ts"),
+    path.join(repoRoot, "src", "adapters", "codex-runtime-hook.ts"),
+    path.join(repoRoot, "src", "adapters", "claude-runtime-hook.ts"),
+  ];
+  const source = implementationFiles.map((filePath) => fs.readFileSync(filePath, "utf8")).join("\n");
+  assert.match(source, /git status --porcelain=v1 -z/);
+  for (const term of ["add", "stash", "reset", "restore", "checkout", "clean", "commit", "rm", "mv"]) {
+    assert.doesNotMatch(source, new RegExp(`\\bgit\\s+${term}\\b`));
+  }
+  assert.doesNotMatch(source, /FOOKS_SESSION_METRICS_SCHEMA_VERSION\\s*=\\s*2/);
+  assert.doesNotMatch(source, /provider billing proof|provider cost proof|token savings proof/i);
+});

--- a/test/worktree-status.test.mjs
+++ b/test/worktree-status.test.mjs
@@ -1,0 +1,73 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+
+const {
+  parseWorktreeStatus,
+  summarizeWorktreeStatus,
+  parseAndSummarizeWorktreeStatus,
+} = require(path.join(repoRoot, "dist", "core", "worktree-status.js"));
+
+test("parseWorktreeStatus parses modified, staged, deleted, and untracked porcelain entries", () => {
+  const entries = parseWorktreeStatus(" M README.md\nA  src/new.ts\n D old.txt\n?? scratch.log\n");
+
+  assert.deepEqual(entries.map((entry) => [entry.path, entry.indexStatus, entry.worktreeStatus, entry.kind, entry.tracked]), [
+    ["README.md", " ", "M", "modified", true],
+    ["src/new.ts", "A", " ", "added", true],
+    ["old.txt", " ", "D", "deleted", true],
+    ["scratch.log", "?", "?", "untracked", false],
+  ]);
+});
+
+test("parseWorktreeStatus preserves staged and worktree type-change status", () => {
+  const entries = parseWorktreeStatus("T  scripts/run.sh\n T docs/link.md\nMT src/mixed.ts\n");
+
+  assert.deepEqual(entries.map((entry) => [entry.path, entry.indexStatus, entry.worktreeStatus, entry.kind, entry.tracked]), [
+    ["scripts/run.sh", "T", " ", "type-changed", true],
+    ["docs/link.md", " ", "T", "type-changed", true],
+    ["src/mixed.ts", "M", "T", "type-changed", true],
+  ]);
+});
+
+test("parseWorktreeStatus preserves rename source and destination for line porcelain", () => {
+  const entries = parseWorktreeStatus("R  src/old.ts -> src/new.ts\n");
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, "renamed");
+  assert.equal(entries[0].originalPath, "src/old.ts");
+  assert.equal(entries[0].path, "src/new.ts");
+});
+
+test("parseWorktreeStatus parses nul-terminated porcelain rename fields", () => {
+  const entries = parseWorktreeStatus("R  src/new.ts\0src/old.ts\0?? notes.md\0", { nulTerminated: true });
+
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].kind, "renamed");
+  assert.equal(entries[0].path, "src/new.ts");
+  assert.equal(entries[0].originalPath, "src/old.ts");
+  assert.equal(entries[1].kind, "untracked");
+  assert.equal(entries[1].path, "notes.md");
+});
+
+test("summarizeWorktreeStatus separates tracked, untracked, ignored, and conflicted paths", () => {
+  const summary = summarizeWorktreeStatus(parseWorktreeStatus(" M README.md\n?? scratch.log\n!! dist/index.js\nUU src/conflict.ts\n"));
+
+  assert.equal(summary.clean, false);
+  assert.deepEqual(summary.changedPaths, ["README.md", "scratch.log", "src/conflict.ts"]);
+  assert.deepEqual(summary.trackedPaths, ["README.md", "src/conflict.ts"]);
+  assert.deepEqual(summary.untrackedPaths, ["scratch.log"]);
+  assert.deepEqual(summary.ignoredPaths, ["dist/index.js"]);
+  assert.deepEqual(summary.conflictedPaths, ["src/conflict.ts"]);
+});
+
+test("parseAndSummarizeWorktreeStatus treats empty or ignored-only output as clean", () => {
+  assert.equal(parseAndSummarizeWorktreeStatus("\n").clean, true);
+  assert.equal(parseAndSummarizeWorktreeStatus("!! dist/index.js\n").clean, true);
+});


### PR DESCRIPTION
## Summary

- carries the parser foundation from the closed/unmerged PR #138 on latest `main`
- adds a local `.fooks/sessions/<session>/worktree.json` sidecar for worktree baseline/latest/delta evidence
- captures worktree evidence only at Codex/Claude `SessionStart` and `Stop`
- adds explicit `fooks status worktree` JSON output while preserving default `fooks status` metrics shape
- stabilizes a Claude adapter timestamp-flake test with deterministic trust status seeding

## Guardrails

- No cache key changes
- No default metrics schema-version churn
- No per-prompt Git calls
- No Git mutation commands
- No provider/billing/runtime-savings claims

## Verification

- [x] `npm run build && node --test test/worktree-status.test.mjs test/worktree-evidence.test.mjs test/claude-adapter-resilience.test.mjs` — pass (17/17)
- [x] `npm run lint` — pass
- [x] `git diff --check` — pass
- [x] static grep for forbidden Git mutation terms over implementation/hook files — no matches
- [x] `npm test` — pass (233/233)
- [x] Ralph architect review — APPROVE / Architectural Status: CLEAR

## Notes

PR #138 was checked before execution and is closed without a merge commit, so this branch uses the allowed fallback path by including the parser commit on a fresh branch from latest `main`.
