### PR TITLE
Expose domain detector evidence inspection

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -105,6 +105,15 @@ fooks compare src/components/Button.tsx --json
 
 `fooks compare` compares the original source bytes with the compact base model-facing payload used for context-reduction estimates. For compressed/hybrid frontend files, that payload comes from fooks' TypeScript AST-derived component contract, behavior, structure, style, bounded source-line ranges, a source fingerprint for freshness checks, hook/effect intent, and form/control signals rather than the full source text. The line ranges are AST-derived edit aids and should be treated as valid only for the matching source fingerprint. The token values are estimated from local byte counts, so this is a local model-facing payload estimate only; it excludes optional edit-guidance overhead. It is not provider tokenizer behavior, not runtime hook envelope overhead, not provider usage/billing tokens, invoices, dashboards, or charged costs, and not a `ccusage` replacement.
 
+To inspect the frontend domain detector evidence for one fixture or file without invoking extractor/profile behavior, run:
+
+```bash
+fooks inspect-domain test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx --json
+npm run smoke:domain-detector
+```
+
+The smoke script builds the local CLI and runs the same WebView fixture inspection as a quick docs-test hook. `fooks inspect-domain` emits only the detector classification, structured `domainDetection.evidence`, and a WebView fallback-first boundary marker when WebView evidence is present. It does not make RN/WebView/TUI support claims, does not enable compact payload reuse, and does not change runtime or pre-read behavior. Use it as a dogfood/debugging surface before any later profile-promotion work.
+
 When source ranges are present, `fooks extract <file> --model-payload` also emits compact `editGuidance`. Its `patchTargets` point agents at likely edit anchors such as component declarations, props, effects, callbacks, event handlers, form controls, submit handlers, validation anchors, and representative snippets. Treat those targets as valid only while `sourceFingerprint.fileHash` and `sourceFingerprint.lineCount` still match the current file; if either freshness value changes, rerun `fooks extract` or read the file before editing. This is AST-derived line-aware patch guidance, not LSP-backed semantic resolution and not provider-tokenizer, billing-token, or provider-cost proof.
 
 ## Supported project shapes

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bench:gate": "npm run build && node benchmarks/scripts/gate.mjs",
     "lint": "npm run typecheck -- --pretty false",
     "smoke:claude": "npm run build && node scripts/smoke-claude-hook.mjs",
+    "smoke:domain-detector": "npm run build && node dist/cli/index.js inspect-domain test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx --json",
     "release:smoke": "npm run build && node scripts/release-smoke.mjs",
     "bench:layer2:r4:repeated": "npm run build && node benchmarks/layer2-frontend-task/run-r4-repeated.js",
     "bench:layer2:provider-cost": "node benchmarks/layer2-frontend-task/run-provider-cost-evidence.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -620,7 +620,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|run|scan|extract|compare|decide|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|run|scan|extract|compare|decide|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -636,6 +636,7 @@ Everyday commands:
   ${displayCliName} run <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
+  ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
@@ -692,6 +693,45 @@ function parseCompareArgs(args: string[]): { filePath: string } {
   }
 
   return { filePath: requireFilePath(filePath) };
