### PR TITLE
Keep fixture expectation docs aligned with the manifest

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -1,6 +1,6 @@
 # Frontend domain fixture expectations
 
-This document is the first fixture expectation baseline for the RN/WebView/TUI domain-profile roadmap. It does **not** add runtime support, extractor behavior, setup eligibility, or public support wording. It only records which small local fixture slots should currently extract, fallback, or remain deferred before any later narrow implementation plan.
+This document is the fixture expectation baseline for the RN/WebView/TUI domain-profile roadmap. It does **not** add runtime support, extractor behavior, setup eligibility, or public support wording. It only records which small local fixture slots should currently extract, fallback, or remain deferred before any later narrow implementation plan.
 
 ## Source policy
 
@@ -8,26 +8,29 @@ Selected first-pass fixtures are limited to `existing-local` or `synthetic-local
 
 ## Selected fixture expectations
 
+The machine-readable fixture expectation manifest at `test/fixtures/frontend-domain-expectations/manifest.json` is the source of truth for selected and deferred slots. This table mirrors that manifest so parallel domain work does not reinterpret selected fixtures differently.
+
 | Slot | ID | Lane | Source kind | Path | Expected outcome | Required proof |
 | --- | --- | --- | --- | --- | --- | --- |
-| F0 | `react-web-regression-form-controls` | React web regression | `existing-local` | `fixtures/compressed/FormControls.tsx` | `extract` | Existing React web extraction remains non-empty and current regressions pass. |
-| F1 | `rn-primitive-basic` | RN primitive/interaction | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN primitives do not become DOM/form semantics. |
-| F3 | `webview-boundary-basic` | WebView boundary | `synthetic-local` | `test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | WebView `source`, injected JS, and `onMessage` remain boundary-first. |
-| F5 | `tui-ink-basic` | TUI/Ink candidate | `synthetic-local` | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `extract` | This is only TSX/JSX extraction evidence for an Ink-like file; it is not a broad TUI support claim. |
-| F6 | `negative-rn-webview-boundary` | Negative fallback | `synthetic-local` | `test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN/WebView bridge-like markers do not receive compact payload reuse. |
+| F0 | `react-web-regression-form-controls` | `react-web` | `existing-local` | `fixtures/compressed/FormControls.tsx` | `extract` | Existing React web extraction remains non-empty and current regressions pass. |
+| F1 | `rn-primitive-basic` | `rn-primitive` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN primitives do not become DOM/form semantics. |
+| F2 | `rn-style-platform-navigation` | `rn-style-platform` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Selected for the current fallback expectation only; `StyleSheet.create`, `Platform.select`, and navigation semantics remain non-promoted. |
+| F3 | `webview-boundary-basic` | `webview-boundary` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | WebView `source`, injected JS, and `onMessage` remain boundary-first. |
+| F5 | `tui-ink-basic` | `tui-ink` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `extract` | This is only TSX/JSX syntax evidence for an Ink-like file; it is not a broad TUI support claim. |
+| F6 | `negative-rn-webview-boundary` | `negative-fallback` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN/WebView bridge-like markers do not receive compact payload reuse. |
+| F9 | `rn-interaction-gesture` | `rn-interaction` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Touchable and gesture markers remain RN evidence only; no gesture runtime safety claim. |
+| F10 | `rn-image-scrollview` | `rn-image-scrollview` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Image, ScrollView, and Dimensions markers remain RN evidence only; no image loading safety claim. |
 
-The machine-readable fixture expectation manifest is `test/fixtures/frontend-domain-expectations/manifest.json`.
-
-That manifest remains the gate between the [Frontend domain contract](frontend-domain-contract.md) and any later detector/profile implementation plan; this baseline does not require a schema migration.
+The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope.
 
 ## Deferred fixture slots
 
 | Slot | ID | Lane | Reason |
 | --- | --- | --- | --- |
-| F2 | `rn-style-platform-navigation` | RN style/platform/navigation | `StyleSheet.create`, `Platform.select`, `.ios` / `.android`, and navigation semantics expand beyond the first evidence baseline. |
-| F4 | `webview-bridge-pair` | WebView bridge | Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning. |
+| F4 | `webview-bridge-pair` | `webview-bridge` | Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning. |
+| F7 | `tui-non-ink-cli-renderer` | `tui-non-ink` | Broad non-Ink terminal renderer semantics are not modeled by the current TSX fixture evidence lane. |
 
-These deferrals do not block the current evidence baseline. They prevent platform/navigation and bridge/security semantics from being mixed into the first fixture expectation pass.
+These deferrals do not block the current evidence baseline. They prevent bridge/security semantics and broad non-Ink terminal UI semantics from being mixed into the fixture expectation lock.
 
 ## Forbidden claims
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3927,6 +3927,22 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.doesNotMatch(contract, /default WebView compact extraction is enabled/i);
 });
 
+function parseMarkdownTableRows(markdown, heading) {
+  const start = markdown.indexOf(`## ${heading}`);
+  assert.notEqual(start, -1, `${heading} heading must exist`);
+  const next = markdown.indexOf("\n## ", start + 1);
+  const section = markdown.slice(start, next === -1 ? undefined : next);
+  return section
+    .split("\n")
+    .filter((line) => line.startsWith("| "))
+    .slice(2)
+    .map((line) => line.slice(1, -1).split("|").map((cell) => cell.trim()));
+}
+
+function stripMarkdownCode(value) {
+  return value.replace(/`/g, "");
+}
+
 test("frontend domain fixture expectations keep exact local outcomes", () => {
   const expectationsPath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json");
   const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
@@ -4018,13 +4034,54 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.doesNotMatch(source, /TUI support is available|TUI\/Ink is supported today|default TUI compact extraction is enabled/i);
   }
 
-  for (const slot of ["F1", "F3", "F6"]) {
+  for (const slot of ["F1", "F2", "F3", "F6", "F9", "F10"]) {
     const item = selected.get(slot);
     const decision = preReadModule.decidePreRead(path.join(repoRoot, item.path), repoRoot, "codex");
     assert.equal(decision.decision, "fallback", `${item.id} should stay fallback-first`);
     assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
     assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
   }
+});
+
+test("frontend domain fixture docs mirror manifest slot expectations", () => {
+  const expectations = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json"), "utf8"),
+  );
+  const docs = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
+  const selectedRows = parseMarkdownTableRows(docs, "Selected fixture expectations");
+  const deferredRows = parseMarkdownTableRows(docs, "Deferred fixture slots");
+  const selectedDocs = new Map(selectedRows.map(([slot, id, lane, sourceKind, fixturePath, outcome]) => [slot, { id, lane, sourceKind, fixturePath, outcome }]));
+  const deferredDocs = new Map(deferredRows.map(([slot, id, lane, reason]) => [slot, { id, lane, reason }]));
+  const selectedManifest = new Map(expectations.selected.map((item) => [item.slot, item]));
+  const deferredManifest = new Map(expectations.deferred.map((item) => [item.slot, item]));
+
+  assert.deepEqual([...selectedDocs.keys()], [...selectedManifest.keys()]);
+  assert.deepEqual([...deferredDocs.keys()], [...deferredManifest.keys()]);
+
+  for (const [slot, item] of selectedManifest) {
+    const row = selectedDocs.get(slot);
+    assert.equal(stripMarkdownCode(row.id), item.id, `${slot} docs id must match manifest`);
+    assert.equal(stripMarkdownCode(row.lane), item.lane, `${slot} docs lane must match manifest`);
+    assert.equal(stripMarkdownCode(row.sourceKind), item.sourceKind, `${slot} docs source kind must match manifest`);
+    assert.equal(stripMarkdownCode(row.fixturePath), item.path, `${slot} docs path must match manifest`);
+    assert.ok(row.outcome.includes(item.expectedOutcome), `${slot} docs outcome must include ${item.expectedOutcome}`);
+    if (item.expectedReason !== undefined) {
+      assert.ok(row.outcome.includes(item.expectedReason), `${slot} docs outcome must include ${item.expectedReason}`);
+    }
+  }
+
+  for (const [slot, item] of deferredManifest) {
+    const row = deferredDocs.get(slot);
+    assert.equal(stripMarkdownCode(row.id), item.id, `${slot} deferred docs id must match manifest`);
+    assert.equal(stripMarkdownCode(row.lane), item.lane, `${slot} deferred docs lane must match manifest`);
+    assert.match(row.reason, /\S/, `${slot} deferred docs reason must be non-empty`);
+  }
+
+  assert.match(docs, /F2[\s\S]*current fallback expectation[\s\S]*navigation semantics remain non-promoted/);
+  assert.doesNotMatch(docs, /React Native support is available|React Native is supported today/i);
+  assert.doesNotMatch(docs, /WebView support is available|WebView is supported today/i);
+  assert.doesNotMatch(docs, /TUI support is available|TUI is supported today/i);
+  assert.doesNotMatch(docs, /default WebView compact extraction is enabled/i);
 });
 
 test("docs give first-run users a clear support and diagnosis path", () => {


### PR DESCRIPTION
## Summary
- Align `docs/frontend-domain-fixture-expectations.md` with the manifest selected/deferred slot set.
- Lock F2/F9/F10 as selected fallback-first fixtures while keeping F4/F7 deferred.
- Add regression coverage that structurally checks docs tables mirror `manifest.json` and guards support-claim wording.

## Verification
- `npm run build`
- `node --test test/domain-detector.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm run lint`
- `npm test` (277 passed)
- `git diff --check`
- forbidden support wording scan over `docs src`

## Boundaries
- Docs/tests only.
- No extractor, runtime, pre-read, or dependency changes.
- No external RN/WebView/TUI corpus validation in this PR.
