### PR TITLE
Define frontend domain fixture expectations

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -1,0 +1,41 @@
+# Frontend domain fixture expectations
+
+This document is the first fixture expectation baseline for the RN/WebView/TUI domain-profile roadmap. It does **not** add runtime support, extractor behavior, setup eligibility, or public support wording. It only records which small local fixture slots should currently extract, fallback, or remain deferred before any later narrow implementation plan.
+
+## Source policy
+
+Selected first-pass fixtures are limited to `existing-local` or `synthetic-local` sources. Public repository candidates from `docs/rn-webview-fixture-candidates.md` remain reference-only for this pass. The first pass must not copy, vendor, or live-fetch external repository files.
+
+## Selected fixture expectations
+
+| Slot | ID | Lane | Source kind | Path | Expected outcome | Required proof |
+| --- | --- | --- | --- | --- | --- | --- |
+| F0 | `react-web-regression-form-controls` | React web regression | `existing-local` | `fixtures/compressed/FormControls.tsx` | `extract` | Existing React web extraction remains non-empty and current regressions pass. |
+| F1 | `rn-primitive-basic` | RN primitive/interaction | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN primitives do not become DOM/form semantics. |
+| F3 | `webview-boundary-basic` | WebView boundary | `synthetic-local` | `test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | WebView `source`, injected JS, and `onMessage` remain boundary-first. |
+| F5 | `tui-ink-basic` | TUI/Ink candidate | `synthetic-local` | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `extract` | This is only TSX/JSX extraction evidence for an Ink-like file; it is not a broad TUI support claim. |
+| F6 | `negative-rn-webview-boundary` | Negative fallback | `synthetic-local` | `test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN/WebView bridge-like markers do not receive compact payload reuse. |
+
+The machine-readable fixture expectation manifest is `test/fixtures/frontend-domain-expectations/manifest.json`.
+
+## Deferred fixture slots
+
+| Slot | ID | Lane | Reason |
+| --- | --- | --- | --- |
+| F2 | `rn-style-platform-navigation` | RN style/platform/navigation | `StyleSheet.create`, `Platform.select`, `.ios` / `.android`, and navigation semantics expand beyond the first evidence baseline. |
+| F4 | `webview-bridge-pair` | WebView bridge | Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning. |
+
+These deferrals do not block the current evidence baseline. They prevent platform/navigation and bridge/security semantics from being mixed into the first fixture expectation pass.
+
+## Forbidden claims
+
+This baseline must not imply any of the following support promotions:
+
+- React Native availability or current support.
+- WebView availability or current support.
+- TUI availability or current support.
+- WebView compact-payload reuse or bridge safety promotion.
+
+## Promotion boundary
+
+A later implementation plan may use this baseline as evidence, but it must still pass a separate approval step before changing runtime behavior, setup eligibility, support wording, or WebView compact-payload policy.

--- a/docs/frontend-domain-profiles.md
+++ b/docs/frontend-domain-profiles.md
@@ -67,5 +67,5 @@ Do not introduce extractor behavior for RN, WebView, or TUI from an abstract pro
 ## Next executable lanes
 
 1. **Docs/process lane** — keep this document, `docs/roadmap.md`, and `docs/rn-webview-fixture-candidates.md` aligned.
