### PR TITLE
Add guarded Codex TS/JS same-file beta support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ The npm package is `oh-my-fooks`; the installed CLI command is `fooks`. Do not d
 ## Pull request checklist
 
 - [ ] Source changes are tracked; generated `dist/` is ignored and rebuilt by scripts.
+- [ ] Frontend/process scope follows [`docs/frontend-scope-taxonomy.md`](docs/frontend-scope-taxonomy.md): selected primary lane, required support work, and `in/support/defer/blocked` boundaries are recorded when applicable.
 - [ ] Docs match the current claim boundary.
 - [ ] `npm run lint` passes.
 - [ ] `npm test` passes.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # fooks
 
-Frontend context compression for iterative React/TSX work in Codex and Claude Code.
+Smaller model-facing context for repeated same-file work in Codex.
 
 `fooks` reduces model-facing input for supported repeated frontend file work. On the first eligible `.tsx` / `.jsx` mention, it records compact context; later same-file prompts may reuse it when safe. Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
 
-`fooks` is for Codex users who repeatedly work on the same React `.tsx` / `.jsx` file. On the first eligible mention, fooks records the component context; on later same-file prompts, it can send a compact model-facing payload instead of the full source when safe.
+`fooks` is for Codex users who repeatedly work on the same supported file in one repo. The strongest path is still React `.tsx` / `.jsx`, and there is now an experimental Codex-first `.ts` / `.js` same-file beta. On the first eligible mention, fooks records the file context; on later same-file prompts, it can send a compact model-facing payload instead of the full source when safe.
 
 - Public npm package: `oh-my-fooks`
 - CLI command: `fooks`
 
 ## 30-second version
 
-Use fooks when you are iterating on the same large React component in Codex and want to avoid repeatedly sending the full file context.
+Use fooks when you are iterating on the same large supported file in Codex and want to avoid repeatedly sending the full file context.
 
 - **Best today:** Codex + repeated same-file `.tsx` / `.jsx` work.
+- **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
 - **Local proof:** `fooks compare` shows the original source size versus the compact fooks model-facing payload for one supported file.
 - **Evidence boundary:** fooks supports prompt-size/context-load estimates and estimate-scoped API-cost evidence under explicit assumptions; it does not prove provider invoices, billing-grade charges, stable runtime-token wins, or Claude/opencode automatic savings.
 
@@ -34,7 +35,7 @@ Then open Codex in that repo and work normally. `fooks compare` gives an immedia
 
 | Best today | Not today |
 | --- | --- |
-| Repeated same-file React `.tsx` / `.jsx` work in Codex. | Universal file-read interception for every language, framework, runtime, or file type. |
+| Repeated same-file React `.tsx` / `.jsx` work in Codex, plus experimental Codex-first `.ts` / `.js` same-file beta. | Universal file-read interception for every language, framework, runtime, or file type. |
 | Local model-facing payload estimates with `fooks compare` and local session estimates with `fooks status`. | Provider billing telemetry, provider tokenizer behavior, provider invoice/dashboard proof, or a `ccusage` replacement. |
 | Project setup that prepares Codex hooks plus narrower Claude/opencode helper paths when available. | A claim that Claude or opencode has Codex-equivalent automatic runtime-token behavior. |
 
@@ -43,11 +44,12 @@ Then open Codex in that repo and work normally. `fooks compare` gives an immedia
 These are useful future directions, but they are not required for the current Codex repeated React workflow:
 
 - Vue, Svelte, or non-React framework support.
-- General `.ts` / backend-file context compression.
 - Multi-file refactor context compression.
 - Universal runtime file-read interception.
 - LSP-backed semantic rename/reference safety.
 - Provider invoice/dashboard or billing-grade charge proof.
+
+Experimental `.ts` / `.js` support is **not** a claim of backend/framework semantic understanding, multi-file refactor support, Vue/SFC support, Claude/opencode parity, read interception, or LSP rename/reference safety. Unsupported or weak TS/JS files fall back to normal full-source behavior.
 
 See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stronger support or stronger evidence claims.
 
@@ -55,7 +57,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stron
 
 | Environment | Current path | Automation level | Do not assume |
 | --- | --- | --- | --- |
-| Codex | Automatic repeated-file hook path through `fooks setup` | Strongest path: repeated same-file `.tsx` / `.jsx` prompts can reuse compact context when safe | Universal file-read interception, stable runtime-token wins, or provider billing/cost proof |
+| Codex | Automatic repeated-file hook path through `fooks setup` | Strongest path: repeated same-file `.tsx` / `.jsx` prompts can reuse compact context when safe; experimental same-file `.ts` / `.js` beta is available after supported Codex setup when module signals are strong enough | Universal file-read interception, stable runtime-token wins, provider billing/cost proof, Vue/SFC support, multi-file refactors, or LSP semantic safety |
 | Claude | Project-local `SessionStart` / `UserPromptSubmit` context hooks plus manual/shared handoff artifacts | Narrower path: first eligible explicit frontend-file prompt is recorded/prepared; a repeated same-file prompt may receive bounded context | `Read` interception, full prompt-interception parity with Codex, or runtime-token savings proof |
 | opencode | Project-local `fooks_extract` tool and `/fooks-extract` slash command | Manual/semi-automatic tool steering | Built-in `read` interception or automatic runtime-token savings |
 
@@ -75,7 +77,7 @@ The `fooks setup` JSON includes a `scope` object so support/debug logs can show 
 Current automatic optimization is intentionally narrow:
 
 - Runtime: Codex hooks
-- Files: `.tsx` and `.jsx`
+- Files: strongest path `.tsx` / `.jsx`; experimental Codex-first `.ts` / `.js` same-file beta
 - Pattern: repeated same-file work in one Codex session
 - First mention: record only
 - Later same-file mentions: reuse a compact fooks payload when safe
@@ -92,7 +94,7 @@ If fooks cannot safely build a payload, it falls back to normal full-source beha
 
 ## Compare a file locally
 
