### PR TITLE
feat: expose domainDetection in extract output

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import ts from "typescript";
 import { hashText } from "./hash";
 import { decideMode } from "./decide";
+import { detectDomainFromSource } from "./domain-detector";
 import type { ExtractionResult, FormSurface, Language, SourceRange, StyleSystem } from "./schema";
 
 const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer", "useLayoutEffect", "useContext", "useId", "useTransition"]);
@@ -644,12 +645,14 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
   }
 
   const { mode, complexityScore, reasons, confidence, useOriginal } = decideMode(base);
+  const domainDetection = detectDomainFromSource(sourceText, filePath);
   const result: ExtractionResult = {
     ...base,
     mode,
     useOriginal,
     rawText: mode === "raw" ? sourceText : undefined,
     snippets: mode === "hybrid" ? base.snippets : undefined,
+    domainDetection,
     meta: {
       ...base.meta,
       complexityScore,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -148,6 +148,7 @@ export type ExtractionResult = {
     decideReason?: string[];
     decideConfidence?: DecisionConfidence;
   };
+  domainDetection?: DomainDetectionResult;
 };
 
 export type ModelFacingPayload = {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1015,6 +1015,33 @@ test("frontend domain detector returns evidence-only classifications for Level 3
   assert.deepEqual(unknown.evidence, []);
 });
 
+test("extract output includes domainDetection for frontend fixtures", () => {
+  const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
+
+  const rn = extractFile(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
+  assert.ok(rn.domainDetection);
+  assert.equal(rn.domainDetection.classification, "react-native");
+  assert.ok(rn.domainDetection.signals.includes("react-native:primitive:View"));
+
+  const webview = extractFile(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
+  assert.ok(webview.domainDetection);
+  assert.equal(webview.domainDetection.classification, "webview");
+  assert.ok(webview.domainDetection.signals.includes("webview:component:WebView"));
+
+  const tui = extractFile(path.join(fixtureRoot, "tui-ink-basic.tsx"));
+  assert.ok(tui.domainDetection);
+  assert.equal(tui.domainDetection.classification, "tui-ink");
+  assert.ok(tui.domainDetection.signals.includes("tui-ink:primitive:Box"));
+
+  const mixed = extractFile(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
+  assert.ok(mixed.domainDetection);
+  assert.equal(mixed.domainDetection.classification, "mixed");
+
+  const unknown = extractFile(path.join(repoRoot, "package.json"));
+  assert.ok(unknown.domainDetection);
+  assert.equal(unknown.domainDetection.classification, "unknown");
+});
+
 test("frontend domain detector and pre-read debug avoid RN WebView TUI support wording", () => {
   const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|default WebView compact extraction is enabled/i;
   const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");


### PR DESCRIPTION
Exposes frontend domain detection results in fooks extract output so users can see domain classification (react-native, webview, tui-ink, etc.) alongside extracted file metadata.

Changes:
- Add domainDetection field to ExtractionResult schema
- Call detectDomainFromSource in extractSource pipeline
- Add integration test coverage

274 tests pass.