### PR TITLE
Clarify benchmark method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Current public summary:
 
 ### Public-code benchmark snapshot
 
+These figures are **not OMX-session benchmarks** and not a full interactive
+"install fooks, work normally" session benchmark. They come from a Codex OAuth
+no-tool benchmark harness that compares matched baseline prompts containing
+real full-source context against matched fooks prompts containing real
+`fooks extract --model-payload` context, using isolated Codex workdirs and AB/BA
+pair order.
+
 | Profile / project | Scope | Accepted pairs | Regressions | Median estimated API-cost reduction | Aggregate estimated API cost | Provider-reported usage tokens |
 | --- | --- | ---: | ---: | ---: | --- | --- |
 | Small fixture lane | 3 task classes × 5 pairs | 15/15 | 4/15 pairs | 4.171% | `$0.588855` baseline → `$0.5547775` fooks (`$0.0340775`, 5.787% lower) | `376,104` baseline → `372,065` fooks |


### PR DESCRIPTION
The launch README now states that the public-code benchmark snapshot is a Codex OAuth no-tool harness comparison of full-source baseline prompts against real fooks model-payload prompts, not an OMX session or full interactive installed-hook session.\n\nConstraint: Public benchmark claims must identify the measured setup, not imply broader interactive runtime behavior.\nRejected: Leave the method only in docs/benchmark-evidence.md | README readers could misread the table as OMX or ordinary session evidence.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Keep README benchmark tables paired with a method sentence whenever evidence lanes change.\nTested: npm ci; npm run lint; git diff --check\nNot-tested: Documentation-only change, no benchmark rerun.
