### PR TITLE
Prevent selected fixture slots from carrying deferred state

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -23,6 +23,10 @@ The machine-readable fixture expectation manifest at `test/fixtures/frontend-dom
 
 The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope.
 
+## Manifest shape guard
+
+Selected fixtures must not carry deferred-only fields such as `deferReason` or `doesNotBlockBaseline`. Deferred fixtures must not carry executable fixture paths, expected outcomes, fallback reasons, required signals, or verification instructions. This keeps the manifest from describing the same slot as both selected and deferred while later RN/WebView/TUI/React Web work is split across branches.
+
 ## Deferred fixture slots
 
 | Slot | ID | Lane | Reason |

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -56,8 +56,6 @@
       "id": "rn-style-platform-navigation",
       "lane": "rn-style-platform",
       "sourceKind": "synthetic-local",
-      "deferReason": "StyleSheet, Platform.select, .ios/.android, and navigation semantics expand beyond the first evidence baseline.",
-      "doesNotBlockBaseline": true,
       "path": "test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx",
       "sourceReference": "Synthetic local fixture, no external repository copy",
       "expectedOutcome": "fallback",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3974,10 +3974,29 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.deepEqual([...deferred.keys()], ["F4", "F7"]);
   assert.deepEqual(expectations.forbiddenFirstPassSourceKinds, ["public-snapshot"]);
 
+  const selectedDeferredOnlyFields = ["deferReason", "doesNotBlockBaseline"];
+  const deferredSelectedOnlyFields = [
+    "path",
+    "sourceReference",
+    "expectedOutcome",
+    "expectedReason",
+    "requiredSignals",
+    "verification",
+    "relatedSourcePaths",
+  ];
+
   for (const item of selected.values()) {
+    for (const field of selectedDeferredOnlyFields) {
+      assert.equal(item[field], undefined, `${item.id} selected fixture must not carry deferred-only ${field}`);
+    }
     assert.ok(["existing-local", "synthetic-local"].includes(item.sourceKind), `${item.id} must stay local/synthetic`);
     assert.ok(["extract", "fallback", "unsupported"].includes(item.expectedOutcome), `${item.id} must have one expected outcome`);
     assert.notEqual(item.sourceKind, "public-snapshot", `${item.id} must not use public snapshots in the first pass`);
+    if (item.expectedOutcome === "fallback") {
+      assert.equal(item.expectedReason, "unsupported-react-native-webview-boundary", `${item.id} fallback fixtures must keep the explicit boundary reason`);
+    } else {
+      assert.equal(item.expectedReason, undefined, `${item.id} non-fallback fixtures must not carry a fallback reason`);
+    }
     assert.ok(!/github\.com|https?:\/\//i.test(item.sourceReference), `${item.id} must not depend on copied/vendor public repo source`);
     for (const evidencePath of collectEvidencePaths(item)) {
       assert.ok(fs.existsSync(path.join(repoRoot, evidencePath)), `${item.id} evidence path must exist: ${evidencePath}`);
@@ -4006,6 +4025,9 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(item.sourceKind, "deferred");
     assert.match(item.deferReason, /\S/);
     assert.equal(item.doesNotBlockBaseline, true);
+    for (const field of deferredSelectedOnlyFields) {
+      assert.equal(item[field], undefined, `${item.id} deferred fixture must not carry selected-only ${field}`);
+    }
   }
   assert.equal(deferred.get("F7").id, "tui-non-ink-cli-renderer");
   assert.equal(deferred.get("F7").supportClaim, "none");
@@ -4078,6 +4100,8 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   }
 
   assert.match(docs, /F2[\s\S]*current fallback expectation[\s\S]*navigation semantics remain non-promoted/);
+  assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
+  assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.doesNotMatch(docs, /React Native support is available|React Native is supported today/i);
   assert.doesNotMatch(docs, /WebView support is available|WebView is supported today/i);
   assert.doesNotMatch(docs, /TUI support is available|TUI is supported today/i);


### PR DESCRIPTION
## Summary
- Remove leftover deferred-only fields from the selected F2 fixture slot.
- Document the manifest shape boundary between selected and deferred fixture entries.
- Add regression guards so selected slots cannot carry deferred-only fields and deferred slots cannot carry executable selected-only fields.

## Verification
- `npm run build`
- `node --test --test-name-pattern "frontend domain fixture expectations|frontend domain fixture docs" test/fooks.test.mjs`
- `node --test test/domain-detector.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm run lint`
- `npm test` (277 passed)
- `git diff --check`
- forbidden support wording scan over `docs src`

## Boundaries
- Manifest/docs/tests only.
- No extractor, detector, runtime, pre-read, CLI, dependency, or manifest schema-version changes.
- No external RN/WebView/TUI corpus validation in this PR.
