### PR TITLE
Add WebView bridge paired fallback fixture evidence

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -16,12 +16,13 @@ The machine-readable fixture expectation manifest at `test/fixtures/frontend-dom
 | F1 | `rn-primitive-basic` | `rn-primitive` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN primitives do not become DOM/form semantics. |
 | F2 | `rn-style-platform-navigation` | `rn-style-platform` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Selected for the current fallback expectation only; `StyleSheet.create`, `Platform.select`, and navigation semantics remain non-promoted. |
 | F3 | `webview-boundary-basic` | `webview-boundary` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | WebView `source`, injected JS, and `onMessage` remain boundary-first. |
+| F4 | `webview-bridge-pair` | `webview-bridge` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/webview/checkout-bridge-native.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Paired native/web checkout bridge fixtures remain fallback-boundary evidence only; the paired web source is recorded in `relatedSourcePaths`. |
 | F5 | `tui-ink-basic` | `tui-ink` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `extract` | This is only TSX/JSX syntax evidence for an Ink-like file; it is not a broad TUI support claim. |
 | F6 | `negative-rn-webview-boundary` | `negative-fallback` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/negative-rn-webview-boundary.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | RN/WebView bridge-like markers do not receive compact payload reuse. |
 | F9 | `rn-interaction-gesture` | `rn-interaction` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Touchable and gesture markers remain RN evidence only; no gesture runtime safety claim. |
 | F10 | `rn-image-scrollview` | `rn-image-scrollview` | `synthetic-local` | `test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx` | `fallback` with `unsupported-react-native-webview-boundary` | Image, ScrollView, and Dimensions markers remain RN evidence only; no image loading safety claim. |
 
-The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope.
+The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope. `F4` is selected only as paired fallback-boundary evidence under the [WebView bridge boundary plan](webview-bridge-boundary-plan.md): its native fixture is the primary `path`, and its paired web fixture is recorded in `relatedSourcePaths`.
 
 ## Manifest shape guard
 
@@ -31,10 +32,9 @@ Selected fixtures must not carry deferred-only fields such as `deferReason` or `
 
 | Slot | ID | Lane | Reason |
 | --- | --- | --- | --- |
-| F4 | `webview-bridge-pair` | `webview-bridge` | Paired native/web bridge fixtures require the [WebView bridge boundary plan](webview-bridge-boundary-plan.md) before compact-payload planning. |
 | F7 | `tui-non-ink-cli-renderer` | `tui-non-ink` | Broad non-Ink terminal renderer semantics are not modeled by the current TSX fixture evidence lane. |
 
-These deferrals do not block the current evidence baseline. They prevent bridge/security semantics and broad non-Ink terminal UI semantics from being mixed into the fixture expectation lock.
+These deferrals do not block the current evidence baseline. They prevent broad non-Ink terminal UI semantics from being mixed into the fixture expectation lock; WebView bridge extraction, bridge safety, and compact-payload reuse remain out of scope even though `F4` now has paired fallback evidence.
 
 ## Forbidden claims
 

--- a/docs/webview-bridge-boundary-plan.md
+++ b/docs/webview-bridge-boundary-plan.md
@@ -1,34 +1,34 @@
 # WebView bridge boundary plan
 
-This plan keeps fixture slot `F4` (`webview-bridge-pair`) deferred until a separate security and boundary review approves a measured fixture pair. It does **not** add WebView support, compact-payload reuse, bridge safety guarantees, runtime behavior, pre-read behavior, setup eligibility, or public support wording.
+This plan keeps fixture slot `F4` (`webview-bridge-pair`) as **selected fallback-boundary evidence** after the readiness gate from PR #215. It does **not** add WebView support, compact-payload reuse, bridge safety guarantees, runtime behavior, pre-read behavior, setup eligibility, or public support wording.
 
-## Readiness-gate PR boundary
+## Selected fallback-evidence boundary
 
