### PR TITLE
Define RN/WebView support promotion gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then open Codex in that repo and work normally. `fooks doctor` is the read-only 
 These are useful future directions, but they are not required for the current Codex repeated React workflow:
 
 - Vue/SFC, Svelte, or broader non-React framework support.
-- React Native or embedded WebView support. A `.tsx` parse is not semantic evidence for RN primitives, native platform behavior, bridge behavior, or WebView security/runtime boundaries.
+- React Native or embedded WebView support. A `.tsx` parse is not semantic evidence for RN primitives, native platform behavior, bridge behavior, or WebView security/runtime boundaries; see the [`docs/roadmap.md`](docs/roadmap.md#react-native--webview-promotion-ladder) promotion ladder before changing public support wording.
 - Broader `.ts` / `.js` coverage beyond the same-file beta.
 - Multi-file refactor context compression.
 - Universal runtime file-read interception or provider-native read-hook parity.

--- a/docs/frontend-scope-taxonomy.md
+++ b/docs/frontend-scope-taxonomy.md
@@ -79,6 +79,8 @@ These lanes are visible during planning but default to defer unless explicitly s
 
 This taxonomy controls PR scope; it does not expand fooks' runtime or framework support claims. React Native and embedded WebView remain a deferred support lane. For fooks claim work, TSX parsing is only syntax-level evidence and must not be treated as semantic support for RN primitives, native platform behavior, bridge behavior, or WebView boundaries. Until dedicated RN/WebView fixtures and evidence exist, RN/WebView files should use normal source reading.
 
+For RN/WebView claim work, classify the first implementation handoff as a Layer 3 `benchmark/evidence` or `docs/process` lane unless an approved plan explicitly selects extractor behavior. The minimum promotion gates are fixture corpus, signal model, benchmark evidence, and claim-boundary wording; failing any gate keeps the lane deferred.
+
 ## Scope classifier template
 
 Use this before implementation:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,28 @@ If the answer you want sounds like “React Native?”, “WebView?”, “Vue?�
 | Read interception / provider-native read hooks | Would make runtime behavior broader than Codex repeated-file hooks. | Not claimed; unsupported cases should fall back to normal source reading. |
 | LSP-backed semantic locations | Would strengthen rename/reference/edit safety beyond line-aware hints. | Decided in [`docs/lsp-extraction-boundary.md`](lsp-extraction-boundary.md): product extraction stays AST-only by default; LSP remains optional evaluation/proof work, not current support. |
 
+### React Native / WebView promotion ladder
+
+React Native and embedded WebView should move through explicit evidence gates instead of jumping from “TSX parses” to “supported.” Treat this as a `frontend-family candidate` ladder:
+
+| Level | Name | What must be true | Public wording allowed |
+| --- | --- | --- | --- |
+| 0 | Deferred/fallback boundary | Obvious RN/WebView markers fall back to normal source reading and docs say TSX parsing is syntax-only evidence. | “Deferred lane”; “not current support.” |
+| 1 | Evidence-lane design | Fixture categories, pass/fail rules, claim boundaries, and benchmark commands are specified before extractor changes. | “Evidence candidate”; no runtime/support claim. |
+| 2 | Fixture/benchmark evidence | Public RN/WebView fixtures exercise native primitives, interaction handlers, StyleSheet/style tokens, platform branches, navigation surfaces, and WebView source/injection boundaries without misleading compact payloads. | “Validated evidence lane” for the measured fixture scope only. |
+| 3 | Experimental extractor candidate | RN/WebView-specific signals are implemented behind narrow tests and safe fallback rules, with no provider/runtime parity claim. | “Experimental same-file RN/WebView TSX candidate” if evidence remains green. |
+| 4 | Narrow support wording | Repeated benchmark evidence and docs/tests prove the exact supported scope. | Narrow support wording for the measured same-file scope only. |
+
+Promotion must stop at the first failed gate. WebView-related files deserve extra caution because URL/source, injected JavaScript, bridge behavior, and sandbox/security assumptions are semantic boundaries, not just JSX structure.
+
+Recommended fixture categories before Level 3:
+
+- React Native primitives: `View`, `Text`, `Image`, `ScrollView`.
+- Interaction components: `Pressable`, `TouchableOpacity`, gesture/event handlers.
+- Styling: `StyleSheet.create`, inline styles, theme/token references.
+- Platform/navigation: `Platform.select`, route params, navigation hooks.
+- Embedded WebView: `react-native-webview`, `source`, injected JavaScript, message bridge boundaries.
+
 ## Future evidence lanes
 
 | Lane | Stronger claim it could unlock | Current boundary |

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3631,6 +3631,13 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.match(combined, /React Native(?:\/WebView| and embedded WebView| \/ embedded WebView)/);
   assert.match(combined, /TSX parsing is (?:syntax-level|only syntax-level)|\.tsx` parse is not semantic evidence/);
   assert.match(combined, /normal source reading/);
+  assert.match(combined, /React Native \/ WebView promotion ladder/);
+  assert.match(combined, /frontend-family candidate/);
+  assert.match(combined, /Fixture\/benchmark evidence/);
+  assert.match(combined, /StyleSheet\.create/);
+  assert.match(combined, /Platform\.select/);
+  assert.match(combined, /react-native-webview/);
+  assert.match(combined, /fixture corpus, signal model, benchmark evidence, and claim-boundary wording/);
   assert.match(preRead, /unsupported-react-native-webview-boundary/);
   assert.doesNotMatch(combined, /React Native support is available/i);
 });


### PR DESCRIPTION
## Summary\n- add a React Native / WebView promotion ladder before any public support wording changes\n- document fixture, signal-model, benchmark-evidence, and claim-boundary gates\n- keep RN/WebView as deferred/fallback-only until evidence satisfies the ladder\n- extend docs regression coverage for the new ladder and fixture categories\n\n## Verification\n- npm test\n- npm run lint\n- git diff --check\n\n## Notes\n- Docs/process only; no extractor/setup/runtime behavior changes.\n- Preserves existing unsupported-react-native-webview-boundary behavior.