-Use `fooks compare` when you want immediate, local proof for a specific frontend file:
+Use `fooks compare` when you want immediate, local proof for a specific supported file:
 
 ```bash
 fooks compare src/components/Button.tsx --json

--- a/docs/frontend-scope-taxonomy.md
+++ b/docs/frontend-scope-taxonomy.md
@@ -10,15 +10,26 @@ Related tracking issue: #131.
 
 Before implementation starts:
 
-1. Pick exactly one core execution lane.
+1. Pick exactly one primary lane unless a bundle exception is declared.
 2. Classify connected frontend concerns as gates, not automatic work.
 3. Default evidence, infrastructure, and backend/API lanes to defer unless explicitly selected.
 4. Run a reuse scan before adding files, helpers, mocks, types, regexes, adapters, or shared utilities.
 5. Require 3+ concrete repetitions or an existing precedent before introducing shared abstractions.
 
+## PR execution contract
+
+Use this contract before implementation or process-only work begins.
+
+1. **User Intent Classification** — classify the primary user intent as one Layer 1 core execution lane (`feature`, `design/UI`, `refactor`, `migration`, `test`) or as one explicitly selected Layer 3 separate lane such as `docs/process`.
+2. **Primary Lane Contract** — select exactly one primary lane by default. A core execution lane is a Layer 1 frontend implementation lane; a primary lane is the single owner for the PR and may also be an explicitly selected Layer 3 separate lane.
+3. **Required Support Work** — list only subordinate work required to complete the primary lane, such as tests, QA, docs, fixtures, or small cleanup. `support` here does not mean product/runtime support, does not expand public support claims, and is not a second primary lane.
+4. **Boundary Gates** — classify connected concerns as `in`, `support`, `defer`, or `blocked`.
+5. **Bundle Exception** — if more than one primary lane is truly required, declare why the work cannot be split, what extra risk it adds, and what extra verification will cover that risk.
+6. **PR Execution** — execute the selected primary lane plus required support work only. Everything else goes into the defer ledger or is marked blocked.
+
 ## Layer 1: core execution lanes
 
-Select at most one lane for a first implementation handoff.
+Select at most one Layer 1 lane for a first implementation handoff. For docs/process-only or evidence-only PRs, select the relevant Layer 3 lane as the primary lane instead of forcing the work into a frontend implementation lane.
 
 | Core lane | Allowed first pass | Must not cross into |
 | --- | --- | --- |
@@ -30,7 +41,14 @@ Select at most one lane for a first implementation handoff.
 
 ## Layer 2: frontend boundary gates
 
-Classify every gate as `in`, `defer`, or `blocked`. A gate is `in` only when it is required for the selected core lane and does not broaden the task beyond that lane's allowed first pass.
+Classify every gate as `in`, `support`, `defer`, or `blocked`.
+
+- `in` means the gate is owned by the selected primary lane.
+- `support` means required subordinate work for the selected primary lane; it is not product/runtime support and not a second primary lane.
+- `defer` means visible but intentionally left for a later lane.
+- `blocked` means the PR cannot safely decide or complete that gate without missing authority, evidence, or upstream work.
+
+A gate is `in` only when it is required for the selected primary lane and does not broaden the task beyond that lane's allowed first pass.
 
 | Boundary gate | Default rule | Incidental scope forbidden unless selected |
 | --- | --- | --- |
@@ -45,7 +63,7 @@ Classify every gate as `in`, `defer`, or `blocked`. A gate is `in` only when it 
 
 ## Layer 3: separate evidence, infrastructure, and defer lanes
 
-These lanes are visible during planning but default to defer unless explicitly selected as the current lane.
+These lanes are visible during planning but default to defer unless explicitly selected as the primary lane. When one of these lanes is selected as primary, Layer 1 core execution lanes should normally defer.
 
 | Separate lane | Default disposition |
 | --- | --- |
@@ -62,27 +80,37 @@ These lanes are visible during planning but default to defer unless explicitly s
 Use this before implementation:
 
 ```md
-Selected core lane: <feature | design/UI | refactor | migration | test>
+Primary lane: <feature | design/UI | refactor | migration | test | BE/API sync | analytics/telemetry/logging | performance/bundle | build/tooling/dependencies | hooks/enforcement | benchmark/evidence | docs/process>
+Primary lane type: <Layer 1 core execution lane | Layer 3 separate lane>
 One-sentence change: <exact behavior/boundary/state/test intent>
+Required support work:
+- tests: <support | defer | blocked> — <reason>
+- QA: <support | defer | blocked> — <reason>
+- docs: <support | defer | blocked> — <reason>
+- fixtures: <support | defer | blocked> — <reason>
+- small cleanup: <support | defer | blocked> — <reason>
+
+Bundle exception: <none | required>
+- If required: <why this cannot split into separate PRs, added risk, extra verification>
 
 Layer 2 boundary gates:
-- routing/app shell: <in | defer | blocked> — <reason>
-- state/data flow: <in | defer | blocked> — <reason>
-- forms/validation: <in | defer | blocked> — <reason>
-- accessibility: <in | defer | blocked> — <reason>
-- i18n/content/locale: <in | defer | blocked> — <reason>
-- error/loading/empty states: <in | defer | blocked> — <reason>
-- component API/props: <in | defer | blocked> — <reason>
-- styling tokens/classes: <in | defer | blocked> — <reason>
+- routing/app shell: <in | support | defer | blocked> — <reason>
+- state/data flow: <in | support | defer | blocked> — <reason>
+- forms/validation: <in | support | defer | blocked> — <reason>
+- accessibility: <in | support | defer | blocked> — <reason>
+- i18n/content/locale: <in | support | defer | blocked> — <reason>
+- error/loading/empty states: <in | support | defer | blocked> — <reason>
+- component API/props: <in | support | defer | blocked> — <reason>
+- styling tokens/classes: <in | support | defer | blocked> — <reason>
 
 Layer 3 separate/defer lanes:
-- BE/API sync: defer — out of current repo-side path
-- analytics/telemetry/logging: <defer | selected>
-- performance/bundle: <defer | selected>
-- build/tooling/dependencies: <defer | selected>
-- hooks/enforcement: <defer | selected>
-- benchmark/evidence: <defer | selected>
-- docs/process: <defer | selected>
+- BE/API sync: <selected | defer | blocked> — <reason>
+- analytics/telemetry/logging: <selected | defer | blocked> — <reason>
+- performance/bundle: <selected | defer | blocked> — <reason>
+- build/tooling/dependencies: <selected | defer | blocked> — <reason>
+- hooks/enforcement: <selected | defer | blocked> — <reason>
+- benchmark/evidence: <selected | defer | blocked> — <reason>
+- docs/process: <selected | defer | blocked> — <reason>
 
 Reuse scan:
 - Existing references checked: <2-5 file refs or "none found after scan">
@@ -96,10 +124,13 @@ Defer ledger:
 
 A frontend task is ready to execute only when:
 
-- [ ] Exactly one core lane is selected.
-- [ ] All Layer 2 gates are classified as `in`, `defer`, or `blocked`.
-- [ ] Layer 3 lanes are deferred unless explicitly selected.
+- [ ] Exactly one primary lane is selected, unless a bundle exception is declared.
+- [ ] The primary lane type is identified as a Layer 1 core execution lane or Layer 3 separate lane.
+- [ ] Required support work is listed and justified.
+- [ ] All Layer 2 gates are classified as `in`, `support`, `defer`, or `blocked`.
+- [ ] Layer 3 lanes are deferred unless explicitly selected as the primary lane.
+- [ ] Any bundle exception explains why the work cannot split, the added risk, and the extra verification.
 - [ ] BE/API sync is deferred unless a separate approved BE/API lane exists.
 - [ ] Reuse scan evidence is recorded before new files/helpers are added.
 - [ ] Shared abstractions have 3+ repetition evidence or an existing precedent.
-- [ ] The final report includes selected lane, gates marked `in`, defer ledger, tests run, and known gaps.
+- [ ] The final report includes selected primary lane, support work performed, gates marked `in` or `support`, defer ledger, tests run, and known gaps.

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,7 @@ Before a public release, keep the public claim surface aligned to this matrix:
 
 | Environment | Release-ready wording | Do not claim |
 | --- | --- | --- |
-| Codex | Automatic repeated-file hook path through `fooks setup` | Universal file-read interception |
+| Codex | Automatic repeated-file hook path through `fooks setup`; strongest path remains repeated same-file React `.tsx` / `.jsx`, with an experimental Codex-first `.ts` / `.js` same-file beta after supported setup when module signals are strong enough | Universal file-read interception, Vue/SFC support, multi-file refactors, Claude/opencode parity, stable/GA TS/JS support, or LSP semantic safety |
 | Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