-The first follow-up after this plan is a readiness-gate-only PR. That PR may strengthen docs and regression tests for the promotion conditions, but it must not add native/web fixture files, move `F4` from deferred to selected, or change detector, extractor, runtime, pre-read, setup, or CLI behavior.
+`F4` now names a measured synthetic-local native/web fixture pair. The pair is selected only to prove that WebView bridge-shaped code stays fallback-first; it is not an extraction profile, support claim, safety claim, or compact-payload reuse approval.
 
-The later synthetic-local bridge-pair PR is a separate lane. It can only start after the readiness gate is locked, and its expected outcome remains `fallback` unless a separate security review approves a narrower extraction profile.
+The synthetic bridge pair remains a separate lane from detector/runtime work. Its expected outcome is `fallback` unless a separate security review approves a narrower extraction profile.
 
-## Why this stays deferred
+## Why extraction still stays deferred
 
 WebView bridge code is not just frontend TSX. A bridge pair can combine native React Native code, embedded HTML or web React code, injected JavaScript strings, `postMessage` / `onMessage` boundaries, and serialization or validation logic. Compressing or reusing compact payloads across that boundary can hide the exact message contract that a maintainer needs to inspect.
 
-`F4` therefore remains deferred until a later PR names a narrow fixture pair and proves that fallback-first behavior is still preserved.
+`F4` therefore provides fallback evidence only. It names a narrow fixture pair and proves that fallback-first behavior is still preserved.
 
-## Required fixture pair before promotion
+## Fixture pair
 
-A future `F4` promotion must use only local or synthetic-local fixtures unless a separate public-corpus approval explicitly pins external source provenance. The minimum pair is:
+The current `F4` pair uses only local or synthetic-local fixtures:
 
-1. **Native side fixture** — a React Native file that renders `WebView`, defines `source` or injected JavaScript, and handles `onMessage` or bridge callbacks.
-2. **Web side fixture** — the paired HTML/web React/JavaScript surface that calls `postMessage` or receives native bridge messages.
-3. **Boundary contract note** — a short explanation of the message names, payload shape, trust boundary, and why fallback remains the expected outcome.
+1. **Native side fixture** — `test/fixtures/frontend-domain-expectations/webview/checkout-bridge-native.tsx` renders `WebView`, defines a synthetic local `source`, and handles `onMessage` for a narrow checkout bridge callback.
+2. **Web side fixture** — `test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html` calls `window.ReactNativeWebView.postMessage` with a narrow checkout message.
+3. **Boundary contract note** — the message contract is `checkout.submit` with a small payload (`cartId`, `totalCents`) and an optional `checkout.ack` acknowledgement path. The trust boundary is the native/web message boundary; fallback remains expected because fooks does not model WebView bridge safety or compact-payload reuse across that boundary.
 
-## Promotion gates
+## Promotion gates for any future extraction work
 
-Promotion from deferred to selected may happen only after all gates are true:
+Promotion from fallback evidence to extraction may happen only after all gates are true:
 
 1. The manifest still has exactly one expected outcome for the bridge pair.
 2. The expected outcome is `fallback` unless a later security review explicitly approves a narrower extraction profile.
-3. `unsupported-react-native-webview-boundary` remains the fallback reason for native WebView bridge files.
+3. `unsupported-react-native-webview-boundary` remains the fallback reason for native WebView bridge files until such a review exists.
 4. The docs avoid WebView support, bridge safety, and compact-payload reuse claims.
 5. Tests prove the native side and web side stay paired and local.
 6. The PR states that WebView bridge evidence is not general React Native, React Web, or WebView support.
@@ -38,8 +38,6 @@ Promotion from deferred to selected may happen only after all gates are true:
 - No WebView compact-payload reuse.
 - No bridge safety claim.
 - No automatic extraction across native/web message boundaries.
