### PR TITLE
Prove design-review metadata before runtime exposure

### DIFF
--- a/fixtures/design-review/FormStateReview.tsx
+++ b/fixtures/design-review/FormStateReview.tsx
@@ -1,0 +1,40 @@
+type FormStateReviewProps = {
+  loading?: boolean;
+  error?: string | null;
+  disabled?: boolean;
+  onSubmit?: (email: string, role: string) => void;
+};
+
+export function FormStateReview({ loading = false, error = null, disabled = false, onSubmit }: FormStateReviewProps) {
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    onSubmit?.(String(form.get("email") ?? ""), String(form.get("role") ?? "viewer"));
+  }
+
+  return (
+    <form className="grid gap-4 rounded-2xl border border-slate-200 p-5 shadow-sm" onSubmit={handleSubmit}>
+      <label className="grid gap-1 text-sm font-medium">
+        Email
+        <input className="rounded-md border px-3 py-2" disabled={disabled || loading} name="email" required type="email" />
+      </label>
+      <label className="grid gap-1 text-sm font-medium">
+        Role
+        <select className="rounded-md border px-3 py-2" disabled={disabled || loading} name="role" defaultValue="viewer">
+          <option value="viewer">Viewer</option>
+          <option value="editor">Editor</option>
+        </select>
+      </label>
+      <label className="grid gap-1 text-sm font-medium">
+        Notes
+        <textarea className="min-h-20 rounded-md border px-3 py-2" disabled={disabled || loading} name="notes" />
+      </label>
+      {error ? <p className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</p> : null}
+      <footer className="flex items-center justify-end gap-3">
+        <button className="rounded-lg bg-slate-900 px-4 py-2 text-white disabled:bg-slate-300" disabled={disabled || loading} type="submit">
+          {loading ? "Saving..." : "Save"}
+        </button>
+      </footer>
+    </form>
+  );
+}

--- a/fixtures/design-review/GenericLayout.tsx
+++ b/fixtures/design-review/GenericLayout.tsx
@@ -1,0 +1,8 @@
+export function GenericLayout() {
+  return (
+    <div>
+      <span>Overview</span>
+      <p>Static content without design-system-specific signals.</p>
+    </div>
+  );
+}

