### PR TITLE
Keep WebView bridge pairs deferred behind a boundary plan

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -31,7 +31,7 @@ Selected fixtures must not carry deferred-only fields such as `deferReason` or `
 
 | Slot | ID | Lane | Reason |
 | --- | --- | --- | --- |
-| F4 | `webview-bridge-pair` | `webview-bridge` | Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning. |
+| F4 | `webview-bridge-pair` | `webview-bridge` | Paired native/web bridge fixtures require the [WebView bridge boundary plan](webview-bridge-boundary-plan.md) before compact-payload planning. |
 | F7 | `tui-non-ink-cli-renderer` | `tui-non-ink` | Broad non-Ink terminal renderer semantics are not modeled by the current TSX fixture evidence lane. |
 
 These deferrals do not block the current evidence baseline. They prevent bridge/security semantics and broad non-Ink terminal UI semantics from being mixed into the fixture expectation lock.

--- a/docs/webview-bridge-boundary-plan.md
+++ b/docs/webview-bridge-boundary-plan.md
@@ -1,0 +1,37 @@
+# WebView bridge boundary plan
+
+This plan keeps fixture slot `F4` (`webview-bridge-pair`) deferred until a separate security and boundary review approves a measured fixture pair. It does **not** add WebView support, compact-payload reuse, bridge safety guarantees, runtime behavior, pre-read behavior, setup eligibility, or public support wording.
+
+## Why this stays deferred
+
+WebView bridge code is not just frontend TSX. A bridge pair can combine native React Native code, embedded HTML or web React code, injected JavaScript strings, `postMessage` / `onMessage` boundaries, and serialization or validation logic. Compressing or reusing compact payloads across that boundary can hide the exact message contract that a maintainer needs to inspect.
+
+`F4` therefore remains deferred until a later PR names a narrow fixture pair and proves that fallback-first behavior is still preserved.
+
+## Required fixture pair before promotion
+
+A future `F4` promotion must use only local or synthetic-local fixtures unless a separate public-corpus approval explicitly pins external source provenance. The minimum pair is:
+
+1. **Native side fixture** — a React Native file that renders `WebView`, defines `source` or injected JavaScript, and handles `onMessage` or bridge callbacks.
+2. **Web side fixture** — the paired HTML/web React/JavaScript surface that calls `postMessage` or receives native bridge messages.
+3. **Boundary contract note** — a short explanation of the message names, payload shape, trust boundary, and why fallback remains the expected outcome.
+
+## Promotion gates
+
+Promotion from deferred to selected may happen only after all gates are true:
+
+1. The manifest still has exactly one expected outcome for the bridge pair.
+2. The expected outcome is `fallback` unless a later security review explicitly approves a narrower extraction profile.
+3. `unsupported-react-native-webview-boundary` remains the fallback reason for native WebView bridge files.
+4. The docs avoid WebView support, bridge safety, and compact-payload reuse claims.
+5. Tests prove the native side and web side stay paired and local.
+6. The PR states that WebView bridge evidence is not general React Native, React Web, or WebView support.
+
+## Explicit non-goals
+
+- No WebView compact-payload reuse.
+- No bridge safety claim.
+- No automatic extraction across native/web message boundaries.
+- No public repository vendoring or live fetch.
+- No manifest schema migration.
+- No runtime, CLI, setup, or pre-read behavior change.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2423,7 +2423,7 @@ test("scan regenerates when the persisted scan index is corrupt", () => {
   assert.ok(result.files.length >= 5);
   assert.ok(result.refreshedEntries >= 5);
   assert.equal(persistedIndex.observability, undefined);
-  assert.equal(persistedIndex.projectRoot, tempDir);
+  assert.equal(persistedIndex.projectRoot, fs.realpathSync(tempDir));
 });
 
 test("scan only refreshes changed files after cache warm-up", () => {
@@ -3860,8 +3860,9 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   const architecture = fs.readFileSync(path.join(repoRoot, "docs", "rn-webview-architecture.md"), "utf8");
   const domainProfiles = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-profiles.md"), "utf8");
   const fixtureExpectations = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
+  const webviewBridgePlan = fs.readFileSync(path.join(repoRoot, "docs", "webview-bridge-boundary-plan.md"), "utf8");
   const preRead = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
-  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}\n${architecture}\n${domainProfiles}\n${fixtureExpectations}`;
+  const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}\n${architecture}\n${domainProfiles}\n${fixtureExpectations}\n${webviewBridgePlan}`;
 
   assert.match(combined, /React Native(?:\/WebView| and embedded WebView| \/ embedded WebView)/);
   assert.match(combined, /TSX parsing is (?:syntax-level|only syntax-level)|\.tsx` parse is not semantic evidence/);
