### PR TITLE
Report OMX payload pilot with explicit caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ pair order.
 
 Task-median reductions for the larger profiles were Next.js App Router summary `30.681%`, Layout Router refactor plan `28.699%`, Error Boundary test strategy `19.447%`; Tailwind Utilities summary `78.992%`, Variants refactor plan `38.238%`, CSS Parser test strategy `33.582%`.
 
+### Diagnostic OMX payload-surface pilot
+
+A 2026-04-24 single-pair diagnostic checked whether the same fooks payload advantage survives the `omx exec` command surface. This is **not** an installed-hook repeated-session benchmark and is **not** stable public runtime evidence yet. It compared one Tailwind large file (`packages/tailwindcss/src/utilities.ts`) as full source (`213,836` bytes) versus real `fooks extract --model-payload` output (`3,517` bytes), with no tool calls, using `gpt-5.4-mini`.
+
+| Surface | Full-source input tokens | Fooks-payload input tokens | Input-token reduction | Total-token reduction |
+| --- | ---: | ---: | ---: | ---: |
+| Plain `codex exec` | `65,497` | `13,593` | 79.246% | 78.996% |
+| `omx exec` | `63,122` | `11,218` | 82.228% | 81.962% |
+
+This supports only a narrow diagnostic statement: for this controlled no-tool Tailwind payload pilot, fooks' model-facing payload stayed much smaller through both plain Codex and OMX command surfaces. It does **not** prove that ordinary interactive OMX sessions, installed hooks, provider invoices, or stable runtime costs drop by the same amount.
+
 Detailed evidence and current claim boundaries are maintained in the curated benchmark evidence page: https://github.com/minislively/fooks/blob/main/docs/benchmark-evidence.md
 
 The benchmark evidence is not provider invoice/dashboard proof, not actual charged-cost proof, not provider billing-token proof, and not a Claude or opencode automatic savings claim.

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -333,6 +333,27 @@ catalog pricing:
   - task median reductions: Utilities summary `78.992%`, Variants refactor
     plan `38.238%`, CSS Parser test strategy `33.582%`.
 
+### Diagnostic OMX payload-surface pilot, 2026-04-24
+
+A separate single-pair diagnostic checked whether the payload-size effect also
+survives the `omx exec` command surface. This was not an installed-hook
+repeated-session benchmark and is not launch-grade runtime evidence. It used one
+Tailwind large file (`packages/tailwindcss/src/utilities.ts`), `gpt-5.4-mini`,
+no tool calls, and compared prompts containing either the full source
+(`213,836` bytes) or real `fooks extract --model-payload` output (`3,517`
+bytes).
+
+| Surface | Full-source input tokens | Fooks-payload input tokens | Input-token reduction | Total-token reduction |
+| --- | ---: | ---: | ---: | ---: |
+| Plain `codex exec` | `65,497` | `13,593` | `79.246%` | `78.996%` |
+| `omx exec` | `63,122` | `11,218` | `82.228%` | `81.962%` |
+
+This supports only a diagnostic command-surface statement: fooks' compact
+model-facing payload stayed much smaller through both plain Codex and OMX command
+surfaces in this controlled no-tool pilot. It does not prove ordinary interactive
+OMX-session savings, installed-hook savings, provider invoices, or stable runtime
+cost reductions.
+
 These larger-profile runs explain why the small fixture lane had only a weak
 cost signal: Codex requests include a fixed wrapper/system overhead, so a small
 local prompt reduction can be diluted. On larger Next.js/Tailwind payloads, the


### PR DESCRIPTION
The controlled no-tool pilot showed the fooks model-facing payload remains much smaller through both plain Codex and OMX command surfaces, but it is only single-pair diagnostic evidence. README and benchmark docs now expose the result without converting it into an installed-hook or ordinary interactive-session claim.\n\nConstraint: The live pilot was not an installed-hook repeated-session benchmark and must not be framed as stable runtime or invoice proof.\nRejected: Put the 82% figure in the headline | it would overclaim a diagnostic single-pair command-surface result.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Do not broaden this to OMX-session savings until a multi-pair installed-hook benchmark passes quality gates.\nTested: npm ci; npm run lint; git diff --check\nNot-tested: No new live benchmark run in this commit; it documents the existing 2026-04-24 pilot artifact.
