### PR TITLE
Expose frontend domain detector evidence

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { extractFile } from "../core/extract";
+import { detectDomainFromSource } from "../core/domain-detector";
 import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/payload/model-facing";
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import type { PreReadDecision } from "../core/schema";
@@ -56,6 +57,7 @@ export function decidePreRead(
   }
 
   const sourceText = fs.readFileSync(resolvedPath, "utf8");
+  const domainDetection = detectDomainFromSource(sourceText, resolvedPath);
   if (hasReactNativeWebViewBoundaryMarker(sourceText)) {
     return {
       runtime,
@@ -63,7 +65,7 @@ export function decidePreRead(
       eligible: true,
       decision: "fallback",
       reasons: [REACT_NATIVE_WEBVIEW_BOUNDARY_REASON],
-      debug: {},
+      debug: { domainDetection },
       fallback: {
         action: "full-read",
         reason: REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
@@ -82,6 +84,7 @@ export function decidePreRead(
     decideReason: result.meta.decideReason,
     decideConfidence: result.meta.decideConfidence,
     language: result.language,
+    domainDetection,
   };
 
   if (readiness.ready) {

--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+export type DomainLabel = "react-web" | "react-native" | "webview" | "tui-ink" | "mixed" | "unknown";
+export type FrontendDomainClassification = DomainLabel;
+
+export type FrontendDomainEvidence = {
+  domain: Exclude<DomainLabel, "mixed" | "unknown">;
+  signal: string;
+  detail: string;
+};
+
+export type DomainDetectionResult = {
+  classification: FrontendDomainClassification;
+  /** @deprecated Use classification. */
+  domain: DomainLabel;
+  evidence: FrontendDomainEvidence[];
+  /** @deprecated Use evidence. */
+  signals: string[];
+};
+
+const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
+const RN_MODULE = "react-native";
+const WEBVIEW_MODULE = "react-native-webview";
+const INK_MODULE = "ink";
+const RN_PRIMITIVES = new Set(["View", "Text", "Image", "ScrollView", "Pressable", "TouchableOpacity"]);
+const WEB_DOM_TAGS = new Set(["div", "span", "form", "input", "button", "select", "textarea", "label"]);
+const WEBVIEW_PROPS = new Set(["source", "injectedJavaScript", "onMessage"]);
+const TUI_PRIMITIVES = new Set(["Box", "Text"]);
+const TUI_HOOKS = new Set(["useInput"]);
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".tsx") return ts.ScriptKind.TSX;
+  if (ext === ".jsx") return ts.ScriptKind.JSX;
+  if (ext === ".js") return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function addEvidence(
+  evidence: FrontendDomainEvidence[],
+  domain: FrontendDomainEvidence["domain"],
+  signal: string,
+  detail: string,
+): void {
+  if (evidence.some((item) => item.domain === domain && item.signal === signal && item.detail === detail)) return;
+  evidence.push({ domain, signal, detail });
+}
+
+function hasEvidence(evidence: FrontendDomainEvidence[], domain: FrontendDomainEvidence["domain"]): boolean {
+  return evidence.some((item) => item.domain === domain);
+}
+
+function signalList(evidence: FrontendDomainEvidence[]): string[] {
+  return evidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`);
+}
+
+function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): DomainDetectionResult {
+  const domainEvidence = ["react-native", "webview", "tui-ink"] as const;
+  const matched = domainEvidence.filter((domain) => hasEvidence(evidence, domain));
+  let classification: DomainLabel;
+  if (matched.length > 1) {
+    classification = "mixed";
+  } else if (matched.length === 1) {
+    classification = matched[0];
+  } else if (hasWebDom) {
+    classification = "react-web";
+  } else {
+    classification = "unknown";
+  }
+
+  return {
+    classification,
+    domain: classification,
+    evidence,
+    signals: signalList(evidence),
+  };
+}
+
+export function detectDomainFromSource(sourceText: string, filePath = "source.tsx"): DomainDetectionResult {
+  if (!FRONTEND_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
+    return classify([], false);
+  }
+
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
+  const importedNamesByModule = new Map<string, Set<string>>();
+  const evidence: FrontendDomainEvidence[] = [];
+  let hasWebDom = false;
+
+  function rememberImportedName(moduleName: string, name: string): void {
+    const names = importedNamesByModule.get(moduleName) ?? new Set<string>();
+    names.add(name);
+    importedNamesByModule.set(moduleName, names);
+  }
+
+  function hasImportedName(moduleName: string, name: string): boolean {
+    return importedNamesByModule.get(moduleName)?.has(name) === true;
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const moduleName = node.moduleSpecifier.text;
+      if (moduleName === RN_MODULE || moduleName.startsWith(`${RN_MODULE}/`)) {
+        addEvidence(evidence, "react-native", "import", moduleName);
+      }
+      if (moduleName === WEBVIEW_MODULE) {
+        addEvidence(evidence, "webview", "import", moduleName);
+      }
+      if (moduleName === INK_MODULE) {
+        addEvidence(evidence, "tui-ink", "import", moduleName);
+      }
+
+      const importClause = node.importClause;
+      if (importClause?.name) rememberImportedName(moduleName, importClause.name.text);
+      if (importClause?.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
+        for (const element of importClause.namedBindings.elements) {
+          rememberImportedName(moduleName, element.name.text);
+        }
+      }
+    }
+
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
+      const [specifier] = node.arguments;
+      if (specifier && ts.isStringLiteral(specifier)) {
+        const moduleName = specifier.text;
+        if (moduleName === RN_MODULE || moduleName.startsWith(`${RN_MODULE}/`)) addEvidence(evidence, "react-native", "require", moduleName);
+        if (moduleName === WEBVIEW_MODULE) addEvidence(evidence, "webview", "require", moduleName);
+        if (moduleName === INK_MODULE) addEvidence(evidence, "tui-ink", "require", moduleName);
+      }
+    }
+
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tagName = node.tagName;
+      const tag = ts.isIdentifier(tagName) ? tagName.text : ts.isPropertyAccessExpression(tagName) ? tagName.name.text : undefined;
+      if (tag) {
+        if (RN_PRIMITIVES.has(tag) && hasImportedName(RN_MODULE, tag)) addEvidence(evidence, "react-native", "primitive", tag);
+        if (tag === "WebView" && hasImportedName(WEBVIEW_MODULE, tag)) addEvidence(evidence, "webview", "component", tag);
+        if (TUI_PRIMITIVES.has(tag) && hasImportedName(INK_MODULE, tag)) addEvidence(evidence, "tui-ink", "primitive", tag);
+        if (WEB_DOM_TAGS.has(tag)) hasWebDom = true;
+      }
+    }
+
+    if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name) && WEBVIEW_PROPS.has(node.name.text) && hasEvidence(evidence, "webview")) {
+      addEvidence(evidence, "webview", "prop", node.name.text);
+    }
+
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const expression = node.expression.expression;
+      const property = node.expression.name.text;
+      if (ts.isIdentifier(expression) && expression.text === "StyleSheet" && property === "create") {
+        addEvidence(evidence, "react-native", "style-factory", "StyleSheet.create");
+      }
+      if (ts.isIdentifier(expression) && expression.text === "Platform" && property === "select") {
+        addEvidence(evidence, "react-native", "platform-select", "Platform.select");
+      }
+    }
+
+    if (ts.isIdentifier(node) && TUI_HOOKS.has(node.text) && hasImportedName(INK_MODULE, node.text)) {
+      addEvidence(evidence, "tui-ink", "hook", node.text);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return classify(evidence, hasWebDom);
+}
+
+export function detectDomain(filePath: string): DomainDetectionResult {
+  const sourceText = FRONTEND_EXTENSIONS.has(path.extname(filePath).toLowerCase()) ? fs.readFileSync(filePath, "utf8") : "";
+  return detectDomainFromSource(sourceText, filePath);
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,4 +1,5 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
+import type { DomainDetectionResult } from "./domain-detector";
 
 export type OutputMode = "raw" | "compressed" | "hybrid";
 export type Language = "tsx" | "jsx" | "ts" | "js";
@@ -215,6 +216,7 @@ export type PreReadDecision = {
     decideReason?: string[];
     decideConfidence?: DecisionConfidence;
     language?: ExtractionResult["language"];
+    domainDetection?: DomainDetectionResult;
   };
   fallback?: {
     action: "full-read";

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -1,0 +1,89 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomain, detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+
+const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
+const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|default WebView compact extraction is enabled/i;
+
+function assertSignals(result, expectedSignals) {
+  for (const signal of expectedSignals) {
+    assert.ok(result.signals.includes(signal), `missing signal ${signal}`);
+  }
+}
+
+test("detects React Native evidence signals without support wording", () => {
+  const primitive = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
+  assert.equal(primitive.classification, "react-native");
+  assert.equal(primitive.domain, "react-native");
+  assertSignals(primitive, [
+    "react-native:import:react-native",
+    "react-native:primitive:View",
+    "react-native:primitive:Text",
+    "react-native:primitive:Pressable",
+  ]);
+
+  const styled = detectDomain(path.join(fixtureRoot, "rn-style-platform-navigation.tsx"));
+  assert.equal(styled.classification, "react-native");
+  assertSignals(styled, [
+    "react-native:primitive:ScrollView",
+    "react-native:style-factory:StyleSheet.create",
+    "react-native:platform-select:Platform.select",
+  ]);
+
+  const image = detectDomain(path.join(fixtureRoot, "rn-image-scrollview.tsx"));
+  assert.equal(image.classification, "react-native");
+  assertSignals(image, ["react-native:primitive:Image", "react-native:primitive:ScrollView"]);
+
+  const touchable = detectDomain(path.join(fixtureRoot, "rn-interaction-gesture.tsx"));
+  assert.equal(touchable.classification, "react-native");
+  assertSignals(touchable, ["react-native:primitive:TouchableOpacity"]);
+
+  assert.doesNotMatch(JSON.stringify([primitive, styled, image, touchable]), forbiddenSupportClaims);
+});
+
+test("detects WebView evidence signals without support wording", () => {
+  const result = detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
+  assert.equal(result.classification, "webview");
+  assertSignals(result, [
+    "webview:import:react-native-webview",
+    "webview:component:WebView",
+    "webview:prop:source",
+    "webview:prop:injectedJavaScript",
+    "webview:prop:onMessage",
+  ]);
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+});
+
+test("detects TUI Ink evidence signals without support wording", () => {
+  const result = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
+  assert.equal(result.classification, "tui-ink");
+  assertSignals(result, ["tui-ink:import:ink", "tui-ink:primitive:Box", "tui-ink:primitive:Text", "tui-ink:hook:useInput"]);
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+});
+
+test("classifies mixed and unknown fallback cases", () => {
+  const mixed = detectDomain(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
+  assert.equal(mixed.classification, "mixed");
+  assert.ok(mixed.signals.some((signal) => signal.startsWith("react-native:")));
+  assert.ok(mixed.signals.some((signal) => signal.startsWith("webview:")));
+
+  const unknown = detectDomainFromSource("export const answer = 42;", "utility.ts");
+  assert.equal(unknown.classification, "unknown");
+  assert.deepEqual(unknown.evidence, []);
+
+  assert.doesNotMatch(JSON.stringify([mixed, unknown]), forbiddenSupportClaims);
+});
+
+test("changed detector source does not introduce forbidden support wording", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "src", "core", "domain-detector.ts"), "utf8");
+  assert.doesNotMatch(source, forbiddenSupportClaims);
+});

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -27,6 +27,7 @@ const {
 const { RAW_ORIGINAL_SIZE_THRESHOLD_BYTES } = require(path.join(repoRoot, "dist", "core", "decide.js"));
 const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 const { assessPayloadReadiness } = require(path.join(repoRoot, "dist", "core", "payload", "readiness.js"));
+const { detectDomain, detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
 const codexPreReadModule = require(path.join(repoRoot, "dist", "adapters", "codex-pre-read.js"));
 const { decideCodexPreRead } = codexPreReadModule;
 const preReadModule = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
@@ -961,6 +962,82 @@ test("readiness helper uses stable reasons and ignores debug metadata", () => {
 
   assert.equal(compressedReadiness.signals.usedComplexityScore, false);
   assert.equal(compressedReadiness.signals.usedDecideReason, false);
+});
+
+test("frontend domain detector returns evidence-only classifications for Level 3 signals", () => {
+  const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
+
+  const rn = detectDomain(path.join(fixtureRoot, "rn-style-platform-navigation.tsx"));
+  assert.equal(rn.classification, "react-native");
+  assert.equal(rn.domain, "react-native");
+  assert.ok(rn.signals.includes("react-native:import:react-native"));
+  assert.ok(rn.signals.includes("react-native:primitive:View"));
+  assert.ok(rn.signals.includes("react-native:primitive:Text"));
+  assert.ok(rn.signals.includes("react-native:primitive:ScrollView"));
+  assert.ok(rn.signals.includes("react-native:style-factory:StyleSheet.create"));
+  assert.ok(rn.signals.includes("react-native:platform-select:Platform.select"));
+
+  const image = detectDomain(path.join(fixtureRoot, "rn-image-scrollview.tsx"));
+  assert.equal(image.classification, "react-native");
+  assert.ok(image.signals.includes("react-native:primitive:Image"));
+  assert.ok(image.signals.includes("react-native:primitive:ScrollView"));
+
+  const pressable = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
+  assert.equal(pressable.classification, "react-native");
+  assert.ok(pressable.signals.includes("react-native:primitive:Pressable"));
+
+  const touchable = detectDomain(path.join(fixtureRoot, "rn-interaction-gesture.tsx"));
+  assert.equal(touchable.classification, "react-native");
+  assert.ok(touchable.signals.includes("react-native:primitive:TouchableOpacity"));
+
+  const webview = detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
+  assert.equal(webview.classification, "webview");
+  assert.ok(webview.signals.includes("webview:import:react-native-webview"));
+  assert.ok(webview.signals.includes("webview:component:WebView"));
+  assert.ok(webview.signals.includes("webview:prop:source"));
+  assert.ok(webview.signals.includes("webview:prop:injectedJavaScript"));
+  assert.ok(webview.signals.includes("webview:prop:onMessage"));
+
+  const tui = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
+  assert.equal(tui.classification, "tui-ink");
+  assert.ok(tui.signals.includes("tui-ink:import:ink"));
+  assert.ok(tui.signals.includes("tui-ink:primitive:Box"));
+  assert.ok(tui.signals.includes("tui-ink:primitive:Text"));
+  assert.ok(tui.signals.includes("tui-ink:hook:useInput"));
+
+  const mixed = detectDomain(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
+  assert.equal(mixed.classification, "mixed");
+  assert.ok(mixed.signals.some((signal) => signal.startsWith("react-native:")));
+  assert.ok(mixed.signals.some((signal) => signal.startsWith("webview:")));
+
+  const unknown = detectDomainFromSource("export const answer = 42;", "utility.ts");
+  assert.equal(unknown.classification, "unknown");
+  assert.deepEqual(unknown.evidence, []);
+});
+
+test("frontend domain detector and pre-read debug avoid RN WebView TUI support wording", () => {
+  const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|default WebView compact extraction is enabled/i;
+  const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
+  const results = [
+    detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx")),
+    detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx")),
+    detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx")),
+    detectDomain(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx")),
+    detectDomainFromSource("export const answer = 42;", "utility.ts"),
+    preReadModule.decidePreRead(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"), repoRoot, "codex").debug.domainDetection,
+  ];
+
+  for (const result of results) {
+    assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+    assert.ok(Array.isArray(result.evidence), "detector result must carry evidence");
+    assert.equal(typeof result.classification, "string");
+  }
+
+  const changedSource = [
+    fs.readFileSync(path.join(repoRoot, "src", "core", "domain-detector.ts"), "utf8"),
+    fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8"),
+  ].join("\n");
+  assert.doesNotMatch(changedSource, forbiddenSupportClaims);
 });
 
 test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise", () => {


### PR DESCRIPTION
## Summary
- Adds an AST-based frontend domain detector for React Native, WebView, TUI/Ink, mixed, unknown, and React web classifications.
- Wires detector output into pre-read debug metadata only, preserving RN/WebView full-read fallback behavior.
- Adds dedicated and integration tests proving requested signals and guarding against RN/WebView/TUI support wording.

Closes #203.

## Verification
- npm run lint
- node --test test/domain-detector.test.mjs
- npm run build && node --test test/fooks.test.mjs

## Notes
- Detector output is evidence/classification only; it does not promote runtime support, setup eligibility, or WebView compact extraction.