@@ -3878,6 +3879,9 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.match(fixtureExpectations, /selected\/deferred fixture baseline|Selected fixture expectations/);
   assert.match(fixtureExpectations, /public repository candidates .* reference-only/is);
   assert.match(fixtureExpectations, /WebView compact-payload reuse or bridge safety promotion/);
+  assert.match(webviewBridgePlan, /WebView bridge boundary plan/);
+  assert.match(webviewBridgePlan, /fallback-first behavior is still preserved/);
+  assert.match(webviewBridgePlan, /No automatic extraction across native\/web message boundaries/);
   assert.match(candidates, /React Native \/ WebView fixture candidate survey/);
   assert.match(candidates, /React Native \/ WebView architecture direction/);
   assert.match(architecture, /shared TypeScript AST core, separate domain signal profiles/);
@@ -4138,6 +4142,7 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
     fs.readFileSync(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json"), "utf8"),
   );
   const docs = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
+  const webviewBridgePlan = fs.readFileSync(path.join(repoRoot, "docs", "webview-bridge-boundary-plan.md"), "utf8");
   const selectedRows = parseMarkdownTableRows(docs, "Selected fixture expectations");
   const deferredRows = parseMarkdownTableRows(docs, "Deferred fixture slots");
   const selectedDocs = new Map(selectedRows.map(([slot, id, lane, sourceKind, fixturePath, outcome]) => [slot, { id, lane, sourceKind, fixturePath, outcome }]));
@@ -4170,10 +4175,25 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /F2[\s\S]*current fallback expectation[\s\S]*navigation semantics remain non-promoted/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
+  assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
+  assert.match(webviewBridgePlan, /`F4` \(`webview-bridge-pair`\) deferred/);
+  assert.match(webviewBridgePlan, /Native side fixture/);
+  assert.match(webviewBridgePlan, /Web side fixture/);
+  assert.match(webviewBridgePlan, /Boundary contract note/);
+  assert.match(webviewBridgePlan, /unsupported-react-native-webview-boundary/);
+  assert.match(webviewBridgePlan, /expected outcome is `fallback`/);
+  assert.match(webviewBridgePlan, /No WebView compact-payload reuse/);
+  assert.match(webviewBridgePlan, /No bridge safety claim/);
+  assert.match(webviewBridgePlan, /No automatic extraction across native\/web message boundaries/);
   assert.doesNotMatch(docs, /React Native support is available|React Native is supported today/i);
   assert.doesNotMatch(docs, /WebView support is available|WebView is supported today/i);
   assert.doesNotMatch(docs, /TUI support is available|TUI is supported today/i);
   assert.doesNotMatch(docs, /default WebView compact extraction is enabled/i);
+  assert.doesNotMatch(webviewBridgePlan, /React Native support is available|React Native is supported today/i);
+  assert.doesNotMatch(webviewBridgePlan, /WebView support is available|WebView is supported today/i);
+  assert.doesNotMatch(webviewBridgePlan, /WebView compact payload reuse is supported/i);
+  assert.doesNotMatch(webviewBridgePlan, /bridge safety is guaranteed/i);
+  assert.doesNotMatch(webviewBridgePlan, /default WebView compact extraction is enabled/i);
 });
 
 test("docs give first-run users a clear support and diagnosis path", () => {


### PR DESCRIPTION
## Summary
- Add a WebView bridge boundary plan for deferred F4 (`webview-bridge-pair`).
- Link the deferred fixture expectation row to the new plan.
- Add regression coverage for bridge-pair gates and forbidden support/compact-reuse claims.
- Normalize the corrupt scan-index test expectation to the realpath project root persisted by current scan output.

## Verification
- `npm run build`
- targeted fooks docs tests
- `node --test test/domain-detector.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm run lint`
- `npm test` (287 passed)
- `git diff --check`
- forbidden support wording scan over `docs src`

## Boundaries
- No WebView support promotion.
- No compact-payload reuse or bridge safety claim.
- No extractor, detector, runtime, pre-read, CLI, setup, dependency, or manifest schema changes.
- No external WebView bridge corpus validation in this PR.