-- No native/web synthetic bridge fixture files in the readiness-gate-only PR.
-- No `F4` selected promotion in the readiness-gate-only PR.
-- No detector, extractor, runtime, pre-read, setup, or CLI behavior change in the readiness-gate-only PR.
+- No detector, extractor, runtime, pre-read, setup, or CLI behavior change in the paired-fixture evidence PR.
 - No public repository vendoring or live fetch.
 - No manifest schema migration.

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -27,6 +27,7 @@ function expectedClassificationForLane(lane) {
   if (lane === "tui-ink") return "tui-ink";
   if (lane.startsWith("rn-")) return "react-native";
   if (lane === "webview-boundary") return "webview";
+  if (lane === "webview-bridge") return "mixed";
   if (lane === "negative-fallback") return "mixed";
   throw new Error(`No detector classification expectation for lane: ${lane}`);
 }

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -95,6 +95,34 @@
       "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
     },
     {
+      "slot": "F4",
+      "id": "webview-bridge-pair",
+      "lane": "webview-bridge",
+      "path": "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-native.tsx",
+      "relatedSourcePaths": [
+        "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html"
+      ],
+      "sourceKind": "synthetic-local",
+      "sourceReference": "Synthetic local paired WebView bridge fixtures, no external repository copy",
+      "expectedOutcome": "fallback",
+      "expectedReason": "unsupported-react-native-webview-boundary",
+      "requiredSignals": [
+        "react-native-webview import",
+        "WebView source",
+        "onMessage",
+        "postMessage",
+        "checkout.submit"
+      ],
+      "forbiddenClaims": [
+        "No WebView support claim",
+        "No bridge safety claim",
+        "No compact payload reuse"
+      ],
+      "supportClaim": "none",
+      "evidenceScope": "fallback-boundary-evidence-only",
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary and docs/tests prove the native/web fixtures stay paired and local"
+    },
+    {
       "slot": "F5",
       "id": "tui-ink-basic",
       "lane": "tui-ink",
@@ -186,14 +214,6 @@
     }
   ],
   "deferred": [
-    {
-      "slot": "F4",
-      "id": "webview-bridge-pair",
-      "lane": "webview-bridge",
-      "sourceKind": "deferred",
-      "deferReason": "Paired native/web bridge fixtures require separate security and boundary review before compact-payload planning.",
-      "doesNotBlockBaseline": true
-    },
     {
       "slot": "F7",
       "id": "tui-non-ink-cli-renderer",

--- a/test/fixtures/frontend-domain-expectations/webview/checkout-bridge-native.tsx
+++ b/test/fixtures/frontend-domain-expectations/webview/checkout-bridge-native.tsx
@@ -1,0 +1,43 @@
+import { View } from "react-native";
+import { WebView } from "react-native-webview";
+
+const checkoutBridgeHtml = require("./checkout-bridge-web.html");
+
+type CheckoutBridgeMessage = {
+  type: "checkout.submit";
+  cartId: string;
+  totalCents: number;
+};
+
+function parseCheckoutMessage(data: string): CheckoutBridgeMessage | null {
+  try {
+    const message = JSON.parse(data) as Partial<CheckoutBridgeMessage>;
+    if (message.type !== "checkout.submit") {
+      return null;
+    }
+    if (typeof message.cartId !== "string" || typeof message.totalCents !== "number") {
+      return null;
+    }
+    return message as CheckoutBridgeMessage;
+  } catch {
+    return null;
+  }
+}
+
+export function CheckoutBridgeNativeFixture() {
+  return (
+    <View>
+      <WebView
+        source={checkoutBridgeHtml}
+        injectedJavaScript="window.__checkoutBridgeReady = true;"
+        onMessage={(event) => {
+          const message = parseCheckoutMessage(event.nativeEvent.data);
+          if (message) {
+            // Synthetic-local acknowledgement path only; not a payment, auth, or bridge-safety implementation.
+            event.currentTarget.postMessage(JSON.stringify({ type: "checkout.ack", cartId: message.cartId }));
+          }
+        }}
+      />
+    </View>
+  );
+}

--- a/test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html
+++ b/test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <button id="submit-checkout">Submit checkout</button>
+    <script>
+      const checkoutMessage = {
+        type: "checkout.submit",
+        cartId: "synthetic-cart-001",
+        totalCents: 4200,
+      };
+
+      document.getElementById("submit-checkout").addEventListener("click", () => {
+        window.ReactNativeWebView.postMessage(JSON.stringify(checkoutMessage));
+      });
+
+      window.addEventListener("message", (event) => {
+        const acknowledgement = JSON.parse(event.data);
+        if (acknowledgement.type === "checkout.ack") {
+          document.body.dataset.checkoutAck = acknowledgement.cartId;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3998,9 +3998,16 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.equal(selected.get("webview-boundary-basic").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("negative-rn-webview-boundary").expectedOutcome, "fallback");
   assert.equal(selected.get("negative-rn-webview-boundary").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("webview-bridge-pair").expectedOutcome, "fallback");
+  assert.equal(selected.get("webview-bridge-pair").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("webview-bridge-pair").supportClaim, "none");
+  assert.equal(selected.get("webview-bridge-pair").evidenceScope, "fallback-boundary-evidence-only");
+  assert.deepEqual(selected.get("webview-bridge-pair").relatedSourcePaths, [
+    "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html",
+  ]);
+  assert.equal(deferred.get("webview-bridge-pair"), undefined);
   assert.equal(selected.get("tui-ink-basic").supportClaim, "none");
   assert.equal(selected.get("tui-ink-basic").evidenceScope, "syntax-evidence-only");
-  assert.equal(deferred.get("webview-bridge-pair").sourceKind, "deferred");
 
   assert.doesNotMatch(contract, /React Native support is available/i);
   assert.doesNotMatch(contract, /WebView support is available/i);
@@ -4051,8 +4058,8 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     return resolved;
   };
 
-  assert.deepEqual([...selected.keys()], ["F0", "F1", "F2", "F3", "F5", "F6", "F9", "F10"]);
-  assert.deepEqual([...deferred.keys()], ["F4", "F7"]);
+  assert.deepEqual([...selected.keys()], ["F0", "F1", "F2", "F3", "F4", "F5", "F6", "F9", "F10"]);
+  assert.deepEqual([...deferred.keys()], ["F7"]);
   assert.deepEqual(expectations.forbiddenFirstPassSourceKinds, ["public-snapshot"]);
 
   const selectedDeferredOnlyFields = ["deferReason", "doesNotBlockBaseline"];
@@ -4092,6 +4099,14 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F2").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("F3").expectedOutcome, "fallback");
   assert.equal(selected.get("F3").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F4").id, "webview-bridge-pair");
+  assert.equal(selected.get("F4").expectedOutcome, "fallback");
+  assert.equal(selected.get("F4").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.equal(selected.get("F4").supportClaim, "none");
+  assert.equal(selected.get("F4").evidenceScope, "fallback-boundary-evidence-only");
+  assert.deepEqual(selected.get("F4").relatedSourcePaths, [
+    "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html",
+  ]);
   assert.equal(selected.get("F5").expectedOutcome, "extract");
   assert.equal(selected.get("F5").supportClaim, "none");
   assert.equal(selected.get("F5").evidenceScope, "syntax-evidence-only");
@@ -4110,14 +4125,23 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
       assert.equal(item[field], undefined, `${item.id} deferred fixture must not carry selected-only ${field}`);
     }
   }
-  const webviewBridgePair = deferred.get("F4");
-  assert.equal(webviewBridgePair.id, "webview-bridge-pair");
-  assert.equal(webviewBridgePair.lane, "webview-bridge");
-  assert.equal(webviewBridgePair.path, undefined);
-  assert.equal(webviewBridgePair.expectedOutcome, undefined);
-  assert.equal(webviewBridgePair.expectedReason, undefined);
-  assert.equal(webviewBridgePair.requiredSignals, undefined);
-  assert.equal(webviewBridgePair.verification, undefined);
+  assert.equal(deferred.get("F4"), undefined, "webview bridge pair must not be both selected and deferred");
+  const webviewBridgePaths = collectEvidencePaths(selected.get("F4"));
+  assert.equal(new Set(webviewBridgePaths).size, webviewBridgePaths.length, "WebView bridge evidence paths must be distinct");
+  assert.equal(webviewBridgePaths.length, 2, "WebView bridge evidence must include native and web sides");
+  for (const evidencePath of webviewBridgePaths) {
+    const resolved = resolveFixtureEvidencePath(evidencePath);
+    const source = fs.readFileSync(resolved, "utf8");
+    assert.doesNotMatch(source, /github\.com|https?:\/\/|public-snapshot|live-fetch|vendor-external/i);
+  }
+  const webviewBridgeNative = fs.readFileSync(path.join(repoRoot, selected.get("F4").path), "utf8");
+  const webviewBridgeWeb = fs.readFileSync(path.join(repoRoot, selected.get("F4").relatedSourcePaths[0]), "utf8");
+  assert.match(webviewBridgeNative, /checkout\.submit/);
+  assert.match(webviewBridgeNative, /onMessage/);
+  assert.match(webviewBridgeNative, /postMessage/);
+  assert.match(webviewBridgeWeb, /checkout\.submit/);
+  assert.match(webviewBridgeWeb, /ReactNativeWebView\.postMessage/);
+  assert.doesNotMatch(webviewBridgeNative + webviewBridgeWeb, /WebView support is available|bridge safety is guaranteed|compact[- ]payload reuse is (?:available|enabled|safe)/i);
   assert.equal(deferred.get("F7").id, "tui-non-ink-cli-renderer");
   assert.equal(deferred.get("F7").supportClaim, "none");
   assert.equal(deferred.get("F7").path, undefined);
@@ -4145,7 +4169,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.doesNotMatch(source, /TUI support is available|TUI\/Ink is supported today|default TUI compact extraction is enabled/i);
   }
 
-  for (const slot of ["F1", "F2", "F3", "F6", "F9", "F10"]) {
+  for (const slot of ["F1", "F2", "F3", "F4", "F6", "F9", "F10"]) {
     const item = selected.get(slot);
     const decision = preReadModule.decidePreRead(path.join(repoRoot, item.path), repoRoot, "codex");
     assert.equal(decision.decision, "fallback", `${item.id} should stay fallback-first`);
@@ -4193,14 +4217,14 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
-  assert.match(webviewBridgePlan, /`F4` \(`webview-bridge-pair`\) deferred/);
+  assert.match(webviewBridgePlan, /`F4` \(`webview-bridge-pair`\) as \*\*selected fallback-boundary evidence\*\*/);
+  assert.match(webviewBridgePlan, /checkout\.submit/);
   assert.match(webviewBridgePlan, /Native side fixture/);
   assert.match(webviewBridgePlan, /Web side fixture/);
   assert.match(webviewBridgePlan, /Boundary contract note/);
-  assert.match(webviewBridgePlan, /readiness-gate-only PR/);
-  assert.match(webviewBridgePlan, /later synthetic-local bridge-pair PR is a separate lane/);
-  assert.match(webviewBridgePlan, /must not add native\/web fixture files/);
-  assert.match(webviewBridgePlan, /move `F4` from deferred to selected/);
+  assert.match(webviewBridgePlan, /Selected fallback-evidence boundary/);
+  assert.match(webviewBridgePlan, /synthetic bridge pair remains a separate lane/);
+  assert.match(webviewBridgePlan, /expected outcome is `fallback`/);
   assert.match(webviewBridgePlan, /detector, extractor, runtime, pre-read, setup, or CLI behavior/);
   assert.match(webviewBridgePlan, /unsupported-react-native-webview-boundary/);
   assert.match(webviewBridgePlan, /expected outcome is `fallback`/);


### PR DESCRIPTION
## Summary

- Add synthetic-local paired WebView bridge fallback evidence for `F4`.
- Move `webview-bridge-pair` from deferred to selected fallback evidence with native `path` + web `relatedSourcePaths`.
- Update docs/tests to keep expected outcome `fallback` and forbid WebView support, bridge safety, or compact-payload reuse claims.

## Boundary

This PR does **not** add WebView support, bridge safety guarantees, compact-payload reuse, or detector/runtime/pre-read/setup/CLI behavior changes.

## Verification

- `git diff --check`
- targeted `node --test --test-name-pattern "webview|frontend domain|fixture expectation|pre-read treats React Native and WebView markers" test/fooks.test.mjs test/domain-detector.test.mjs` — PASS 8/8
- `npm run build` — PASS
- `npm run lint` — PASS
- `npm test` — PASS 288/288
- Architect verification — APPROVE
