### PR TITLE
Improve frontend design payload anchors

### DIFF
--- a/src/core/design-review-metadata.ts
+++ b/src/core/design-review-metadata.ts
@@ -161,6 +161,7 @@ function classifyRegion(label: string): DesignReviewVisualRegionV0["kind"] {
   if (["form", "fieldset", "label"].includes(normalized)) return "form";
   if (["ul", "ol", "li", "table", "tbody", "tr"].includes(normalized) || normalized.includes("list")) return "list";
   if (["button", "input", "select", "textarea"].includes(normalized)) return "control";
+  if (["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"].includes(normalized)) return "content";
   if (["section", "header", "footer", "main", "nav", "aside", "article"].includes(normalized) || normalized.includes("card") || normalized.includes("panel")) return "layout";
   if (/^[A-Z]/.test(label)) return "content";
   return "unknown";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -727,6 +727,10 @@ test("design-review metadata covers planned fixture categories conservatively", 
   );
   assert.ok(tailwind.styleReferences.some((item) => item.kind === "tailwind-group"));
   assert.ok(tailwind.visualRegions.some((item) => item.label === "section" || item.label === "TailwindVariantCard"));
+  assert.ok(
+    tailwind.visualRegions.filter((item) => item.kind === "unknown").length <= 1,
+    "TailwindVariantCard design metadata should classify text content regions instead of leaving noisy unknown visual regions",
+  );
 
   const form = deriveDesignReviewMetadata(extractFile(designReviewFixture("FormStateReview.tsx")));
   assert.ok(form);


### PR DESCRIPTION
## Summary
- Classify source-derived JSX text tags (`h1`-`h6`, `p`, `span`) as design-review `content` regions.
- Add a regression assertion that `TailwindVariantCard` has at most 1 unknown visual region.
- Keeps the first lane narrow: no LSP/provider/runtime/visual/accessibility claim expansion and no cap changes.

## Verification
- `npm run build`
- `node --test test/fooks.test.mjs --test-name-pattern "design-review metadata covers planned fixture categories conservatively"` → 119/119 pass
- `npm run lint`
- `npm test` → 255/255 pass
- Architect verification: APPROVED
- Post-deslop regression: `npm test` → 255/255 pass

## Notes / Risks
- `div` remains unknown intentionally; generic containers are not promoted without stronger semantics.
- `span` can be decorative in some code, but this remains a bounded source-derived heuristic and does not broaden external proof claims.