--- a/fixtures/design-review/StyledPanel.tsx
+++ b/fixtures/design-review/StyledPanel.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+type StyledPanelProps = {
+  tone?: "info" | "success";
+  compact?: boolean;
+  title: string;
+  children: React.ReactNode;
+};
+
+const PanelRoot = styled.section<{ $tone: "info" | "success"; $compact: boolean }>`
+  border-radius: 18px;
+  border: 1px solid ${({ $tone }) => ($tone === "success" ? "#22c55e" : "#3b82f6")};
+  background: ${({ $tone }) => ($tone === "success" ? "#f0fdf4" : "#eff6ff")};
+  padding: ${({ $compact }) => ($compact ? "12px" : "24px")};
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+`;
+
+const PanelHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+`;
+
+export function StyledPanel({ tone = "info", compact = false, title, children }: StyledPanelProps) {
+  return (
+    <PanelRoot $tone={tone} $compact={compact}>
+      <PanelHeader>
+        <h2>{title}</h2>
+        {compact ? <span>Compact</span> : null}
+      </PanelHeader>
+      <div>{children}</div>
+    </PanelRoot>
+  );
+}

--- a/fixtures/design-review/TailwindVariantCard.tsx
+++ b/fixtures/design-review/TailwindVariantCard.tsx
@@ -1,0 +1,47 @@
+type TailwindVariantCardProps = {
+  variant?: "primary" | "neutral" | "danger";
+  size?: "sm" | "md" | "lg";
+  selected?: boolean;
+  disabled?: boolean;
+  title: string;
+  description: string;
+  actions: string[];
+  onSelect?: () => void;
+};
+
+export function TailwindVariantCard({
+  variant = "primary",
+  size = "md",
+  selected = false,
+  disabled = false,
+  title,
+  description,
+  actions,
+  onSelect,
+}: TailwindVariantCardProps) {
+  const toneClass = variant === "danger" ? "border-red-500 bg-red-50 text-red-950" : variant === "neutral" ? "border-slate-200 bg-white text-slate-900" : "border-blue-500 bg-blue-50 text-blue-950";
+  const sizeClass = size === "lg" ? "p-6 text-lg" : size === "sm" ? "p-3 text-sm" : "p-4 text-base";
+  const selectedClass = selected ? "ring-2 ring-blue-500 shadow-lg" : "shadow-sm";
+  const disabledClass = disabled ? "opacity-50 cursor-not-allowed" : "hover:-translate-y-0.5";
+
+  return (
+    <section className={`rounded-xl border transition ${toneClass} ${sizeClass} ${selectedClass} ${disabledClass}`}>
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-semibold tracking-tight">{title}</h3>
+          <p className="mt-1 text-sm opacity-80">{description}</p>
+        </div>
+        <button className="rounded-full bg-blue-600 px-3 py-1 text-white disabled:bg-slate-300" disabled={disabled} onClick={onSelect}>
+          Select
+        </button>
+      </header>
+      <ul className="mt-4 grid gap-2">
+        {actions.map((action) => (
+          <li className="rounded-md bg-white/70 px-3 py-2 text-sm" key={action}>
+            {action}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/core/design-review-metadata.ts
+++ b/src/core/design-review-metadata.ts
@@ -1,0 +1,534 @@
+import type { ExtractionResult, SourceFingerprint, SourceRange, StyleSystem } from "./schema";
+
+export const DESIGN_REVIEW_METADATA_SCHEMA_VERSION = "design-review-metadata.v0" as const;
+
+export const DESIGN_REVIEW_METADATA_ITEM_CAPS = {
+  visualRegions: 12,
+  variantAxes: 8,
+  stateAxes: 8,
+  interactionAnchors: 12,
+  styleReferences: 16,
+} as const;
+
+export type DesignReviewEvidenceSource = "contract" | "behavior" | "structure" | "style" | "snippet";
+
+export type DesignReviewEvidenceRefV0 = {
+  source: DesignReviewEvidenceSource;
+  field: string;
+  value?: string;
+  loc?: SourceRange;
+};
+
+export type DesignReviewVisualRegionV0 = {
+  label: string;
+  kind: "layout" | "form" | "list" | "content" | "control" | "unknown";
+  loc?: SourceRange;
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+export type DesignReviewVariantAxisV0 = {
+  name: string;
+  values?: string[];
+  loc?: SourceRange;
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+export type DesignReviewStateAxisV0 = {
+  name: string;
+  kind: "boolean" | "async" | "empty" | "error" | "selection" | "unknown";
+  loc?: SourceRange;
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+export type DesignReviewInteractionAnchorV0 = {
+  label: string;
+  kind: "event-handler" | "form-control" | "submit-handler" | "validation-anchor";
+  loc?: SourceRange;
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+export type DesignReviewStyleReferenceV0 = {
+  kind: "tailwind-group" | "css-module" | "styled-component" | "inline-style" | "css-variable" | "theme-key" | "unknown";
+  label: string;
+  loc?: SourceRange;
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+export type DesignReviewCompressionContractV0 = {
+  sourceDerivedOnly: true;
+  notVisualProof: true;
+  notFigmaBacked: true;
+  notAccessibilityAudit: true;
+  notLspBacked: true;
+  notProviderTokenized: true;
+  maxItems: typeof DESIGN_REVIEW_METADATA_ITEM_CAPS;
+  staleWhen: ["sourceFingerprint.fileHash changes", "sourceFingerprint.lineCount changes"];
+  requiredUserActionOnStale: "rerun extraction or read current source before editing";
+};
+
+export type DesignReviewMetadataV0 = {
+  schemaVersion: typeof DESIGN_REVIEW_METADATA_SCHEMA_VERSION;
+  freshness: SourceFingerprint;
+  scope: {
+    kind: "same-file" | "same-component";
+    filePath: string;
+    componentName?: string;
+    componentLoc?: SourceRange;
+  };
+  confidence: "high" | "medium" | "low";
+  confidenceReasons: string[];
+  visualRegions: DesignReviewVisualRegionV0[];
+  variantAxes: DesignReviewVariantAxisV0[];
+  stateAxes: DesignReviewStateAxisV0[];
+  interactionAnchors: DesignReviewInteractionAnchorV0[];
+  styleReferences: DesignReviewStyleReferenceV0[];
+  compressionContract: DesignReviewCompressionContractV0;
+};
+
+export type DesignReviewFreshnessAssessment = {
+  fresh: boolean;
+  usableForEditing: boolean;
+  reasons: string[];
+  requiredUserActionOnStale?: DesignReviewCompressionContractV0["requiredUserActionOnStale"];
+};
+
+type EvidenceBearingItem = {
+  evidence: DesignReviewEvidenceRefV0[];
+};
+
+const VARIANT_AXIS_NAMES = new Set(["variant", "tone", "size", "disabled", "selected", "loading", "compact"]);
+const STATE_KEYWORDS = ["loading", "submitting", "pending", "error", "empty", "selected", "active", "expanded", "collapsed", "disabled"];
+const ASYNC_STATES = new Set(["loading", "submitting", "pending"]);
+const ERROR_STATES = new Set(["error"]);
+const EMPTY_STATES = new Set(["empty"]);
+const SELECTION_STATES = new Set(["selected", "active"]);
+
+function fingerprintOf(result: ExtractionResult): SourceFingerprint | undefined {
+  if (!result.fileHash || !Number.isFinite(result.meta.lineCount)) return undefined;
+  return {
+    fileHash: result.fileHash,
+    lineCount: result.meta.lineCount,
+  };
+}
+
+function evidence(source: DesignReviewEvidenceSource, field: string, value?: string, loc?: SourceRange): DesignReviewEvidenceRefV0 {
+  return {
+    source,
+    field,
+    ...(value ? { value } : {}),
+    ...(loc ? { loc } : {}),
+  };
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function propName(summary: string): string | undefined {
+  const match = summary.match(/^([A-Za-z_$][\w$]*)\??\s*:/);
+  return match?.[1];
+}
+
+function propValues(summary: string): string[] | undefined {
+  const values = [...summary.matchAll(/["']([^"']+)["']/g)].map((match) => match[1]).filter(Boolean);
+  return values.length > 0 ? [...new Set(values)].slice(0, 8) : undefined;
+}
+
+function addUniqueBy<T>(items: T[], candidate: T, keyOf: (item: T) => string): void {
+  const key = keyOf(candidate);
+  if (items.some((item) => keyOf(item) === key)) return;
+  items.push(candidate);
+}
+
+function allEmittedEvidence(metadata: {
+  visualRegions: EvidenceBearingItem[];
+  variantAxes: EvidenceBearingItem[];
+  stateAxes: EvidenceBearingItem[];
+  interactionAnchors: EvidenceBearingItem[];
+  styleReferences: EvidenceBearingItem[];
+}): DesignReviewEvidenceRefV0[][] {
+  return [
+    ...metadata.visualRegions.map((item) => item.evidence),
+    ...metadata.variantAxes.map((item) => item.evidence),
+    ...metadata.stateAxes.map((item) => item.evidence),
+    ...metadata.interactionAnchors.map((item) => item.evidence),
+    ...metadata.styleReferences.map((item) => item.evidence),
+  ];
+}
+
+function classifyRegion(label: string): DesignReviewVisualRegionV0["kind"] {
+  const normalized = label.toLowerCase();
+  if (["form", "fieldset", "label"].includes(normalized)) return "form";
+  if (["ul", "ol", "li", "table", "tbody", "tr"].includes(normalized) || normalized.includes("list")) return "list";
+  if (["button", "input", "select", "textarea"].includes(normalized)) return "control";
+  if (["section", "header", "footer", "main", "nav", "aside", "article"].includes(normalized) || normalized.includes("card") || normalized.includes("panel")) return "layout";
+  if (/^[A-Z]/.test(label)) return "content";
+  return "unknown";
+}
+
+function stateKind(name: string): DesignReviewStateAxisV0["kind"] {
+  const normalized = name.toLowerCase();
+  if ([...ASYNC_STATES].some((item) => normalized.includes(item))) return "async";
+  if ([...ERROR_STATES].some((item) => normalized.includes(item))) return "error";
+  if ([...EMPTY_STATES].some((item) => normalized.includes(item))) return "empty";
+  if ([...SELECTION_STATES].some((item) => normalized.includes(item))) return "selection";
+  if (/^(is|has|can|should)[A-Z]/.test(name) || normalized.startsWith("is") || normalized.startsWith("has")) return "boolean";
+  return "unknown";
+}
+
+function styleKind(system: StyleSystem | undefined, summary: string): DesignReviewStyleReferenceV0["kind"] {
+  if (system === "tailwind") return "tailwind-group";
+  if (system === "css-modules") return "css-module";
+  if (system === "styled-components") return "styled-component";
+  if (system === "inline-style") return "inline-style";
+  if (summary.includes("css-var")) return "css-variable";
+  if (summary.includes("theme")) return "theme-key";
+  return "unknown";
+}
+
+function compressionContract(): DesignReviewCompressionContractV0 {
+  return {
+    sourceDerivedOnly: true,
+    notVisualProof: true,
+    notFigmaBacked: true,
+    notAccessibilityAudit: true,
+    notLspBacked: true,
+    notProviderTokenized: true,
+    maxItems: DESIGN_REVIEW_METADATA_ITEM_CAPS,
+    staleWhen: ["sourceFingerprint.fileHash changes", "sourceFingerprint.lineCount changes"],
+    requiredUserActionOnStale: "rerun extraction or read current source before editing",
+  };
+}
+
+function visualRegionsFrom(result: ExtractionResult): DesignReviewVisualRegionV0[] {
+  const regions: DesignReviewVisualRegionV0[] = [];
+
+  if (result.componentName) {
+    addUniqueBy(
+      regions,
+      {
+        label: result.componentName,
+        kind: classifyRegion(result.componentName),
+        ...(result.componentLoc ? { loc: result.componentLoc } : {}),
+        evidence: [evidence("structure", "componentName", result.componentName, result.componentLoc)],
+      },
+      (item) => item.label,
+    );
+  }
+
+  for (const section of result.structure?.sections ?? []) {
+    addUniqueBy(
+      regions,
+      {
+        label: section,
+        kind: classifyRegion(section),
+        evidence: [evidence("structure", "sections", section)],
+      },
+      (item) => item.label,
+    );
+  }
+
+  for (const block of result.structure?.repeatedBlocks ?? []) {
+    addUniqueBy(
+      regions,
+      {
+        label: block === "array-map-render" ? "list" : block,
+        kind: "list",
+        evidence: [evidence("structure", "repeatedBlocks", block)],
+      },
+      (item) => `${item.kind}:${item.label}`,
+    );
+  }
+
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    const label = control.name ? `${control.tag}[name=${control.name}]` : control.tag;
+    addUniqueBy(
+      regions,
+      {
+        label,
+        kind: "control",
+        ...(control.loc ? { loc: control.loc } : {}),
+        evidence: [evidence("behavior", "formSurface.controls", label, control.loc)],
+      },
+      (item) => item.label,
+    );
+  }
+
+  for (const snippet of result.snippets ?? []) {
+    if (!snippet.loc) continue;
+    addUniqueBy(
+      regions,
+      {
+        label: snippet.label,
+        kind: snippet.reason === "conditional-render" ? "content" : "unknown",
+        loc: snippet.loc,
+        evidence: [evidence("snippet", `snippets.${snippet.reason}`, snippet.label, snippet.loc)],
+      },
+      (item) => `${item.label}:${item.loc?.startLine ?? ""}`,
+    );
+  }
+
+  return regions.slice(0, DESIGN_REVIEW_METADATA_ITEM_CAPS.visualRegions);
+}
+
+function variantAxesFrom(result: ExtractionResult): DesignReviewVariantAxisV0[] {
+  const axes: DesignReviewVariantAxisV0[] = [];
+
+  for (const summary of result.contract?.propsSummary ?? []) {
+    const name = propName(summary);
+    if (!name || !VARIANT_AXIS_NAMES.has(name)) continue;
+    const values = propValues(summary);
+    addUniqueBy(
+      axes,
+      {
+        name,
+        ...(values ? { values } : {}),
+        ...(result.contract?.propsLoc ? { loc: result.contract.propsLoc } : {}),
+        evidence: [evidence("contract", "propsSummary", summary, result.contract?.propsLoc)],
+      },
+      (item) => item.name,
+    );
+  }
+
+  for (const branch of result.structure?.conditionalRenders ?? []) {
+    for (const name of VARIANT_AXIS_NAMES) {
+      if (!new RegExp(`\\b${name}\\b`, "i").test(branch)) continue;
+      addUniqueBy(
+        axes,
+        {
+          name,
+          evidence: [evidence("structure", "conditionalRenders", compact(branch))],
+        },
+        (item) => item.name,
+      );
+    }
+  }
+
+  return axes.slice(0, DESIGN_REVIEW_METADATA_ITEM_CAPS.variantAxes);
+}
+
+function stateAxesFrom(result: ExtractionResult): DesignReviewStateAxisV0[] {
+  const axes: DesignReviewStateAxisV0[] = [];
+  const addState = (name: string, ref: DesignReviewEvidenceRefV0): void => {
+    const cleaned = name.trim();
+    if (!cleaned || /^set[A-Z]/.test(cleaned)) return;
+    addUniqueBy(
+      axes,
+      {
+        name: cleaned,
+        kind: stateKind(cleaned),
+        ...(ref.loc ? { loc: ref.loc } : {}),
+        evidence: [ref],
+      },
+      (item) => item.name.toLowerCase(),
+    );
+  };
+
+  for (const summary of result.behavior?.stateSummary ?? []) {
+    for (const part of summary.split(",").map((item) => item.trim()).filter(Boolean)) {
+      addState(part, evidence("behavior", "stateSummary", summary));
+    }
+  }
+
+  for (const branch of result.structure?.conditionalRenders ?? []) {
+    for (const keyword of STATE_KEYWORDS) {
+      if (new RegExp(`\\b${keyword}\\b`, "i").test(branch)) {
+        addState(keyword, evidence("structure", "conditionalRenders", compact(branch)));
+      }
+    }
+  }
+
+  for (const signal of result.behavior?.effectSignals ?? []) {
+    if (signal.hasAsyncWork) {
+      addState("asyncWork", evidence("behavior", "effectSignals", signal.hook, signal.loc));
+    }
+  }
+
+  return axes.slice(0, DESIGN_REVIEW_METADATA_ITEM_CAPS.stateAxes);
+}
+
+function interactionAnchorsFrom(result: ExtractionResult): DesignReviewInteractionAnchorV0[] {
+  const anchors: DesignReviewInteractionAnchorV0[] = [];
+
+  for (const signal of result.behavior?.eventHandlerSignals ?? []) {
+    addUniqueBy(
+      anchors,
+      {
+        label: signal.name,
+        kind: "event-handler",
+        ...(signal.loc ? { loc: signal.loc } : {}),
+        evidence: [evidence("behavior", "eventHandlerSignals", signal.trigger ?? signal.name, signal.loc)],
+      },
+      (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`,
+    );
+  }
+
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    const label = control.name ? `${control.tag}[name=${control.name}]` : control.tag;
+    addUniqueBy(
+      anchors,
+      {
+        label,
+        kind: "form-control",
+        ...(control.loc ? { loc: control.loc } : {}),
+        evidence: [evidence("behavior", "formSurface.controls", label, control.loc)],
+      },
+      (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`,
+    );
+  }
+
+  for (const handler of result.behavior?.formSurface?.submitHandlers ?? []) {
+    addUniqueBy(
+      anchors,
+      {
+        label: handler.value,
+        kind: "submit-handler",
+        ...(handler.loc ? { loc: handler.loc } : {}),
+        evidence: [evidence("behavior", "formSurface.submitHandlers", handler.value, handler.loc)],
+      },
+      (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`,
+    );
+  }
+
+  for (const anchor of result.behavior?.formSurface?.validationAnchors ?? []) {
+    addUniqueBy(
+      anchors,
+      {
+        label: anchor.value,
+        kind: "validation-anchor",
+        ...(anchor.loc ? { loc: anchor.loc } : {}),
+        evidence: [evidence("behavior", "formSurface.validationAnchors", anchor.value, anchor.loc)],
+      },
+      (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`,
+    );
+  }
+
+  return anchors.slice(0, DESIGN_REVIEW_METADATA_ITEM_CAPS.interactionAnchors);
+}
+
+function styleReferencesFrom(result: ExtractionResult): DesignReviewStyleReferenceV0[] {
+  const references: DesignReviewStyleReferenceV0[] = [];
+  const system = result.style?.system;
+
+  for (const summary of result.style?.summary ?? []) {
+    addUniqueBy(
+      references,
+      {
+        kind: styleKind(system, summary),
+        label: summary,
+        evidence: [evidence("style", "summary", summary)],
+      },
+      (item) => `${item.kind}:${item.label}`,
+    );
+  }
+
+  if (system && system !== "unknown") {
+    addUniqueBy(
+      references,
+      {
+        kind: styleKind(system, system),
+        label: system,
+        evidence: [evidence("style", "system", system)],
+      },
+      (item) => `${item.kind}:${item.label}`,
+    );
+  }
+
+  if (result.style?.hasStyleBranching) {
+    addUniqueBy(
+      references,
+      {
+        kind: styleKind(system, "style-branching"),
+        label: "style-branching",
+        evidence: [evidence("style", "hasStyleBranching", "true")],
+      },
+      (item) => `${item.kind}:${item.label}`,
+    );
+  }
+
+  return references.slice(0, DESIGN_REVIEW_METADATA_ITEM_CAPS.styleReferences);
+}
+
+function confidenceFor(
+  result: ExtractionResult,
+  metadata: Pick<DesignReviewMetadataV0, "visualRegions" | "variantAxes" | "stateAxes" | "interactionAnchors" | "styleReferences">,
+): Pick<DesignReviewMetadataV0, "confidence" | "confidenceReasons"> {
+  const confidenceReasons: string[] = [];
+  const evidenceSources = new Set<DesignReviewEvidenceSource>();
+  for (const refs of allEmittedEvidence(metadata)) {
+    for (const ref of refs) evidenceSources.add(ref.source);
+  }
+
+  if (result.componentName) confidenceReasons.push("component-identity-present");
+  if (result.contract?.propsSummary?.length) confidenceReasons.push("contract-props-present");
+  if (metadata.styleReferences.some((item) => item.kind !== "unknown")) confidenceReasons.push("style-system-evidence-present");
+  if (metadata.interactionAnchors.length > 0 || metadata.stateAxes.length > 0) confidenceReasons.push("behavior-or-state-evidence-present");
+  if (metadata.visualRegions.length > 0) confidenceReasons.push("visual-region-evidence-present");
+
+  const everyItemHasEvidence = allEmittedEvidence(metadata).every((refs) => refs.length > 0);
+  if (everyItemHasEvidence) confidenceReasons.push("all-items-have-evidence");
+
+  const hasStrongDesignSurface =
+    metadata.variantAxes.length >= 2 ||
+    metadata.interactionAnchors.length >= 2 ||
+    metadata.styleReferences.some((item) => item.kind === "styled-component");
+  const hasKnownStyle = metadata.styleReferences.some((item) => item.kind !== "unknown");
+
+  if (result.componentName && everyItemHasEvidence && evidenceSources.size >= 2 && hasKnownStyle && hasStrongDesignSurface) {
+    return { confidence: "high", confidenceReasons };
+  }
+  if (result.componentName && everyItemHasEvidence && (evidenceSources.size >= 2 || metadata.visualRegions.length >= 2 || hasKnownStyle)) {
+    return { confidence: "medium", confidenceReasons };
+  }
+  return {
+    confidence: "low",
+    confidenceReasons: confidenceReasons.length ? confidenceReasons : ["weak-source-derived-design-signals"],
+  };
+}
+
+export function deriveDesignReviewMetadata(result: ExtractionResult): DesignReviewMetadataV0 | undefined {
+  if (result.language !== "tsx" && result.language !== "jsx") return undefined;
+
+  const freshness = fingerprintOf(result);
+  if (!freshness) return undefined;
+
+  const visualRegions = visualRegionsFrom(result);
+  const variantAxes = variantAxesFrom(result);
+  const stateAxes = stateAxesFrom(result);
+  const interactionAnchors = interactionAnchorsFrom(result);
+  const styleReferences = styleReferencesFrom(result);
+  const confidence = confidenceFor(result, { visualRegions, variantAxes, stateAxes, interactionAnchors, styleReferences });
+
+  return {
+    schemaVersion: DESIGN_REVIEW_METADATA_SCHEMA_VERSION,
+    freshness,
+    scope: {
+      kind: result.componentName && result.componentLoc ? "same-component" : "same-file",
+      filePath: result.filePath,
+      ...(result.componentName ? { componentName: result.componentName } : {}),
+      ...(result.componentLoc ? { componentLoc: result.componentLoc } : {}),
+    },
+    confidence: confidence.confidence,
+    confidenceReasons: confidence.confidenceReasons,
+    visualRegions,
+    variantAxes,
+    stateAxes,
+    interactionAnchors,
+    styleReferences,
+    compressionContract: compressionContract(),
+  };
+}
+
+export function assessDesignReviewMetadataFreshness(metadata: DesignReviewMetadataV0, current: SourceFingerprint): DesignReviewFreshnessAssessment {
+  const reasons: string[] = [];
+  if (metadata.freshness.fileHash !== current.fileHash) reasons.push("stale-fileHash");
+  if (metadata.freshness.lineCount !== current.lineCount) reasons.push("stale-lineCount");
+
+  const fresh = reasons.length === 0;
+  return {
+    fresh,
+    usableForEditing: fresh,
+    reasons: fresh ? ["fresh"] : reasons,
+    ...(fresh ? {} : { requiredUserActionOnStale: metadata.compressionContract.requiredUserActionOnStale }),
+  };
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -18,6 +18,12 @@ const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
 const require = createRequire(import.meta.url);
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const {
+  DESIGN_REVIEW_METADATA_ITEM_CAPS,
+  DESIGN_REVIEW_METADATA_SCHEMA_VERSION,
+  assessDesignReviewMetadataFreshness,
+  deriveDesignReviewMetadata,
+} = require(path.join(repoRoot, "dist", "core", "design-review-metadata.js"));
 const { RAW_ORIGINAL_SIZE_THRESHOLD_BYTES } = require(path.join(repoRoot, "dist", "core", "decide.js"));
 const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 const { assessPayloadReadiness } = require(path.join(repoRoot, "dist", "core", "payload", "readiness.js"));
@@ -503,6 +509,236 @@ test("model-facing payload keeps hybrid snippets and prunes unknown style noise"
   assert.equal("meta" in payload, false);
   assert.ok(payload.behavior.eventHandlers.includes("handleAcknowledge"));
   assert.ok(payload.structure.conditionalRenders.length >= 1);
+});
+
+function designReviewFixture(name) {
+  return path.join(repoRoot, "fixtures", "design-review", name);
+}
+
+function allDesignEvidenceLists(metadata) {
+  return [
+    ...metadata.visualRegions.map((item) => item.evidence),
+    ...metadata.variantAxes.map((item) => item.evidence),
+    ...metadata.stateAxes.map((item) => item.evidence),
+    ...metadata.interactionAnchors.map((item) => item.evidence),
+    ...metadata.styleReferences.map((item) => item.evidence),
+  ];
+}
+
+function assertAllDesignItemsHaveEvidence(metadata) {
+  for (const evidence of allDesignEvidenceLists(metadata)) {
+    assert.ok(Array.isArray(evidence));
+    assert.ok(evidence.length > 0);
+    for (const ref of evidence) {
+      assert.match(ref.source, /^(contract|behavior|structure|style|snippet)$/);
+      assert.equal(typeof ref.field, "string");
+      assert.ok(ref.field.length > 0);
+    }
+  }
+}
+
+function assertDesignCaps(metadata) {
+  assert.ok(metadata.visualRegions.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.visualRegions);
+  assert.ok(metadata.variantAxes.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.variantAxes);
+  assert.ok(metadata.stateAxes.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.stateAxes);
+  assert.ok(metadata.interactionAnchors.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.interactionAnchors);
+  assert.ok(metadata.styleReferences.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.styleReferences);
+}
+
+function designStressItems(count, factory) {
+  return Array.from({ length: count }, (_, index) => factory(index));
+}
+
+function syntheticCapStressExtraction(baseResult) {
+  const manyControls = designStressItems(20, (index) => ({
+    tag: index % 2 === 0 ? "input" : "textarea",
+    name: `field${index}`,
+    loc: { startLine: index + 10, endLine: index + 10 },
+  }));
+  const manyHandlers = designStressItems(20, (index) => ({
+    name: `handleAction${index}`,
+    trigger: `onClick${index}`,
+    loc: { startLine: index + 40, endLine: index + 40 },
+  }));
+  const manySubmitHandlers = designStressItems(20, (index) => ({
+    value: `handleSubmit${index}`,
+    loc: { startLine: index + 70, endLine: index + 70 },
+  }));
+  const manyValidationAnchors = designStressItems(20, (index) => ({
+    value: `validate${index}`,
+    loc: { startLine: index + 100, endLine: index + 100 },
+  }));
+
+  return {
+    ...baseResult,
+    mode: "hybrid",
+    contract: {
+      ...baseResult.contract,
+      propsSummary: [
+        'variant?: "primary" | "secondary"',
+        'tone?: "info" | "warning"',
+        'size?: "sm" | "lg"',
+        "disabled?: boolean",
+        "selected?: boolean",
+        "loading?: boolean",
+        "compact?: boolean",
+      ],
+    },
+    behavior: {
+      ...baseResult.behavior,
+      stateSummary: designStressItems(20, (index) => `loading${index}, error${index}`),
+      eventHandlerSignals: manyHandlers,
+      formSurface: {
+        controls: manyControls,
+        submitHandlers: manySubmitHandlers,
+        validationAnchors: manyValidationAnchors,
+      },
+    },
+    structure: {
+      ...baseResult.structure,
+      sections: designStressItems(30, (index) => `section${index}`),
+      repeatedBlocks: designStressItems(20, (index) => `list${index}`),
+      conditionalRenders: designStressItems(20, (index) => `loading${index} || error${index} || selected`),
+    },
+    style: {
+      ...baseResult.style,
+      system: "tailwind",
+      summary: designStressItems(30, (index) => `tailwind-token-group-${index}`),
+      hasStyleBranching: true,
+    },
+    snippets: designStressItems(20, (index) => ({
+      label: `conditional-${index}`,
+      code: `{condition${index} ? <span /> : null}`,
+      reason: "conditional-render",
+      loc: { startLine: index + 130, endLine: index + 130 },
+    })),
+  };
+}
+
+test("design-review metadata derives source-only schema with freshness and contract boundaries", () => {
+  const result = extractFile(designReviewFixture("TailwindVariantCard.tsx"));
+  const metadata = deriveDesignReviewMetadata(result);
+
+  assert.ok(metadata);
+  assert.equal(metadata.schemaVersion, DESIGN_REVIEW_METADATA_SCHEMA_VERSION);
+  assert.deepEqual(metadata.freshness, {
+    fileHash: result.fileHash,
+    lineCount: result.meta.lineCount,
+  });
+  assert.deepEqual(metadata.scope, {
+    kind: "same-component",
+    filePath: result.filePath,
+    componentName: "TailwindVariantCard",
+    componentLoc: result.componentLoc,
+  });
+  assert.equal(metadata.confidence, "high");
+  assert.equal(metadata.compressionContract.sourceDerivedOnly, true);
+  assert.equal(metadata.compressionContract.notVisualProof, true);
+  assert.equal(metadata.compressionContract.notFigmaBacked, true);
+  assert.equal(metadata.compressionContract.notAccessibilityAudit, true);
+  assert.equal(metadata.compressionContract.notLspBacked, true);
+  assert.equal(metadata.compressionContract.notProviderTokenized, true);
+  assert.deepEqual(metadata.compressionContract.maxItems, DESIGN_REVIEW_METADATA_ITEM_CAPS);
+  assert.ok(metadata.compressionContract.staleWhen.includes("sourceFingerprint.fileHash changes"));
+  assert.equal(metadata.compressionContract.requiredUserActionOnStale, "rerun extraction or read current source before editing");
+  assertAllDesignItemsHaveEvidence(metadata);
+  assertDesignCaps(metadata);
+});
+
+test("design-review metadata covers planned fixture categories conservatively", () => {
+  const tailwind = deriveDesignReviewMetadata(extractFile(designReviewFixture("TailwindVariantCard.tsx")));
+  assert.ok(tailwind);
+  assert.equal(tailwind.confidence, "high");
+  assert.deepEqual(
+    ["variant", "size", "selected", "disabled"].every((name) => tailwind.variantAxes.some((axis) => axis.name === name)),
+    true,
+  );
+  assert.ok(tailwind.styleReferences.some((item) => item.kind === "tailwind-group"));
+  assert.ok(tailwind.visualRegions.some((item) => item.label === "section" || item.label === "TailwindVariantCard"));
+
+  const form = deriveDesignReviewMetadata(extractFile(designReviewFixture("FormStateReview.tsx")));
+  assert.ok(form);
+  assert.ok(["medium", "high"].includes(form.confidence));
+  assert.ok(form.interactionAnchors.some((item) => item.kind === "form-control" && item.label.includes("email")));
+  assert.ok(form.interactionAnchors.some((item) => item.kind === "form-control" && item.label.includes("notes")));
+  assert.ok(form.interactionAnchors.some((item) => item.kind === "submit-handler"));
+  assert.ok(form.stateAxes.some((item) => item.name === "loading"));
+  assert.ok(form.stateAxes.some((item) => item.name === "error"));
+  assert.ok(form.visualRegions.some((item) => item.kind === "form" || item.kind === "control"));
+
+  const styled = deriveDesignReviewMetadata(extractFile(designReviewFixture("StyledPanel.tsx")));
+  assert.ok(styled);
+  assert.ok(["medium", "high"].includes(styled.confidence));
+  assert.ok(styled.styleReferences.some((item) => item.kind === "styled-component"));
+  assert.ok(styled.variantAxes.some((axis) => axis.name === "tone"));
+  assert.ok(styled.variantAxes.some((axis) => axis.name === "compact"));
+  assert.ok(styled.visualRegions.some((item) => item.label === "PanelRoot" || item.label === "StyledPanel"));
+
+  const generic = deriveDesignReviewMetadata(extractFile(designReviewFixture("GenericLayout.tsx")));
+  assert.ok(generic);
+  assert.notEqual(generic.confidence, "high");
+  assert.deepEqual(generic.variantAxes, []);
+  assert.deepEqual(generic.stateAxes, []);
+
+  for (const metadata of [tailwind, form, styled, generic]) {
+    assertAllDesignItemsHaveEvidence(metadata);
+    assertDesignCaps(metadata);
+  }
+});
+
+test("design-review metadata enforces item caps on over-cap extraction signals", () => {
+  const baseResult = extractFile(designReviewFixture("TailwindVariantCard.tsx"));
+  const metadata = deriveDesignReviewMetadata(syntheticCapStressExtraction(baseResult));
+
+  assert.ok(metadata);
+  assert.equal(metadata.visualRegions.length, DESIGN_REVIEW_METADATA_ITEM_CAPS.visualRegions);
+  assert.ok(metadata.variantAxes.length <= DESIGN_REVIEW_METADATA_ITEM_CAPS.variantAxes);
+  assert.equal(metadata.stateAxes.length, DESIGN_REVIEW_METADATA_ITEM_CAPS.stateAxes);
+  assert.equal(metadata.interactionAnchors.length, DESIGN_REVIEW_METADATA_ITEM_CAPS.interactionAnchors);
+  assert.equal(metadata.styleReferences.length, DESIGN_REVIEW_METADATA_ITEM_CAPS.styleReferences);
+  assertAllDesignItemsHaveEvidence(metadata);
+  assertDesignCaps(metadata);
+});
+
+test("design-review metadata blocks stale freshness from edit-safe use", () => {
+  const result = extractFile(designReviewFixture("TailwindVariantCard.tsx"));
+  const metadata = deriveDesignReviewMetadata(result);
+  assert.ok(metadata);
+
+  const changed = assessDesignReviewMetadataFreshness(metadata, {
+    fileHash: metadata.freshness.fileHash === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
+    lineCount: metadata.freshness.lineCount + 1,
+  });
+
+  assert.equal(changed.fresh, false);
+  assert.equal(changed.usableForEditing, false);
+  assert.ok(changed.reasons.includes("stale-fileHash"));
+  assert.ok(changed.reasons.includes("stale-lineCount"));
+  assert.equal(changed.requiredUserActionOnStale, "rerun extraction or read current source before editing");
+
+  const fresh = assessDesignReviewMetadataFreshness(metadata, metadata.freshness);
+  assert.deepEqual(fresh, {
+    fresh: true,
+    usableForEditing: true,
+    reasons: ["fresh"],
+  });
+});
+
+test("design-review helper remains internal and default model-facing payloads stay unchanged", () => {
+  const tailwindResult = extractFile(designReviewFixture("TailwindVariantCard.tsx"));
+  const defaultPayload = toModelFacingPayload(tailwindResult, repoRoot);
+  const guidedPayload = toModelFacingPayload(tailwindResult, repoRoot, { includeEditGuidance: true });
+  const cliPayload = run(["extract", "fixtures/design-review/TailwindVariantCard.tsx", "--model-payload"]);
+  const modulePayload = run(["extract", "fixtures/ts-js-beta/module-utils.ts", "--model-payload"]);
+  const rawPayload = toModelFacingPayload(extractFile(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx")), repoRoot);
+
+  for (const payload of [defaultPayload, guidedPayload, cliPayload, modulePayload, rawPayload]) {
+    assert.equal("designReviewMetadata" in payload, false);
+  }
+  assert.equal("editGuidance" in defaultPayload, false);
+  assert.equal("editGuidance" in guidedPayload, true);
+  assert.equal("editGuidance" in cliPayload && "designReviewMetadata" in cliPayload.editGuidance, false);
+  assert.equal("editGuidance" in modulePayload, false);
 });
 
 test("model-facing payload uses original source for tiny raw fixtures", () => {


### PR DESCRIPTION
## Summary
- Add internal `design-review-metadata.v0` derivation helper with source fingerprints, evidence refs, conservative confidence, item caps, and explicit non-goal contract flags.
- Add design-review fixtures for Tailwind variants, form state, styled-components, and low-signal generic layout.
- Add regression tests for schema/freshness, stale reuse blocking, fixture expectations, over-cap truncation, and unchanged default model-facing payload behavior.

## Boundaries
- No runtime payload emission of design-review metadata.
- No public docs/support claim expansion.
- No Figma/browser/a11y/LSP/provider expansion.
- No unrelated benchmark/R4 changes included.

## Verification
- `git diff --check`
- `npm run lint`
- `node --test test/fooks.test.mjs --test-name-pattern "design-review"` (passes; Node loads full file: 111/111)
- `npm test` (247/247)
- Ralph architect review: APPROVE after textarea fixture + cap stress test fixes
- Ralph deslop pass: changed-files-only; stale hash assertion hardened and cap stress setup deduplicated; post-deslop gates passed

## Notes
- Runtime design-review payload emission remains intentionally not tested because it is out of scope for this PR.
