### PR TITLE
Add Claude benchmark parity with Codex Layer 2 R4 benchmarks

### DIFF
--- a/benchmarks/layer2-frontend-task/claude-wrapper.js
+++ b/benchmarks/layer2-frontend-task/claude-wrapper.js
@@ -1,0 +1,181 @@
+/**
+ * Claude API Wrapper
+ *
+ * Calls the Anthropic Messages API directly using native fetch.
+ * Mirrors the CodexWrapper interface for paired benchmark parity.
+ */
+class ClaudeWrapper {
+  constructor(options = {}) {
+    this.model = options.model || process.env.CLAUDE_MODEL || 'claude-sonnet-4-6';
+    this.timeoutMs = Number(options.timeoutMs || process.env.CLAUDE_TIMEOUT_MS || 300000);
+    this.apiKey = options.apiKey || process.env.ANTHROPIC_API_KEY || '';
+    this.apiUrl = options.apiUrl || process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+  }
+
+  /**
+   * Claude 실행
+   * @param {string} context - 컨텍스트 (vanilla: 전체 파일, fooks: 추출된 payload)
+   * @param {string} taskPrompt - 작업 지시문
+   * @returns {Promise<Object>} 실행 결과
+   */
+  async run(context, taskPrompt) {
+    const startTime = Date.now();
+    const timestamp = new Date().toISOString();
+    const fullPrompt = this.buildPrompt(context, taskPrompt);
+
+    if (!this.apiKey) {
+      return {
+        exitCode: -1,
+        success: false,
+        error: 'ANTHROPIC_API_KEY is not set',
+        latencyMs: Date.now() - startTime,
+        timestamp,
+        stdout: '',
+        stderr: 'ANTHROPIC_API_KEY is not set',
+        lastMessage: '',
+        runtimeUsage: {
+          inputTokens: null,
+          outputTokens: null,
+          totalTokens: null,
+          source: null,
+          claimBoundary: 'Anthropic API usage is not provider billing telemetry.',
+        },
+        metadata: {
+          model: this.model,
+          timeoutMs: this.timeoutMs,
+          promptLength: fullPrompt.length,
+          promptTokens: Math.ceil(fullPrompt.length / 3.5),
+        },
+      };
+    }
+
+    let responseText = '';
+    let usage = { input_tokens: null, output_tokens: null };
+    let response;
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+      response = await fetch(this.apiUrl, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          max_tokens: 4096,
+          messages: [
+            { role: 'user', content: fullPrompt },
+          ],
+        }),
+      });
+
+      clearTimeout(timeoutId);
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const errorBody = JSON.stringify(data, null, 2);
+        return {
+          exitCode: response.status,
+          success: false,
+          error: `Anthropic API error: ${response.status} ${response.statusText}`,
+          latencyMs: Date.now() - startTime,
+          timestamp,
+          stdout: '',
+          stderr: errorBody,
+          lastMessage: '',
+          runtimeUsage: {
+            inputTokens: null,
+            outputTokens: null,
+            totalTokens: null,
+            source: null,
+            claimBoundary: 'Anthropic API usage is not provider billing telemetry.',
+          },
+          metadata: {
+            model: this.model,
+            timeoutMs: this.timeoutMs,
+            promptLength: fullPrompt.length,
+            promptTokens: Math.ceil(fullPrompt.length / 3.5),
+          },
+        };
+      }
+
+      responseText = data.content?.[0]?.text || '';
+      usage = data.usage || { input_tokens: null, output_tokens: null };
+
+      return {
+        exitCode: 0,
+        success: true,
+        stdout: responseText,
+        stderr: '',
+        lastMessage: responseText,
+        latencyMs: Date.now() - startTime,
+        timestamp,
+        runtimeUsage: {
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          totalTokens: usage.input_tokens !== null && usage.output_tokens !== null
+            ? usage.input_tokens + usage.output_tokens
+            : null,
+          source: 'anthropic-api-usage-field',
+          claimBoundary: 'Anthropic API usage fields are not provider billing tokens or costs.',
+        },
+        metadata: {
+          model: this.model,
+          timeoutMs: this.timeoutMs,
+          promptLength: fullPrompt.length,
+          promptTokens: Math.ceil(fullPrompt.length / 3.5),
+        },
+      };
+    } catch (error) {
+      return {
+        exitCode: -1,
+        success: false,
+        error: error.message,
+        latencyMs: Date.now() - startTime,
+        timestamp,
+        stdout: '',
+        stderr: error.message,
+        lastMessage: '',
+        runtimeUsage: {
+          inputTokens: null,
+          outputTokens: null,
+          totalTokens: null,
+          source: null,
+          claimBoundary: 'Anthropic API usage is not provider billing telemetry.',
+        },
+        metadata: {
+          model: this.model,
+          timeoutMs: this.timeoutMs,
+          promptLength: fullPrompt.length,
+          promptTokens: Math.ceil(fullPrompt.length / 3.5),
+        },
+      };
+    }
+  }
+
+  buildPrompt(context, taskPrompt) {
+    return `# Task: ${taskPrompt}
+
+## Context (File Content or Extracted Structure):
+${context}
+
+## Instructions:
+1. Refactor the code into modular components as specified
+2. Maintain all existing functionality
+3. Ensure no circular dependencies
+4. Keep each file under 200 lines
+5. Add proper barrel exports
+6. Use only the provided context; do not inspect the filesystem or target paths
+
+## Output:
+Provide the proposed file tree and concise code skeleton for each new file. Do not edit files.`;
+  }
+}
+
+module.exports = ClaudeWrapper;

