### PR TITLE
Fix branch audit crash when fetch stdout is ignored

### DIFF
--- a/scripts/audit-remote-branches.mjs
+++ b/scripts/audit-remote-branches.mjs
@@ -7,12 +7,13 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 function run(command, args, options = {}) {
-  return execFileSync(command, args, {
+  const output = execFileSync(command, args, {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     ...options,
-  }).trimEnd();
+  });
+  return output === null ? "" : output.trimEnd();
 }
 
 function tryRun(command, args, fallback = "") {

--- a/test/audit-remote-branches.test.mjs
+++ b/test/audit-remote-branches.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const auditScript = path.join(repoRoot, "scripts", "audit-remote-branches.mjs");
+
+function writeExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content, { mode: 0o755 });
+}
+
+test("remote branch audit handles ignored fetch stdout", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-branch-audit-"));
+  const binDir = path.join(tempDir, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeExecutable(path.join(binDir, "git"), `#!/bin/sh
+args="$*"
+case "$args" in
+  "remote get-url origin")
+    printf '%s\n' 'https://github.com/minislively/fooks.git'
+    ;;
+  "fetch --prune origin")
+    exit 0
+    ;;
+  "rev-parse --verify origin/main")
+    printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    ;;
+  "branch -r --format=%(refname:short)")
+    printf '%s\n' 'origin/main' 'origin/feature-a'
+    ;;
+  "rev-list --left-right --count origin/main...origin/feature-a")
+    printf '%s\n' '0 1'
+    ;;
+  "cherry origin/main origin/feature-a")
+    printf '%s\n' '+ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    ;;
+  "log -1 --format=%cs origin/feature-a")
+    printf '%s\n' '2026-04-27'
+    ;;
+  "log -1 --format=%s origin/feature-a")
+    printf '%s\n' 'Example branch audit fixture'
+    ;;
+  "rev-parse --short=12 origin/feature-a")
+    printf '%s\n' 'bbbbbbbbbbbb'
+    ;;
+  *)
+    printf 'unexpected git args: %s\n' "$args" >&2
+    exit 64
+    ;;
+esac
+`);
+
+  writeExecutable(path.join(binDir, "gh"), `#!/bin/sh
+printf '%s\n' '[]'
+`);
+
+  try {
+    const stdout = execFileSync(process.execPath, [auditScript, "--json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.summary.totalBranches, 1);
+    assert.equal(result.branches[0].branch, "feature-a");
+    assert.equal(result.branches[0].classification, "valid-candidate");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- fix branch-audit dogfood crash when the fetch subprocess ignores stdout
- add a regression test that stubs git/gh and exercises the default fetch path

## Evidence
- Open issues before work: none
- Open PRs before work: none
- Main dogfood failure: `npm run branch:audit` failed with `Cannot read properties of null (reading 'trimEnd')`\n\n## Verification\n- `node --test test/audit-remote-branches.test.mjs`\n- `node scripts/audit-remote-branches.mjs --json`\n- `node scripts/audit-remote-branches.mjs --no-fetch --json`\n- `npm run --silent branch:audit`\n- `npm test` (289 pass, 0 fail)\n