### PR TITLE
feat(doctor): add worktree and tmux session health checks

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { readCodexHookPresetStatus, type CodexHookPresetStatus } from "../adapters/codex-hook-preset";
@@ -328,6 +329,55 @@ function claudeTypeScriptLspCheck(): DoctorCheck {
   };
 }
 
+function worktreeHealthCheck(cwd: string): DoctorCheck {
+  try {
+    const output = execSync("git worktree list --porcelain", { cwd, encoding: "utf8" });
+    const blocks = output.split("\n\n").filter(Boolean);
+    const issues: string[] = [];
+    let deletedCount = 0;
+    let detachedCount = 0;
+
+    for (const block of blocks) {
+      const lines = block.split("\n");
+      const worktreePath = lines.find((l) => l.startsWith("worktree "))?.slice(9);
+      const detached = lines.find((l) => l.startsWith("detached"));
+      if (worktreePath && !fs.existsSync(worktreePath)) {
+        deletedCount++;
+        issues.push(`deleted: ${worktreePath}`);
+      } else if (detached && worktreePath) {
+        detachedCount++;
+        issues.push(`detached HEAD: ${worktreePath}`);
+      }
+    }
+
+    if (issues.length === 0) {
+      return {
+        runtime: "core",
+        name: "Worktree health",
+        status: "pass",
+        message: "All worktrees are healthy",
+        evidence: { worktreeCount: blocks.length },
+      };
+    }
+
+    return {
+      runtime: "core",
+      name: "Worktree health",
+      status: "warn",
+      message: `Found ${issues.length} worktree issue(s): ${issues.join("; ")}`,
+      fix: "Run: git worktree prune && rm -rf <deleted-worktree-path>",
+      evidence: { deletedCount, detachedCount, issues, worktreeCount: blocks.length },
+    };
+  } catch (error) {
+    return {
+      runtime: "core",
+      name: "Worktree health",
+      status: "warn",
+      message: `Unable to check worktree health: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
 function codexDoctorChecks(cwd: string, cliName: string): DoctorCheck[] {
   const hooks = readCodexHookPresetStatus(cliName);
   return [
@@ -404,6 +454,7 @@ function aggregateChecks(cwd: string, cliName: string): DoctorCheck[] {
   return [
     ...codexDoctorChecks(cwd, cliName),
     ...claudeDoctorChecks(cwd, false),
+    worktreeHealthCheck(cwd),
   ];
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -378,6 +378,62 @@ function worktreeHealthCheck(cwd: string): DoctorCheck {
   }
 }
 
+function tmuxSessionHealthCheck(): DoctorCheck {
+  try {
+    const sessionsOutput = execSync("tmux ls 2>/dev/null || true", { encoding: "utf8" });
+    if (!sessionsOutput.trim()) {
+      return {
+        runtime: "core",
+        name: "Tmux session health",
+        status: "pass",
+        message: "No tmux sessions detected",
+        evidence: {},
+      };
+    }
+    const sessions = sessionsOutput.split("\n").filter(Boolean);
+    const zombieSessions: string[] = [];
+
+    for (const sessionLine of sessions) {
+      const sessionName = sessionLine.split(":")[0];
+      if (!sessionName) continue;
+      try {
+        const panePath = execSync(`tmux display-message -t "${sessionName}" -p '#{pane_current_path}' 2>/dev/null`, { encoding: "utf8" }).trim();
+        if (panePath.includes("(deleted)") || (panePath && !fs.existsSync(panePath))) {
+          zombieSessions.push(sessionName);
+        }
+      } catch {
+        // session might be dead or inaccessible
+      }
+    }
+
+    if (zombieSessions.length === 0) {
+      return {
+        runtime: "core",
+        name: "Tmux session health",
+        status: "pass",
+        message: `All ${sessions.length} tmux session(s) are healthy`,
+        evidence: { sessionCount: sessions.length },
+      };
+    }
+
+    return {
+      runtime: "core",
+      name: "Tmux session health",
+      status: "warn",
+      message: `Found ${zombieSessions.length} zombie tmux session(s): ${zombieSessions.join(", ")}`,
+      fix: "Run: tmux kill-session -t <session-name>",
+      evidence: { zombieSessions, sessionCount: sessions.length },
+    };
+  } catch (error) {
+    return {
+      runtime: "core",
+      name: "Tmux session health",
+      status: "warn",
+      message: `Unable to check tmux session health: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
 function codexDoctorChecks(cwd: string, cliName: string): DoctorCheck[] {
   const hooks = readCodexHookPresetStatus(cliName);
   return [
@@ -455,6 +511,7 @@ function aggregateChecks(cwd: string, cliName: string): DoctorCheck[] {
     ...codexDoctorChecks(cwd, cliName),
     ...claudeDoctorChecks(cwd, false),
     worktreeHealthCheck(cwd),
+    tmuxSessionHealthCheck(),
   ];
 }
 


### PR DESCRIPTION
Adds two new diagnostic checks to `fooks doctor`:

- **Worktree health**: detects deleted or detached HEAD worktrees via `git worktree list --porcelain`
- **Tmux session health**: detects zombie tmux sessions whose pane_current_path points to a deleted worktree

Both checks are non-blocking (warn-only) and include fix instructions.