### PR TITLE
Add read-only fooks artifact audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then open Codex in that repo and work normally. `fooks doctor` is the read-only 
 1. Install the package: `npm install -g fxxk-frontned-hooks`.
 2. Confirm the command resolves to the package you expect: `which fooks` and `fooks --help`.
 3. Activate only the repo you are inside: `fooks setup`. The default output should be a short `ready`, `partial`, or `blocked` summary, not a debug JSON wall.
-4. Diagnose locally: `fooks doctor` for readiness, `fooks status` for local estimated session telemetry, and `fooks compare <file> --json` for one-file payload proof.
+4. Diagnose locally: `fooks doctor` for readiness, `fooks status` for local estimated session telemetry, `fooks status artifacts` for a read-only fooks tmux/worktree/branch audit, and `fooks compare <file> --json` for one-file payload proof.
 5. Use `fooks setup --json` only when you need support/debug paths, runtime manifests, or issue-report evidence.
 
 ## Strongest path / beta path / not today
@@ -96,6 +96,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stron
 | `fooks setup` | current project + runtime homes | Creates project-local `.fooks/` state, may add project-local `.opencode/` helper files, and may update runtime-home files such as Codex hooks/manifests or Claude handoff manifests. |
 | `fooks doctor` | current project + runtime-home inspection | Reads local setup and hook-readiness artifacts without writing files; it is not live provider health, billing-token, cost, or `ccusage` proof. |
 | `fooks status` | current project inspection | Reads local fooks telemetry/status; it is not a package installer or billing-token report. |
+| `fooks status artifacts` | current project + local git/tmux inspection | Read-only audit of fooks-scoped tmux sessions, git worktrees, and branches that may be merged into the selected base; it does not prove inactivity and never deletes artifacts. |
 
 By default, `fooks setup` prints a short readiness summary so the command does not look like a wall of debug JSON. Use `fooks setup --json` when you need the full `scope` object and support/debug paths that show what is project-local versus user-runtime/home scoped.
 
@@ -217,6 +218,7 @@ fooks status          # local estimated context-size telemetry for this repo
 fooks status codex   # check Codex attach/hook state
 fooks status claude  # check Claude project-local context hook / handoff health
 fooks status cache   # check local fooks cache health
+fooks status artifacts # read-only fooks tmux/worktree/branch artifact audit
 fooks compare src/components/Button.tsx --json  # local original-vs-fooks payload estimate
 ```
 
@@ -228,6 +230,8 @@ fooks scan
 ```
 
 `fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider billing tokens, provider costs, or a `ccusage` replacement.
+
+`fooks status artifacts` is a read-only dogfood cleanup audit for local fooks artifacts after PRs merge. It inspects local git worktrees/branches and tmux panes, scopes results to fooks-like names or `.omx-worktrees` paths, and uses conservative labels such as `activeOrUnknown`, `likelyMerged`, `missingPath`, and `candidateCleanup`. The command does not run `git fetch`, `git worktree prune`, `git worktree remove`, `git branch -d`, or `tmux kill-session`; any `manualCleanupCommands` in the JSON are copy/paste suggestions only. Missing worktree paths only suggest `git worktree prune --dry-run` so operators can inspect before deciding whether to run cleanup manually. Verify the PR is merged and the session/worktree is inactive before copying any command.
 
 ## opencode support
 
@@ -269,6 +273,7 @@ fooks doctor codex
 fooks status codex
 fooks status claude
 fooks status cache
+fooks status artifacts
 ```
 
 `fooks doctor` is the safest first diagnostic after setup because it is read-only and summarizes local setup artifacts, missing hook events, manifests, adapter files, trust status, cache health, and supported source-file presence. Focused `fooks doctor claude` also reports the optional TypeScript language server as a warning-only host-tooling hint. It does not prove live provider health; it is not a ccusage replacement and not provider billing telemetry or provider costs.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -77,6 +77,7 @@ fooks doctor claude
 fooks status codex
 fooks status claude
 fooks status cache
