### PR TITLE
Fallback when DOM JSX mixes with non-web domain evidence

### DIFF
--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -91,7 +91,7 @@ function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): Domai
   const domainEvidence = ["react-native", "webview", "tui-ink"] as const;
   const matched = domainEvidence.filter((domain) => hasEvidence(evidence, domain));
   let classification: DomainLabel;
-  if (matched.length > 1) {
+  if (matched.length > 1 || (matched.length === 1 && hasWebDom)) {
     classification = "mixed";
   } else if (matched.length === 1) {
     classification = matched[0];

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -102,6 +102,43 @@ test("classifies mixed and unknown fallback cases", () => {
   assert.doesNotMatch(JSON.stringify([mixed, unknown]), forbiddenSupportClaims);
 });
 
+test("classifies web DOM mixed with non-web frontend signals as fallback", () => {
+  const rnDom = detectDomainFromSource(
+    `import { View } from "react-native";
+     export function Mixed() { return <div><View /></div>; }`,
+    "MixedRnDom.tsx",
+  );
+  assert.equal(rnDom.classification, "mixed");
+  assert.equal(rnDom.outcome, "fallback");
+  assert.equal(rnDom.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(rnDom.signals.includes("react-native:import:react-native"));
+  assert.ok(rnDom.signals.includes("react-native:primitive:View"));
+
+  const webviewDom = detectDomainFromSource(
+    `import { WebView } from "react-native-webview";
+     export function Mixed() { return <form><WebView source={{ html: "<p>checkout</p>" }} /></form>; }`,
+    "MixedWebViewDom.tsx",
+  );
+  assert.equal(webviewDom.classification, "mixed");
+  assert.equal(webviewDom.outcome, "fallback");
+  assert.equal(webviewDom.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(webviewDom.signals.includes("webview:import:react-native-webview"));
+  assert.ok(webviewDom.signals.includes("webview:component:WebView"));
+
+  const tuiDom = detectDomainFromSource(
+    `import { Box } from "ink";
+     export function Mixed() { return <div><Box /></div>; }`,
+    "MixedTuiDom.tsx",
+  );
+  assert.equal(tuiDom.classification, "mixed");
+  assert.equal(tuiDom.outcome, "fallback");
+  assert.equal(tuiDom.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(tuiDom.signals.includes("tui-ink:import:ink"));
+  assert.ok(tuiDom.signals.includes("tui-ink:primitive:Box"));
+
+  assert.doesNotMatch(JSON.stringify([rnDom, webviewDom, tuiDom]), forbiddenSupportClaims);
+});
+
 test("treats bare WebView JSX as a fallback-first boundary signal", () => {
   const result = detectDomainFromSource(`export function Preview() { return <WebView source={{ uri: "https://example.test" }} />; }`, "Preview.tsx");
   assert.equal(result.classification, "webview");


### PR DESCRIPTION
## Summary
- Classify DOM JSX mixed with RN/WebView/TUI evidence as `mixed`.
- Keep mixed classifications fallback-first with the existing unsupported boundary reason.
- Add detector tests for RN+DOM, WebView+DOM, and TUI+DOM mixed cases.

## Verification
- `npm run build`
- `node --test test/domain-detector.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm run lint`
- `npm test` (279 passed)
- `git diff --check`
- forbidden support wording scan over `docs src`

## Boundaries
- Conservative detector behavior only.
- No extractor/profile support promotion.
- No manifest, docs, runtime, pre-read, CLI, or dependency changes.
