### PR TITLE
Restore claim-safe benchmark impact visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Use fooks when you are iterating on the same large supported file in Codex and w
 - **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
 - **Roadmap asks, not current support:** Vue/SFC, broader TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity.
 - **Local proof:** `fooks compare` shows the original source size versus the compact fooks model-facing payload for one supported file.
+- **Benchmark impact:** the latest launch-grade evidence is estimate-scoped API cost, not billing proof: the corrected 2026-04-22 Codex OAuth campaign accepted 15/15 matched pairs and reduced median estimated OpenAI API cost by 4.171% under recorded pricing assumptions; larger Next.js and Tailwind profiles reported 26.492% and 38.238% median estimated API-cost reductions.
 - **Evidence boundary:** fooks supports prompt-size/context-load estimates and estimate-scoped API-cost evidence under explicit assumptions; it does not prove provider invoices, billing-grade charges, stable runtime-token wins, or Claude/opencode automatic savings.
 
 ## Quick start and local proof
@@ -126,7 +127,9 @@ Current public summary:
 
 - Local commands support **model-facing context / prompt-size estimate** wording.
 - The 2026-04-14 Codex-oriented proxy snapshot showed a prepared-context estimate reduction from roughly 2.1M to 450K estimated context tokens in a 5-task sample, with no success-rate regression in that sample.
-- Later benchmark lanes include estimate-scoped API-cost evidence, but that wording must stay qualified as **estimated API cost under explicit pricing assumptions**.
+- The corrected 2026-04-22 Codex OAuth provider-cost campaign reached launch-grade estimated-cost evidence for the small fixture lane: 3 task classes × 5 accepted matched pairs, 0 command-execution events, 15/15 accepted, an overall median estimated API-cost reduction of 4.171%, and aggregate estimated API cost of `$0.588855` baseline vs `$0.5547775` fooks (`$0.0340775`, 5.787% lower) under the recorded pricing assumption. Provider-reported usage tokens in that campaign were `376,104` baseline vs `372,065` fooks; 4/15 individual pairs still regressed.
+- Larger corrected public-code profiles made the impact easier to see under the same estimate-scoped boundary: the Next.js profile reported 15/15 accepted pairs, 0 regressions, median estimated API-cost reduction of 26.492%, provider-reported usage tokens `446,275` baseline vs `382,139` fooks, and aggregate estimated API cost `$0.88386` vs `$0.64497`; the Tailwind profile reported 15/15 accepted pairs, 0 regressions, median estimated API-cost reduction of 38.238%, provider-reported usage tokens `718,616` baseline vs `381,583` fooks, and aggregate estimated API cost `$1.598875` vs `$0.64853`.
+- These provider-cost benchmark lanes are **estimated API cost under explicit pricing assumptions**. They do not prove invoice/dashboard savings, actual charged-cost savings, provider billing-token savings, stable runtime-token savings, or stable wall-clock/latency savings.
 - Direct runtime-token/time evidence remains unstable or negative in some diagnostics, so fooks does not claim stable runtime-token, wall-clock, or latency wins.
 
 Detailed evidence and current claim boundaries are maintained in the curated benchmark evidence page: https://github.com/minislively/fooks/blob/main/docs/benchmark-evidence.md

--- a/docs/release.md
+++ b/docs/release.md
@@ -84,6 +84,21 @@ acceptance in both modes, so it remained `insufficient-accepted-pairs` and
 produced no comparable accepted-pair medians. Do not use this rerun as a win
 claim; it only reinforces the current release boundary.
 
+Release copy should also keep the positive L2a impact visible when it is labeled
+correctly. The curated benchmark evidence records a corrected 2026-04-22 Codex
+OAuth provider-cost campaign with `launch-grade-estimated-cost-evidence`: 3 task
+classes × 5 accepted matched pairs, 0 command-execution events, 15/15 accepted,
+and a 4.171% overall median estimated API-cost reduction under the recorded
+pricing assumption. Larger corrected public-code profiles also reached
+launch-grade estimated-cost evidence: Next.js reported a 26.492% median
+estimated API-cost reduction with provider-reported usage tokens `446,275`
+baseline vs `382,139` fooks, and Tailwind reported a 38.238% median estimated
+API-cost reduction with provider-reported usage tokens `718,616` baseline vs
+`381,583` fooks. This is L2a estimated-cost evidence only: it is not provider
+invoice/dashboard proof, actual charged-cost proof, provider billing-token
+savings, stable runtime-token/time proof, or a Claude/opencode automatic savings
+claim.
+
 A user who already has another global `fooks` binary may see command conflicts. Ask them to inspect their global npm binaries before installing or reinstall into a clean prefix when debugging:
 
 ```bash
@@ -97,7 +112,7 @@ npm ls -g --depth=0 | grep -E 'fooks|oh-my-fooks'
 | Risk | Current disposition | Release implication |
 | --- | --- | --- |
 | `npm publish` not run | Keep unresolved until explicit human approval; use `npm run release:smoke` and `npm publish --dry-run` only for proof. | Blocks real publication, not docs/code PR merge. |
-| Layer 2 stable applied-code / multi-task evidence absent | Applied repeated diagnostics exist but are negative/insufficient: the pre-launch run accepted only 4/7 pairs and regressed on CLI runtime/time medians; the same-day risk-closure rerun accepted 0/3 pairs before stopping. Multi-task evidence still does not exist. | Blocks stable Layer 2 runtime-token/time win claims and applied-code benchmark-win wording. |
+| Layer 2 stable applied-code / runtime-token evidence absent | Applied repeated diagnostics exist but are negative/insufficient: the pre-launch run accepted only 4/7 pairs and regressed on CLI runtime/time medians; the same-day risk-closure rerun accepted 0/3 pairs before stopping. Separate corrected provider-cost campaigns do show launch-grade L2a estimated API-cost reductions under recorded pricing assumptions, including larger Next.js/Tailwind profiles, but they are not applied-code, runtime-token/time, or billing-grade proof. | Blocks stable Layer 2 runtime-token/time win claims and applied-code benchmark-win wording; allows only estimate-scoped API-cost wording. |
 | Direct-Codex runtime-token regression | Negative/unstable Formbricks evidence is documented and linked. | Blocks stable runtime-token/time win claims. |
 | Local `fooks status` estimates | Bare status is documented as local context-size telemetry only. | Blocks billing-token, provider-cost, or `ccusage` replacement wording. |
 | Claude/opencode automatic savings | Claude now has bounded project-local context hooks that record/prepare the first eligible frontend-file prompt, then add repeated same-file context, but no measured runtime-token savings and no `Read` interception. opencode remains a manual/semi-automatic tool bridge. | Keep Claude context-hook wording and opencode tool wording only. |


### PR DESCRIPTION
## Summary

Fixes #154.

- Restores a concise public benchmark-impact summary in `README.md`.
- Surfaces the corrected 2026-04-22 launch-grade estimated API-cost campaign plus larger Next.js/Tailwind profiles.
- Updates `docs/release.md` so release-facing guidance keeps positive L2a impact visible while preserving PR #153 support-boundary caveats.

## Claim boundary

All benchmark numbers come from `docs/benchmark-evidence.md` only. The wording stays scoped to estimated API cost under recorded pricing assumptions and does not claim provider invoice/dashboard proof, actual charged-cost savings, provider billing-token savings, stable runtime-token/time/latency wins, or Claude/opencode automatic savings.

## Verification

- `npm run lint`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