+}
+
+type InspectDomainCliResult = {
+  schemaVersion: 1;
+  command: "inspect-domain";
+  filePath: string;
+  domainDetection: {
+    classification: string;
+    evidence: Array<{ domain: string; signal: string; detail: string }>;
+  };
+  fallbackFirst: {
+    applies: boolean;
+    reason?: string;
+  };
+};
+
+function hasWebViewEvidence(evidence: Array<{ domain: string }>): boolean {
+  return evidence.some((item) => item.domain === "webview");
+}
+
+function buildInspectDomainResult(options: {
+  filePath: string;
+  cwd: string;
+  detection: { classification: string; evidence: Array<{ domain: string; signal: string; detail: string }> };
+}): InspectDomainCliResult {
+  const relative = path.relative(options.cwd, options.filePath) || path.basename(options.filePath);
+  const webViewFallbackFirst = hasWebViewEvidence(options.detection.evidence);
+  return {
+    schemaVersion: 1,
+    command: "inspect-domain",
+    filePath: relative,
+    domainDetection: {
+      classification: options.detection.classification,
+      evidence: options.detection.evidence,
+    },
+    fallbackFirst: webViewFallbackFirst
+      ? { applies: true, reason: "unsupported-react-native-webview-boundary" }
+      : { applies: false },
+  };
 }
 
 function parseDoctorArgs(args: string[]): { target: "all" | "codex" | "claude"; json: boolean; help: boolean } {
@@ -974,6 +1014,14 @@ async function run(): Promise<void> {
       const extracted = extractFile(file);
       const result = decideMode(asBase(extracted));
       print({ filePath: file, ...result });
+      return;
+    }
+
+    case "inspect-domain": {
+      const { detectDomain } = await import("../core/domain-detector.js");
+      const { filePath: file } = parseCompareArgs(rest);
+      const detection = detectDomain(file);
+      print(buildInspectDomainResult({ filePath: file, cwd: process.cwd(), detection }));
       return;
     }
     case "attach": {

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
@@ -86,4 +87,40 @@ test("classifies mixed and unknown fallback cases", () => {
 test("changed detector source does not introduce forbidden support wording", () => {
   const source = fs.readFileSync(path.join(repoRoot, "src", "core", "domain-detector.ts"), "utf8");
   assert.doesNotMatch(source, forbiddenSupportClaims);
+});
+
+test("CLI inspect-domain prints detector evidence without support claims", () => {
+  const fixture = path.join(fixtureRoot, "webview-boundary-basic.tsx");
+  const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(cli.status, 0, cli.stderr);
+  const result = JSON.parse(cli.stdout);
+
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "inspect-domain");
+  assert.equal(result.filePath, path.relative(repoRoot, fixture));
+  assert.deepEqual(Object.keys(result.domainDetection).sort(), ["classification", "evidence"]);
+  assert.equal(result.domainDetection.classification, "webview");
+  assert.ok(result.domainDetection.evidence.some((item) => item.domain === "webview" && item.signal === "component" && item.detail === "WebView"));
+  assert.deepEqual(result.fallbackFirst, { applies: true, reason: "unsupported-react-native-webview-boundary" });
+  assert.equal("signals" in result.domainDetection, false);
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+});
+
+test("CLI inspect-domain keeps non-WebView fixture output as evidence-only non-fallback inspection", () => {
+  const fixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
+  const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(cli.status, 0, cli.stderr);
+  const result = JSON.parse(cli.stdout);
+  assert.equal(result.domainDetection.classification, "react-native");
+  assert.deepEqual(result.fallbackFirst, { applies: false });
+  assert.ok(result.domainDetection.evidence.some((item) => item.domain === "react-native" && item.signal === "primitive" && item.detail === "View"));
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2674,6 +2674,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks setup/);
   assert.match(help, /fooks doctor \[codex\|claude\] \[--json\]/);
   assert.match(help, /fooks compare <file> \[--json\]/);
+  assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status artifacts/);
   assert.match(help, /Codex: automatic repeated-file runtime hook path/);
@@ -2692,6 +2693,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(usage, /fooks setup/);
 
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  assert.match(pkg.scripts?.["smoke:domain-detector"], /inspect-domain test\/fixtures\/frontend-domain-expectations\/webview-boundary-basic\.tsx --json/);
   assert.equal(pkg.scripts?.postinstall, undefined);
   assert.equal(pkg.scripts?.preinstall, undefined);
   assert.equal(pkg.scripts?.prepare, undefined);
@@ -4009,6 +4011,9 @@ test("docs give first-run users a clear support and diagnosis path", () => {
   assert.match(combined, /fooks setup\s+# short ready \/ partial \/ blocked summary/);
   assert.match(combined, /fooks doctor/);
   assert.match(combined, /fooks status/);
+  assert.match(combined, /fooks inspect-domain test\/fixtures\/frontend-domain-expectations\/webview-boundary-basic\.tsx --json/);
+  assert.match(combined, /npm run smoke:domain-detector/);
+  assert.match(combined, /domainDetection\.evidence/);
   assert.match(combined, /fooks setup --json/);
   assert.match(combined, /React \/ Next\.js/);
   assert.match(combined, /Ink .*React CLI/s);


### PR DESCRIPTION
## Summary
- Adds `fooks inspect-domain <file> [--json]` for operator-facing inspection of frontend domain detector evidence.
- Keeps output evidence-only: `domainDetection.classification`, `domainDetection.evidence`, and a WebView fallback-first marker when WebView evidence is present.
- Adds a `smoke:domain-detector` docs-test hook and setup docs guidance for dogfooding before profile work.

References #205.

## Boundaries
- No extractor/profile/runtime behavior changes.
- No RN/WebView/TUI support claims.
- WebView remains fallback-first via `unsupported-react-native-webview-boundary`.

## Verification
- `npm run build`
- `node --test test/domain-detector.test.mjs`
- `node --test test/fooks.test.mjs --test-name-pattern "cli help|docs give first-run|frontend domain"`
- `npm run smoke:domain-detector`
- `npm run lint`
- `git diff --check`
- Architect verification: APPROVED