+fooks status artifacts
 ```
 
 Good signs:
@@ -86,10 +87,13 @@ Good signs:
 - Codex status is connected/ready-style.
 - Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
+- Artifact status reports fooks-scoped tmux sessions, git worktrees, and branches as local read-only cleanup candidates; it may show zero candidates or blockers when git/tmux are unavailable.
 
 `fooks doctor [codex|claude] [--json]` is read-only. It checks local fooks setup artifacts, runtime manifests, hook event installation, Codex trust status, cache health, and supported source-file presence. Focused `fooks doctor claude` also includes an optional TypeScript language server host-tooling check as warning-only. It does not mutate `.fooks/`, Codex hooks, Claude project-local settings, or runtime-home manifests. It also does not prove live provider health; it is not a ccusage replacement and not provider billing telemetry or provider costs.
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider billing tokens, provider costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
+
+`fooks status artifacts` is also read-only. It audits local fooks-scoped tmux panes, git worktrees, and branches against `origin/main` when available, falling back to `main`. It reports conservative statuses (`activeOrUnknown`, `likelyMerged`, `missingPath`, `candidateCleanup`) and a claim boundary that local evidence does not prove inactivity. The command never deletes anything and never runs cleanup commands. If JSON includes `manualCleanupCommands`, copy them only after verifying the PR merged and the session/worktree is inactive. Missing worktree paths only suggest `git worktree prune --dry-run`; inspect that output before deciding whether to run any real cleanup manually.
 
 ## 4. Compare one frontend file locally
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -645,6 +645,7 @@ Everyday commands:
   ${displayCliName} status claude
   ${displayCliName} status cache
   ${displayCliName} status worktree
+  ${displayCliName} status artifacts
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
   ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -1045,7 +1046,12 @@ async function run(): Promise<void> {
         print(currentWorktreeEvidenceStatus(process.cwd()));
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', 'cache', or 'worktree'");
+      if (arg1 === "artifacts") {
+        const { auditArtifacts } = await import("../core/artifact-audit.js");
+        print(auditArtifacts(process.cwd()));
+        return;
+      }
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', or 'artifacts'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/core/artifact-audit.ts
+++ b/src/core/artifact-audit.ts
@@ -1,0 +1,389 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+export const ARTIFACT_AUDIT_SCHEMA_VERSION = 1;
+export const ARTIFACT_AUDIT_COMMAND = "status artifacts";
+export const ARTIFACT_AUDIT_SCOPE = "fooks";
+export const ARTIFACT_AUDIT_CLAIM_BOUNDARY =
+  "Local read-only fooks artifact candidates only; does not prove inactivity and never deletes tmux sessions, worktrees, or branches.";
+export const DEFAULT_ARTIFACT_AUDIT_TIMEOUT_MS = 3000;
+
+export type ArtifactAuditStatus = "activeOrUnknown" | "likelyMerged" | "missingPath" | "candidateCleanup";
+export type ArtifactAuditCommandRunner = (command: string, args: string[], cwd: string) => string;
+export type ArtifactAuditPathExists = (targetPath: string) => boolean;
+
+export type ArtifactAuditWorktree = {
+  path: string;
+  branch?: string;
+  head?: string;
+  detached: boolean;
+  exists: boolean;
+  current: boolean;
+  status: ArtifactAuditStatus;
+  reasons: string[];
+  manualCleanupCommands: string[];
+};
+
+export type ArtifactAuditBranch = {
+  branch: string;
+  mergedIntoBase: boolean;
+  current: boolean;
+  checkedOut: boolean;
+  status: ArtifactAuditStatus;
+  reasons: string[];
+  manualCleanupCommands: string[];
+};
+
+export type ArtifactAuditSessionPane = {
+  path: string;
+  exists: boolean;
+  deleted: boolean;
+  current: boolean;
+  worktreePath?: string;
+};
+
+export type ArtifactAuditSession = {
+  session: string;
+  status: ArtifactAuditStatus;
+  reasons: string[];
+  panes: ArtifactAuditSessionPane[];
+  manualCleanupCommands: string[];
+};
+
+export type ArtifactAuditResult = {
+  schemaVersion: typeof ARTIFACT_AUDIT_SCHEMA_VERSION;
+  command: typeof ARTIFACT_AUDIT_COMMAND;
+  scope: typeof ARTIFACT_AUDIT_SCOPE;
+  baseRef?: string;
+  generatedAt: string;
+  claimBoundary: typeof ARTIFACT_AUDIT_CLAIM_BOUNDARY;
+  blockers: string[];
+  sessions: ArtifactAuditSession[];
+  worktrees: ArtifactAuditWorktree[];
+  branches: ArtifactAuditBranch[];
+  manualCleanupCommands: string[];
+};
+
+export type ArtifactAuditOptions = {
+  runner?: ArtifactAuditCommandRunner;
+  pathExists?: ArtifactAuditPathExists;
+  now?: () => string;
+};
+
+type ParsedWorktree = {
+  path: string;
+  branch?: string;
+  head?: string;
+  detached: boolean;
+};
+
+type ParsedPane = {
+  session: string;
+  path: string;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function errorDetail(error: unknown): string {
+  const maybeError = error && typeof error === "object" ? (error as { message?: unknown; stderr?: unknown; signal?: unknown; code?: unknown }) : {};
+  const stderr = maybeError.stderr;
+  const stderrText = Buffer.isBuffer(stderr) ? stderr.toString("utf8").trim() : typeof stderr === "string" ? stderr.trim() : "";
+  const message = typeof maybeError.message === "string" ? maybeError.message.trim() : String(error);
+  const status = maybeError.signal ? `signal ${String(maybeError.signal)}` : maybeError.code !== undefined ? `code ${String(maybeError.code)}` : "";
+  const detail = stderrText || message || "unknown error";
+  return status ? `${detail} (${status})` : detail;
+}
+
+function normalizeBranch(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function includesFooksSignal(value: string, cwd: string): boolean {
+  const lower = value.replace(/\\/g, "/").toLowerCase();
+  const cwdBase = path.basename(cwd).toLowerCase();
+  return lower.includes("fooks") || lower.includes(".omx-worktrees") || (cwdBase.includes("fooks") && lower.includes(cwdBase));
+}
+
+function safeResolve(targetPath: string): string {
+  return path.resolve(targetPath.replace(/ \(deleted\)$/u, ""));
+}
+
+function samePath(left: string, right: string): boolean {
+  return safeResolve(left) === safeResolve(right);
+}
+
+function pathContainsCwd(parent: string, cwd: string): boolean {
+  return isInsidePath(cwd, parent);
+}
+
+function isInsidePath(child: string, parent: string): boolean {
+  const relative = path.relative(safeResolve(parent), safeResolve(child));
+  return relative === "" || (Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function panePathDeleted(panePath: string): boolean {
+  return panePath.includes("(deleted)");
+}
+
+function panePathWithoutDeletedMarker(panePath: string): string {
+  return panePath.replace(/ \(deleted\)$/u, "").trim();
+}
+
+export function defaultArtifactAuditCommandRunner(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: DEFAULT_ARTIFACT_AUDIT_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+export function parseGitWorktreePorcelain(output: string): ParsedWorktree[] {
+  const worktrees: ParsedWorktree[] = [];
+  for (const block of output.split(/\n\n/u).map((item) => item.trim()).filter(Boolean)) {
+    const lines = block.split(/\r?\n/u);
+    const worktreePath = lines.find((line) => line.startsWith("worktree "))?.slice("worktree ".length);
+    if (!worktreePath) continue;
+
+    const head = lines.find((line) => line.startsWith("HEAD "))?.slice("HEAD ".length);
+    const branch = normalizeBranch(lines.find((line) => line.startsWith("branch "))?.slice("branch ".length));
+    worktrees.push({ path: worktreePath, branch, head, detached: !branch });
+  }
+  return worktrees;
+}
+
+export function parseGitBranchList(output: string): string[] {
+  return uniqueSorted(output.split(/\r?\n/u).map((line) => line.trim().replace(/^\*\s*/u, "")).filter(Boolean).map((line) => normalizeBranch(line) ?? line));
+}
+
+export function parseTmuxPaneList(output: string): ParsedPane[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const [session, ...pathParts] = line.split("\t");
+      const panePath = pathParts.join("\t");
+      return session && panePath ? { session, path: panePath } : undefined;
+    })
+    .filter((entry): entry is ParsedPane => Boolean(entry));
+}
+
+function readOptional(runner: ArtifactAuditCommandRunner, command: string, args: string[], cwd: string, blockers: string[], label: string): string {
+  try {
+    return runner(command, args, cwd);
+  } catch (error) {
+    blockers.push(`${label} unavailable: ${errorDetail(error)}`);
+    return "";
+  }
+}
+
+function resolveBaseRef(runner: ArtifactAuditCommandRunner, cwd: string, blockers: string[]): string | undefined {
+  for (const baseRef of ["origin/main", "main"]) {
+    try {
+      runner("git", ["rev-parse", "--verify", baseRef], cwd);
+      return baseRef;
+    } catch {
+      // Try the next local read-only base candidate.
+    }
+  }
+  blockers.push("git base ref unavailable: neither origin/main nor main could be verified");
+  return undefined;
+}
+
+function checkedOutBranches(worktrees: ArtifactAuditWorktree[], ignoredStatuses: Set<ArtifactAuditStatus> = new Set()): Set<string> {
+  const branches = new Set<string>();
+  for (const worktree of worktrees) {
+    if (!worktree.branch || ignoredStatuses.has(worktree.status)) continue;
+    branches.add(worktree.branch);
+  }
+  return branches;
+}
+
+export function auditArtifacts(cwd = process.cwd(), options: ArtifactAuditOptions = {}): ArtifactAuditResult {
+  const runner = options.runner ?? defaultArtifactAuditCommandRunner;
+  const pathExists = options.pathExists ?? fs.existsSync;
+  const generatedAt = options.now?.() ?? nowIso();
+  const blockers: string[] = [];
+  const currentCwd = safeResolve(cwd);
+
+  const worktreeOutput = readOptional(runner, "git", ["worktree", "list", "--porcelain"], cwd, blockers, "git worktree list");
+  const baseRef = resolveBaseRef(runner, cwd, blockers);
+  const branchOutput = readOptional(runner, "git", ["branch", "--format=%(refname:short)"], cwd, blockers, "git branch list");
+  const mergedOutput = baseRef ? readOptional(runner, "git", ["branch", "--merged", baseRef], cwd, blockers, `git branch --merged ${baseRef}`) : "";
+  const tmuxOutput = readOptional(runner, "tmux", ["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}"], cwd, blockers, "tmux pane list");
+
+  const parsedWorktrees = parseGitWorktreePorcelain(worktreeOutput);
+  const allBranches = parseGitBranchList(branchOutput);
+  const mergedBranches = new Set(parseGitBranchList(mergedOutput));
+  const currentWorktree = parsedWorktrees.find((worktree) => pathContainsCwd(worktree.path, currentCwd));
+  const currentBranch = currentWorktree?.branch;
+
+  const worktrees: ArtifactAuditWorktree[] = parsedWorktrees
+    .filter((worktree) => includesFooksSignal(worktree.path, cwd) || includesFooksSignal(worktree.branch ?? "", cwd))
+    .map((worktree) => {
+      const exists = pathExists(worktree.path);
+      const current = pathContainsCwd(worktree.path, currentCwd);
+      const reasons: string[] = [];
+      const manualCleanupCommands: string[] = [];
+      let status: ArtifactAuditStatus = "activeOrUnknown";
+
+      if (!exists) {
+        status = "missingPath";
+        reasons.push("worktree path is missing from the filesystem");
+        manualCleanupCommands.push("git worktree prune --dry-run");
+      } else if (worktree.branch && mergedBranches.has(worktree.branch) && !current && worktree.branch !== currentBranch) {
+        status = "likelyMerged";
+        reasons.push(`branch is merged into ${baseRef ?? "the selected base"}`);
+        manualCleanupCommands.push(`git worktree remove ${shellQuote(worktree.path)}`);
+      } else {
+        if (current) reasons.push("worktree is the current working directory");
+        if (!worktree.branch) reasons.push("worktree is detached");
+        if (worktree.branch && !mergedBranches.has(worktree.branch)) reasons.push(`branch is not reported merged into ${baseRef ?? "the selected base"}`);
+        if (worktree.branch && worktree.branch === currentBranch) reasons.push("branch is the current branch");
+      }
+
+      return {
+        path: worktree.path,
+        branch: worktree.branch,
+        head: worktree.head,
+        detached: worktree.detached,
+        exists,
+        current,
+        status,
+        reasons: uniqueSorted(reasons),
+        manualCleanupCommands: uniqueSorted(manualCleanupCommands),
+      };
+    });
+
+  const nonCandidateCheckedOutBranches = checkedOutBranches(worktrees, new Set(["likelyMerged", "missingPath", "candidateCleanup"]));
+  const allCheckedOutBranches = checkedOutBranches(worktrees);
+
+  const branches: ArtifactAuditBranch[] = allBranches
+    .filter((branch) => includesFooksSignal(branch, cwd))
+    .filter((branch) => branch !== "main" && branch !== "master")
+    .map((branch) => {
+      const current = branch === currentBranch;
+      const checkedOut = allCheckedOutBranches.has(branch);
+      const reasons: string[] = [];
+      const manualCleanupCommands: string[] = [];
+      let status: ArtifactAuditStatus = "activeOrUnknown";
+      const mergedIntoBase = mergedBranches.has(branch);
+
+      if (current) reasons.push("branch is the current branch");
+      if (!mergedIntoBase) reasons.push(`branch is not reported merged into ${baseRef ?? "the selected base"}`);
+      if (nonCandidateCheckedOutBranches.has(branch)) reasons.push("branch is checked out in an active or unknown worktree");
+
+      if (mergedIntoBase && !current && !nonCandidateCheckedOutBranches.has(branch)) {
+        status = "likelyMerged";
+        reasons.push(`branch is merged into ${baseRef ?? "the selected base"}`);
+        if (!checkedOut) {
+          manualCleanupCommands.push(`git branch -d ${shellQuote(branch)}`);
+        } else {
+          reasons.push("branch is checked out in a candidate worktree; remove the worktree before deleting the branch");
+        }
+      }
+
+      return {
+        branch,
+        mergedIntoBase,
+        current,
+        checkedOut,
+        status,
+        reasons: uniqueSorted(reasons),
+        manualCleanupCommands: uniqueSorted(manualCleanupCommands),
+      };
+    });
+
+  const worktreeByPath = worktrees.filter((worktree) => worktree.exists).sort((left, right) => right.path.length - left.path.length);
+  const panesBySession = new Map<string, ArtifactAuditSessionPane[]>();
+  for (const pane of parseTmuxPaneList(tmuxOutput)) {
+    const cleanPanePath = panePathWithoutDeletedMarker(pane.path);
+    const deleted = panePathDeleted(pane.path);
+    const exists = !deleted && pathExists(cleanPanePath);
+    const current = pathContainsCwd(cleanPanePath, currentCwd) || pathContainsCwd(currentCwd, cleanPanePath);
+    const mappedWorktree = worktreeByPath.find((worktree) => isInsidePath(cleanPanePath, worktree.path));
+    if (!includesFooksSignal(pane.session, cwd) && !includesFooksSignal(cleanPanePath, cwd) && !mappedWorktree) continue;
+    const panes = panesBySession.get(pane.session) ?? [];
+    panes.push({
+      path: pane.path,
+      exists,
+      deleted,
+      current,
+      worktreePath: mappedWorktree?.path,
+    });
+    panesBySession.set(pane.session, panes);
+  }
+
+  const candidateWorktreePaths = new Set(worktrees.filter((worktree) => worktree.status === "likelyMerged").map((worktree) => worktree.path));
+  const sessions: ArtifactAuditSession[] = [...panesBySession.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([session, panes]) => {
+      const reasons: string[] = [];
+      const manualCleanupCommands: string[] = [];
+      const allPanesMissing = panes.length > 0 && panes.every((pane) => pane.deleted || !pane.exists);
+      const existingPanes = panes.filter((pane) => pane.exists);
+      const existingPanesAllCandidateWorktrees = existingPanes.length > 0 && existingPanes.every((pane) => pane.worktreePath && candidateWorktreePaths.has(pane.worktreePath));
+      const anyCurrentPane = panes.some((pane) => pane.current);
+      let status: ArtifactAuditStatus = "activeOrUnknown";
+
+      if (allPanesMissing) {
+        status = "candidateCleanup";
+        reasons.push("all panes point at missing or deleted paths");
+      } else if (existingPanesAllCandidateWorktrees && !anyCurrentPane) {
+        status = "candidateCleanup";
+        reasons.push("all existing panes map to audited worktrees whose branches are likely merged");
+      } else {
+        if (anyCurrentPane) reasons.push("session has a pane at the current working directory");
+        if (existingPanes.some((pane) => !pane.worktreePath || !candidateWorktreePaths.has(pane.worktreePath))) {
+          reasons.push("session has a live pane outside likely-merged audited worktrees");
+        }
+      }
+
+      if (status === "candidateCleanup") {
+        manualCleanupCommands.push(`tmux kill-session -t ${shellQuote(session)}`);
+      }
+
+      return {
+        session,
+        status,
+        reasons: uniqueSorted(reasons),
+        panes,
+        manualCleanupCommands,
+      };
+    });
+
+  const manualCleanupCommands = uniqueSorted([
+    ...sessions.flatMap((session) => session.manualCleanupCommands),
+    ...worktrees.flatMap((worktree) => worktree.manualCleanupCommands),
+    ...branches.flatMap((branch) => branch.manualCleanupCommands),
+  ]);
+
+  return {
+    schemaVersion: ARTIFACT_AUDIT_SCHEMA_VERSION,
+    command: ARTIFACT_AUDIT_COMMAND,
+    scope: ARTIFACT_AUDIT_SCOPE,
+    baseRef,
+    generatedAt,
+    claimBoundary: ARTIFACT_AUDIT_CLAIM_BOUNDARY,
+    blockers: uniqueSorted(blockers),
+    sessions,
+    worktrees,
+    branches,
+    manualCleanupCommands,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,3 +53,26 @@ export type {
   WorktreeSnapshot,
   WorktreeStatusRunner,
 } from "./core/worktree-evidence";
+
+export {
+  ARTIFACT_AUDIT_CLAIM_BOUNDARY,
+  ARTIFACT_AUDIT_COMMAND,
+  ARTIFACT_AUDIT_SCHEMA_VERSION,
+  ARTIFACT_AUDIT_SCOPE,
+  auditArtifacts,
+  defaultArtifactAuditCommandRunner,
+  parseGitBranchList,
+  parseGitWorktreePorcelain,
+  parseTmuxPaneList,
+} from "./core/artifact-audit";
+export type {
+  ArtifactAuditBranch,
+  ArtifactAuditCommandRunner,
+  ArtifactAuditOptions,
+  ArtifactAuditPathExists,
+  ArtifactAuditResult,
+  ArtifactAuditSession,
+  ArtifactAuditSessionPane,
+  ArtifactAuditStatus,
+  ArtifactAuditWorktree,
+} from "./core/artifact-audit";

--- a/test/artifact-audit.test.mjs
+++ b/test/artifact-audit.test.mjs
@@ -1,0 +1,181 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+
+const {
+  ARTIFACT_AUDIT_CLAIM_BOUNDARY,
+  auditArtifacts,
+  parseGitBranchList,
+  parseGitWorktreePorcelain,
+  parseTmuxPaneList,
+} = require(path.join(repoRoot, "dist", "core", "artifact-audit.js"));
+
+function makeRunner(outputs, calls = []) {
+  return (command, args, cwd) => {
+    calls.push([command, args, cwd]);
+    const key = `${command} ${args.join(" ")}`;
+    const value = outputs[key];
+    if (value instanceof Error) throw value;
+    if (value === undefined) throw new Error(`unexpected command: ${key}`);
+    return value;
+  };
+}
+
+test("artifact audit parsers handle git worktrees, branches, and tmux panes", () => {
+  assert.deepEqual(parseGitWorktreePorcelain("worktree /repo/fooks\nHEAD abc\nbranch refs/heads/fooks-feature\n\nworktree /repo/detached\nHEAD def\ndetached\n"), [
+    { path: "/repo/fooks", head: "abc", branch: "fooks-feature", detached: false },
+    { path: "/repo/detached", head: "def", branch: undefined, detached: true },
+  ]);
+  assert.deepEqual(parseGitBranchList("  main\n* fooks-feature\nrefs/heads/fooks-other\n"), ["fooks-feature", "fooks-other", "main"]);
+  assert.deepEqual(parseTmuxPaneList("fooks-old\t/work/.omx-worktrees/fooks-old\nignored-without-tab\n"), [
+    { session: "fooks-old", path: "/work/.omx-worktrees/fooks-old" },
+  ]);
+});
+
+test("artifact audit reports conservative candidates and only manual cleanup commands", () => {
+  const cwd = "/repo/fooks-main";
+  const existing = new Set([
+    cwd,
+    "/work/.omx-worktrees/fooks-feature",
+    "/work/.omx-worktrees/fooks-active",
+  ]);
+  const calls = [];
+  const result = auditArtifacts(cwd, {
+    now: () => "2026-04-25T00:00:00.000Z",
+    pathExists: (target) => existing.has(target),
+    runner: makeRunner({
+      "git worktree list --porcelain": [
+        `worktree ${cwd}`,
+        "HEAD 111",
+        "branch refs/heads/fooks-current",
+        "",
+        "worktree /work/.omx-worktrees/fooks-feature",
+        "HEAD 222",
+        "branch refs/heads/fooks-feature",
+        "",
+        "worktree /work/.omx-worktrees/fooks-active",
+        "HEAD 333",
+        "branch refs/heads/fooks-active",
+        "",
+        "worktree /work/.omx-worktrees/fooks-missing",
+        "HEAD 444",
+        "branch refs/heads/fooks-missing",
+        "",
+      ].join("\n"),
+      "git rev-parse --verify origin/main": "origin-main-sha\n",
+      "git branch --format=%(refname:short)": "fooks-current\nfooks-feature\nfooks-active\nfooks-missing\nfooks-loose\nmain\n",
+      "git branch --merged origin/main": "fooks-feature\nfooks-missing\nfooks-loose\nmain\n",
+      "tmux list-panes -a -F #{session_name}\t#{pane_current_path}": [
+        "fooks-old\t/work/.omx-worktrees/fooks-feature",
+        "fooks-active\t/work/.omx-worktrees/fooks-active",
+        `fooks-current\t${cwd}`,
+        "fooks-missing\t/gone/fooks-path (deleted)",
+      ].join("\n"),
+    }, calls),
+  });
+
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "status artifacts");
+  assert.equal(result.scope, "fooks");
+  assert.equal(result.baseRef, "origin/main");
+  assert.equal(result.claimBoundary, ARTIFACT_AUDIT_CLAIM_BOUNDARY);
+  assert.deepEqual(result.blockers, []);
+
+  const worktreeByBranch = new Map(result.worktrees.map((item) => [item.branch, item]));
+  assert.equal(worktreeByBranch.get("fooks-current")?.status, "activeOrUnknown");
+  assert.equal(worktreeByBranch.get("fooks-feature")?.status, "likelyMerged");
+  assert.deepEqual(worktreeByBranch.get("fooks-feature")?.manualCleanupCommands, ["git worktree remove '/work/.omx-worktrees/fooks-feature'"]);
+  assert.equal(worktreeByBranch.get("fooks-active")?.status, "activeOrUnknown");
+  assert.equal(worktreeByBranch.get("fooks-missing")?.status, "missingPath");
+  assert.deepEqual(worktreeByBranch.get("fooks-missing")?.manualCleanupCommands, ["git worktree prune --dry-run"]);
+
+  const branchByName = new Map(result.branches.map((item) => [item.branch, item]));
+  assert.equal(branchByName.get("fooks-current")?.status, "activeOrUnknown");
+  assert.equal(branchByName.get("fooks-active")?.status, "activeOrUnknown");
+  assert.equal(branchByName.get("fooks-loose")?.status, "likelyMerged");
+  assert.deepEqual(branchByName.get("fooks-loose")?.manualCleanupCommands, ["git branch -d 'fooks-loose'"]);
+  assert.equal(branchByName.get("main"), undefined);
+
+  const sessionByName = new Map(result.sessions.map((item) => [item.session, item]));
+  assert.equal(sessionByName.get("fooks-old")?.status, "candidateCleanup");
+  assert.deepEqual(sessionByName.get("fooks-old")?.manualCleanupCommands, ["tmux kill-session -t 'fooks-old'"]);
+  assert.equal(sessionByName.get("fooks-active")?.status, "activeOrUnknown");
+  assert.deepEqual(sessionByName.get("fooks-active")?.manualCleanupCommands, []);
+  assert.equal(sessionByName.get("fooks-current")?.status, "activeOrUnknown");
+  assert.deepEqual(sessionByName.get("fooks-current")?.manualCleanupCommands, []);
+  assert.equal(sessionByName.get("fooks-missing")?.status, "candidateCleanup");
+
+  assert.ok(result.manualCleanupCommands.includes("git worktree prune --dry-run"));
+  assert.ok(result.manualCleanupCommands.includes("git branch -d 'fooks-loose'"));
+  assert.ok(result.manualCleanupCommands.includes("tmux kill-session -t 'fooks-old'"));
+  assert.ok(calls.every(([command, args]) => command !== "git" || !["fetch", "prune", "worktree remove", "branch -d"].includes(args.join(" "))));
+});
+
+test("artifact audit falls back to local main and does not mark by name alone", () => {
+  const cwd = "/repo/fooks-main";
+  const result = auditArtifacts(cwd, {
+    pathExists: (target) => target === cwd || target === "/work/fooks-name-only",
+    runner: makeRunner({
+      "git worktree list --porcelain": `worktree ${cwd}\nHEAD 111\nbranch refs/heads/main\n\nworktree /work/fooks-name-only\nHEAD 222\nbranch refs/heads/fooks-name-only\n`,
+      "git rev-parse --verify origin/main": new Error("missing origin main"),
+      "git rev-parse --verify main": "main-sha\n",
+      "git branch --format=%(refname:short)": "main\nfooks-name-only\n",
+      "git branch --merged main": "main\n",
+      "tmux list-panes -a -F #{session_name}\t#{pane_current_path}": "fooks-name-only\t/work/fooks-name-only\n",
+    }),
+  });
+
+  assert.equal(result.baseRef, "main");
+  assert.equal(result.worktrees.find((item) => item.branch === "fooks-name-only")?.status, "activeOrUnknown");
+  assert.equal(result.branches.find((item) => item.branch === "fooks-name-only")?.status, "activeOrUnknown");
+  assert.equal(result.sessions.find((item) => item.session === "fooks-name-only")?.status, "activeOrUnknown");
+  assert.deepEqual(result.manualCleanupCommands, []);
+});
+
+
+test("artifact audit treats child cwd as the active worktree and suppresses cleanup", () => {
+  const worktreeRoot = "/repo/fooks-current";
+  const cwd = `${worktreeRoot}/src/components`;
+  const result = auditArtifacts(cwd, {
+    pathExists: (target) => target === worktreeRoot || target === cwd,
+    runner: makeRunner({
+      "git worktree list --porcelain": `worktree ${worktreeRoot}\nHEAD 111\nbranch refs/heads/fooks-current\n`,
+      "git rev-parse --verify origin/main": "origin-main-sha\n",
+      "git branch --format=%(refname:short)": "fooks-current\n",
+      "git branch --merged origin/main": "fooks-current\n",
+      "tmux list-panes -a -F #{session_name}\t#{pane_current_path}": `fooks-current\t${worktreeRoot}`,
+    }),
+  });
+
+  assert.equal(result.worktrees[0]?.current, true);
+  assert.equal(result.worktrees[0]?.status, "activeOrUnknown");
+  assert.deepEqual(result.worktrees[0]?.manualCleanupCommands, []);
+  assert.equal(result.branches[0]?.current, true);
+  assert.equal(result.branches[0]?.status, "activeOrUnknown");
+  assert.equal(result.sessions[0]?.status, "activeOrUnknown");
+  assert.deepEqual(result.sessions[0]?.manualCleanupCommands, []);
+  assert.deepEqual(result.manualCleanupCommands, []);
+});
+
+
+test("status artifacts emits JSON and remains read-only when git and tmux are unavailable", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-artifact-audit-"));
+  const before = fs.readdirSync(tempDir);
+  const result = JSON.parse(execFileSync(process.execPath, [cli, "status", "artifacts"], { cwd: tempDir, encoding: "utf8" }));
+
+  assert.equal(result.command, "status artifacts");
+  assert.match(result.claimBoundary, /never deletes/);
+  assert.ok(Array.isArray(result.blockers));
+  assert.deepEqual(fs.readdirSync(tempDir), before);
+});

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2569,6 +2569,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks doctor \[codex\|claude\] \[--json\]/);
   assert.match(help, /fooks compare <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
+  assert.match(help, /fooks status artifacts/);
   assert.match(help, /Codex: automatic repeated-file runtime hook path/);
   assert.match(help, /Claude: project-local context hooks/);
   assert.match(help, /opencode: manual\/semi-automatic custom tool/);
@@ -2590,6 +2591,27 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.equal(pkg.scripts?.prepare, undefined);
   assert.match(pkg.scripts?.["release:smoke"], /scripts\/release-smoke\.mjs/);
   assert.doesNotMatch(pkg.scripts?.["release:smoke"], /publish|version|tag/);
+});
+
+test("status artifacts route reports read-only audit JSON", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-status-artifacts-"));
+  const before = fileSnapshot(tempDir);
+
+  const result = run(["status", "artifacts"], tempDir);
+
+  assert.equal(result.command, "status artifacts");
+  assert.equal(result.scope, "fooks");
+  assert.match(result.claimBoundary, /never deletes/);
+  assert.ok(Array.isArray(result.manualCleanupCommands));
+  assert.deepEqual(fileSnapshot(tempDir), before);
+
+  let output = "";
+  try {
+    runText(["status", "unknown"], tempDir);
+  } catch (error) {
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.match(output, /artifacts/);
 });
 
 test("doctor rejects unknown targets and exposes bounded command help", () => {


### PR DESCRIPTION
## Summary
- add `fooks status artifacts` as a read-only audit for fooks-scoped tmux sessions, git worktrees, and branches
- classify only conservative local candidates (`activeOrUnknown`, `likelyMerged`, `missingPath`, `candidateCleanup`) and keep cleanup as manual JSON strings
- document the inspect-first operator flow and add regression coverage for cleanup suppression, including child-cwd active worktrees

Closes #187.

## Safety
- no cleanup commands are executed by the audit path
- missing worktree paths only suggest `git worktree prune --dry-run`
- active/current worktrees, current branch, and live tmux panes suppress unsafe cleanup suggestions

## Tests
- `npm run build`
- `node --test test/artifact-audit.test.mjs test/fooks.test.mjs`
- `npm test`
