### PR TITLE
Survey RN/WebView fixture candidates

### DIFF
--- a/docs/rn-webview-fixture-candidates.md
+++ b/docs/rn-webview-fixture-candidates.md
@@ -1,0 +1,72 @@
+# React Native / WebView fixture candidate survey
+
+_Last reviewed: 2026-04-25 via GitHub repository metadata and tree inspection._
+
+This survey is the next step after the [React Native / WebView promotion ladder](roadmap.md#react-native--webview-promotion-ladder). It does **not** make React Native or embedded WebView a supported fooks lane. It only identifies public repositories that could seed a future evidence lane.
+
+## Selection criteria
+
+A repository is a good candidate when it satisfies most of these gates:
+
+1. **Public and inspectable** — open source repository with a clear license or public contribution model.
+2. **Recently active** — updated recently enough that fixture shape reflects current React Native practice.
+3. **TS/TSX surface** — enough `.tsx` / `.ts` files to exercise fooks' TypeScript parser without inventing synthetic examples.
+4. **Signal coverage** — covers at least one RN/WebView signal family:
+   - native primitives: `View`, `Text`, `Image`, `ScrollView`;
+   - interactions: `Pressable`, `TouchableOpacity`, gesture/event handlers;
+   - styles: `StyleSheet.create`, inline styles, theme/token references;
+   - platform/navigation: `Platform.select`, platform-specific files, route params, navigation hooks;
+   - WebView boundaries: `react-native-webview`, `source`, injected JavaScript, `onMessage`, native/web bridge surfaces.
+5. **Claim safety** — useful for fixture evidence without implying support for native platform behavior, bridge behavior, provider runtime tokens, or WebView security boundaries.
+
+## Tier A: preferred seed candidates
+
+| Candidate | Why it belongs in the first evidence pass | Useful fixture surfaces | Boundary / risk |
+| --- | --- | --- | --- |
+| [`react-native-webview/react-native-webview`](https://github.com/react-native-webview/react-native-webview) | Canonical WebView package; direct coverage for embedded WebView surfaces. Metadata snapshot: MIT, 7k+ stars, active on 2026-04-24. | `src/WebView.tsx`, `src/WebViewShared.tsx`, platform files such as `src/WebView.android.tsx`, `src/WebView.ios.tsx`, plus WebView type surfaces. | Great for WebView boundary detection, but it is a library implementation, not a product app. Do not generalize to all app workflows. |
+| [`mattermost/mattermost-mobile`](https://github.com/mattermost/mattermost-mobile) | Large real-world React Native product app. Metadata snapshot: Apache-2.0, 2k+ stars, active on 2026-04-24. | Message composer, navigation header, image viewer, input accessory, and `Pressable`-style UI paths found in tree inspection. | Large corpus; sample narrowly to avoid benchmark noise and proprietary-service assumptions. |
+| [`RocketChat/Rocket.Chat.ReactNative`](https://github.com/RocketChat/Rocket.Chat.ReactNative) | Real-world chat app with RN UI density. Metadata snapshot: MIT, 2k+ stars, active on 2026-04-24. | Message composer, autocomplete, image viewer, room/user UI, navigation-adjacent components. | Chat-app semantics overlap with Mattermost; avoid over-sampling one product category. |
+| [`Expensify/App`](https://github.com/Expensify/App) | Very large cross-platform app with broad TS/TSX surface and platform-specific component variants. Metadata snapshot: MIT, 4k+ stars, active on 2026-04-25. | Platform-specific files such as `.android.tsx` / `.ios.tsx`, action-sheet and navigation-related surfaces, WebView mocks. | Huge repo; use as stress/reference only after the first small corpus is stable. |
+| [`gronxb/webview-bridge`](https://github.com/gronxb/webview-bridge) | Focused TypeScript WebView bridge project with React Native and web examples. Metadata snapshot: MIT, 400+ stars, active on 2026-04-18. | `example/*/react-native/App.tsx`, bridge files under `example/*/react-native/src/bridge.ts`, and `packages/react-native/src/createWebView.tsx`. | Bridge-specific; useful for message-boundary evidence, not general RN component extraction. |
+
+## Tier B: optional follow-up candidates
+
+| Candidate | Why it may be useful later | Defer reason |
+| --- | --- | --- |
+| [`Jellify-Music/App`](https://github.com/Jellify-Music/App) | Cross-platform RN music app with navigation and media/control surfaces; metadata snapshot: MIT, 1k+ stars, active on 2026-04-24. | Good product diversity, but not needed until chat/WebView seeds are covered. |
+| [`inokawa/react-native-react-bridge`](https://github.com/inokawa/react-native-react-bridge) | WebView-style React-to-RN bridge examples; metadata snapshot: MIT, active on 2026-04-09. | Smaller and more specialized than `gronxb/webview-bridge`; use only if bridge coverage is thin. |
+| [`expo/expo`](https://github.com/expo/expo) | Large universal native app framework with React Native + web surfaces; metadata snapshot: MIT, very active. | Framework-scale repo can skew corpus selection; better as later stress/reference, not seed evidence. |
+| [`react-navigation/react-navigation`](https://github.com/react-navigation/react-navigation) | Canonical navigation library for React Native and Web apps; active and high-signal for navigation semantics. | Library/framework surface, not a representative app component corpus; use for targeted navigation fixtures only. |
+
+## Explicitly deferred / weak candidates
+
+- Curated-list repos such as [`ReactNativeNews/React-Native-Apps`](https://github.com/ReactNativeNews/React-Native-Apps) and [`reactnativecn/react-native-guide`](https://github.com/reactnativecn/react-native-guide): useful discovery indexes, not fixture sources.
+- Old or low-activity forks of Rocket.Chat / WebView examples: too stale for support-lane evidence.
+- Single-purpose payment/WebView wrappers: useful only after the core WebView and bridge categories are represented.
+
+## Recommended first fixture slice
+
+Start with a small corpus before any extractor behavior change:
+
+1. **WebView boundary fixture** — one file from `react-native-webview/react-native-webview` that includes WebView props, `source`, `onMessage`, or injected JavaScript behavior.
+2. **Bridge fixture** — one `gronxb/webview-bridge` React Native example plus its paired bridge file.
+3. **RN primitive/interaction fixture** — one Mattermost or Rocket.Chat component with native primitives and event handlers.
+4. **Platform/navigation fixture** — one platform-specific or navigation-heavy file from Mattermost, Rocket.Chat, or Expensify.
+5. **Negative fallback fixture** — one obvious RN/WebView file that should continue to trigger `unsupported-react-native-webview-boundary` until Level 3 of the promotion ladder is intentionally opened.
+
+## Acceptance bar before moving to extractor prototype
+
+Do not start RN/WebView extractor behavior until a candidate PR can show:
+
+- fixture corpus selected with stable commit SHAs or pinned snapshots;
+- each fixture mapped to a signal family and expected fallback/extract behavior;
+- tests prove current unsupported/fallback wording remains intact;
+- benchmark/evidence commands are documented;
+- WebView files are reviewed for URL/source, injected JavaScript, and message-bridge boundaries before compact-payload reuse is allowed.
+
+## Non-goals
+
+- No public RN/WebView support claim from this survey.
+- No provider-token, billing, runtime-token, or native platform correctness claim.
+- No setup/doctor support promotion without fixture evidence.
+- No extractor changes until a separate plan selects the experimental extractor lane.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,7 +42,7 @@ React Native and embedded WebView should move through explicit evidence gates in
 | 3 | Experimental extractor candidate | RN/WebView-specific signals are implemented behind narrow tests and safe fallback rules, with no provider/runtime parity claim. | “Experimental same-file RN/WebView TSX candidate” if evidence remains green. |
 | 4 | Narrow support wording | Repeated benchmark evidence and docs/tests prove the exact supported scope. | Narrow support wording for the measured same-file scope only. |
 
-Promotion must stop at the first failed gate. WebView-related files deserve extra caution because URL/source, injected JavaScript, bridge behavior, and sandbox/security assumptions are semantic boundaries, not just JSX structure.
+Promotion must stop at the first failed gate. WebView-related files deserve extra caution because URL/source, injected JavaScript, bridge behavior, and sandbox/security assumptions are semantic boundaries, not just JSX structure. Candidate repositories for the first evidence pass are tracked in [React Native / WebView fixture candidate survey](rn-webview-fixture-candidates.md).
 
 Recommended fixture categories before Level 3:
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3625,13 +3625,23 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   const roadmap = fs.readFileSync(path.join(repoRoot, "docs", "roadmap.md"), "utf8");
   const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
   const taxonomy = fs.readFileSync(path.join(repoRoot, "docs", "frontend-scope-taxonomy.md"), "utf8");
+  const candidates = fs.readFileSync(path.join(repoRoot, "docs", "rn-webview-fixture-candidates.md"), "utf8");
   const preRead = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
-  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}`;
+  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}`;
 
   assert.match(combined, /React Native(?:\/WebView| and embedded WebView| \/ embedded WebView)/);
   assert.match(combined, /TSX parsing is (?:syntax-level|only syntax-level)|\.tsx` parse is not semantic evidence/);
   assert.match(combined, /normal source reading/);
   assert.match(combined, /React Native \/ WebView promotion ladder/);
+  assert.match(roadmap, /React Native \/ WebView fixture candidate survey/);
+  assert.match(candidates, /React Native \/ WebView fixture candidate survey/);
+  assert.match(candidates, /Tier A: preferred seed candidates/);
+  assert.match(candidates, /Recommended first fixture slice/);
+  assert.match(candidates, /react-native-webview\/react-native-webview/);
+  assert.match(candidates, /mattermost\/mattermost-mobile/);
+  assert.match(candidates, /RocketChat\/Rocket\.Chat\.ReactNative/);
+  assert.match(candidates, /Expensify\/App/);
+  assert.match(candidates, /gronxb\/webview-bridge/);
   assert.match(combined, /frontend-family candidate/);
   assert.match(combined, /Fixture\/benchmark evidence/);
   assert.match(combined, /StyleSheet\.create/);
@@ -3640,6 +3650,7 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.match(combined, /fixture corpus, signal model, benchmark evidence, and claim-boundary wording/);
   assert.match(preRead, /unsupported-react-native-webview-boundary/);
   assert.doesNotMatch(combined, /React Native support is available/i);
+  assert.doesNotMatch(combined, /React Native(?: \/ WebView)? is supported today/i);
 });
 
 test("docs give first-run users a clear support and diagnosis path", () => {


### PR DESCRIPTION
## Summary
- add RN/WebView fixture candidate survey for a future evidence lane
- link the roadmap promotion ladder to the candidate survey
- keep RN/WebView fallback-only and explicitly non-supporting for now
- lock candidate survey and no-support wording in docs regression tests

## Sources reviewed
- https://github.com/react-native-webview/react-native-webview
- https://github.com/mattermost/mattermost-mobile
- https://github.com/RocketChat/Rocket.Chat.ReactNative
- https://github.com/Expensify/App
- https://github.com/gronxb/webview-bridge
- https://github.com/Jellify-Music/App
- https://github.com/inokawa/react-native-react-bridge
- https://github.com/expo/expo
- https://github.com/react-navigation/react-navigation

## Verification
- npm test
- npm run lint
- git diff --check
