### PR TITLE
Prevent premature WebView bridge fixture promotion

### DIFF
--- a/docs/webview-bridge-boundary-plan.md
+++ b/docs/webview-bridge-boundary-plan.md
@@ -2,6 +2,12 @@
 
 This plan keeps fixture slot `F4` (`webview-bridge-pair`) deferred until a separate security and boundary review approves a measured fixture pair. It does **not** add WebView support, compact-payload reuse, bridge safety guarantees, runtime behavior, pre-read behavior, setup eligibility, or public support wording.
 
+## Readiness-gate PR boundary
+
+The first follow-up after this plan is a readiness-gate-only PR. That PR may strengthen docs and regression tests for the promotion conditions, but it must not add native/web fixture files, move `F4` from deferred to selected, or change detector, extractor, runtime, pre-read, setup, or CLI behavior.
+
+The later synthetic-local bridge-pair PR is a separate lane. It can only start after the readiness gate is locked, and its expected outcome remains `fallback` unless a separate security review approves a narrower extraction profile.
+
 ## Why this stays deferred
 
 WebView bridge code is not just frontend TSX. A bridge pair can combine native React Native code, embedded HTML or web React code, injected JavaScript strings, `postMessage` / `onMessage` boundaries, and serialization or validation logic. Compressing or reusing compact payloads across that boundary can hide the exact message contract that a maintainer needs to inspect.
@@ -32,6 +38,8 @@ Promotion from deferred to selected may happen only after all gates are true:
 - No WebView compact-payload reuse.
 - No bridge safety claim.
 - No automatic extraction across native/web message boundaries.
+- No native/web synthetic bridge fixture files in the readiness-gate-only PR.
+- No `F4` selected promotion in the readiness-gate-only PR.
+- No detector, extractor, runtime, pre-read, setup, or CLI behavior change in the readiness-gate-only PR.
 - No public repository vendoring or live fetch.
 - No manifest schema migration.
-- No runtime, CLI, setup, or pre-read behavior change.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4101,6 +4101,14 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
       assert.equal(item[field], undefined, `${item.id} deferred fixture must not carry selected-only ${field}`);
     }
   }
+  const webviewBridgePair = deferred.get("F4");
+  assert.equal(webviewBridgePair.id, "webview-bridge-pair");
+  assert.equal(webviewBridgePair.lane, "webview-bridge");
+  assert.equal(webviewBridgePair.path, undefined);
+  assert.equal(webviewBridgePair.expectedOutcome, undefined);
+  assert.equal(webviewBridgePair.expectedReason, undefined);
+  assert.equal(webviewBridgePair.requiredSignals, undefined);
+  assert.equal(webviewBridgePair.verification, undefined);
   assert.equal(deferred.get("F7").id, "tui-non-ink-cli-renderer");
   assert.equal(deferred.get("F7").supportClaim, "none");
   assert.equal(deferred.get("F7").path, undefined);
@@ -4180,6 +4188,11 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(webviewBridgePlan, /Native side fixture/);
   assert.match(webviewBridgePlan, /Web side fixture/);
   assert.match(webviewBridgePlan, /Boundary contract note/);
+  assert.match(webviewBridgePlan, /readiness-gate-only PR/);
+  assert.match(webviewBridgePlan, /later synthetic-local bridge-pair PR is a separate lane/);
+  assert.match(webviewBridgePlan, /must not add native\/web fixture files/);
+  assert.match(webviewBridgePlan, /move `F4` from deferred to selected/);
+  assert.match(webviewBridgePlan, /detector, extractor, runtime, pre-read, setup, or CLI behavior/);
   assert.match(webviewBridgePlan, /unsupported-react-native-webview-boundary/);
   assert.match(webviewBridgePlan, /expected outcome is `fallback`/);
   assert.match(webviewBridgePlan, /No WebView compact-payload reuse/);
@@ -4193,6 +4206,8 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.doesNotMatch(webviewBridgePlan, /WebView support is available|WebView is supported today/i);
   assert.doesNotMatch(webviewBridgePlan, /WebView compact payload reuse is supported/i);
   assert.doesNotMatch(webviewBridgePlan, /bridge safety is guaranteed/i);
+  assert.doesNotMatch(webviewBridgePlan, /WebView bridge is safe/i);
+  assert.doesNotMatch(webviewBridgePlan, /compact[- ]payload reuse is (?:available|enabled|safe)/i);
   assert.doesNotMatch(webviewBridgePlan, /default WebView compact extraction is enabled/i);
 });
 


### PR DESCRIPTION
## Summary
- lock the F4 WebView bridge readiness-gate-only boundary in docs
- assert F4 remains deferred without selected-only fixture fields
- extend forbidden claim checks for WebView support, bridge safety, and compact-payload reuse wording

## Verification
- npm run build
- node --test test/fooks.test.mjs
- npm run lint
- git diff --check
- npm test (287 passed)
- architect verification: APPROVE

## Notes
- This does not add native/web bridge fixture files.
- This does not change detector, extractor, runtime, pre-read, setup, or CLI behavior.
- Synthetic-local bridge-pair design remains a later lane.