### PR TITLE
polish: tighten README opening for v0.1.0 public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # fooks
 
-Smaller model-facing context for repeated React component work in Codex.
+Frontend context compression for iterative React/TSX work in Codex and Claude Code.
 
-Broad category: Frontend context compression for Codex and Claude Code. Current strongest path: Codex repeated React component work; Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
+`fooks` reduces model-facing input for supported repeated frontend file work. On the first eligible `.tsx` / `.jsx` mention, it records compact context; later same-file prompts may reuse it when safe. Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
 
 `fooks` is for Codex users who repeatedly work on the same React `.tsx` / `.jsx` file. On the first eligible mention, fooks records the component context; on later same-file prompts, it can send a compact model-facing payload instead of the full source when safe.
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2918,7 +2918,7 @@ test("docs describe local compare estimates without billing-cost claims", () => 
 ${setup}
 ${release}`;
 
-  assert.match(readme, /Frontend context compression for Codex and Claude Code/);
+  assert.match(readme, /Frontend context compression for.*Codex and Claude Code/);
   assert.match(combined, /fooks compare src\/components\/Button\.tsx/);
   assert.match(combined, /local model-facing payload estimate|local file-level estimate/);
   assert.match(combined, /TypeScript AST-derived/);


### PR DESCRIPTION
Tightens the README opening paragraph for public release:\n\n- Leads with 'Frontend context compression' instead of 'Smaller model-facing context'\n- Front-loads supported paths (Codex/Claude/opencode) in first sentence\n- Keeps Claude/opencode boundary warning in opening paragraph\n- Removes redundant 'Current strongest path' framing\n\nNo code changes; docs only.