### PR TITLE
docs: mark red-team cache finding as historical

### DIFF
--- a/RED_TEAM_REPORT.md
+++ b/RED_TEAM_REPORT.md
@@ -5,11 +5,13 @@
 **Tester:** Codex CLI (OMX)  
 **Target:** fooks v0.1.0 (frontend context compression engine)
 
+> **Status note (2026-04-27):** This is a historical red-team snapshot, not the current release state. The cache-corruption scan blocker is now covered by PR #213 (`799c135`), which treats unreadable extraction cache entries and persisted scan indexes as cache misses and adds corrupt-index regression coverage. Keep the original finding text below as provenance only; do not reuse it as a current open P0 claim without rerunning the red-team scenario.
+
 ---
 
 ## Executive Summary
 
-Fooks is a frontend context compression engine that generally handles edge cases gracefully but has **critical vulnerabilities** in cache corruption handling and moderate issues with tiny file inflation.
+Fooks is a frontend context compression engine that generally handles edge cases gracefully. At the time of this historical run it still had **critical vulnerabilities** in cache corruption handling and moderate issues with tiny file inflation.
 
 | Risk Level | Count | Issues |
 |------------|-------|--------|

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3829,6 +3829,15 @@ test("package release surface keeps internal docs out of the npm tarball", () =>
   assert.match(gitignore, /\.opencode\//);
 });
 
+test("red-team report marks cache corruption finding as historical after recovery fix", () => {
+  const redTeam = fs.readFileSync(path.join(repoRoot, "RED_TEAM_REPORT.md"), "utf8");
+
+  assert.match(redTeam, /historical red-team snapshot, not the current release state/);
+  assert.match(redTeam, /cache-corruption scan blocker is now covered by PR #213 \(`799c135`\)/);
+  assert.match(redTeam, /unreadable extraction cache entries and persisted scan indexes as cache misses/);
+  assert.match(redTeam, /do not reuse it as a current open P0 claim without rerunning the red-team scenario/);
+});
+
 test("docs describe local compare estimates without billing-cost claims", () => {
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
   const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");


### PR DESCRIPTION
## Summary
- Add a status note to the historical red-team report so PR #213 cache recovery is not misread as an open P0.
- Add regression coverage that locks the provenance/current-state boundary.

## Verification
- npm ci
- npm run build
- node --test test/fooks.test.mjs (134/134 passing)
- git diff --check

## Boundaries
- Documentation/test-only change.
- Does not claim new cache behavior beyond PR #213.
- Keeps original red-team finding text as historical provenance.