### PR TITLE
Preserve frontend domain boundaries through detector outcomes

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -22,13 +22,8 @@ function relativePath(filePath: string, cwd: string): string {
 }
 
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
-  return (
-    /\bfrom\s+["']react-native(?:\/[^"']*)?["']/.test(sourceText) ||
-    /\brequire\(\s*["']react-native(?:\/[^"']*)?["']\s*\)/.test(sourceText) ||
-    /\bfrom\s+["']react-native-webview["']/.test(sourceText) ||
-    /\brequire\(\s*["']react-native-webview["']\s*\)/.test(sourceText) ||
-    /<WebView(?:\s|>|\/)/.test(sourceText)
-  );
+  const domainDetection = detectDomainFromSource(sourceText);
+  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
 }
 
 export function decidePreRead(
@@ -58,7 +53,7 @@ export function decidePreRead(
 
   const sourceText = fs.readFileSync(resolvedPath, "utf8");
   const domainDetection = detectDomainFromSource(sourceText, resolvedPath);
-  if (hasReactNativeWebViewBoundaryMarker(sourceText)) {
+  if (domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON) {
     return {
       runtime,
       filePath: outputPath,

--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -4,6 +4,9 @@ import ts from "typescript";
 
 export type DomainLabel = "react-web" | "react-native" | "webview" | "tui-ink" | "mixed" | "unknown";
 export type FrontendDomainClassification = DomainLabel;
+export type FrontendDomainOutcome = "extract" | "fallback" | "deferred" | "unsupported";
+
+export const FRONTEND_DOMAIN_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 
 export type FrontendDomainEvidence = {
   domain: Exclude<DomainLabel, "mixed" | "unknown">;
@@ -15,6 +18,8 @@ export type DomainDetectionResult = {
   classification: FrontendDomainClassification;
   /** @deprecated Use classification. */
   domain: DomainLabel;
+  outcome: FrontendDomainOutcome;
+  reason?: string;
   evidence: FrontendDomainEvidence[];
   /** @deprecated Use evidence. */
   signals: string[];
@@ -24,7 +29,19 @@ const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const RN_MODULE = "react-native";
 const WEBVIEW_MODULE = "react-native-webview";
 const INK_MODULE = "ink";
-const RN_PRIMITIVES = new Set(["View", "Text", "Image", "ScrollView", "Pressable", "TouchableOpacity"]);
+const RN_PRIMITIVES = new Set([
+  "View",
+  "Text",
+  "TextInput",
+  "Image",
+  "ScrollView",
+  "FlatList",
+  "Pressable",
+  "TouchableOpacity",
+  "TouchableHighlight",
+  "TouchableNativeFeedback",
+  "TouchableWithoutFeedback",
+]);
 const WEB_DOM_TAGS = new Set(["div", "span", "form", "input", "button", "select", "textarea", "label"]);
 const WEBVIEW_PROPS = new Set(["source", "injectedJavaScript", "onMessage"]);
 const TUI_PRIMITIVES = new Set(["Box", "Text"]);
@@ -56,6 +73,20 @@ function signalList(evidence: FrontendDomainEvidence[]): string[] {
   return evidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`);
 }
 
+function outcomeForClassification(classification: DomainLabel): Pick<DomainDetectionResult, "outcome" | "reason"> {
+  switch (classification) {
+    case "react-web":
+    case "tui-ink":
+      return { outcome: "extract" };
+    case "react-native":
+    case "webview":
+    case "mixed":
+      return { outcome: "fallback", reason: FRONTEND_DOMAIN_BOUNDARY_REASON };
+    case "unknown":
+      return { outcome: "deferred" };
+  }
+}
+
 function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): DomainDetectionResult {
   const domainEvidence = ["react-native", "webview", "tui-ink"] as const;
   const matched = domainEvidence.filter((domain) => hasEvidence(evidence, domain));
@@ -73,6 +104,7 @@ function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): Domai
   return {
     classification,
     domain: classification,
+    ...outcomeForClassification(classification),
     evidence,
     signals: signalList(evidence),
   };
@@ -135,7 +167,7 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
       const tag = ts.isIdentifier(tagName) ? tagName.text : ts.isPropertyAccessExpression(tagName) ? tagName.name.text : undefined;
       if (tag) {
         if (RN_PRIMITIVES.has(tag) && hasImportedName(RN_MODULE, tag)) addEvidence(evidence, "react-native", "primitive", tag);
-        if (tag === "WebView" && hasImportedName(WEBVIEW_MODULE, tag)) addEvidence(evidence, "webview", "component", tag);
+        if (tag === "WebView") addEvidence(evidence, "webview", "component", tag);
         if (TUI_PRIMITIVES.has(tag) && hasImportedName(INK_MODULE, tag)) addEvidence(evidence, "tui-ink", "primitive", tag);
         if (WEB_DOM_TAGS.has(tag)) hasWebDom = true;
       }

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -24,10 +24,13 @@ test("detects React Native evidence signals without support wording", () => {
   const primitive = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
   assert.equal(primitive.classification, "react-native");
   assert.equal(primitive.domain, "react-native");
+  assert.equal(primitive.outcome, "fallback");
+  assert.equal(primitive.reason, "unsupported-react-native-webview-boundary");
   assertSignals(primitive, [
     "react-native:import:react-native",
     "react-native:primitive:View",
     "react-native:primitive:Text",
+    "react-native:primitive:TextInput",
     "react-native:primitive:Pressable",
   ]);
 
@@ -53,6 +56,8 @@ test("detects React Native evidence signals without support wording", () => {
 test("detects WebView evidence signals without support wording", () => {
   const result = detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
   assert.equal(result.classification, "webview");
+  assert.equal(result.outcome, "fallback");
+  assert.equal(result.reason, "unsupported-react-native-webview-boundary");
   assertSignals(result, [
     "webview:import:react-native-webview",
     "webview:component:WebView",
@@ -66,6 +71,7 @@ test("detects WebView evidence signals without support wording", () => {
 test("detects TUI Ink evidence signals without support wording", () => {
   const result = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
   assert.equal(result.classification, "tui-ink");
+  assert.equal(result.outcome, "extract");
   assertSignals(result, ["tui-ink:import:ink", "tui-ink:primitive:Box", "tui-ink:primitive:Text", "tui-ink:hook:useInput"]);
   assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });
@@ -73,14 +79,25 @@ test("detects TUI Ink evidence signals without support wording", () => {
 test("classifies mixed and unknown fallback cases", () => {
   const mixed = detectDomain(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
   assert.equal(mixed.classification, "mixed");
+  assert.equal(mixed.outcome, "fallback");
+  assert.equal(mixed.reason, "unsupported-react-native-webview-boundary");
   assert.ok(mixed.signals.some((signal) => signal.startsWith("react-native:")));
   assert.ok(mixed.signals.some((signal) => signal.startsWith("webview:")));
 
   const unknown = detectDomainFromSource("export const answer = 42;", "utility.ts");
   assert.equal(unknown.classification, "unknown");
+  assert.equal(unknown.outcome, "deferred");
   assert.deepEqual(unknown.evidence, []);
 
   assert.doesNotMatch(JSON.stringify([mixed, unknown]), forbiddenSupportClaims);
+});
+
+test("treats bare WebView JSX as a fallback-first boundary signal", () => {
+  const result = detectDomainFromSource(`export function Preview() { return <WebView source={{ uri: "https://example.test" }} />; }`, "Preview.tsx");
+  assert.equal(result.classification, "webview");
+  assert.equal(result.outcome, "fallback");
+  assert.equal(result.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(result.signals.includes("webview:component:WebView"));
 });
 
 test("changed detector source does not introduce forbidden support wording", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -974,6 +974,8 @@ test("frontend domain detector returns evidence-only classifications for Level 3
   assert.ok(rn.signals.includes("react-native:primitive:View"));
   assert.ok(rn.signals.includes("react-native:primitive:Text"));
   assert.ok(rn.signals.includes("react-native:primitive:ScrollView"));
+  assert.equal(rn.outcome, "fallback");
+  assert.equal(rn.reason, "unsupported-react-native-webview-boundary");
   assert.ok(rn.signals.includes("react-native:style-factory:StyleSheet.create"));
   assert.ok(rn.signals.includes("react-native:platform-select:Platform.select"));
 
@@ -984,7 +986,9 @@ test("frontend domain detector returns evidence-only classifications for Level 3
 
   const pressable = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
   assert.equal(pressable.classification, "react-native");
+  assert.equal(pressable.outcome, "fallback");
   assert.ok(pressable.signals.includes("react-native:primitive:Pressable"));
+  assert.ok(pressable.signals.includes("react-native:primitive:TextInput"));
 
   const touchable = detectDomain(path.join(fixtureRoot, "rn-interaction-gesture.tsx"));
   assert.equal(touchable.classification, "react-native");
@@ -992,6 +996,8 @@ test("frontend domain detector returns evidence-only classifications for Level 3
 
   const webview = detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
   assert.equal(webview.classification, "webview");
+  assert.equal(webview.outcome, "fallback");
+  assert.equal(webview.reason, "unsupported-react-native-webview-boundary");
   assert.ok(webview.signals.includes("webview:import:react-native-webview"));
   assert.ok(webview.signals.includes("webview:component:WebView"));
   assert.ok(webview.signals.includes("webview:prop:source"));
@@ -1000,6 +1006,7 @@ test("frontend domain detector returns evidence-only classifications for Level 3
 
   const tui = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
   assert.equal(tui.classification, "tui-ink");
+  assert.equal(tui.outcome, "extract");
   assert.ok(tui.signals.includes("tui-ink:import:ink"));
   assert.ok(tui.signals.includes("tui-ink:primitive:Box"));
   assert.ok(tui.signals.includes("tui-ink:primitive:Text"));
@@ -1007,11 +1014,14 @@ test("frontend domain detector returns evidence-only classifications for Level 3
 
   const mixed = detectDomain(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
   assert.equal(mixed.classification, "mixed");
+  assert.equal(mixed.outcome, "fallback");
+  assert.equal(mixed.reason, "unsupported-react-native-webview-boundary");
   assert.ok(mixed.signals.some((signal) => signal.startsWith("react-native:")));
   assert.ok(mixed.signals.some((signal) => signal.startsWith("webview:")));
 
   const unknown = detectDomainFromSource("export const answer = 42;", "utility.ts");
   assert.equal(unknown.classification, "unknown");
+  assert.equal(unknown.outcome, "deferred");
   assert.deepEqual(unknown.evidence, []);
 });
 
@@ -1065,6 +1075,25 @@ test("frontend domain detector and pre-read debug avoid RN WebView TUI support w
     fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8"),
   ].join("\n");
   assert.doesNotMatch(changedSource, forbiddenSupportClaims);
+});
+
+test("pre-read uses frontend domain detector for bare WebView fallback boundaries", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-bare-webview-"));
+  const bareWebViewPath = path.join(tempDir, "BareWebView.tsx");
+  fs.writeFileSync(
+    bareWebViewPath,
+    `export function BareWebView() {
+  return <WebView source={{ uri: "https://example.test" }} />;
+}
+`,
+  );
+
+  const result = preReadModule.decidePreRead(bareWebViewPath, tempDir, "codex");
+  assert.equal(result.decision, "fallback");
+  assert.deepEqual(result.reasons, ["unsupported-react-native-webview-boundary"]);
+  assert.equal(result.debug.domainDetection.classification, "webview");
+  assert.equal(result.debug.domainDetection.outcome, "fallback");
+  assert.ok(result.debug.domainDetection.signals.includes("webview:component:WebView"));
 });
 
 test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise", () => {
@@ -2913,7 +2942,6 @@ test("doctor is read-only for prepared project, Codex, and Claude paths", () => 
   assert.deepEqual(fileSnapshot(codexHome), beforeCodex);
   assert.deepEqual(fileSnapshot(claudeHome), beforeClaude);
 });
-
 
 test("setup runtime summary keeps Claude and opencode claims bounded", () => {
   const tempDir = makeTempProject();


### PR DESCRIPTION
## Summary
- add explicit `outcome` / `reason` semantics to frontend domain detection
- route pre-read RN/WebView fallback through detector output instead of a parallel regex path
- keep RN/WebView/mixed fallback-first, unknown deferred, and TUI/react-web extract as contract-gated outcomes
- lock bare `<WebView>` fallback behavior and expanded RN primitive evidence in tests

## Verification
- `npm run build`
- `node --test test/domain-detector.test.mjs`
- `node --test --test-name-pattern "docs and pre-read boundary|frontend domain|pre-read treats React Native and WebView markers|bare WebView" test/fooks.test.mjs`
- `npm run lint`
- `npm test` — 276 passed
- Ralph architect verification: APPROVE

## Notes
- This is detector-gate work only; it does not promote React Native, WebView, or TUI support claims.