-2. **Fixture/test-shape lane** — select a small fixture corpus and expected outcomes without changing extraction behavior.
+2. **Fixture/test-shape lane** — maintain the selected/deferred fixture baseline and expected outcomes in [`Frontend domain fixture expectations`](frontend-domain-fixture-expectations.md) without changing extraction behavior.
 3. **Experimental implementation lane** — only after fixture/test-shape evidence is explicit and current web/RN-WebView fallback regressions are protected.

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "purpose": "Fixture expectation baseline for RN/WebView/TUI evidence planning; not runtime support.",
+  "selectedSourceKinds": ["existing-local", "synthetic-local"],
+  "forbiddenFirstPassSourceKinds": ["public-snapshot"],
+  "selected": [
+    {
+      "slot": "F0",
+      "id": "react-web-regression-form-controls",
+      "lane": "react-web",
+      "path": "fixtures/compressed/FormControls.tsx",
+      "sourceKind": "existing-local",
+      "sourceReference": "Existing local compressed React web fixture",
+      "expectedOutcome": "extract",
+      "requiredSignals": ["form", "input", "select", "textarea", "className"],
+      "forbiddenClaims": ["No RN/WebView/TUI support claim"],
+      "verification": "extractFile returns a non-empty React web extraction result"
+    },
+    {
+      "slot": "F1",
+      "id": "rn-primitive-basic",
+      "lane": "rn-primitive",
+      "path": "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local fixture, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": ["react-native import", "View", "Text", "TextInput", "Pressable"],
+      "forbiddenClaims": ["No React Native support claim", "No DOM/form semantic inference"],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    },
+    {
+      "slot": "F3",
+      "id": "webview-boundary-basic",
+      "lane": "webview-boundary",
+      "path": "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local fixture, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": ["react-native-webview import", "source", "injectedJavaScript", "onMessage"],
+      "forbiddenClaims": ["No WebView support claim", "No WebView compact payload reuse"],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    },
+    {
+      "slot": "F5",
+      "id": "tui-ink-basic",
+      "lane": "tui-ink",
+      "path": "test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local Ink-like TSX fixture, no ink dependency required for parsing",
+      "expectedOutcome": "extract",
+      "requiredSignals": ["Ink-like import", "Box", "Text", "useInput", "terminal layout"],
+      "forbiddenClaims": ["No broad TUI support claim", "No RN/WebView fallback boundary implied"],
+      "verification": "extractFile returns a non-empty TSX extraction result"
+    },
+    {
+      "slot": "F6",
+      "id": "negative-rn-webview-boundary",
+      "lane": "negative-fallback",
+      "path": "test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local fixture combining RN and WebView boundary markers",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": ["react-native import", "react-native-webview import", "html source", "onMessage"],
+      "forbiddenClaims": ["No compact payload reuse", "No bridge safety claim"],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    }
+  ],
+  "deferred": [
+    {
+      "slot": "F2",
+      "id": "rn-style-platform-navigation",
+      "lane": "rn-style-platform",
+      "sourceKind": "deferred",
+      "deferReason": "StyleSheet, Platform.select, .ios/.android, and navigation semantics expand beyond the first evidence baseline.",
+      "doesNotBlockBaseline": true
+    },
+    {
+      "slot": "F4",
+      "id": "webview-bridge-pair",
+      "lane": "webview-bridge",
+      "sourceKind": "deferred",
+      "deferReason": "Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning.",
+      "doesNotBlockBaseline": true
+    }
+  ]
+}