@@ -62,7 +62,7 @@ Bare `fooks status` reports local estimated context-size telemetry from `.fooks/
 
 `fooks extract <file> --model-payload` may expose `editGuidance.patchTargets` when source ranges are available. Public wording may describe those patch targets as compact, AST-derived line-aware edit anchors for components, props, effects, callbacks, event handlers, form controls, submit handlers, validation anchors, and representative snippets. Public wording must also state the freshness rule: use the targets only while `sourceFingerprint.fileHash` and `sourceFingerprint.lineCount` match the current source, otherwise rerun extraction or read the file before editing. Do not describe this guidance as LSP-backed semantic rename/reference resolution, provider tokenizer behavior, provider billing-token proof, provider-cost proof, or a `ccusage` replacement.
 
-Automatic runtime pre-read payloads stay compact unless a gated Codex edit path is active: repeated exact-file `.tsx` / `.jsx` edit-intent prompts may include bounded `editGuidance` only after positive freshness, source fingerprint equality, and payload-budget checks pass. First-turn prompts, read/inspect/explain/summarize/review-only prompts, ambiguous or multi-file prompts, stale/missing targets, and fallback paths must continue to omit `editGuidance`. Public wording must not describe this as live Codex edit outcome proof.
+Automatic runtime pre-read payloads stay compact unless a gated Codex edit path is active: repeated exact-file `.tsx` / `.jsx` edit-intent prompts may include bounded `editGuidance` only after positive freshness, source fingerprint equality, and payload-budget checks pass. Experimental `.ts` / `.js` beta payloads remain same-file, module-signal gated, and must continue to omit `editGuidance` in this release slice. First-turn prompts, read/inspect/explain/summarize/review-only prompts, ambiguous or multi-file prompts, stale/missing targets, and fallback paths must continue to omit `editGuidance`. Public wording must not describe this as live Codex edit outcome proof.
 
 Codex setup/attach/status readiness is also local state only. It may show that
 Codex hooks, manifests, and trust metadata were prepared, but it is not live

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,11 @@
 # Roadmap and future evidence lanes
 
-This page frames common "does fooks support X?" questions as future support or evidence lanes. These items are **not required** for the current strongest workflow: Codex repeated same-file React `.tsx` / `.jsx` context reduction.
+This page frames common "does fooks support X?" questions as future support or evidence lanes. These items are **not required** for the current strongest workflow: Codex repeated same-file React `.tsx` / `.jsx` context reduction, with a narrower experimental Codex-first `.ts` / `.js` same-file beta.
 
 ## Current strongest workflow
 
 - Runtime: Codex hooks prepared by `fooks setup`.
-- Files: React `.tsx` / `.jsx` components.
+- Files: React `.tsx` / `.jsx` components (strongest path), plus experimental Codex-first `.ts` / `.js` same-file beta after supported setup.
 - Pattern: repeated same-file work in one Codex session.
 - Evidence: local model-facing prompt/context estimates, plus estimate-scoped API-cost evidence where the benchmark docs say the assumptions hold.
 
@@ -14,7 +14,7 @@ This page frames common "does fooks support X?" questions as future support or e
 | Lane | Why it matters | Current boundary |
 | --- | --- | --- |
 | Vue / Svelte / broader frontend frameworks | Would expand the component extraction model beyond React. | Not part of the current automatic path. |
-| General `.ts` / backend files | Would make fooks useful outside React component loops. | Current extraction and public wording stay frontend-focused. |
+| Broader `.ts` / `.js` coverage beyond the beta | Would make fooks useful outside React component loops more consistently. | Experimental Codex-first same-file `.ts` / `.js` beta exists, but it is module-signal gated, same-file only, and not provider-parity, multi-file, or semantic-safety support. |
 | Multi-file refactor context compression | Would support broader agentic refactors where several files must stay in view. | Current strongest path is repeated same-file work. |
 | Universal read interception | Would make runtime behavior broader than Codex repeated-file hooks. | Not claimed; unsupported cases should fall back to normal source reading. |
 | LSP-backed semantic locations | Would strengthen rename/reference/edit safety beyond line-aware hints. | Current source ranges and patch targets are AST-derived edit aids, not LSP semantic proof. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Setup fooks
 
-Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex remains the automatic repeated-file hook path. Claude setup is narrower: it installs project-local context hooks for `SessionStart` and `UserPromptSubmit`, where the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context, plus manual/shared handoff artifacts. opencode setup remains a bounded project-local tool readiness summary.
+Use this when you want one explicit command to prepare fooks for a supported frontend repo. Codex remains the automatic repeated-file hook path. Claude setup is narrower: it installs project-local context hooks for `SessionStart` and `UserPromptSubmit`, where the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context, plus manual/shared handoff artifacts. opencode setup remains a bounded project-local tool readiness summary. Experimental Codex-first `.ts` / `.js` same-file beta depends on an already-supported Codex setup in this release slice; TS/JS-only project setup eligibility is still deferred.
 
 ## 1. Install
 
@@ -118,6 +118,8 @@ When source ranges are present, `fooks extract <file> --model-payload` also emit
 ### No React component found
 
 Run setup from the project root and confirm the repo has `.tsx` or `.jsx` component files.
+
+Experimental `.ts` / `.js` same-file beta does **not** yet make TS/JS-only projects setup-eligible by themselves. In this release slice, TS/JS beta works after an already-supported Codex setup or through explicit CLI extraction/comparison commands.
 
 ### Account context
 

--- a/fixtures/ts-js-beta/comments-only.ts
+++ b/fixtures/ts-js-beta/comments-only.ts
@@ -1,0 +1,2 @@
+// beta fallback fixture
+// no declarations here on purpose

--- a/fixtures/ts-js-beta/module-config.js
+++ b/fixtures/ts-js-beta/module-config.js
@@ -1,0 +1,11 @@
+export const DEFAULT_THEME = {
+  accent: "violet",
+  density: "compact",
+};
+
+export function mergeThemeConfig(baseConfig, overrides = {}) {
+  return {
+    ...baseConfig,
+    ...overrides,
+  };
+}

--- a/fixtures/ts-js-beta/module-utils.ts
+++ b/fixtures/ts-js-beta/module-utils.ts
@@ -1,0 +1,20 @@
+export type Currency = "USD" | "KRW";
+
+export interface FormatOptions {
+  currency: Currency;
+  minimumFractionDigits?: number;
+}
+
+export function formatAmount(value: number, options: FormatOptions): string {
+  const fractionDigits = options.minimumFractionDigits ?? 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: options.currency,
+    minimumFractionDigits: fractionDigits,
+  }).format(value);
+}
+
+export const DEFAULT_OPTIONS: FormatOptions = {
+  currency: "USD",
+  minimumFractionDigits: 2,
+};

--- a/fixtures/ts-js-beta/weak-config.js
+++ b/fixtures/ts-js-beta/weak-config.js
@@ -1,0 +1,1 @@
+const answer = 42;

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -194,7 +194,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   }
 
   const prompt = input.prompt ?? "";
-  const promptContext = resolvePromptFileContext(prompt, cwd);
+  const promptContext = resolvePromptFileContext(prompt, cwd, "codex-ts-js-beta");
   const target = promptContext.filePath;
   const policy = promptContext.policy;
   const escapeHatchUsed = hasFullReadEscapeHatch(prompt);

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -4,9 +4,14 @@ import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/pa
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import type { PreReadDecision } from "../core/schema";
 
-const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 
 export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance">;
+
+function eligibleExtensions(runtime: PreReadDecision["runtime"]): ReadonlySet<string> {
+  return runtime === "codex" ? CODEX_TS_JS_BETA_EXTENSIONS : REACT_ELIGIBLE_EXTENSIONS;
+}
 
 function relativePath(filePath: string, cwd: string): string {
   const relative = path.relative(cwd, filePath);
@@ -21,9 +26,9 @@ export function decidePreRead(
 ): PreReadDecision {
   const resolvedPath = path.resolve(filePath);
   const outputPath = relativePath(resolvedPath, cwd);
-  const extension = path.extname(resolvedPath);
+  const extension = path.extname(resolvedPath).toLowerCase();
 
-  if (!ELIGIBLE_EXTENSIONS.has(extension)) {
+  if (!eligibleExtensions(runtime).has(extension)) {
     return {
       runtime,
       filePath: outputPath,

--- a/src/core/context-policy.ts
+++ b/src/core/context-policy.ts
@@ -2,10 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import type { FileTarget } from "./discover";
 
-const ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+const REACT_EXTENSIONS = new Set([".tsx", ".jsx"]);
+const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const ESCAPE_HATCH_TOKENS = ["#fooks-full-read", "#fooks-disable-pre-read"] as const;
-const FILE_TOKEN_PATTERN = /(?:[A-Za-z]:)?[A-Za-z0-9_./\\-]+\.(?:tsx|jsx)\b/g;
+const FILE_TOKEN_PATTERN = /(?:[A-Za-z]:)?[A-Za-z0-9_./\\-]+\.(?:tsx|jsx|ts|js)\b/g;
 const STOPWORDS = new Set(["add", "the", "fix", "update", "to", "for", "with", "from", "and", "this", "that"]);
+
+export type ContextCapability = "react-only" | "codex-ts-js-beta";
 
 export type PromptSpecificity = "exact-file" | "file-hinted" | "ambiguous";
 export type ContextMode = "no-op" | "light" | "light-minimal" | "full" | "auto";
@@ -43,13 +46,17 @@ function isWithinCwd(resolved: string, cwd: string): boolean {
   return relativeToCwd === "" || (!relativeToCwd.startsWith(`..${path.sep}`) && relativeToCwd !== ".." && !path.isAbsolute(relativeToCwd));
 }
 
-function normalizeCandidate(token: string, cwd: string): PromptTarget | null {
+function eligibleExtensions(capability: ContextCapability): ReadonlySet<string> {
+  return capability === "codex-ts-js-beta" ? CODEX_TS_JS_BETA_EXTENSIONS : REACT_EXTENSIONS;
+}
+
+function normalizeCandidate(token: string, cwd: string, capability: ContextCapability): PromptTarget | null {
   const cleaned = trimPromptToken(token);
   if (!cleaned) return null;
 
   const resolved = path.isAbsolute(cleaned) ? path.resolve(cleaned) : path.resolve(cwd, cleaned);
   const extension = path.extname(resolved).toLowerCase();
-  if (!ELIGIBLE_EXTENSIONS.has(extension)) return null;
+  if (!eligibleExtensions(capability).has(extension)) return null;
   if (!isWithinCwd(resolved, cwd)) return null;
 
   const relativeToCwd = path.relative(cwd, resolved) || path.basename(resolved);
@@ -89,12 +96,12 @@ function totalBytes(cwd: string, files: string[]): number {
   return total;
 }
 
-export function extractPromptTargets(prompt: string, cwd = process.cwd()): PromptTarget[] {
-  return uniqueTargets([...prompt.matchAll(FILE_TOKEN_PATTERN)].map((match) => normalizeCandidate(match[0], cwd)).filter((target): target is PromptTarget => Boolean(target)));
+export function extractPromptTargets(prompt: string, cwd = process.cwd(), capability: ContextCapability = "react-only"): PromptTarget[] {
+  return uniqueTargets([...prompt.matchAll(FILE_TOKEN_PATTERN)].map((match) => normalizeCandidate(match[0], cwd, capability)).filter((target): target is PromptTarget => Boolean(target)));
 }
 
-export function extractPromptTarget(prompt: string, cwd = process.cwd()): string | null {
-  return extractPromptTargets(prompt, cwd)[0]?.filePath ?? null;
+export function extractPromptTarget(prompt: string, cwd = process.cwd(), capability: ContextCapability = "react-only"): string | null {
+  return extractPromptTargets(prompt, cwd, capability)[0]?.filePath ?? null;
 }
 
 export function hasFullReadEscapeHatch(prompt: string): boolean {
@@ -105,8 +112,8 @@ export function codexRuntimeEscapeHatches(): readonly string[] {
   return ESCAPE_HATCH_TOKENS;
 }
 
-export function classifyPromptContext(prompt: string, cwd = process.cwd()): PromptContextPolicy {
-  const targets = extractPromptTargets(prompt, cwd);
+export function classifyPromptContext(prompt: string, cwd = process.cwd(), capability: ContextCapability = "react-only"): PromptContextPolicy {
+  const targets = extractPromptTargets(prompt, cwd, capability);
   if (targets.length > 0) {
     const selected = targets.filter((target) => target.exists).slice(0, 1);
     return {
@@ -136,8 +143,8 @@ export function classifyPromptContext(prompt: string, cwd = process.cwd()): Prom
   };
 }
 
-export function resolvePromptFileContext(prompt: string, cwd = process.cwd()): { filePath?: string; source: "prompt-target" | "none"; policy: PromptContextPolicy } {
-  const policy = classifyPromptContext(prompt, cwd);
+export function resolvePromptFileContext(prompt: string, cwd = process.cwd(), capability: ContextCapability = "react-only"): { filePath?: string; source: "prompt-target" | "none"; policy: PromptContextPolicy } {
+  const policy = classifyPromptContext(prompt, cwd, capability);
   const filePath = policy.targets.find((target) => target.exists)?.filePath ?? policy.targets[0]?.filePath;
   return filePath ? { filePath, source: "prompt-target", policy } : { source: "none", policy };
 }
@@ -150,8 +157,14 @@ function promptKeywords(prompt: string): string[] {
     .filter((word) => word.length > 2 && !STOPWORDS.has(word));
 }
 
-export function discoverRelevantFilesByPolicy(prompt: string, allFiles: FileTarget[], cwd = process.cwd(), maxFiles = 5): { files: string[]; policy: PromptContextPolicy } {
-  const explicitPolicy = classifyPromptContext(prompt, cwd);
+export function discoverRelevantFilesByPolicy(
+  prompt: string,
+  allFiles: FileTarget[],
+  cwd = process.cwd(),
+  maxFiles = 5,
+  capability: ContextCapability = "react-only",
+): { files: string[]; policy: PromptContextPolicy } {
+  const explicitPolicy = classifyPromptContext(prompt, cwd, capability);
   if (explicitPolicy.promptSpecificity === "exact-file") {
     const files = explicitPolicy.targets.filter((target) => target.exists).slice(0, 1).map((target) => target.filePath);
     return {

--- a/src/core/decide.ts
+++ b/src/core/decide.ts
@@ -84,11 +84,13 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
   const jsxDepth = base.structure?.jsxDepth ?? 0;
   const conditionalCount = base.structure?.conditionalRenders?.length ?? 0;
   const repeatedCount = base.structure?.repeatedBlocks?.length ?? 0;
+  const moduleDeclarationCount = base.structure?.moduleDeclarations?.length ?? 0;
   const hookCount = base.behavior?.hooks.length ?? 0;
   const handlerCount = base.behavior?.eventHandlers?.length ?? 0;
   const styleBranching = base.style?.hasStyleBranching ? 1 : 0;
   const importCount = base.meta.importCount;
   const rawSizeBytes = base.meta.rawSizeBytes;
+  const moduleLanguage = base.language === "ts" || base.language === "js";
 
   const complexityScore =
     lineCount * 0.05 +
@@ -110,8 +112,9 @@ export function decideMode(base: Omit<ExtractionResult, "mode">): DecideMetrics 
   if (styleBranching) reasons.push("style-branching");
   if (importCount >= 8) reasons.push("import-heavy");
   if (lineCount >= 120) reasons.push("long-file");
+  if (moduleLanguage && moduleDeclarationCount > 0) reasons.push("module-structure");
 
-  const isRawCandidate = lineCount <= 45 && jsxDepth <= 3 && conditionalCount <= 1 && hookCount <= 1 && handlerCount <= 1 && !styleBranching;
+  const isRawCandidate = !moduleLanguage && lineCount <= 45 && jsxDepth <= 3 && conditionalCount <= 1 && hookCount <= 1 && handlerCount <= 1 && !styleBranching;
   const isHybridCandidate = conditionalCount >= 2 || handlerCount >= 3 || hookCount >= 3 || styleBranching === 1;
 
   if (isRawCandidate) {

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -23,12 +23,14 @@ function getLanguage(filePath: string): Language {
   const ext = path.extname(filePath);
   if (ext === ".tsx") return "tsx";
   if (ext === ".jsx") return "jsx";
+  if (ext === ".js") return "js";
   return "ts";
 }
 
 function getScriptKind(language: Language): ts.ScriptKind {
   if (language === "tsx") return ts.ScriptKind.TSX;
   if (language === "jsx") return ts.ScriptKind.JSX;
+  if (language === "js") return ts.ScriptKind.JS;
   return ts.ScriptKind.TS;
 }
 
@@ -173,6 +175,63 @@ function getComponentName(exports: ExtractionResult["exports"]): string | undefi
   const defaultExport = exports.find((item) => item.kind === "default" && isPascal(item.name));
   if (defaultExport) return defaultExport.name;
   return exports.find((item) => isPascal(item.name))?.name;
+}
+
+function collectModuleDeclarations(sourceFile: ts.SourceFile): NonNullable<NonNullable<ExtractionResult["structure"]>["moduleDeclarations"]> {
+  const declarations: NonNullable<NonNullable<ExtractionResult["structure"]>["moduleDeclarations"]> = [];
+
+  const addDeclaration = (
+    kind: NonNullable<NonNullable<ExtractionResult["structure"]>["moduleDeclarations"]>[number]["kind"],
+    value: string | undefined,
+    node: ts.Node,
+    exported = false,
+  ): void => {
+    if (!value) return;
+    const compacted = compactText(value);
+    if (!compacted) return;
+    declarations.push({
+      kind,
+      value: compacted,
+      ...(exported ? { exported: true } : {}),
+      loc: sourceRangeOf(sourceFile, node),
+    });
+  };
+
+  const isExported = (node: ts.Node): boolean =>
+    ts.canHaveModifiers(node) && (ts.getModifiers(node) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      addDeclaration("function", statement.name.text, statement, isExported(statement));
+      continue;
+    }
+    if (ts.isClassDeclaration(statement) && statement.name) {
+      addDeclaration("class", statement.name.text, statement, isExported(statement));
+      continue;
+    }
+    if (ts.isInterfaceDeclaration(statement)) {
+      addDeclaration("interface", statement.name.text, statement, isExported(statement));
+      continue;
+    }
+    if (ts.isTypeAliasDeclaration(statement)) {
+      addDeclaration("type", statement.name.text, statement, isExported(statement));
+      continue;
+    }
+    if (ts.isEnumDeclaration(statement)) {
+      addDeclaration("enum", statement.name.text, statement, isExported(statement));
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      const exported = isExported(statement);
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          addDeclaration("variable", declaration.name.text, declaration, exported);
+        }
+      }
+    }
+  }
+
+  return dedupeBy(declarations, (item) => `${item.kind}:${item.value}:${item.loc?.startLine ?? ""}`).slice(0, 12);
 }
 
 function findDeclarationByName(sourceFile: ts.SourceFile, name: string): ts.Node | undefined {
@@ -555,6 +614,9 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
   const style = detectStyleSystem(sourceFile);
   const behaviorStructure = collectBehaviorAndStructure(sourceFile);
   const importCount = sourceFile.statements.filter(ts.isImportDeclaration).length;
+  const moduleDeclarations = language === "ts" || language === "js"
+    ? collectModuleDeclarations(sourceFile)
+    : [];
   const base: Omit<ExtractionResult, "mode"> = {
     filePath,
     fileHash,
@@ -574,6 +636,12 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
       generatedAt: new Date().toISOString(),
     },
   };
+  if (moduleDeclarations.length > 0) {
+    base.structure = {
+      ...base.structure,
+      moduleDeclarations,
+    };
+  }
 
   const { mode, complexityScore, reasons, confidence, useOriginal } = decideMode(base);
   const result: ExtractionResult = {

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -13,6 +13,10 @@ export type ModelFacingPayloadOptions = {
   includeEditGuidance?: boolean;
 };
 
+function supportsEditGuidance(result: ExtractionResult): boolean {
+  return result.language === "tsx" || result.language === "jsx";
+}
+
 function pruneArray<T>(value: T[] | undefined): T[] | undefined {
   return value && value.length > 0 ? value : undefined;
 }
@@ -30,6 +34,7 @@ function hasSourceRanges(result: ExtractionResult): boolean {
   return Boolean(
     result.componentLoc ||
       result.contract?.propsLoc ||
+      result.structure?.moduleDeclarations?.some((item) => item.loc) ||
       result.snippets?.some((item) => item.loc) ||
       result.behavior?.effectSignals?.some((item) => item.loc) ||
       result.behavior?.callbackSignals?.some((item) => item.loc) ||
@@ -164,6 +169,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
         ...(pruneArray(result.structure.conditionalRenders) ? { conditionalRenders: result.structure.conditionalRenders } : {}),
         ...(pruneArray(result.structure.repeatedBlocks) ? { repeatedBlocks: result.structure.repeatedBlocks } : {}),
         ...(typeof result.structure.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
+        ...(pruneArray(result.structure.moduleDeclarations) ? { moduleDeclarations: result.structure.moduleDeclarations } : {}),
       })
     : undefined;
 
@@ -175,7 +181,9 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
       })
     : undefined;
   const fingerprint = sourceFingerprint(result);
-  const editGuidance = options.includeEditGuidance ? buildEditGuidance(result, fingerprint) : undefined;
+  const editGuidance = options.includeEditGuidance && supportsEditGuidance(result)
+    ? buildEditGuidance(result, fingerprint)
+    : undefined;
 
   return {
     mode: result.mode,

--- a/src/core/payload/readiness.ts
+++ b/src/core/payload/readiness.ts
@@ -2,8 +2,14 @@ import type { ExtractionResult, ModelFacingPayload, PayloadReadiness } from "../
 
 export function assessPayloadReadiness(result: ExtractionResult, payload: ModelFacingPayload): PayloadReadiness {
   const reasons: string[] = [];
+  const moduleLanguage = result.language === "ts" || result.language === "js";
+  const hasModuleStructure = Boolean(payload.structure?.moduleDeclarations?.some((item) => item.kind !== "variable"));
 
-  if (payload.useOriginal && result.mode === "raw" && payload.rawText) {
+  if (moduleLanguage && !hasModuleStructure) {
+    reasons.push("missing-module-structure");
+  }
+
+  if (!moduleLanguage && payload.useOriginal && result.mode === "raw" && payload.rawText) {
     return {
       ready: true,
       reasons,
@@ -20,7 +26,7 @@ export function assessPayloadReadiness(result: ExtractionResult, payload: ModelF
   }
 
   if (result.mode === "raw") reasons.push("raw-mode");
-  if (!payload.contract) reasons.push("missing-contract");
+  if (!moduleLanguage && !payload.contract) reasons.push("missing-contract");
   if (!payload.behavior) reasons.push("missing-behavior");
   if (!payload.structure) reasons.push("missing-structure");
   if (result.mode === "hybrid" && (!payload.snippets || payload.snippets.length === 0)) {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,5 @@
 export type OutputMode = "raw" | "compressed" | "hybrid";
-export type Language = "tsx" | "jsx" | "ts";
+export type Language = "tsx" | "jsx" | "ts" | "js";
 export type DecisionConfidence = "high" | "medium" | "low";
 export type StyleSystem =
   | "tailwind"
@@ -56,6 +56,11 @@ export type FormSurface = {
   controls?: FormControlSignal[];
   submitHandlers?: LocatedString[];
   validationAnchors?: LocatedString[];
+};
+
+export type ModuleDeclarationSignal = LocatedString & {
+  kind: "function" | "class" | "variable" | "type" | "interface" | "enum";
+  exported?: boolean;
 };
 
 export type PatchTargetKind =
@@ -117,6 +122,7 @@ export type ExtractionResult = {
     conditionalRenders?: string[];
     repeatedBlocks?: string[];
     jsxDepth?: number;
+    moduleDeclarations?: ModuleDeclarationSignal[];
   };
   style?: {
     system?: StyleSystem;
@@ -167,6 +173,7 @@ export type ModelFacingPayload = {
     conditionalRenders?: string[];
     repeatedBlocks?: string[];
     jsxDepth?: number;
+    moduleDeclarations?: ModuleDeclarationSignal[];
   };
   style?: {
     system?: StyleSystem;

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2995,7 +2995,7 @@ test("docs describe local compare estimates without billing-cost claims", () => 
 ${setup}
 ${release}`;
 
