### PR TITLE
Prioritize provider-cost evidence and link OMX diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Current public summary:
 - These provider-cost benchmark lanes are **estimated API cost under explicit pricing assumptions**. They do not prove invoice/dashboard savings, actual charged-cost savings, provider billing-token savings, stable runtime-token savings, or stable wall-clock/latency savings.
 - Direct runtime-token/time evidence remains unstable or negative in some diagnostics, so fooks does not claim stable runtime-token, wall-clock, or latency wins.
 
-### Public-code benchmark snapshot
+### Provider-cost benchmark snapshot (primary evidence)
 
-These figures are **not OMX-session benchmarks** and not a full interactive
+This is the main benchmark section most readers should evaluate first: it answers whether matched full-source vs fooks-payload runs used less provider-reported usage and lower estimated API cost under explicit pricing assumptions. These figures are **not OMX-session benchmarks** and not a full interactive
 "install fooks, work normally" session benchmark. They come from a Codex OAuth
 no-tool benchmark harness that compares matched baseline prompts containing
 real full-source context against matched fooks prompts containing real
@@ -151,16 +151,16 @@ pair order.
 
 Task-median reductions for the larger profiles were Next.js App Router summary `30.681%`, Layout Router refactor plan `28.699%`, Error Boundary test strategy `19.447%`; Tailwind Utilities summary `78.992%`, Variants refactor plan `38.238%`, CSS Parser test strategy `33.582%`.
 
-### Diagnostic OMX payload-surface pilot
+### OMX command-surface diagnostic (secondary evidence)
 
-A 2026-04-24 single-pair diagnostic checked whether the same fooks payload advantage survives the `omx exec` command surface. This is **not** an installed-hook repeated-session benchmark and is **not** stable public runtime evidence yet. It compared one Tailwind large file (`packages/tailwindcss/src/utilities.ts`) as full source (`213,836` bytes) versus real `fooks extract --model-payload` output (`3,517` bytes), with no tool calls, using `gpt-5.4-mini`.
+A 2026-04-24 single-pair diagnostic checked whether the same fooks payload advantage survives the [`omx exec`](https://github.com/Yeachan-Heo/oh-my-codex) command surface from [oh-my-codex (OMX)](https://github.com/Yeachan-Heo/oh-my-codex). This is **not** an installed-hook repeated-session benchmark and is **not** stable public runtime evidence yet. It compared one Tailwind large file (`packages/tailwindcss/src/utilities.ts`) as full source (`213,836` bytes) versus real `fooks extract --model-payload` output (`3,517` bytes), with no tool calls, using `gpt-5.4-mini`.
 
 | Surface | Full-source input tokens | Fooks-payload input tokens | Input-token reduction | Total-token reduction |
 | --- | ---: | ---: | ---: | ---: |
 | Plain `codex exec` | `65,497` | `13,593` | 79.246% | 78.996% |
 | `omx exec` | `63,122` | `11,218` | 82.228% | 81.962% |
 
-This supports only a narrow diagnostic statement: for this controlled no-tool Tailwind payload pilot, fooks' model-facing payload stayed much smaller through both plain Codex and OMX command surfaces. It does **not** prove that ordinary interactive OMX sessions, installed hooks, provider invoices, or stable runtime costs drop by the same amount.
+This is secondary evidence: it explains that the compact payload advantage survives the OMX command surface, but the provider-cost snapshot above is the stronger product-facing evidence. This controlled no-tool Tailwind payload pilot shows fooks' model-facing payload stayed much smaller through both plain Codex and OMX command surfaces. It does **not** prove that ordinary interactive OMX sessions, installed hooks, provider invoices, or stable runtime costs drop by the same amount.
 
 Detailed evidence and current claim boundaries are maintained in the curated benchmark evidence page: https://github.com/minislively/fooks/blob/main/docs/benchmark-evidence.md
 

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -336,7 +336,7 @@ catalog pricing:
 ### Diagnostic OMX payload-surface pilot, 2026-04-24
 
 A separate single-pair diagnostic checked whether the payload-size effect also
-survives the `omx exec` command surface. This was not an installed-hook
+survives the [`omx exec`](https://github.com/Yeachan-Heo/oh-my-codex) command surface from [oh-my-codex (OMX)](https://github.com/Yeachan-Heo/oh-my-codex). This was not an installed-hook
 repeated-session benchmark and is not launch-grade runtime evidence. It used one
 Tailwind large file (`packages/tailwindcss/src/utilities.ts`), `gpt-5.4-mini`,
 no tool calls, and compared prompts containing either the full source
@@ -348,7 +348,7 @@ bytes).
 | Plain `codex exec` | `65,497` | `13,593` | `79.246%` | `78.996%` |
 | `omx exec` | `63,122` | `11,218` | `82.228%` | `81.962%` |
 
-This supports only a diagnostic command-surface statement: fooks' compact
+This is secondary evidence behind the provider-cost snapshot above. It supports only a diagnostic command-surface statement: fooks' compact
 model-facing payload stayed much smaller through both plain Codex and OMX command
 surfaces in this controlled no-tool pilot. It does not prove ordinary interactive
 OMX-session savings, installed-hook savings, provider invoices, or stable runtime


### PR DESCRIPTION
Readers should see the provider-cost benchmark as the primary product-facing evidence, with the OMX payload result framed as secondary command-surface diagnostics. The README and benchmark evidence doc now label that hierarchy explicitly and link the OMX reference to the upstream oh-my-codex repository.\n\nConstraint: OMX payload pilot remains single-pair diagnostic evidence, not installed-hook or interactive-session proof.\nRejected: Lead with the 82% OMX figure | it is visually strong but weaker evidence than the matched provider-cost snapshot.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Keep provider-cost evidence above payload diagnostics unless future multi-pair OMX session evidence passes gates.\nTested: npm ci; npm run lint; git diff --check\nNot-tested: Documentation-only hierarchy/link update, no benchmark rerun.