--- a/test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx
+++ b/test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx
@@ -1,0 +1,10 @@
+import { View } from "react-native";
+import { WebView } from "react-native-webview";
+
+export function UnsafeBridgePreview() {
+  return (
+    <View>
+      <WebView source={{ html: "<script>window.ReactNativeWebView.postMessage('x')</script>" }} onMessage={() => {}} />
+    </View>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
@@ -1,0 +1,13 @@
+import { Pressable, Text, TextInput, View } from "react-native";
+
+export function SearchRow() {
+  return (
+    <View accessibilityLabel="search row">
+      <Text>Search</Text>
+      <TextInput value="" placeholder="Filter" onChangeText={() => {}} />
+      <Pressable onPress={() => {}}>
+        <Text>Apply</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx
+++ b/test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx
@@ -1,0 +1,12 @@
+import { Box, Text, useInput } from "ink";
+
+export function CommandPalette({ focused }: { focused: boolean }) {
+  useInput(() => {});
+
+  return (
+    <Box flexDirection="column">
+      <Text>{focused ? "Focused" : "Idle"}</Text>
+      <Text>Press enter to run</Text>
+    </Box>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx
+++ b/test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx
@@ -1,0 +1,11 @@
+import { WebView } from "react-native-webview";
+
+export function CheckoutWebView() {
+  return (
+    <WebView
+      source={{ uri: "https://example.test/checkout" }}
+      injectedJavaScript="window.ReactNativeWebView.postMessage('ready')"
+      onMessage={() => {}}
+    />
+  );
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3658,8 +3658,10 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   const taxonomy = fs.readFileSync(path.join(repoRoot, "docs", "frontend-scope-taxonomy.md"), "utf8");
   const candidates = fs.readFileSync(path.join(repoRoot, "docs", "rn-webview-fixture-candidates.md"), "utf8");
   const architecture = fs.readFileSync(path.join(repoRoot, "docs", "rn-webview-architecture.md"), "utf8");
+  const domainProfiles = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-profiles.md"), "utf8");
+  const fixtureExpectations = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
   const preRead = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
-  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}\n${architecture}`;
+  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}\n${architecture}\n${domainProfiles}\n${fixtureExpectations}`;
 
   assert.match(combined, /React Native(?:\/WebView| and embedded WebView| \/ embedded WebView)/);
   assert.match(combined, /TSX parsing is (?:syntax-level|only syntax-level)|\.tsx` parse is not semantic evidence/);
@@ -3667,6 +3669,15 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.match(combined, /React Native \/ WebView promotion ladder/);
   assert.match(roadmap, /React Native \/ WebView fixture candidate survey/);
   assert.match(roadmap, /React Native \/ WebView architecture direction/);
+  assert.match(domainProfiles, /Frontend domain profile roadmap/);
+  assert.match(domainProfiles, /Layer 0 — boundary and eligibility policy/);
+  assert.match(domainProfiles, /unsupported-react-native-webview-boundary/);
+  assert.match(domainProfiles, /WebView boundary profile/);
+  assert.match(domainProfiles, /TUI\/Ink candidate profile/);
+  assert.match(domainProfiles, /Frontend domain fixture expectations/);
+  assert.match(fixtureExpectations, /selected\/deferred fixture baseline|Selected fixture expectations/);
+  assert.match(fixtureExpectations, /public repository candidates .* reference-only/is);
+  assert.match(fixtureExpectations, /WebView compact-payload reuse or bridge safety promotion/);
   assert.match(candidates, /React Native \/ WebView fixture candidate survey/);
   assert.match(candidates, /React Native \/ WebView architecture direction/);
   assert.match(architecture, /shared TypeScript AST core, separate domain signal profiles/);
@@ -3693,8 +3704,12 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.doesNotMatch(combined, /React Native(?: \/ WebView)? is supported today/i);
   assert.doesNotMatch(combined, /default WebView compact extraction is enabled/i);
   assert.doesNotMatch(combined, /React Native(?: \/ WebView)? support will ship/i);
+  assert.doesNotMatch(combined, /WebView support is available/i);
+  assert.doesNotMatch(combined, /WebView is supported today/i);
+  assert.doesNotMatch(combined, /WebView compact payload reuse is supported/i);
+  assert.doesNotMatch(combined, /TUI support is available/i);
+  assert.doesNotMatch(combined, /TUI is supported today/i);
 });
-
 
 test("docs describe TUI/Ink fixture survey as future candidate evidence only", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
@@ -3730,6 +3745,57 @@ test("docs describe TUI/Ink fixture survey as future candidate evidence only", (
   assert.doesNotMatch(survey, /runtime-token savings/i);
   assert.doesNotMatch(survey, /provider cost savings/i);
   assert.doesNotMatch(survey, /billing savings/i);
+});
+
+test("frontend domain fixture expectations keep exact local outcomes", () => {
+  const expectationsPath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json");
+  const expectations = JSON.parse(fs.readFileSync(expectationsPath, "utf8"));
+  const selected = new Map(expectations.selected.map((item) => [item.slot, item]));
+  const deferred = new Map(expectations.deferred.map((item) => [item.slot, item]));
+
+  assert.deepEqual([...selected.keys()], ["F0", "F1", "F3", "F5", "F6"]);
+  assert.deepEqual([...deferred.keys()], ["F2", "F4"]);
+  assert.deepEqual(expectations.forbiddenFirstPassSourceKinds, ["public-snapshot"]);
+
+  for (const item of selected.values()) {
+    assert.ok(["existing-local", "synthetic-local"].includes(item.sourceKind), `${item.id} must stay local/synthetic`);
+    assert.ok(["extract", "fallback", "unsupported"].includes(item.expectedOutcome), `${item.id} must have one expected outcome`);
+    assert.notEqual(item.sourceKind, "public-snapshot", `${item.id} must not use public snapshots in the first pass`);
+    assert.ok(!/github\.com|https?:\/\//i.test(item.sourceReference), `${item.id} must not depend on copied/vendor public repo source`);
+  }
+
+  assert.equal(selected.get("F0").expectedOutcome, "extract");
+  assert.equal(selected.get("F1").expectedOutcome, "fallback");
+  assert.equal(selected.get("F1").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F3").expectedOutcome, "fallback");
+  assert.equal(selected.get("F3").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F5").expectedOutcome, "extract");
+  assert.equal(selected.get("F6").expectedOutcome, "fallback");
+  assert.equal(selected.get("F6").expectedReason, "unsupported-react-native-webview-boundary");
+
+  for (const item of deferred.values()) {
+    assert.equal(item.sourceKind, "deferred");
+    assert.match(item.deferReason, /\S/);
+    assert.equal(item.doesNotBlockBaseline, true);
+  }
+
+  const reactWeb = extractFile(path.join(repoRoot, selected.get("F0").path));
+  assert.equal(reactWeb.language, "tsx");
+  assert.ok(["compressed", "hybrid", "raw"].includes(reactWeb.mode));
+  assert.ok(reactWeb.componentName || reactWeb.structure?.jsx?.length > 0);
+
+  const tuiInk = extractFile(path.join(repoRoot, selected.get("F5").path));
+  assert.equal(tuiInk.language, "tsx");
+  assert.ok(["compressed", "hybrid", "raw"].includes(tuiInk.mode));
+  assert.equal(tuiInk.componentName, "CommandPalette");
+
+  for (const slot of ["F1", "F3", "F6"]) {
+    const item = selected.get(slot);
+    const decision = preReadModule.decidePreRead(path.join(repoRoot, item.path), repoRoot, "codex");
+    assert.equal(decision.decision, "fallback", `${item.id} should stay fallback-first`);
+    assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
+    assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
+  }
 });
 
 test("docs give first-run users a clear support and diagnosis path", () => {


### PR DESCRIPTION
Re-opened after #194 merge closed the previous PR #195.\n\n- Rebased onto main after #194 squash merge\n- Resolved conflicts in test/fooks.test.mjs (kept both main assertions and new fixture expectation tests)\n- Added docs/frontend-domain-fixture-expectations.md and fixture files