### PR TITLE
fix: respect explicit updatedAt in patchClaudeTrustStatus

### DIFF
--- a/src/adapters/claude-runtime-trust.ts
+++ b/src/adapters/claude-runtime-trust.ts
@@ -56,7 +56,7 @@ export function patchClaudeTrustStatus(
     ...previous,
     ...partial,
     runtime: "claude",
-    updatedAt: now(),
+    updatedAt: partial.updatedAt ?? now(),
   };
   if (partial.activeFile === undefined && Object.prototype.hasOwnProperty.call(partial, "activeFile")) {
     delete next.activeFile;


### PR DESCRIPTION
Prevents accidental timestamp overwrites when caller passes an explicit updatedAt in the partial.\n\nThis eliminates the flaky behavior in `ensureFreshClaudeContextForTarget` non-stale tests where millisecond drift caused CI failures (see #139).\n\n- 1 file changed\n- 234/234 tests pass\n- No public claim boundary change