--- a/benchmarks/layer2-frontend-task/run-r4-applied.js
+++ b/benchmarks/layer2-frontend-task/run-r4-applied.js
@@ -2,11 +2,7 @@
 /**
  * Run an applied-code R4 benchmark attempt in an isolated workspace.
  *
- * Unlike runner.js, this command allows Codex to write candidate files into a
- * temporary workspace and immediately validates that applied tree with
- * validate-r4-applied.js. It is the first executable path toward lifting the
- * "proposal-only" boundary; repeated matched runs are still required before any
- * stable runtime-token/time claim.
+ * Supports both Codex and Claude providers via --provider flag.
  */
 
 const fs = require('fs');
@@ -15,6 +11,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 const { validate } = require('./validate-r4-applied');
 const { parseCodexRuntimeUsage } = require('./runtime-token-metrics');
+const ClaudeWrapper = require('./claude-wrapper');
 
 function parseArgs(argv) {
   return argv.reduce((acc, arg) => {
@@ -131,27 +128,77 @@ function runCodex(prompt, workdir, model, timeoutMs) {
   });
 }
 
+async function runClaude(prompt, workdir, model, timeoutMs) {
+  const wrapper = new ClaudeWrapper({ model, timeoutMs });
+  const result = await wrapper.run(prompt, 'Write the files now. Do not only describe a plan; create the files in the workspace.');
+
+  // Write files to workdir if Claude returned code blocks
+  if (result.success && result.lastMessage) {
+    const codeBlocks = extractCodeBlocks(result.lastMessage);
+    for (const block of codeBlocks) {
+      const filePath = path.join(workdir, block.filePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, block.content);
+    }
+  }
+
+  return {
+    exitCode: result.exitCode,
+    signal: null,
+    success: result.success,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    lastMessage: result.lastMessage,
+    runtimeUsage: result.runtimeUsage,
+    latencyMs: result.latencyMs,
+  };
+}
+
+function extractCodeBlocks(text) {
+  const blocks = [];
+  const fenceRegex = /```(?:\w+)?\s*\n([\s\S]*?)```/g;
+  const filePathRegex = /^(?:\s*\/\/\s*)?(?:File:\s*)?(.+\.(?:ts|tsx|js|jsx))\s*\n/;
+  let match;
+  while ((match = fenceRegex.exec(text)) !== null) {
+    let content = match[1];
+    const fileMatch = content.match(filePathRegex);
+    if (fileMatch) {
+      const filePath = fileMatch[1].trim();
+      content = content.slice(fileMatch[0].length);
+      blocks.push({ filePath, content });
+    }
+  }
+  return blocks;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const mode = args.mode || 'vanilla';
   const targetFile = args.target;
   const outputPath = args.output;
-  const model = args.model || process.env.CODEX_MODEL || 'gpt-5.4-mini';
-  const timeoutMs = Number(args.timeoutMs || process.env.CODEX_TIMEOUT_MS || 300000);
+  const provider = args.provider || 'codex';
+  const model = args.model || process.env.CODEX_MODEL || process.env.CLAUDE_MODEL || 'gpt-5.4-mini';
+  const timeoutMs = Number(args.timeoutMs || process.env.CODEX_TIMEOUT_MS || process.env.CLAUDE_TIMEOUT_MS || 300000);
   const keepWorkdir = Boolean(args['keep-workdir']);
 
   if (!targetFile || !outputPath || !['vanilla', 'fooks'].includes(mode)) {
-    console.error('Usage: node run-r4-applied.js --mode=vanilla|fooks --target=<file> --output=<json> [--model=<model>] [--timeoutMs=<ms>] [--keep-workdir]');
+    console.error('Usage: node run-r4-applied.js --mode=vanilla|fooks --target=<file> --output=<json> [--provider=codex|claude] [--model=<model>] [--timeoutMs=<ms>] [--keep-workdir]');
     process.exit(1);
   }
 
-  const workdir = args.workdir ? path.resolve(args.workdir) : fs.mkdtempSync(path.join(os.tmpdir(), `fooks-r4-applied-${mode}-`));
+  const workdir = args.workdir ? path.resolve(args.workdir) : fs.mkdtempSync(path.join(os.tmpdir(), `fooks-r4-applied-${provider}-${mode}-`));
   fs.mkdirSync(workdir, { recursive: true });
   const context = buildContext(mode, targetFile);
   const prompt = buildPrompt(context);
   const timestamp = new Date().toISOString();
 
-  const codexResult = await runCodex(prompt, workdir, model, timeoutMs);
+  let providerResult;
+  if (provider === 'claude') {
+    providerResult = await runClaude(prompt, workdir, model, timeoutMs);
+  } else {
+    providerResult = await runCodex(prompt, workdir, model, timeoutMs);
+  }
+
   const candidateRoot = path.join(workdir, 'combobox');
   let validation;
   try {
@@ -165,36 +212,37 @@ async function main() {
   }
 
   const artifact = {
-    status: codexResult.success && validation.status === 'applied-acceptance-validated'
+    status: providerResult.success && validation.status === 'applied-acceptance-validated'
       ? 'applied-code-run-validated'
       : 'applied-code-run-failed',
     schemaVersion: 'layer2-r4-applied-run.v1',
     timestamp,
     mode,
+    provider,
     targetFile: path.resolve(targetFile),
     model,
     sandbox: 'workspace-write isolated tempdir',
     workdir: keepWorkdir ? workdir : null,
     metrics: {
       promptTokensApprox: promptTokensApprox(prompt),
-      latencyMs: codexResult.latencyMs,
+      latencyMs: providerResult.latencyMs,
       retryCount: 0,
-      outputChars: codexResult.lastMessage.length || codexResult.stdout.length,
-      runtimeTokensInput: codexResult.runtimeUsage.inputTokens,
-      runtimeTokensOutput: codexResult.runtimeUsage.outputTokens,
-      runtimeTokensTotal: codexResult.runtimeUsage.totalTokens,
-      runtimeTokenSource: codexResult.runtimeUsage.source,
-      runtimeTokenTelemetryAvailable: codexResult.runtimeUsage.totalTokens !== null,
-      runtimeTokenClaimAvailable: codexResult.runtimeUsage.totalTokens !== null,
-      runtimeTokenClaimBoundary: codexResult.runtimeUsage.claimBoundary,
+      outputChars: providerResult.lastMessage.length || providerResult.stdout.length,
+      runtimeTokensInput: providerResult.runtimeUsage.inputTokens,
+      runtimeTokensOutput: providerResult.runtimeUsage.outputTokens,
+      runtimeTokensTotal: providerResult.runtimeUsage.totalTokens,
+      runtimeTokenSource: providerResult.runtimeUsage.source,
+      runtimeTokenTelemetryAvailable: providerResult.runtimeUsage.totalTokens !== null,
+      runtimeTokenClaimAvailable: providerResult.runtimeUsage.totalTokens !== null,
+      runtimeTokenClaimBoundary: providerResult.runtimeUsage.claimBoundary,
     },
-    codexResult: {
-      exitCode: codexResult.exitCode,
-      signal: codexResult.signal,
-      success: codexResult.success,
-      stderrTail: codexResult.stderr.slice(-4000),
-      stdoutTail: codexResult.stdout.slice(-4000),
-      lastMessageTail: codexResult.lastMessage.slice(-4000),
+    providerResult: {
+      exitCode: providerResult.exitCode,
+      signal: providerResult.signal,
+      success: providerResult.success,
+      stderrTail: providerResult.stderr.slice(-4000),
+      stdoutTail: providerResult.stdout.slice(-4000),
+      lastMessageTail: providerResult.lastMessage.slice(-4000),
     },
     validation,
     claimBoundary: [

--- a/benchmarks/layer2-frontend-task/run-r4-repeated.js
+++ b/benchmarks/layer2-frontend-task/run-r4-repeated.js
@@ -28,12 +28,13 @@ function parseArgs(argv) {
   }, {});
 }
 
-function runApplied({ mode, target, output, model, timeoutMs, keepWorkdir }) {
+function runApplied({ mode, target, output, provider, model, timeoutMs, keepWorkdir }) {
   const args = [
     path.join(__dirname, 'run-r4-applied.js'),
     `--mode=${mode}`,
     `--target=${target}`,
     `--output=${output}`,
+    `--provider=${provider}`,
     `--model=${model}`,
     `--timeoutMs=${timeoutMs}`,
   ];
@@ -58,7 +59,7 @@ function seedPairs(values) {
 }
 
 function usage() {
-  return 'Usage: node run-r4-repeated.js --target=<file> [--output=<summary.json>] [--results-dir=<dir>] [--required-accepted=5] [--max-pairs=8] [--model=gpt-5.4-mini] [--timeoutMs=300000] [--run-id=<id>] [--task-id=<id>] [--setup-id=<id>] [--seed-pair=<vanilla.json>:<fooks.json>] [--keep-workdir]';
+  return 'Usage: node run-r4-repeated.js --target=<file> [--output=<summary.json>] [--results-dir=<dir>] [--required-accepted=5] [--max-pairs=8] [--provider=codex|claude] [--model=<model>] [--timeoutMs=300000] [--run-id=<id>] [--task-id=<id>] [--setup-id=<id>] [--seed-pair=<vanilla.json>:<fooks.json>] [--keep-workdir]';
 }
 
 function taskIdentityFromTarget(target) {
@@ -66,10 +67,11 @@ function taskIdentityFromTarget(target) {
   return `target:${path.relative(process.cwd(), path.resolve(target)).split(path.sep).join('/')}`;
 }
 
-function setupIdentity({ taskIdentity, model, requiredAcceptedPairs, explicitSetupId }) {
+function setupIdentity({ taskIdentity, provider, model, requiredAcceptedPairs, explicitSetupId }) {
   if (explicitSetupId) return explicitSetupId;
   return [
     `task=${taskIdentity || 'unspecified-task'}`,
+    `provider=${provider || 'unspecified-provider'}`,
     `model=${model || 'unspecified-model'}`,
     'runner=run-r4-repeated',
     'prompt=R4-feature-module-split-v1',
@@ -92,15 +94,17 @@ async function main() {
   const output = args.output || defaultPaths.json;
   const requiredAcceptedPairs = Number(args['required-accepted'] || 5);
   const maxPairs = Number(args['max-pairs'] || requiredAcceptedPairs);
-  const model = args.model || process.env.CODEX_MODEL || 'gpt-5.4-mini';
+  const provider = args.provider || 'codex';
+  const model = args.model || process.env.CODEX_MODEL || process.env.CLAUDE_MODEL || 'gpt-5.4-mini';
   const taskIdentity = args['task-id'] || taskIdentityFromTarget(target);
   const resolvedSetupIdentity = setupIdentity({
     taskIdentity,
+    provider,
     model,
     requiredAcceptedPairs,
     explicitSetupId: args['setup-id'] || args['setup-identity'],
   });
-  const timeoutMs = Number(args.timeoutMs || process.env.CODEX_TIMEOUT_MS || 300000);
+  const timeoutMs = Number(args.timeoutMs || process.env.CODEX_TIMEOUT_MS || process.env.CLAUDE_TIMEOUT_MS || 300000);
   const resultsDir = args['results-dir'] || (defaultPaths
     ? path.join(defaultPaths.dir, 'pairs')
     : path.dirname(output));
@@ -122,8 +126,8 @@ async function main() {
     const vanillaPath = `${prefix}-vanilla.json`;
     const fooksPath = `${prefix}-fooks.json`;
 
-    runApplied({ mode: 'vanilla', target, output: vanillaPath, model, timeoutMs, keepWorkdir });
-    runApplied({ mode: 'fooks', target, output: fooksPath, model, timeoutMs, keepWorkdir });
+    runApplied({ mode: 'vanilla', target, output: vanillaPath, provider, model, timeoutMs, keepWorkdir });
+    runApplied({ mode: 'fooks', target, output: fooksPath, provider, model, timeoutMs, keepWorkdir });
     pairs.push({ pairIndex, vanillaPath, fooksPath });
 
     const interim = summarizeRepeatedPairs({

--- a/benchmarks/layer2-frontend-task/runner.js
+++ b/benchmarks/layer2-frontend-task/runner.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /**
- * R4 Feature Module Split - Runner with Codex Wrapper
+ * R4 Feature Module Split - Runner with Provider Wrapper
  */
 
 const fs = require('fs');
 const path = require('path');
 const CodexWrapper = require('./codex-wrapper');
+const ClaudeWrapper = require('./claude-wrapper');
 
 // Parse arguments
 const args = process.argv.slice(2).reduce((acc, arg) => {
@@ -19,13 +20,15 @@ const args = process.argv.slice(2).reduce((acc, arg) => {
 const mode = args.mode || 'vanilla';
 const targetFile = args.target;
 const outputPath = args.output;
-const model = args.model || process.env.CODEX_MODEL || 'gpt-5.4-mini';
+const provider = args.provider || 'codex';
+const model = args.model || process.env.CODEX_MODEL || process.env.CLAUDE_MODEL || 'gpt-5.4-mini';
 
 if (!targetFile || !outputPath) {
-  console.error('Usage: node runner.js --mode=vanilla|fooks --target=<file> --output=<json>');
+  console.error('Usage: node runner.js --mode=vanilla|fooks --target=<file> --output=<json> [--provider=codex|claude] [--model=<model>]');
   process.exit(1);
 }
 
+console.log(`[R4 Runner] Provider: ${provider}`);
 console.log(`[R4 Runner] Mode: ${mode}`);
 console.log(`[R4 Runner] Target: ${targetFile}`);
 
@@ -33,7 +36,7 @@ async function main() {
   // Prepare context based on mode
   let context;
   let fooksPath;
-  
+
   if (mode === 'fooks') {
     // Use fooks extraction
     fooksPath = path.join(__dirname, '../../dist/index.js');
@@ -50,28 +53,32 @@ async function main() {
     console.log(`[R4 Runner] Vanilla mode: reading full file`);
     context = fs.readFileSync(targetFile, 'utf-8');
   }
-  
-  // Initialize Codex wrapper
-  const codex = new CodexWrapper({
-    model
-  });
-  
-  // Execute Codex
+
+  // Initialize provider wrapper
+  let wrapper;
+  if (provider === 'claude') {
+    wrapper = new ClaudeWrapper({ model });
+  } else {
+    wrapper = new CodexWrapper({ model });
+  }
+
+  // Execute benchmark
   const taskPrompt = 'Refactor this combobox component into modular files (components/, hooks/, utils/, types/)';
-  
-  console.log(`[R4 Runner] Calling Codex...`);
-  const result = await codex.run(context, taskPrompt);
-  
-  console.log(`[R4 Runner] Codex completed with exitCode: ${result.exitCode}`);
+
+  console.log(`[R4 Runner] Calling ${provider}...`);
+  const result = await wrapper.run(context, taskPrompt);
+
+  console.log(`[R4 Runner] ${provider} completed with exitCode: ${result.exitCode}`);
   console.log(`[R4 Runner] Latency: ${result.latencyMs}ms`);
   console.log(`[R4 Runner] Prompt tokens: ${result.metadata.promptTokens}`);
-  
+
   // Save result
   const output = {
     mode,
     targetFile,
+    provider,
     timestamp: result.timestamp,
-    codexResult: result,
+    result,
     metrics: {
       promptTokensApprox: result.metadata.promptTokens,
       latencyMs: result.latencyMs,
@@ -85,10 +92,10 @@ async function main() {
       runtimeTokenClaimBoundary: result.runtimeUsage.claimBoundary,
     }
   };
-  
+
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
-  
+
   console.log(`[R4 Runner] Result saved to: ${outputPath}`);
   console.log(`[R4 Runner] Success: ${result.success}`);
 }

--- a/benchmarks/layer2-frontend-task/runtime-token-metrics.js
+++ b/benchmarks/layer2-frontend-task/runtime-token-metrics.js
@@ -15,8 +15,8 @@ function parseCodexRuntimeTokens(...chunks) {
  * Parse the strongest structured Codex CLI runtime-token telemetry available.
  *
  * `totalTokens` is the only comparable runtime-token aggregate used by the
- * repeated L1 gate. `inputTokens` and `outputTokens` are retained when the CLI
- * prints them, but they are optional because older/terser Codex output may only
+ * repeated L1 gate. `inputTokens` and `outputTokens` are retained when the
+ * CLI prints them, but they are optional because older/terser Codex output may only
  * include "tokens used".
  */
 function parseCodexRuntimeUsage(...chunks) {
@@ -60,6 +60,78 @@ function parseCodexRuntimeUsage(...chunks) {
   };
 }
 
+/**
+ * Parse Anthropic API runtime token usage from an API response object.
+ *
+ * Accepts either a raw API response object or text chunks (for compatibility).
+ * When given an object, reads usage.input_tokens and usage.output_tokens directly.
+ * When given text chunks, attempts to parse JSON and extract usage.
+ */
+function parseClaudeRuntimeUsage(...chunks) {
+  const empty = {
+    inputTokens: null,
+    outputTokens: null,
+    totalTokens: null,
+    source: null,
+    claimBoundary: 'Anthropic API usage fields are not provider billing tokens or costs.',
+  };
+
+  // If the first chunk is an object with usage, read directly
+  const first = chunks[0];
+  if (first && typeof first === 'object' && first.usage) {
+    const inputTokens = Number.isFinite(first.usage.input_tokens) ? first.usage.input_tokens : null;
+    const outputTokens = Number.isFinite(first.usage.output_tokens) ? first.usage.output_tokens : null;
+    const totalTokens = inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null;
+    return {
+      ...empty,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      source: totalTokens === null ? null : 'anthropic-api-usage-object',
+    };
+  }
+
+  // Fallback: join text chunks and try to find usage in JSON
+  const text = chunks.filter((chunk) => typeof chunk === 'string' && chunk.length > 0).join('\n');
+  if (!text) return empty;
+
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed.usage) {
+      const inputTokens = Number.isFinite(parsed.usage.input_tokens) ? parsed.usage.input_tokens : null;
+      const outputTokens = Number.isFinite(parsed.usage.output_tokens) ? parsed.usage.output_tokens : null;
+      const totalTokens = inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null;
+      return {
+        ...empty,
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        source: totalTokens === null ? null : 'anthropic-api-json',
+      };
+    }
+  } catch {
+    // Not JSON, try regex fallback
+  }
+
+  const inputTokens = lastNumber([
+    /"input_tokens"\s*:\s*([0-9]+)/gi,
+    /input[_\s]tokens["']?\s*[:=]\s*([0-9][0-9,]*)/gi,
+  ], text);
+  const outputTokens = lastNumber([
+    /"output_tokens"\s*:\s*([0-9]+)/gi,
+    /output[_\s]tokens["']?\s*[:=]\s*([0-9][0-9,]*)/gi,
+  ], text);
+  const totalTokens = inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null;
+
+  return {
+    ...empty,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    source: totalTokens === null ? null : 'anthropic-api-regex',
+  };
+}
+
 function lastNumber(patterns, text) {
   const candidates = [];
   for (const pattern of patterns) {
@@ -72,4 +144,4 @@ function lastNumber(patterns, text) {
   return candidates.length > 0 ? candidates[candidates.length - 1] : null;
 }
 
-module.exports = { parseCodexRuntimeTokens, parseCodexRuntimeUsage };
+module.exports = { parseCodexRuntimeTokens, parseCodexRuntimeUsage, parseClaudeRuntimeUsage };


### PR DESCRIPTION
## Summary
Adds Claude provider support to the Layer 2 R4 task benchmark suite, enabling paired vanilla-vs-fooks comparisons using the Anthropic API.

## Changes
- **claude-wrapper.js**: New Anthropic Messages API wrapper mirroring CodexWrapper interface
- **runner.js**: Added --provider=codex|claude flag (default: codex)
- **run-r4-applied.js**: Added --provider flag with Claude code-block extraction for workspace-write mode
- **run-r4-repeated.js**: Added --provider flag and provider identity tracking
- **runtime-token-metrics.js**: Added parseClaudeRuntimeUsage for Anthropic API usage fields

## Usage
```bash
# Proposal-only smoke
node benchmarks/layer2-frontend-task/runner.js --provider=claude --mode=fooks --target=<file> --output=<json>

# Applied-code attempt
ANTHROPIC_API_KEY=... node benchmarks/layer2-frontend-task/run-r4-applied.js --provider=claude --mode=fooks --target=<file> --output=<json>

# Repeated paired runs
ANTHROPIC_API_KEY=... node benchmarks/layer2-frontend-task/run-r4-repeated.js --provider=claude --target=<file>
```

## Environment
- ANTHROPIC_API_KEY - required for Claude provider
- CLAUDE_MODEL - defaults to claude-sonnet-4-6
- CLAUDE_TIMEOUT_MS - defaults to 300000

🤖 Generated with [Claude Code](https://claude.com/code)