### PR TITLE
Fix artifact audit fooks session scope

### DIFF
--- a/src/core/artifact-audit.ts
+++ b/src/core/artifact-audit.ts
@@ -113,7 +113,7 @@ function shellQuote(value: string): string {
 function includesFooksSignal(value: string, cwd: string): boolean {
   const lower = value.replace(/\\/g, "/").toLowerCase();
   const cwdBase = path.basename(cwd).toLowerCase();
-  return lower.includes("fooks") || lower.includes(".omx-worktrees") || (cwdBase.includes("fooks") && lower.includes(cwdBase));
+  return lower.includes("fooks") || (cwdBase.includes("fooks") && lower.includes(cwdBase));
 }
 
 function safeResolve(targetPath: string): string {

--- a/test/artifact-audit.test.mjs
+++ b/test/artifact-audit.test.mjs
@@ -43,6 +43,27 @@ test("artifact audit parsers handle git worktrees, branches, and tmux panes", ()
   ]);
 });
 
+test("artifact audit excludes non-fooks omx worktree tmux panes by default", () => {
+  const cwd = "/work/fooks.omx-worktrees/fooks-current";
+  const result = auditArtifacts(cwd, {
+    pathExists: (target) => target === cwd || target === "/work/VibeQuant.omx-worktrees/vibequant-feature",
+    runner: makeRunner({
+      "git worktree list --porcelain": `worktree ${cwd}\nHEAD 111\nbranch refs/heads/fooks-current\n`,
+      "git rev-parse --verify origin/main": "origin-main-sha\n",
+      "git branch --format=%(refname:short)": "fooks-current\n",
+      "git branch --merged origin/main": "main\n",
+      "tmux list-panes -a -F #{session_name}\t#{pane_current_path}": [
+        `fooks-current\t${cwd}`,
+        "vibequant\t/work/VibeQuant.omx-worktrees/vibequant-feature",
+      ].join("\n"),
+    }),
+  });
+
+  assert.deepEqual(result.sessions.map((item) => item.session), ["fooks-current"]);
+  assert.equal(result.sessions.find((item) => item.session === "vibequant"), undefined);
+  assert.ok(!result.manualCleanupCommands.some((command) => command.includes("vibequant")));
+});
+
 test("artifact audit reports conservative candidates and only manual cleanup commands", () => {
   const cwd = "/repo/fooks-main";
   const existing = new Set([


### PR DESCRIPTION
Closes #190

## Summary
- tighten artifact audit fooks-signal matching so `.omx-worktrees` alone no longer admits unrelated project panes
- add regression coverage for a non-fooks VibeQuant OMX worktree pane being excluded
- keep audit behavior read-only/conservative with manual cleanup suggestions only

## Tests
- npm run build
- node --test test/artifact-audit.test.mjs test/fooks.test.mjs
- git diff --check