-  assert.match(readme, /Frontend context compression for.*Codex and Claude Code/);
+  assert.match(readme, /Smaller model-facing context for.*Codex/);
   assert.match(combined, /fooks compare src\/components\/Button\.tsx/);
   assert.match(combined, /local model-facing payload estimate|local file-level estimate/);
   assert.match(combined, /TypeScript AST-derived/);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -568,6 +568,28 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.ok(jsx.payload.contract);
   assert.equal("editGuidance" in jsx.payload, false);
 
+  const moduleTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"), repoRoot);
+  assert.equal(moduleTs.eligible, true);
+  assert.equal(moduleTs.decision, "payload");
+  assert.equal(moduleTs.debug.language, "ts");
+  assert.ok(moduleTs.payload.structure.moduleDeclarations?.length);
+  assert.equal("editGuidance" in moduleTs.payload, false);
+
+  const moduleTsWithGuidance = preReadModule.decidePreRead(
+    path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"),
+    repoRoot,
+    "codex",
+    { includeEditGuidance: true },
+  );
+  assert.equal(moduleTsWithGuidance.decision, "payload");
+  assert.equal("editGuidance" in moduleTsWithGuidance.payload, false);
+
+  const moduleJs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "module-config.js"), repoRoot);
+  assert.equal(moduleJs.eligible, true);
+  assert.equal(moduleJs.decision, "payload");
+  assert.equal(moduleJs.debug.language, "js");
+  assert.ok(moduleJs.payload.structure.moduleDeclarations?.length);
+
   const raw = decideCodexPreRead(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), repoRoot);
   assert.equal(raw.eligible, true);
   assert.equal(raw.decision, "payload");
