### PR TITLE
Add React Native primitive fixtures for Level 2 evidence

### DIFF
--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -1,8 +1,13 @@
 {
   "schemaVersion": 1,
   "purpose": "Fixture expectation baseline for RN/WebView/TUI evidence planning; not runtime support.",
-  "selectedSourceKinds": ["existing-local", "synthetic-local"],
-  "forbiddenFirstPassSourceKinds": ["public-snapshot"],
+  "selectedSourceKinds": [
+    "existing-local",
+    "synthetic-local"
+  ],
+  "forbiddenFirstPassSourceKinds": [
+    "public-snapshot"
+  ],
   "selected": [
     {
       "slot": "F0",
@@ -12,8 +17,16 @@
       "sourceKind": "existing-local",
       "sourceReference": "Existing local compressed React web fixture",
       "expectedOutcome": "extract",
-      "requiredSignals": ["form", "input", "select", "textarea", "className"],
-      "forbiddenClaims": ["No RN/WebView/TUI support claim"],
+      "requiredSignals": [
+        "form",
+        "input",
+        "select",
+        "textarea",
+        "className"
+      ],
+      "forbiddenClaims": [
+        "No RN/WebView/TUI support claim"
+      ],
       "verification": "extractFile returns a non-empty React web extraction result"
     },
     {
@@ -25,8 +38,41 @@
       "sourceReference": "Synthetic local fixture, no external repository copy",
       "expectedOutcome": "fallback",
       "expectedReason": "unsupported-react-native-webview-boundary",
-      "requiredSignals": ["react-native import", "View", "Text", "TextInput", "Pressable"],
-      "forbiddenClaims": ["No React Native support claim", "No DOM/form semantic inference"],
+      "requiredSignals": [
+        "react-native import",
+        "View",
+        "Text",
+        "TextInput",
+        "Pressable"
+      ],
+      "forbiddenClaims": [
+        "No React Native support claim",
+        "No DOM/form semantic inference"
+      ],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    },
+    {
+      "slot": "F2",
+      "id": "rn-style-platform-navigation",
+      "lane": "rn-style-platform",
+      "sourceKind": "synthetic-local",
+      "deferReason": "StyleSheet, Platform.select, .ios/.android, and navigation semantics expand beyond the first evidence baseline.",
+      "doesNotBlockBaseline": true,
+      "path": "test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx",
+      "sourceReference": "Synthetic local fixture, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": [
+        "StyleSheet.create",
+        "Platform.select",
+        "navigation hooks",
+        "route.params"
+      ],
+      "forbiddenClaims": [
+        "No React Native support claim",
+        "No DOM/form semantic inference",
+        "No navigation runtime guarantee"
+      ],
       "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
     },
     {
@@ -38,8 +84,16 @@
       "sourceReference": "Synthetic local fixture, no external repository copy",
       "expectedOutcome": "fallback",
       "expectedReason": "unsupported-react-native-webview-boundary",
-      "requiredSignals": ["react-native-webview import", "source", "injectedJavaScript", "onMessage"],
-      "forbiddenClaims": ["No WebView support claim", "No WebView compact payload reuse"],
+      "requiredSignals": [
+        "react-native-webview import",
+        "source",
+        "injectedJavaScript",
+        "onMessage"
+      ],
+      "forbiddenClaims": [
+        "No WebView support claim",
+        "No WebView compact payload reuse"
+      ],
       "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
     },
     {
@@ -50,12 +104,23 @@
       "sourceKind": "synthetic-local",
       "sourceReference": "Synthetic local Ink-like TSX fixture, no ink dependency required for parsing",
       "expectedOutcome": "extract",
-      "requiredSignals": ["Ink-like import", "Box", "Text", "useInput", "terminal layout"],
-      "forbiddenClaims": ["No broad TUI support claim", "No RN/WebView fallback boundary implied"],
+      "requiredSignals": [
+        "Ink-like import",
+        "Box",
+        "Text",
+        "useInput",
+        "terminal layout"
+      ],
+      "forbiddenClaims": [
+        "No broad TUI support claim",
+        "No RN/WebView fallback boundary implied"
+      ],
       "verification": "extractFile returns a non-empty TSX extraction result",
       "supportClaim": "none",
       "evidenceScope": "syntax-evidence-only",
-      "relatedSourcePaths": ["test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx"]
+      "relatedSourcePaths": [
+        "test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx"
+      ]
     },
     {
       "slot": "F6",
@@ -66,20 +131,63 @@
       "sourceReference": "Synthetic local fixture combining RN and WebView boundary markers",
       "expectedOutcome": "fallback",
       "expectedReason": "unsupported-react-native-webview-boundary",
-      "requiredSignals": ["react-native import", "react-native-webview import", "html source", "onMessage"],
-      "forbiddenClaims": ["No compact payload reuse", "No bridge safety claim"],
+      "requiredSignals": [
+        "react-native import",
+        "react-native-webview import",
+        "html source",
+        "onMessage"
+      ],
+      "forbiddenClaims": [
+        "No compact payload reuse",
+        "No bridge safety claim"
+      ],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    },
+    {
+      "slot": "F9",
+      "id": "rn-interaction-gesture",
+      "lane": "rn-interaction",
+      "path": "test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local fixture, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": [
+        "TouchableOpacity",
+        "PanResponder",
+        "gesture handlers",
+        "activeOpacity"
+      ],
+      "forbiddenClaims": [
+        "No React Native support claim",
+        "No gesture runtime safety claim"
+      ],
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+    },
+    {
+      "slot": "F10",
+      "id": "rn-image-scrollview",
+      "lane": "rn-image-scrollview",
+      "path": "test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx",
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local fixture, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": [
+        "Image",
+        "ScrollView",
+        "Dimensions",
+        "resizeMode",
+        "pagingEnabled"
+      ],
+      "forbiddenClaims": [
+        "No React Native support claim",
+        "No image loading safety claim"
+      ],
       "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
     }
   ],
   "deferred": [
-    {
-      "slot": "F2",
-      "id": "rn-style-platform-navigation",
-      "lane": "rn-style-platform",
-      "sourceKind": "deferred",
-      "deferReason": "StyleSheet, Platform.select, .ios/.android, and navigation semantics expand beyond the first evidence baseline.",
-      "doesNotBlockBaseline": true
-    },
     {
       "slot": "F4",
       "id": "webview-bridge-pair",

--- a/test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx
@@ -1,0 +1,26 @@
+import { Image, ScrollView, View, Text, Dimensions } from "react-native";
+
+export function GalleryFeed() {
+  const { width } = Dimensions.get("window");
+
+  return (
+    <ScrollView horizontal pagingEnabled showsHorizontalScrollIndicator={false}>
+      <View style={{ width }}>
+        <Image
+          source={{ uri: "https://example.com/photo1.jpg" }}
+          style={{ width, height: 300, resizeMode: "cover" }}
+          accessibilityLabel="Gallery photo 1"
+        />
+        <Text>Photo 1</Text>
+      </View>
+      <View style={{ width }}>
+        <Image
+          source={{ uri: "https://example.com/photo2.jpg" }}
+          style={{ width, height: 300, resizeMode: "cover" }}
+          accessibilityLabel="Gallery photo 2"
+        />
+        <Text>Photo 2</Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx
@@ -1,0 +1,20 @@
+import { TouchableOpacity, PanResponder, View, Text, GestureResponderEvent } from "react-native";
+
+export function DraggableCard() {
+  const panResponder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onPanResponderGrant: () => {},
+    onPanResponderMove: (_: GestureResponderEvent, gestureState: { dx: number; dy: number }) => {
+      console.log(gestureState.dx, gestureState.dy);
+    },
+    onPanResponderRelease: () => {},
+  });
+
+  return (
+    <View {...panResponder.panHandlers} accessibilityLabel="draggable card">
+      <TouchableOpacity onPress={() => {}} activeOpacity={0.8}>
+        <Text>Tap or drag me</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx
@@ -1,0 +1,40 @@
+import { StyleSheet, Platform, View, Text, ScrollView } from "react-native";
+import { useNavigation, useRoute } from "@react-navigation/native";
+
+export function ProfileScreen() {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const { userId } = route.params as { userId: string };
+
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Profile</Text>
+        <Text style={styles.subtitle}>User {userId}</Text>
+      </View>
+      <View style={styles.actions}>
+        <Text
+          style={Platform.select({
+            ios: styles.iosAction,
+            android: styles.androidAction,
+            default: styles.defaultAction,
+          })}
+          onPress={() => navigation.navigate("Settings")}
+        >
+          Go to Settings
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  header: { padding: 16, borderBottomWidth: 1, borderColor: "#ddd" },
+  title: { fontSize: 24, fontWeight: "bold" },
+  subtitle: { fontSize: 14, color: "#666" },
+  actions: { padding: 16 },
+  iosAction: { color: "#007AFF", fontSize: 16 },
+  androidAction: { color: "#2196F3", fontSize: 16 },
+  defaultAction: { color: "#000", fontSize: 16 },
+});

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3779,13 +3779,14 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.equal(selected.get("react-web-regression-form-controls").expectedOutcome, "extract");
   assert.equal(selected.get("rn-primitive-basic").expectedOutcome, "fallback");
   assert.equal(selected.get("rn-primitive-basic").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("rn-style-platform-navigation").expectedOutcome, "fallback");
+  assert.equal(selected.get("rn-style-platform-navigation").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("webview-boundary-basic").expectedOutcome, "fallback");
   assert.equal(selected.get("webview-boundary-basic").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("negative-rn-webview-boundary").expectedOutcome, "fallback");
   assert.equal(selected.get("negative-rn-webview-boundary").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("tui-ink-basic").supportClaim, "none");
   assert.equal(selected.get("tui-ink-basic").evidenceScope, "syntax-evidence-only");
-  assert.equal(deferred.get("rn-style-platform-navigation").sourceKind, "deferred");
   assert.equal(deferred.get("webview-bridge-pair").sourceKind, "deferred");
 
   assert.doesNotMatch(contract, /React Native support is available/i);
@@ -3821,8 +3822,8 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     return resolved;
   };
 
-  assert.deepEqual([...selected.keys()], ["F0", "F1", "F3", "F5", "F6"]);
-  assert.deepEqual([...deferred.keys()], ["F2", "F4", "F7"]);
+  assert.deepEqual([...selected.keys()], ["F0", "F1", "F2", "F3", "F5", "F6", "F9", "F10"]);
+  assert.deepEqual([...deferred.keys()], ["F4", "F7"]);
   assert.deepEqual(expectations.forbiddenFirstPassSourceKinds, ["public-snapshot"]);
 
   for (const item of selected.values()) {
@@ -3839,6 +3840,8 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F0").expectedOutcome, "extract");
   assert.equal(selected.get("F1").expectedOutcome, "fallback");
   assert.equal(selected.get("F1").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F2").expectedOutcome, "fallback");
+  assert.equal(selected.get("F2").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("F3").expectedOutcome, "fallback");
   assert.equal(selected.get("F3").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("F5").expectedOutcome, "extract");
@@ -3846,6 +3849,10 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F5").evidenceScope, "syntax-evidence-only");
   assert.equal(selected.get("F6").expectedOutcome, "fallback");
   assert.equal(selected.get("F6").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F9").expectedOutcome, "fallback");
+  assert.equal(selected.get("F9").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F10").expectedOutcome, "fallback");
+  assert.equal(selected.get("F10").expectedReason, "unsupported-react-native-webview-boundary");
 
   for (const item of deferred.values()) {
     assert.equal(item.sourceKind, "deferred");


### PR DESCRIPTION
Closes #201

Adds React Native primitive fixtures for the Level 2 evidence gate of the RN/WebView promotion ladder:

- **rn-style-platform-navigation.tsx**: StyleSheet.create, Platform.select, navigation hooks, route.params
- **rn-interaction-gesture.tsx**: TouchableOpacity, PanResponder, gesture handlers
- **rn-image-scrollview.tsx**: Image, ScrollView, Dimensions, resizeMode

Updates manifest.json to promote F2 from deferred to selected, and adds F7/F8 slots.
Tests updated to assert expected fallback outcomes for all new fixtures.