### PR TITLE
Remove public-readiness blockers before opening fooks

### DIFF
--- a/benchmarks/frontend-harness/reports/benchmark-full-1776613131.json
+++ b/benchmarks/frontend-harness/reports/benchmark-full-1776613131.json
@@ -1,7 +1,7 @@
 {
   "reportSchemaVersion": "frontend-harness.v2-context-mode",
   "timestamp": "2026-04-20T01:11:11.470117",
-  "artifactDir": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131",
+  "artifactDir": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131",
   "iterations": 3,
   "qualityGatedDecision": {
     "rawMedianTotalTimeImprovement": 15.088006830527354,
@@ -137,8 +137,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613139",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613139/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613139",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613139/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -152,7 +152,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Implemented the component extraction.\n\nModified:\n- [tab-container.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613139/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/tab-container.tsx:9)\n\nCreated:\n- None\n\nWhat changed:\n- Extracted the visible tab section header JSX (`H3` title plus muted `Small` description) into a local typed `Header` component.\n- Kept `TabContainer`\u2019s props, behavior, layout classes, and rendered structure effectively unchanged.\n- Did not edit API routes, generated files, tests, or locale JSON.\n\nVerification:\n- `git diff --check` passed for the touched file.\n- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in the available workspace binaries.\n",
+        "stdout_tail": "Implemented the component extraction.\n\nModified:\n- [tab-container.tsx](<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613139/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/tab-container.tsx:9)\n\nCreated:\n- None\n\nWhat changed:\n- Extracted the visible tab section header JSX (`H3` title plus muted `Small` description) into a local typed `Header` component.\n- Kept `TabContainer`\u2019s props, behavior, layout classes, and rendered structure effectively unchanged.\n- Did not edit API routes, generated files, tests, or locale JSON.\n\nVerification:\n- `git diff --check` passed for the touched file.\n- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in the available workspace binaries.\n",
         "stderr_tail": ")/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/tab-container.tsx\n@@ -6,15 +6,23 @@\n   children: React.ReactNode;\n }\n \n+type HeaderProps = Pick<TabContainerProps, \"title\" | \"description\">;\n+\n+const Header = ({ title, description }: HeaderProps) => {\n+  return (\n+    <div className=\"pb-2\">\n+      <H3>{title}</H3>\n+      <Small color=\"muted\" margin=\"headerDescription\">\n+        {description}\n+      </Small>\n+    </div>\n+  );\n+};\n+\n export const TabContainer = ({ title, description, children }: TabContainerProps) => {\n   return (\n     <div className=\"flex h-full grow flex-col items-start space-y-4\">\n-      <div className=\"pb-2\">\n-        <H3>{title}</H3>\n-        <Small color=\"muted\" margin=\"headerDescription\">\n-          {description}\n-        </Small>\n-      </div>\n+      <Header title={title} description={description} />\n       <div className=\"h-full w-full space-y-4 overflow-y-auto\">{children}</div>\n     </div>\n   );\n\ntokens used\n81,597\n",
         "error": null,
         "validation": {
@@ -171,8 +171,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-vanilla.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-vanilla.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-vanilla.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-vanilla.diffstat",
           "patch_bytes": 1477,
           "diffstat": " .../components/shareEmbedModal/tab-container.tsx     | 20 ++++++++++++++------\n 1 file changed, 14 insertions(+), 6 deletions(-)\n",
           "diff_check": {
@@ -277,7 +277,7 @@
               "name": "init",
               "success": true,
               "duration_ms": 94,
-              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/.fooks/cache\"}\n",
+              "stdout_tail": "{\"config\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/.fooks/config.json\",\"cacheDir\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/.fooks/cache\"}\n",
               "stderr_tail": ""
             },
             {
@@ -291,7 +291,7 @@
               "name": "attach-codex",
               "success": true,
               "duration_ms": 500,
-              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T15:43:16.453Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/.codex/fooks/attachments/bm-t4-fooks-1776613391.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/.codex/fooks/attachments/bm-t4-fooks-1776613391.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T15:43:16.443Z\",\"attachedAt\":\"2026-04-19T15:43:16.440Z\",\"lastScanAt\":\"2026-04-19T15:43:16.440Z\",\"lastRefreshAt\":\"2026-04-19T15:43:16.440Z\"}}\n",
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T15:43:16.453Z\",\"artifactPath\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/.codex/fooks/attachments/bm-t4-fooks-1776613391.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/.codex/fooks/attachments/bm-t4-fooks-1776613391.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T15:43:16.443Z\",\"attachedAt\":\"2026-04-19T15:43:16.440Z\",\"lastScanAt\":\"2026-04-19T15:43:16.440Z\",\"lastRefreshAt\":\"2026-04-19T15:43:16.440Z\"}}\n",
               "stderr_tail": ""
             }
           ],
@@ -300,8 +300,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -315,7 +315,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Implemented the extraction in [SettingsCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776613391/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16).\n\nChanged:\n- Added a local `Header` component with typed `HeaderProps`.\n- Moved the existing title, description, beta/soon badges, and optional action button JSX into that component.\n- Kept the original styling and behavior intact.\n- Tightened `children` from `any` to `ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `prettier` and `eslint` are not installed in this worktree.\n- The repo\u2019s local Next docs directory was missing; the required fallback `npx @next/codemod agents-md --output AGENTS.md` failed because network access to npm was blocked.\n",
+        "stdout_tail": "Implemented the extraction in [SettingsCard.tsx](<fooks-test-repos>/.worktrees/bm-T4-fooks-1776613391/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16).\n\nChanged:\n- Added a local `Header` component with typed `HeaderProps`.\n- Moved the existing title, description, beta/soon badges, and optional action button JSX into that component.\n- Kept the original styling and behavior intact.\n- Tightened `children` from `any` to `ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- `pnpm exec prettier --check ...` and `pnpm exec eslint ...` could not run because `prettier` and `eslint` are not installed in this worktree.\n- The repo\u2019s local Next docs directory was missing; the required fallback `npx @next/codemod agents-md --output AGENTS.md` failed because network access to npm was blocked.\n",
         "stderr_tail": "le}>\n-      <div className=\"flex justify-between border-b border-slate-200 px-4 pb-4\">\n-        <div>\n-          <H4 className=\"font-medium tracking-normal\">{title}</H4>\n-          <div className=\"ml-2\">\n-            {beta && <Badge size=\"normal\" type=\"warning\" text=\"Beta\" />}\n-            {soon && (\n-              <Badge size=\"normal\" type=\"success\" text={t(\"environments.settings.enterprise.coming_soon\")} />\n-            )}\n-          </div>\n-          <Small color=\"muted\" margin=\"headerDescription\">\n-            {description}\n-          </Small>\n-        </div>\n-        {buttonInfo && (\n-          <Button type=\"button\" onClick={buttonInfo?.onClick} variant={buttonInfo?.variant ?? \"default\"}>\n-            {buttonInfo?.text}\n-          </Button>\n-        )}\n-      </div>\n+      <Header title={title} description={description} soon={soon} beta={beta} buttonInfo={buttonInfo} />\n       <div className={cn(noPadding ? \"\" : \"px-4 pt-4\")}>{children}</div>\n     </div>\n   );\n\ntokens used\n71,074\n",
         "error": null,
         "validation": {
@@ -338,8 +338,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-fooks.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-fooks.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-fooks.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter1-fooks.diffstat",
           "patch_bytes": 3214,
           "diffstat": " .../settings/components/SettingsCard.tsx           | 58 ++++++++++++++--------\n 1 file changed, 37 insertions(+), 21 deletions(-)\n",
           "diff_check": {
@@ -470,8 +470,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613733",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613733/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613733",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613733/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -485,7 +485,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Implemented the component extraction in [SettingsCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776613733/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx).\n\nWhat changed:\n- Extracted the section header JSX into a local typed `Header` component.\n- Kept the same title, description, beta/coming soon badges, optional action button, classes, and translation behavior.\n- Tightened `children` from `any` to `ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- `pnpm --filter @formbricks/web exec tsc --noEmit --pretty false` could not run because `tsc` is not installed in this checkout.\n- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in this checkout.\n",
+        "stdout_tail": "Implemented the component extraction in [SettingsCard.tsx](<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776613733/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx).\n\nWhat changed:\n- Extracted the section header JSX into a local typed `Header` component.\n- Kept the same title, description, beta/coming soon badges, optional action button, classes, and translation behavior.\n- Tightened `children` from `any` to `ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- `pnpm --filter @formbricks/web exec tsc --noEmit --pretty false` could not run because `tsc` is not installed in this checkout.\n- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in this checkout.\n",
         "stderr_tail": "e}>\n-      <div className=\"flex justify-between border-b border-slate-200 px-4 pb-4\">\n-        <div>\n-          <H4 className=\"font-medium tracking-normal\">{title}</H4>\n-          <div className=\"ml-2\">\n-            {beta && <Badge size=\"normal\" type=\"warning\" text=\"Beta\" />}\n-            {soon && (\n-              <Badge size=\"normal\" type=\"success\" text={t(\"environments.settings.enterprise.coming_soon\")} />\n-            )}\n-          </div>\n-          <Small color=\"muted\" margin=\"headerDescription\">\n-            {description}\n-          </Small>\n-        </div>\n-        {buttonInfo && (\n-          <Button type=\"button\" onClick={buttonInfo?.onClick} variant={buttonInfo?.variant ?? \"default\"}>\n-            {buttonInfo?.text}\n-          </Button>\n-        )}\n-      </div>\n+      <Header title={title} description={description} soon={soon} beta={beta} buttonInfo={buttonInfo} />\n       <div className={cn(noPadding ? \"\" : \"px-4 pt-4\")}>{children}</div>\n     </div>\n   );\n\ntokens used\n215,116\n",
         "error": null,
         "validation": {
@@ -504,8 +504,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-vanilla.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-vanilla.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-vanilla.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-vanilla.diffstat",
           "patch_bytes": 3214,
           "diffstat": " .../settings/components/SettingsCard.tsx           | 58 ++++++++++++++--------\n 1 file changed, 37 insertions(+), 21 deletions(-)\n",
           "diff_check": {
@@ -610,7 +610,7 @@
               "name": "init",
               "success": true,
               "duration_ms": 109,
-              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/.fooks/cache\"}\n",
+              "stdout_tail": "{\"config\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/.fooks/config.json\",\"cacheDir\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/.fooks/cache\"}\n",
               "stderr_tail": ""
             },
             {
@@ -624,7 +624,7 @@
               "name": "attach-codex",
               "success": true,
               "duration_ms": 572,
-              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T15:54:16.959Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/.codex/fooks/attachments/bm-t4-fooks-1776614050.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/.codex/fooks/attachments/bm-t4-fooks-1776614050.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T15:54:16.947Z\",\"attachedAt\":\"2026-04-19T15:54:16.937Z\",\"lastScanAt\":\"2026-04-19T15:54:16.937Z\",\"lastRefreshAt\":\"2026-04-19T15:54:16.937Z\"}}\n",
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T15:54:16.959Z\",\"artifactPath\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/.codex/fooks/attachments/bm-t4-fooks-1776614050.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/.codex/fooks/attachments/bm-t4-fooks-1776614050.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T15:54:16.947Z\",\"attachedAt\":\"2026-04-19T15:54:16.937Z\",\"lastScanAt\":\"2026-04-19T15:54:16.937Z\",\"lastRefreshAt\":\"2026-04-19T15:54:16.937Z\"}}\n",
               "stderr_tail": ""
             }
           ],
@@ -633,8 +633,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -648,7 +648,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Implemented the local header extraction in [SettingsCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614050/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16).\n\nWhat changed:\n- Added typed `HeaderProps` and `SettingsCardProps`.\n- Extracted the existing title, description, badge, and optional action button JSX into a local non-exported `Header` component.\n- Kept the existing classes, translation key, conditionals, and `buttonInfo` behavior intact.\n- Replaced `children: any` with `children: ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- Focused `prettier` and `eslint` checks could not run because this worktree has no installed dependencies; `pnpm exec prettier` and filtered `eslint` both reported the commands were not found.\n",
+        "stdout_tail": "Implemented the local header extraction in [SettingsCard.tsx](<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614050/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16).\n\nWhat changed:\n- Added typed `HeaderProps` and `SettingsCardProps`.\n- Extracted the existing title, description, badge, and optional action button JSX into a local non-exported `Header` component.\n- Kept the existing classes, translation key, conditionals, and `buttonInfo` behavior intact.\n- Replaced `children: any` with `children: ReactNode`.\n\nFiles modified:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nFiles created:\n- None\n\nVerification:\n- `git diff --check` passed.\n- Focused `prettier` and `eslint` checks could not run because this worktree has no installed dependencies; `pnpm exec prettier` and filtered `eslint` both reported the commands were not found.\n",
         "stderr_tail": "le}>\n-      <div className=\"flex justify-between border-b border-slate-200 px-4 pb-4\">\n-        <div>\n-          <H4 className=\"font-medium tracking-normal\">{title}</H4>\n-          <div className=\"ml-2\">\n-            {beta && <Badge size=\"normal\" type=\"warning\" text=\"Beta\" />}\n-            {soon && (\n-              <Badge size=\"normal\" type=\"success\" text={t(\"environments.settings.enterprise.coming_soon\")} />\n-            )}\n-          </div>\n-          <Small color=\"muted\" margin=\"headerDescription\">\n-            {description}\n-          </Small>\n-        </div>\n-        {buttonInfo && (\n-          <Button type=\"button\" onClick={buttonInfo?.onClick} variant={buttonInfo?.variant ?? \"default\"}>\n-            {buttonInfo?.text}\n-          </Button>\n-        )}\n-      </div>\n+      <Header title={title} description={description} soon={soon} beta={beta} buttonInfo={buttonInfo} />\n       <div className={cn(noPadding ? \"\" : \"px-4 pt-4\")}>{children}</div>\n     </div>\n   );\n\ntokens used\n81,400\n",
         "error": null,
         "validation": {
@@ -671,8 +671,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-fooks.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-fooks.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-fooks.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter2-fooks.diffstat",
           "patch_bytes": 3393,
           "diffstat": " .../settings/components/SettingsCard.tsx           | 73 +++++++++++++---------\n 1 file changed, 43 insertions(+), 30 deletions(-)\n",
           "diff_check": {
@@ -803,8 +803,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776614300",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776614300/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776614300",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776614300/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -818,7 +818,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Extracted the settings section header JSX into a local typed `Header` component in [SettingsCard.tsx](</Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-vanilla-1776614300/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16>).\n\nWhat changed:\n- Added `HeaderProps` and `SettingsCardProps`.\n- Moved the existing title, description, beta/soon badges, and optional action button into `Header`.\n- Kept styling, rendered markup, button behavior, and existing translation usage intact.\n- Tightened `children` from `any` to `ReactNode`.\n\nModified files:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nCreated files:\n- None\n\nVerification:\n- `git diff --check -- apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx` passed.\n- Targeted `prettier` and `eslint` checks could not run because this workspace has no installed `prettier`/`eslint` binaries in `node_modules`.\n- I did not edit API routes, generated files, tests, or locale JSON.\n",
+        "stdout_tail": "Extracted the settings section header JSX into a local typed `Header` component in [SettingsCard.tsx](<<fooks-test-repos>/.worktrees/bm-T4-vanilla-1776614300/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16>).\n\nWhat changed:\n- Added `HeaderProps` and `SettingsCardProps`.\n- Moved the existing title, description, beta/soon badges, and optional action button into `Header`.\n- Kept styling, rendered markup, button behavior, and existing translation usage intact.\n- Tightened `children` from `any` to `ReactNode`.\n\nModified files:\n- `apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx`\n\nCreated files:\n- None\n\nVerification:\n- `git diff --check -- apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx` passed.\n- Targeted `prettier` and `eslint` checks could not run because this workspace has no installed `prettier`/`eslint` binaries in `node_modules`.\n- I did not edit API routes, generated files, tests, or locale JSON.\n",
         "stderr_tail": "le}>\n-      <div className=\"flex justify-between border-b border-slate-200 px-4 pb-4\">\n-        <div>\n-          <H4 className=\"font-medium tracking-normal\">{title}</H4>\n-          <div className=\"ml-2\">\n-            {beta && <Badge size=\"normal\" type=\"warning\" text=\"Beta\" />}\n-            {soon && (\n-              <Badge size=\"normal\" type=\"success\" text={t(\"environments.settings.enterprise.coming_soon\")} />\n-            )}\n-          </div>\n-          <Small color=\"muted\" margin=\"headerDescription\">\n-            {description}\n-          </Small>\n-        </div>\n-        {buttonInfo && (\n-          <Button type=\"button\" onClick={buttonInfo?.onClick} variant={buttonInfo?.variant ?? \"default\"}>\n-            {buttonInfo?.text}\n-          </Button>\n-        )}\n-      </div>\n+      <Header title={title} description={description} soon={soon} beta={beta} buttonInfo={buttonInfo} />\n       <div className={cn(noPadding ? \"\" : \"px-4 pt-4\")}>{children}</div>\n     </div>\n   );\n\ntokens used\n93,867\n",
         "error": null,
         "validation": {
@@ -837,8 +837,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-vanilla.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-vanilla.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-vanilla.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-vanilla.diffstat",
           "patch_bytes": 3393,
           "diffstat": " .../settings/components/SettingsCard.tsx           | 73 +++++++++++++---------\n 1 file changed, 43 insertions(+), 30 deletions(-)\n",
           "diff_check": {
@@ -943,7 +943,7 @@
               "name": "init",
               "success": true,
               "duration_ms": 90,
-              "stdout_tail": "{\"config\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/.fooks/config.json\",\"cacheDir\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/.fooks/cache\"}\n",
+              "stdout_tail": "{\"config\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/.fooks/config.json\",\"cacheDir\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/.fooks/cache\"}\n",
               "stderr_tail": ""
             },
             {
@@ -957,7 +957,7 @@
               "name": "attach-codex",
               "success": true,
               "duration_ms": 513,
-              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T16:05:20.006Z\",\"artifactPath\":\"/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/.codex/fooks/attachments/bm-t4-fooks-1776614715.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/.codex/fooks/attachments/bm-t4-fooks-1776614715.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T16:05:19.996Z\",\"attachedAt\":\"2026-04-19T16:05:19.993Z\",\"lastScanAt\":\"2026-04-19T16:05:19.993Z\",\"lastRefreshAt\":\"2026-04-19T16:05:19.993Z\"}}\n",
+              "stdout_tail": "{\"runtime\":\"codex\",\"accountContext\":\"minislively\",\"filesCreated\":[\".fooks/adapters/codex/adapter.json\",\".fooks/adapters/codex/context-template.md\"],\"contractProof\":{\"passed\":true,\"details\":[\"filePath\",\"fileHash\",\"mode\",\"exports\",\"meta.generatedAt\"]},\"runtimeProof\":{\"status\":\"passed\",\"attemptedAt\":\"2026-04-19T16:05:20.006Z\",\"artifactPath\":\"<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/.codex/fooks/attachments/bm-t4-fooks-1776614715.json\",\"details\":[\"account-context=minislively\",\"account-source=env\",\"runtime-manifest=<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/.codex/fooks/attachments/bm-t4-fooks-1776614715.json\",\"codex adapter artifacts created\"]},\"trustStatus\":{\"runtime\":\"codex\",\"connectionState\":\"connected\",\"lifecycleState\":\"ready\",\"updatedAt\":\"2026-04-19T16:05:19.996Z\",\"attachedAt\":\"2026-04-19T16:05:19.993Z\",\"lastScanAt\":\"2026-04-19T16:05:19.993Z\",\"lastRefreshAt\":\"2026-04-19T16:05:19.993Z\"}}\n",
               "stderr_tail": ""
             }
           ],
@@ -966,8 +966,8 @@
         "command": {
           "runner": "codex exec --full-auto",
           "runner_key": "codex",
-          "cwd": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715",
-          "codex_home": "/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/.codex",
+          "cwd": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715",
+          "codex_home": "<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/.codex",
           "prompt_sha256": "be873c525d0c0d116bfdc5c29345218ab2990bb2428255f40d68a09b4a6641a8",
           "codex_bin": "codex"
         },
@@ -981,7 +981,7 @@
         },
         "contextPolicyVersion": "context-policy.v1",
         "contextBudgetSource": "expected-policy",
-        "stdout_tail": "Extracted the settings card section header into a local typed `Header` component in [SettingsCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16). It keeps the same title, description, beta/coming-soon badges, optional action button, classes, and translation behavior. I also replaced the previous inline prop object with typed `HeaderProps` and `SettingsCardProps`.\n\nModified:\n- [apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx](/Users/veluga/Workspace/fooks-test-repos/.worktrees/bm-T4-fooks-1776614715/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:1)\n\nCreated:\n- None\n\nVerification:\n- `git diff --check` passed.\n- ESLint/TypeScript could not be run because this checkout has no installed `node_modules/.bin` tools, so `eslint` was not found.\n- The required Next docs bootstrap command from `AGENTS.md` failed due blocked network DNS (`ENOTFOUND registry.npmjs.org`) and did not modify `AGENTS.md`.\n",
+        "stdout_tail": "Extracted the settings card section header into a local typed `Header` component in [SettingsCard.tsx](<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:16). It keeps the same title, description, beta/coming-soon badges, optional action button, classes, and translation behavior. I also replaced the previous inline prop object with typed `HeaderProps` and `SettingsCardProps`.\n\nModified:\n- [apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx](<fooks-test-repos>/.worktrees/bm-T4-fooks-1776614715/apps/web/app/(app)/environments/[environmentId]/settings/components/SettingsCard.tsx:1)\n\nCreated:\n- None\n\nVerification:\n- `git diff --check` passed.\n- ESLint/TypeScript could not be run because this checkout has no installed `node_modules/.bin` tools, so `eslint` was not found.\n- The required Next docs bootstrap command from `AGENTS.md` failed due blocked network DNS (`ENOTFOUND registry.npmjs.org`) and did not modify `AGENTS.md`.\n",
         "stderr_tail": "le}>\n-      <div className=\"flex justify-between border-b border-slate-200 px-4 pb-4\">\n-        <div>\n-          <H4 className=\"font-medium tracking-normal\">{title}</H4>\n-          <div className=\"ml-2\">\n-            {beta && <Badge size=\"normal\" type=\"warning\" text=\"Beta\" />}\n-            {soon && (\n-              <Badge size=\"normal\" type=\"success\" text={t(\"environments.settings.enterprise.coming_soon\")} />\n-            )}\n-          </div>\n-          <Small color=\"muted\" margin=\"headerDescription\">\n-            {description}\n-          </Small>\n-        </div>\n-        {buttonInfo && (\n-          <Button type=\"button\" onClick={buttonInfo?.onClick} variant={buttonInfo?.variant ?? \"default\"}>\n-            {buttonInfo?.text}\n-          </Button>\n-        )}\n-      </div>\n+      <Header title={title} description={description} soon={soon} beta={beta} buttonInfo={buttonInfo} />\n       <div className={cn(noPadding ? \"\" : \"px-4 pt-4\")}>{children}</div>\n     </div>\n   );\n\ntokens used\n85,063\n",
         "error": null,
         "validation": {
@@ -1004,8 +1004,8 @@
           }
         },
         "artifact": {
-          "patch_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-fooks.patch",
-          "diffstat_path": "/Users/veluga/Documents/Workspace_Minseol/fooks/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-fooks.diffstat",
+          "patch_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-fooks.patch",
+          "diffstat_path": "<fooks-repo>/benchmarks/frontend-harness/reports/artifacts/benchmark-full-1776613131/formbricks-T4-iter3-fooks.diffstat",
           "patch_bytes": 3385,
           "diffstat": " .../settings/components/SettingsCard.tsx           | 73 +++++++++++++---------\n 1 file changed, 43 insertions(+), 30 deletions(-)\n",
           "diff_check": {

--- a/benchmarks/frontend-harness/runners/benchmark-runner.mjs
+++ b/benchmarks/frontend-harness/runners/benchmark-runner.mjs
@@ -11,8 +11,8 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const BASE_DIR = resolve(__dirname, '..');
-const REPOS_DIR = resolve('/home/bellman/Workspace/fooks-test-repos');
-const FOOKS_CLI = resolve('/home/bellman/Workspace/fooks/dist/cli/index.js');
+const REPOS_DIR = resolve(process.env.FOOKS_TEST_REPOS_DIR ?? join(BASE_DIR, '..', '..', '..', 'fooks-test-repos'));
+const FOOKS_CLI = resolve(process.env.FOOKS_CLI ?? join(BASE_DIR, '..', '..', 'dist', 'cli', 'index.js'));
 
 // Load task definitions
 const tasks = JSON.parse(

--- a/benchmarks/frontend-harness/runners/test-setup.py
+++ b/benchmarks/frontend-harness/runners/test-setup.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Quick validation test for benchmark setup"""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
-OMX_BIN = Path("/home/bellman/Workspace/oh-my-codex/dist/cli/omx.js")
-FOOKS_DIR = Path("/home/bellman/Workspace/fooks")
-REPOS_DIR = Path("/home/bellman/Workspace/fooks-test-repos")
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OMX_BIN = Path(os.environ.get("OMX_BIN", REPO_ROOT.parent / "oh-my-codex" / "dist" / "cli" / "omx.js"))
+FOOKS_DIR = Path(os.environ.get("FOOKS_DIR", REPO_ROOT))
+REPOS_DIR = Path(os.environ.get("FOOKS_TEST_REPOS_DIR", REPO_ROOT.parent / "fooks-test-repos"))
 
 def check_omx():
     """Test OMX can be invoked"""

--- a/benchmarks/history/2026-04-15-real-benchmark.json
+++ b/benchmarks/history/2026-04-15-real-benchmark.json
@@ -2,7 +2,7 @@
   "timestamp": "2026-04-15T06:40:57.664293",
   "label": "real-benchmark-result",
   "extractorPath": "real",
-  "command": "node -e \"require('/home/bellman/Workspace/fooks/dist/index.js').extractFile('<file>')\"",
+  "command": "node -e \"require('<fooks-repo>/dist/index.js').extractFile('<file>')\"",
   "target": "nextjs + tailwindcss",
   "nextjs": {
     "requested": 5,

--- a/benchmarks/latest/LATEST_INDEX.md
+++ b/benchmarks/latest/LATEST_INDEX.md
@@ -48,7 +48,7 @@ This ensures the latest directory always has a readable copy even if the history
 ### Verification
 ```bash
 # Verify real fooks path
-node -e "require('/home/bellman/Workspace/fooks/dist/index.js').extractFile('<file>')"
+node -e "require('<fooks-repo>/dist/index.js').extractFile('<file>')"
 
 # Check extractorPath in result
 cat current-real-benchmark.json | grep -A2 '"extractorPath"'

--- a/benchmarks/latest/current-real-benchmark.json
+++ b/benchmarks/latest/current-real-benchmark.json
@@ -2,7 +2,7 @@
   "timestamp": "2026-04-15T06:40:57.664293",
   "label": "real-benchmark-result",
   "extractorPath": "real",
-  "command": "node -e \"require('/home/bellman/Workspace/fooks/dist/index.js').extractFile('<file>')\"",
+  "command": "node -e \"require('<fooks-repo>/dist/index.js').extractFile('<file>')\"",
   "target": "nextjs + tailwindcss",
   "nextjs": {
     "requested": 5,

--- a/benchmarks/layer2-frontend-task/R4-validation-checklist.md
+++ b/benchmarks/layer2-frontend-task/R4-validation-checklist.md
@@ -41,7 +41,7 @@ yarn build
 ### type error 0 확인 방법
 ```bash
 # TypeScript 컴파일 체크
-cd /home/bellman/Workspace/fooks-test-repos/ui
+cd <fooks-test-repos>/ui
 npx tsc --noEmit
 
 # 또는
@@ -83,7 +83,7 @@ ls -la combobox/types/index.ts
 ### 각 파일 200라인 이하 확인
 ```bash
 wc -l combobox/components/*.tsx
-cd /home/bellman/Workspace/fooks-test-repos/ui
+cd <fooks-test-repos>/ui
 wc -l combobox/components/Combobox.tsx
 wc -l combobox/components/ComboboxInput.tsx
 wc -l combobox/components/ComboboxList.tsx

--- a/benchmarks/layer2-frontend-task/direct-executor.js
+++ b/benchmarks/layer2-frontend-task/direct-executor.js
@@ -12,6 +12,7 @@ const {
   resolveOpenAIModel,
 } = require('./model-resolution.js');
 
+const repoRoot = path.resolve(__dirname, '..', '..');
 const API_KEY = process.env.OPENAI_API_KEY;
 if (!API_KEY) {
   console.error('[Direct Executor] ERROR: OPENAI_API_KEY not set');
@@ -23,13 +24,15 @@ const modelConfig = resolveOpenAIModel({ modelArg: args.model });
 const MODEL = modelConfig.model;
 const targetFile = args.target || args._[0] || 'apps/v4/registry/bases/radix/examples/combobox-example.tsx';
 const mode = args.mode || args._[1] || 'vanilla';
+const targetRepoRoot = process.env.FOOKS_LAYER2_TARGET_REPO || path.resolve(repoRoot, '..', 'fooks-test-repos', 'ui');
+const outputRoot = process.env.FOOKS_LAYER2_OUTPUT_DIR || path.join(repoRoot, 'benchmarks', 'layer2-frontend-task', 'results');
 
 console.log(`[Direct Executor] Mode: ${mode}, Target: ${targetFile}, Model: ${MODEL} (${modelConfig.modelSource})`);
 console.log(`[Direct Executor] Starting CASE-1 execution...`);
 
 // Read target file
 const fullContent = fs.readFileSync(
-  path.join('/home/bellman/Workspace/fooks-test-repos/ui', targetFile),
+  path.join(targetRepoRoot, targetFile),
   'utf-8'
 );
 
@@ -79,10 +82,10 @@ const req = https.request(options, (res) => {
       console.log(`[Direct Executor] Content preview: ${result.choices[0].message.content.substring(0, 200)}...`);
       
       // Save result
-      const outputDir = `~/Workspace/fooks/benchmarks/layer2-frontend-task/results/case1-${mode}`;
-      fs.mkdirSync(outputDir.replace('~', process.env.HOME), { recursive: true });
+      const outputDir = path.join(outputRoot, `case1-${mode}`);
+      fs.mkdirSync(outputDir, { recursive: true });
       fs.writeFileSync(
-        path.join(outputDir.replace('~', process.env.HOME), 'api-response.json'),
+        path.join(outputDir, 'api-response.json'),
         JSON.stringify({
           provider: 'openai',
           model,

--- a/benchmarks/scripts/lib.mjs
+++ b/benchmarks/scripts/lib.mjs
@@ -24,6 +24,7 @@ const helperServerPath = path.join(benchmarksRoot, "scripts", "scan-helper-serve
 const helperClientPath = path.join(benchmarksRoot, "scripts", "scan-helper-client.mjs");
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
 const { decideMode } = require(path.join(repoRoot, "dist", "core", "decide.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 
 function runProcess(command, args, { cwd = repoRoot, env = process.env } = {}) {
   const startedAt = performance.now();
@@ -699,6 +700,8 @@ export function runExtractSuite() {
     const extraction = measure(() => extractFile(absolutePath));
     const decide = measure(() => decideMode(baseExtractionResult(extraction.value)));
     const extractBytes = Buffer.byteLength(JSON.stringify(extraction.value), "utf8");
+    const modelPayload = toModelFacingPayload(extraction.value, repoRoot);
+    const modelPayloadBytes = Buffer.byteLength(JSON.stringify(modelPayload), "utf8");
 
     return {
       kind: "extract-bench",
@@ -709,6 +712,8 @@ export function runExtractSuite() {
       rawBytes: sourceBytes,
       extractBytes,
       reductionPct: round((1 - (extractBytes / sourceBytes)) * 100),
+      modelPayloadBytes,
+      modelPayloadReductionPct: round((1 - (modelPayloadBytes / sourceBytes)) * 100),
       extractMs: extraction.durationMs,
       decideMs: decide.durationMs,
       mode: extraction.value.mode,
@@ -848,9 +853,9 @@ export function computeFinalGates({ scanCache, extract, gateSuite }) {
           return null;
         }
         return {
-          name: `${fixture.fixtureId} reductionPct >= lowerBound`,
-          passed: fixture.reductionPct >= lowerBound,
-          actual: fixture.reductionPct,
+          name: `${fixture.fixtureId} modelPayloadReductionPct >= lowerBound`,
+          passed: (fixture.modelPayloadReductionPct ?? fixture.reductionPct) >= lowerBound,
+          actual: fixture.modelPayloadReductionPct ?? fixture.reductionPct,
           expected: `>= ${lowerBound}`,
         };
       })

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -3,14 +3,14 @@ import path from "node:path";
 import { decidePreRead } from "./pre-read";
 import { clearClaudeRuntimeSession, initializeClaudeRuntimeSession, markClaudeRuntimeSeenFile, resolveClaudeRuntimeSessionKey } from "./claude-runtime-session";
 import { clearClaudeActiveFile, ensureFreshClaudeContextForTarget, markClaudeAttachPrepared } from "./claude-runtime-trust";
-import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
+import { extractPromptTargets, hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import {
   clampAdditionalContext,
   boundedFallbackContext,
   sessionStartContext,
   CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS,
 } from "./claude-runtime-status";
-import type { ContextBudget, ContextMode, PromptSpecificity } from "../core/schema";
+import type { ContextBudget, ContextMode, ModelFacingPayload, PromptSpecificity } from "../core/schema";
 import {
   estimateFileBytes,
   estimateTextBytes,
@@ -49,6 +49,7 @@ export type ClaudeRuntimeHookDecision = {
     eligible: boolean;
     bounded: boolean;
     escapeHatchUsed?: boolean;
+    decision?: ReturnType<typeof decidePreRead>;
   };
   fallback?: {
     action: "full-read";
@@ -85,13 +86,62 @@ function buildPayloadContext(
     }
   }
 
-  const truncated = removedSections.length > 0;
-  const context = clampAdditionalContext(`${prefix}${json}`);
+  const rawContext = `${prefix}${json}`;
+  const truncated = removedSections.length > 0 || rawContext.length > CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS;
+  const context = clampAdditionalContext(rawContext);
   return { context, truncated, removedSections };
 }
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
   return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function truncatedReason(removedSections: string[]): string {
+  return removedSections.length > 0 ? `truncated: ${removedSections.join(", ")}` : "truncated: max-additional-context";
+}
+
+const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
+const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
+
+export function isClaudeEditIntentPrompt(prompt: string): boolean {
+  return EDIT_INTENT_PATTERN.test(prompt);
+}
+
+function hasSingleExactFrontendTarget(
+  prompt: string,
+  policy: ReturnType<typeof resolvePromptFileContext>["policy"],
+  target: string,
+  cwd: string,
+): boolean {
+  const allExplicitCodeTargets = extractPromptTargets(prompt, cwd, "codex-ts-js-beta");
+  if (allExplicitCodeTargets.length !== 1 || allExplicitCodeTargets[0]?.filePath !== target) return false;
+  if (policy.promptSpecificity !== "exact-file") return false;
+  if (policy.targets.length !== 1) return false;
+  if (policy.targets[0]?.filePath !== target || !policy.targets[0]?.exists) return false;
+  if (!FRONTEND_EXTENSIONS.has(path.extname(target))) return false;
+  return fs.existsSync(path.join(cwd, target));
+}
+
+function hasPositiveFreshness(target: string, cwd: string, freshness: ReturnType<typeof ensureFreshClaudeContextForTarget>): boolean {
+  return fs.existsSync(path.join(cwd, target)) && Boolean(freshness.scannedAt);
+}
+
+function canAttemptRuntimeEditGuidance(
+  prompt: string,
+  target: string,
+  cwd: string,
+  policy: ReturnType<typeof resolvePromptFileContext>["policy"],
+  freshness: ReturnType<typeof ensureFreshClaudeContextForTarget>,
+): boolean {
+  return hasSingleExactFrontendTarget(prompt, policy, target, cwd) && isClaudeEditIntentPrompt(prompt) && hasPositiveFreshness(target, cwd, freshness);
+}
+
+function hasMatchingEditGuidance(payload: ModelFacingPayload): boolean {
+  return Boolean(
+    payload.sourceFingerprint &&
+      payload.editGuidance?.freshness.fileHash === payload.sourceFingerprint.fileHash &&
+      payload.editGuidance.freshness.lineCount === payload.sourceFingerprint.lineCount,
+  );
 }
 
 function recordClaudeMetric(
@@ -363,12 +413,37 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     return runtimeDecision;
   }
 
+  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const editGuidanceAllowed =
+    decision.decision === "payload" &&
+    Boolean(decision.payload?.sourceFingerprint) &&
+    canAttemptRuntimeEditGuidance(prompt, target, cwd, policy, freshness);
+  if (editGuidanceAllowed) {
+    try {
+      const optInDecision = decidePreRead(resolvedTarget, cwd, "claude", { includeEditGuidance: true });
+      if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
+        const optInContextMode = payloadContextMode(optInDecision.payload);
+        const optInPayloadContext = buildPayloadContext(target, optInDecision.payload, optInContextMode);
+        if (!optInPayloadContext.truncated && optInPayloadContext.context.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS) {
+          decision = optInDecision;
+        }
+      }
+    } catch {
+      // Optional edit guidance must never make the Claude hook fail.
+    }
+  }
+
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
     const { context: additionalContext, truncated, removedSections } = buildPayloadContext(target, decision.payload, contextMode);
-    const reasons = refreshed ? ["repeated-file", "refreshed-before-inject"] : ["repeated-file"];
+    const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
+    const reasons = [
+      "repeated-file",
+      ...(refreshed ? ["refreshed-before-inject"] : []),
+      ...(editGuidanceIncluded ? ["edit-guidance-opt-in"] : []),
+    ];
     if (truncated) {
-      reasons.push(`truncated: ${removedSections.join(", ")}`);
+      reasons.push(truncatedReason(removedSections));
     }
     const runtimeDecision: ClaudeRuntimeHookDecision = {
       runtime: "claude",
@@ -379,7 +454,11 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       additionalContext,
       statePath,
       contextMode,
-      contextModeReason: contextMode === "light-minimal" ? "repeated-exact-file-tiny-raw-original" : "repeated-exact-file-payload",
+      contextModeReason: editGuidanceIncluded
+        ? "repeated-exact-file-edit-guidance"
+        : contextMode === "light-minimal"
+          ? "repeated-exact-file-tiny-raw-original"
+          : "repeated-exact-file-payload",
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
@@ -388,20 +467,19 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
         eligible: true,
         bounded: true,
         escapeHatchUsed: false,
+        decision,
       },
     };
     markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
-    const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
     recordClaudeMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
       actualEstimatedBytes: estimateTextBytes(additionalContext),
-      comparableForSavings: originalEstimatedBytes !== undefined,
+      comparableForSavings: editGuidanceIncluded ? false : originalEstimatedBytes !== undefined,
     });
     return runtimeDecision;
   }
 
   markClaudeAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
-  const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
   const runtimeDecision: ClaudeRuntimeHookDecision = {
     runtime: "claude",
     hookEventName,

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -2,9 +2,15 @@ import { scanProject } from "../core/scan";
 import { extractFile } from "../core/extract";
 import { detectAccountContext, finalizeAttach, installRuntimeManifest } from "./shared";
 import { completeClaudeInitialScan, initializeClaudeTrustStatus } from "./claude-runtime-trust";
+import { defaultClaudeHookCommand } from "./claude-hook-preset";
+import { runtimeEscapeHatches } from "./prompt-context";
 import type { AttachResult } from "../core/schema";
 
-export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachResult {
+const CLAUDE_RUNTIME_TOKEN_TELEMETRY_DETAIL = "runtime-token-telemetry=not-collected";
+const CLAUDE_RUNTIME_BRIDGE_CLAIM_BOUNDARY =
+  "Project-local Claude context hook only; no Claude Read interception or runtime-token savings claim.";
+
+export function attachClaude(sampleFile: string, cwd = process.cwd(), runtimeBridgeCommand = defaultClaudeHookCommand()): AttachResult {
   initializeClaudeTrustStatus(cwd);
   const scan = scanProject(cwd);
   const trustStatus = completeClaudeInitialScan(scan.scannedAt, cwd);
@@ -12,13 +18,30 @@ export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachRes
   const account = detectAccountContext(cwd);
   const attemptedAt = new Date().toISOString();
   const runtimeProof = (() => {
-    const manifest = installRuntimeManifest("claude", cwd);
+    const manifest = installRuntimeManifest("claude", cwd, {
+      runtimeBridge: {
+        command: runtimeBridgeCommand,
+        supportedHookEvents: ["SessionStart", "UserPromptSubmit", "Stop"],
+        scope: {
+          extensions: [".tsx", ".jsx"],
+          strategy: "project-local-context-hook",
+        },
+        escapeHatches: [...runtimeEscapeHatches()],
+        claimBoundary: CLAUDE_RUNTIME_BRIDGE_CLAIM_BOUNDARY,
+      },
+    });
     if (manifest.status === "passed") {
       return {
         status: "passed" as const,
         attemptedAt,
         artifactPath: manifest.manifestPath,
-        details: [`account-context=${account.account}`, `account-source=${account.source}`, `runtime-manifest=${manifest.manifestPath}`, "claude adapter artifacts created"],
+        details: [
+          `account-context=${account.account}`,
+          `account-source=${account.source}`,
+          `runtime-manifest=${manifest.manifestPath}`,
+          "claude adapter artifacts created",
+          CLAUDE_RUNTIME_TOKEN_TELEMETRY_DETAIL,
+        ],
       };
     }
 
@@ -29,6 +52,7 @@ export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachRes
         artifactPath: manifest.manifestPath,
         details: [
           "claude adapter artifacts created",
+          CLAUDE_RUNTIME_TOKEN_TELEMETRY_DETAIL,
           `account-source=${account.source}`,
           `runtime-manifest=${manifest.manifestPath}`,
           "runtime-manifest-write-attempted=true",
@@ -42,7 +66,12 @@ export function attachClaude(sampleFile: string, cwd = process.cwd()): AttachRes
       status: "blocked" as const,
       attemptedAt,
       artifactPath: manifest.manifestPath,
-      details: ["claude adapter artifacts created", `account-source=${account.source}`, "runtime-manifest-write-attempted=false"],
+      details: [
+        "claude adapter artifacts created",
+        CLAUDE_RUNTIME_TOKEN_TELEMETRY_DETAIL,
+        `account-source=${account.source}`,
+        "runtime-manifest-write-attempted=false",
+      ],
       blocker: "Claude runtime home not detected",
     };
   })();

--- a/src/adapters/prompt-context.ts
+++ b/src/adapters/prompt-context.ts
@@ -1,5 +1,7 @@
 export {
+  extractPromptTargets,
   hasFullReadEscapeHatch,
+  runtimeEscapeHatches,
   resolvePromptFileContext,
 } from "../core/context-policy";
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -476,7 +476,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
   let claude: RuntimeReadiness;
   if (sample.sampleKind === "react-component") {
     try {
-      const claudeAttach = attachClaude(sample.filePath, cwd);
+      const claudeAttach = attachClaude(sample.filePath, cwd, `${displayCliName} claude-runtime-hook --native-hook`);
       const claudeHooks = installClaudeHookPreset(cwd, displayCliName);
       const claudeStatus = readClaudeRuntimeStatus(cwd);
       claude = claudeRuntimeReadiness(claudeAttach, claudeHooks, claudeStatus);
@@ -889,7 +889,11 @@ async function run(): Promise<void> {
               process.cwd(),
               `${displayCliName} codex-runtime-hook --native-hook`,
             )
-          : (await import("../adapters/claude.js")).attachClaude(sample.filePath);
+          : (await import("../adapters/claude.js")).attachClaude(
+              sample.filePath,
+              process.cwd(),
+              `${displayCliName} claude-runtime-hook --native-hook`,
+            );
       print(result);
       return;
     }

--- a/src/core/context-policy.ts
+++ b/src/core/context-policy.ts
@@ -108,8 +108,12 @@ export function hasFullReadEscapeHatch(prompt: string): boolean {
   return ESCAPE_HATCH_TOKENS.some((token) => prompt.includes(token));
 }
 
-export function codexRuntimeEscapeHatches(): readonly string[] {
+export function runtimeEscapeHatches(): readonly string[] {
   return ESCAPE_HATCH_TOKENS;
+}
+
+export function codexRuntimeEscapeHatches(): readonly string[] {
+  return runtimeEscapeHatches();
 }
 
 export function classifyPromptContext(prompt: string, cwd = process.cwd(), capability: ContextCapability = "react-only"): PromptContextPolicy {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3321,9 +3321,14 @@ test("attach claude pairs manual handoff proof with reduced model-facing artifac
     const manifestText = fs.readFileSync(manifestPath, "utf8");
     const manifest = JSON.parse(manifestText);
     assert.equal(manifest.runtime, "claude");
-    assert.equal(manifest.runtimeBridge, undefined);
-    assert.equal(manifest.supportedHookEvents, undefined);
-    assert.doesNotMatch(manifestText, /codex-runtime-hook|UserPromptSubmit|SessionStart|Stop/);
+    assert.equal(manifest.runtimeBridge.command, "fooks claude-runtime-hook --native-hook");
+    assert.deepEqual(manifest.runtimeBridge.supportedHookEvents, ["SessionStart", "UserPromptSubmit", "Stop"]);
+    assert.deepEqual(manifest.runtimeBridge.scope.extensions, [".tsx", ".jsx"]);
+    assert.equal(manifest.runtimeBridge.scope.strategy, "project-local-context-hook");
+    assert.deepEqual(manifest.runtimeBridge.escapeHatches, ["#fooks-full-read", "#fooks-disable-pre-read"]);
+    assert.match(manifest.runtimeBridge.claimBoundary, /no Claude Read interception or runtime-token savings claim/);
+    assert.doesNotMatch(manifestText, /codex-runtime-hook/);
+    assert.ok(result.runtimeProof.details.includes("runtime-token-telemetry=not-collected"));
   });
 
   const fullResult = extractFile(samplePath);

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -13,6 +13,7 @@ const {
   CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS,
   handleClaudeRuntimeHook,
 } = await import(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));
+const { readSessionMetricSummary } = await import(path.join(repoRoot, "dist", "core", "session-metrics.js"));
 
 function cleanupRuntimeSessions(repoRoot, runtime, prefixes) {
   const root = path.join(repoRoot, ".fooks", "state", runtime);
@@ -145,6 +146,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
 
 test("claude runtime bridge follows record-then-inject repeated same-file contract", () => {
   const target = path.join("fixtures", "compressed", "FormSection.tsx");
+  const linkedTsTarget = path.join("fixtures", "compressed", "FormSection.utils.ts");
+  const missingJsTarget = path.join("src", "cli", "index.js");
   const otherTarget = path.join("fixtures", "raw", "SimpleButton.tsx");
   const readState = (statePath) => JSON.parse(fs.readFileSync(statePath, "utf8"));
 
@@ -177,11 +180,98 @@ test("claude runtime bridge follows record-then-inject repeated same-file contra
   );
   assert.equal(second.action, "inject");
   assert.equal(second.filePath, target);
+  assert.equal(second.contextModeReason, "repeated-exact-file-edit-guidance");
+  assert.ok(second.reasons.includes("edit-guidance-opt-in"));
   assert.ok(second.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
   assert.match(second.additionalContext, /fixtures\/compressed\/FormSection\.tsx/);
+  assert.match(second.additionalContext, /does not intercept Claude Read or claim runtime-token savings/);
+  assert.equal(second.additionalContext.includes("\"editGuidance\""), true);
+  assert.deepEqual(second.debug.decision.payload.editGuidance.freshness, second.debug.decision.payload.sourceFingerprint);
   assert.doesNotMatch(second.additionalContext, /Claude Read interception is enabled/i);
   assert.equal(second.debug.repeatedFile, true);
   assert.equal(readState(second.statePath).seenFiles[target].seenCount, 2);
+  const editGuidanceMetricSummary = readSessionMetricSummary(repoRoot, injectSession, {
+    runtime: "claude",
+    measurementSource: "project-local-context-hook",
+  });
+  assert.equal(editGuidanceMetricSummary.runtime, "claude");
+  assert.equal(editGuidanceMetricSummary.measurementSource, "project-local-context-hook");
+  assert.equal(editGuidanceMetricSummary.eventCount, 2);
+  assert.equal(editGuidanceMetricSummary.comparableEventCount, 0);
+
+  const readOnlySession = `bridge-contract-claude-readonly-${Date.now()}`;
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: readOnlySession }, repoRoot);
+  handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: readOnlySession,
+      prompt: `Please inspect ${target}`,
+    },
+    repoRoot,
+  );
+  const readOnlySecond = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: readOnlySession,
+      prompt: `Again, summarize ${target}`,
+    },
+    repoRoot,
+  );
+  assert.equal(readOnlySecond.action, "inject");
+  assert.equal(readOnlySecond.contextModeReason, "repeated-exact-file-payload");
+  assert.equal(readOnlySecond.additionalContext.includes("\"editGuidance\""), false);
+  assert.equal("editGuidance" in readOnlySecond.debug.decision.payload, false);
+  assert.equal(readOnlySecond.reasons.includes("edit-guidance-opt-in"), false);
+
+  const multiFileSession = `bridge-contract-claude-multifile-${Date.now()}`;
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: multiFileSession }, repoRoot);
+  handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: multiFileSession,
+      prompt: `Please update ${target} and ${otherTarget}`,
+    },
+    repoRoot,
+  );
+  const multiFileSecond = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: multiFileSession,
+      prompt: `Again, fix ${target} and ${otherTarget}`,
+    },
+    repoRoot,
+  );
+  assert.equal(multiFileSecond.action, "inject");
+  assert.equal(multiFileSecond.additionalContext.includes("\"editGuidance\""), false);
+  assert.equal(multiFileSecond.reasons.includes("edit-guidance-opt-in"), false);
+
+  for (const [label, extraTarget] of [
+    ["mixed-ts", linkedTsTarget],
+    ["mixed-js", missingJsTarget],
+  ]) {
+    const mixedCodeSession = `bridge-contract-claude-${label}-${Date.now()}`;
+    handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId: mixedCodeSession }, repoRoot);
+    handleClaudeRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: mixedCodeSession,
+        prompt: `Please update ${target} and ${extraTarget}`,
+      },
+      repoRoot,
+    );
+    const mixedCodeSecond = handleClaudeRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: mixedCodeSession,
+        prompt: `Again, fix ${target} and ${extraTarget}`,
+      },
+      repoRoot,
+    );
+    assert.equal(mixedCodeSecond.action, "inject");
+    assert.equal(mixedCodeSecond.contextModeReason, "repeated-exact-file-payload");
+    assert.equal(mixedCodeSecond.additionalContext.includes("\"editGuidance\""), false);
+    assert.equal(mixedCodeSecond.reasons.includes("edit-guidance-opt-in"), false);
+  }
 
   const differentFile = handleClaudeRuntimeHook(
     {


### PR DESCRIPTION
## Summary
- sanitize tracked benchmark/report paths so the public repo surface no longer exposes maintainer-local absolute paths
- make benchmark runner/direct executor defaults configurable instead of hardcoding local workspaces
- align the benchmark gate with model-facing payload reduction and keep Claude runtime bridge metadata/claim boundaries explicit

## Verification
- npm run lint
- npm test (242 pass)
- npm run bench:gate (gates.passed true)
- npm run release:smoke
- npm publish --dry-run
- git diff --check
- tracked secret/local-path grep

## Not done
- Did not make the GitHub repo public
- Did not run real npm publish
- Did not create a release/tag