@@ -575,12 +597,22 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.equal(raw.payload.useOriginal, true);
   assert.equal(raw.payload.rawText?.length, 356);
 
+  const weakTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "empty.ts"), repoRoot);
+  assert.equal(weakTs.eligible, true);
+  assert.equal(weakTs.decision, "fallback");
+  assert.ok(weakTs.reasons.includes("missing-module-structure"));
+  assert.equal(weakTs.fallback.reason, "missing-module-structure");
+
+  const claudeTs = preReadModule.decidePreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"), repoRoot, "claude");
+  assert.equal(claudeTs.eligible, false);
+  assert.equal(claudeTs.decision, "fallback");
+  assert.ok(claudeTs.reasons.includes("ineligible-extension"));
+
   const linkedTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-linked", "Button.types.ts"), repoRoot);
-  assert.equal(linkedTs.eligible, false);
-  assert.equal(linkedTs.decision, "fallback");
-  assert.equal("payload" in linkedTs, false);
-  assert.ok(linkedTs.reasons.includes("ineligible-extension"));
-  assert.equal(linkedTs.filePath, path.join("fixtures", "ts-linked", "Button.types.ts"));
+  assert.equal(linkedTs.eligible, true);
+  assert.equal(linkedTs.decision, "payload");
+  assert.ok(linkedTs.payload.structure.moduleDeclarations?.length);
+  assert.equal(linkedTs.debug.language, "ts");
 });
 
 test("codex pre-read falls back for larger raw files past the original-source threshold", () => {
@@ -673,6 +705,12 @@ test("runtime prompt parser finds eligible tsx/jsx paths and escape hatches", ()
   const tsTarget = extractPromptTarget("Check fixtures/ts-linked/Button.types.ts too", repoRoot);
   assert.equal(tsTarget, null);
 
+  const codexTsTarget = extractPromptTarget("Check fixtures/ts-linked/Button.types.ts too", repoRoot, "codex-ts-js-beta");
+  assert.equal(codexTsTarget, path.join("fixtures", "ts-linked", "Button.types.ts"));
+
+  const codexJsTarget = extractPromptTarget("Inspect fixtures/ts-js-beta/module-config.js please", repoRoot, "codex-ts-js-beta");
+  assert.equal(codexJsTarget, path.join("fixtures", "ts-js-beta", "module-config.js"));
+
   assert.equal(hasFullReadEscapeHatch("Need exact source #fooks-full-read"), true);
   assert.equal(hasFullReadEscapeHatch("Need exact source #fooks-disable-pre-read"), true);
   assert.equal(hasFullReadEscapeHatch("No override here"), false);
@@ -692,11 +730,50 @@ test("shared context policy distinguishes exact-file light/no-op from ambiguous 
   assert.equal(exactNew.contextMode, "no-op");
   assert.equal(exactNew.contextBudget.selectedFiles, 0);
 
+  const codexTs = classifyPromptContext("Inspect fixtures/ts-linked/Button.types.ts", repoRoot, "codex-ts-js-beta");
+  assert.equal(codexTs.promptSpecificity, "exact-file");
+  assert.equal(codexTs.contextMode, "light");
+  assert.equal(codexTs.targets[0].filePath, path.join("fixtures", "ts-linked", "Button.types.ts"));
+
   const ambiguous = discoverRelevantFilesByPolicy("Add loading state to the form section", discoverProjectFilesForTest(tempDir), tempDir);
   assert.equal(ambiguous.policy.promptSpecificity, "ambiguous");
   assert.equal(ambiguous.policy.contextMode, "auto");
   assert.ok(ambiguous.files.length > 0);
   assert.ok(ambiguous.files.length <= 5);
+});
+
+test("ts/js extraction and readiness stay module-gated", () => {
+  const moduleTs = extractFile(path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"));
+  assert.equal(moduleTs.language, "ts");
+  assert.ok(moduleTs.structure.moduleDeclarations?.some((item) => item.value === "formatAmount"));
+  const moduleTsPayload = toModelFacingPayload(moduleTs, repoRoot);
+  assert.ok(moduleTsPayload.structure.moduleDeclarations?.length);
+  const moduleTsReadiness = assessPayloadReadiness(moduleTs, moduleTsPayload);
+  assert.equal(moduleTsReadiness.ready, true);
+  assert.equal(moduleTsReadiness.reasons.includes("missing-module-structure"), false);
+
+  const moduleJs = extractFile(path.join(repoRoot, "fixtures", "ts-js-beta", "module-config.js"));
+  assert.equal(moduleJs.language, "js");
+  assert.ok(moduleJs.structure.moduleDeclarations?.some((item) => item.value === "mergeThemeConfig"));
+  const moduleJsPayload = toModelFacingPayload(moduleJs, repoRoot);
+  assert.ok(moduleJsPayload.structure.moduleDeclarations?.length);
+  assert.equal(assessPayloadReadiness(moduleJs, moduleJsPayload).ready, true);
+
+  const weakTs = extractFile(path.join(repoRoot, "fixtures", "ts-js-beta", "empty.ts"));
+  assert.equal(weakTs.language, "ts");
+  const weakTsPayload = toModelFacingPayload(weakTs, repoRoot);
+  const weakTsReadiness = assessPayloadReadiness(weakTs, weakTsPayload);
+  assert.equal(weakTsReadiness.ready, false);
+  assert.ok(weakTsReadiness.reasons.includes("missing-module-structure"));
+
+  const weakJs = extractFile(path.join(repoRoot, "fixtures", "ts-js-beta", "weak-config.js"));
+  assert.equal(weakJs.language, "js");
+  assert.ok(weakJs.structure.moduleDeclarations?.some((item) => item.kind === "variable"));
+  const weakJsPayload = toModelFacingPayload(weakJs, repoRoot, { includeEditGuidance: true });
+  const weakJsReadiness = assessPayloadReadiness(weakJs, weakJsPayload);
+  assert.equal(weakJsReadiness.ready, false);
+  assert.ok(weakJsReadiness.reasons.includes("missing-module-structure"));
+  assert.equal("editGuidance" in weakJsPayload, false);
 });
 
 function discoverProjectFilesForTest(cwd) {
@@ -1321,8 +1398,8 @@ test("runtime hook supports jsx repeated prompts and ignores linked ts prompts",
     },
     repoRoot,
   );
-  assert.equal(tsPrompt.action, "noop");
-  assert.ok(tsPrompt.reasons.includes("no-eligible-file-in-prompt"));
+  assert.equal(tsPrompt.action, "record");
+  assert.equal(tsPrompt.filePath, path.join("fixtures", "ts-linked", "Button.types.ts"));
 });
 
 test("cli codex-runtime-hook reuses runtime decision logic and advertises the command", () => {


### PR DESCRIPTION
## Summary
- add a Codex-only TS/JS same-file beta path guarded by module-structure readiness
- let `fooks setup` and `fooks doctor` recognize strong TS/JS-only Codex beta repos without widening Claude/opencode
- keep Claude/opencode on the existing React-only surface and tighten docs around non-goals

## What changed
- extend Codex prompt target / pre-read eligibility from React-only to guarded `.ts` / `.js`
- add TS/JS module declaration extraction and readiness gating
- keep TS/JS edit guidance disabled in this release slice
- allow Codex-only setup eligibility when a repo has a strong same-file TS/JS beta module
- document the beta boundary in README/setup/release/roadmap

## Explicit non-goals
- Vue / SFC support
- multi-file refactors
- read interception
- provider parity across runtimes
- LSP rename/reference semantics
- GA/stable TS/JS support claims

## Verification
- npm run lint
- npm test -- --runInBand
- `node dist/cli/index.js extract fixtures/ts-js-beta/module-utils.ts --model-payload`
- `node dist/cli/index.js codex-pre-read fixtures/ts-js-beta/weak-config.js`
- TS/JS-only `fooks setup` + `fooks doctor codex` smoke