### PR TITLE
Keep RN readiness evidence from implying support

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -24,6 +24,20 @@ The machine-readable fixture expectation manifest at `test/fixtures/frontend-dom
 
 The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope. `F4` is selected only as paired fallback-boundary evidence under the [WebView bridge boundary plan](webview-bridge-boundary-plan.md): its native fixture is the primary `path`, and its paired web fixture is recorded in `relatedSourcePaths`.
 
+
+## RN component semantics readiness gate
+
+The RN fixture lane is a readiness gate, not a support promise. Selected RN fixtures must stay fallback/evidence-only until a later detector/profile promotion plan explicitly changes runtime behavior. The current fallback reason, `unsupported-react-native-webview-boundary`, is the shared source-reading boundary reason for this pass; it must not be treated as a permanent domain model for every RN semantic.
+
+| Semantics group | Selected slots | Evidence examples | Required boundary |
+| --- | --- | --- | --- |
+| Primitives/input | `F1` | `View`, `Text`, `TextInput`, `Pressable` | RN primitives must not be reinterpreted as DOM controls, forms, or React Web extraction evidence. |
+| Style/platform/navigation | `F2` | `StyleSheet.create`, `Platform.select`, navigation and route markers | Style and navigation markers remain RN evidence only; no navigation runtime guarantee. |
+| Interaction/list | `F9` | `TouchableOpacity`, `FlatList`, `PanResponder`, gesture handlers | Interaction and list markers remain fallback-boundary evidence only; no gesture, list virtualization, or runtime safety claim. |
+| Media/layout | `F10` | `Image`, `ScrollView`, `Dimensions`, `resizeMode`, `pagingEnabled` | Media and layout markers remain fallback-boundary evidence only; no image loading, layout, or RN support claim. |
+
+Execution for this gate should prefer strengthening docs, manifest metadata, and regression tests around existing RN fixture slots before adding new synthetic fixtures.
+
 ## Manifest shape guard
 
 Selected fixtures must not carry deferred-only fields such as `deferReason` or `doesNotBlockBaseline`. Deferred fixtures must not carry executable fixture paths, expected outcomes, fallback reasons, required signals, or verification instructions. This keeps the manifest from describing the same slot as both selected and deferred while later RN/WebView/TUI/React Web work is split across branches.

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -60,7 +60,7 @@ test("detects React Native evidence signals without support wording", () => {
 
   const touchable = detectDomain(path.join(fixtureRoot, "rn-interaction-gesture.tsx"));
   assert.equal(touchable.classification, "react-native");
-  assertSignals(touchable, ["react-native:primitive:TouchableOpacity"]);
+  assertSignals(touchable, ["react-native:primitive:TouchableOpacity", "react-native:primitive:FlatList"]);
 
   assert.doesNotMatch(JSON.stringify([primitive, styled, image, touchable]), forbiddenSupportClaims);
 });

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -49,7 +49,10 @@
         "No React Native support claim",
         "No DOM/form semantic inference"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary",
+      "supportClaim": "none",
+      "evidenceScope": "rn-component-semantics-readiness-only",
+      "fallbackReasonScope": "current-boundary-reason-only"
     },
     {
       "slot": "F2",
@@ -71,7 +74,10 @@
         "No DOM/form semantic inference",
         "No navigation runtime guarantee"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary",
+      "supportClaim": "none",
+      "evidenceScope": "rn-component-semantics-readiness-only",
+      "fallbackReasonScope": "current-boundary-reason-only"
     },
     {
       "slot": "F3",
@@ -180,15 +186,20 @@
       "expectedReason": "unsupported-react-native-webview-boundary",
       "requiredSignals": [
         "TouchableOpacity",
+        "FlatList",
         "PanResponder",
         "gesture handlers",
         "activeOpacity"
       ],
       "forbiddenClaims": [
         "No React Native support claim",
-        "No gesture runtime safety claim"
+        "No gesture runtime safety claim",
+        "No list virtualization support claim"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary and detector evidence includes TouchableOpacity plus FlatList without list/runtime support claims",
+      "supportClaim": "none",
+      "evidenceScope": "rn-component-semantics-readiness-only",
+      "fallbackReasonScope": "current-boundary-reason-only"
     },
     {
       "slot": "F10",
@@ -210,7 +221,10 @@
         "No React Native support claim",
         "No image loading safety claim"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary",
+      "supportClaim": "none",
+      "evidenceScope": "rn-component-semantics-readiness-only",
+      "fallbackReasonScope": "current-boundary-reason-only"
     }
   ],
   "deferred": [

--- a/test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx
@@ -1,6 +1,7 @@
-import { TouchableOpacity, PanResponder, View, Text, GestureResponderEvent } from "react-native";
+import { FlatList, TouchableOpacity, PanResponder, View, Text, GestureResponderEvent } from "react-native";
 
 export function DraggableCard() {
+  const actions = ["tap", "drag"];
   const panResponder = PanResponder.create({
     onStartShouldSetPanResponder: () => true,
     onPanResponderGrant: () => {},
@@ -15,6 +16,11 @@ export function DraggableCard() {
       <TouchableOpacity onPress={() => {}} activeOpacity={0.8}>
         <Text>Tap or drag me</Text>
       </TouchableOpacity>
+      <FlatList
+        data={actions}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => <Text>{item}</Text>}
+      />
     </View>
   );
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1031,6 +1031,7 @@ test("frontend domain detector returns evidence-only classifications for Level 3
   const touchable = detectDomain(path.join(fixtureRoot, "rn-interaction-gesture.tsx"));
   assert.equal(touchable.classification, "react-native");
   assert.ok(touchable.signals.includes("react-native:primitive:TouchableOpacity"));
+  assert.ok(touchable.signals.includes("react-native:primitive:FlatList"));
 
   const webview = detectDomain(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
   assert.equal(webview.classification, "webview");
@@ -3962,6 +3963,7 @@ test("docs describe TUI/Ink fixture survey as future candidate evidence only", (
 
 test("frontend domain contract locks taxonomy and pre-detector promotion gates", () => {
   const contract = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-contract.md"), "utf8");
+  const fixtureExpectations = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
   const expectations = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json"), "utf8"),
   );
@@ -3980,6 +3982,10 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(contract, /fallback-first posture/);
   assert.match(contract, /React Native and TUI\/Ink fixtures .* are \*\*not support claims\*\*/s);
   assert.match(contract, /RN primitives must not be reinterpreted as DOM controls/);
+  assert.match(fixtureExpectations, /RN component semantics readiness gate/);
+  assert.match(fixtureExpectations, /current fallback reason, `unsupported-react-native-webview-boundary`, is the shared source-reading boundary reason for this pass/);
+  assert.match(fixtureExpectations, /must not be treated as a permanent domain model for every RN semantic/);
+  assert.match(fixtureExpectations, /Interaction and list markers remain fallback-boundary evidence only/);
   assert.match(contract, /TUI\/Ink fixtures must not be generalized into arbitrary terminal UI support/);
   assert.match(contract, /fixture expectation manifest at `test\/fixtures\/frontend-domain-expectations\/manifest\.json` is the pre-detector\/profile gate/);
   assert.match(contract, /This issue does not migrate the manifest schema/);
@@ -3994,6 +4000,12 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.equal(selected.get("rn-primitive-basic").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("rn-style-platform-navigation").expectedOutcome, "fallback");
   assert.equal(selected.get("rn-style-platform-navigation").expectedReason, "unsupported-react-native-webview-boundary");
+  for (const rnId of ["rn-primitive-basic", "rn-style-platform-navigation", "rn-interaction-gesture", "rn-image-scrollview"]) {
+    assert.equal(selected.get(rnId).supportClaim, "none");
+    assert.equal(selected.get(rnId).evidenceScope, "rn-component-semantics-readiness-only");
+    assert.equal(selected.get(rnId).fallbackReasonScope, "current-boundary-reason-only");
+  }
+  assert.ok(selected.get("rn-interaction-gesture").requiredSignals.includes("FlatList"));
   assert.equal(selected.get("webview-boundary-basic").expectedOutcome, "fallback");
   assert.equal(selected.get("webview-boundary-basic").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("negative-rn-webview-boundary").expectedOutcome, "fallback");
@@ -4114,8 +4126,16 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F6").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("F9").expectedOutcome, "fallback");
   assert.equal(selected.get("F9").expectedReason, "unsupported-react-native-webview-boundary");
+  assert.ok(selected.get("F9").requiredSignals.includes("FlatList"));
   assert.equal(selected.get("F10").expectedOutcome, "fallback");
   assert.equal(selected.get("F10").expectedReason, "unsupported-react-native-webview-boundary");
+
+  for (const slot of ["F1", "F2", "F9", "F10"]) {
+    assert.equal(selected.get(slot).supportClaim, "none", `${selected.get(slot).id} must not claim RN support`);
+    assert.equal(selected.get(slot).evidenceScope, "rn-component-semantics-readiness-only", `${selected.get(slot).id} must stay readiness evidence only`);
+    assert.equal(selected.get(slot).fallbackReasonScope, "current-boundary-reason-only", `${selected.get(slot).id} must frame fallback reason as current boundary wording only`);
+    assert.ok(selected.get(slot).forbiddenClaims.some((claim) => /No React Native support claim/.test(claim)), `${selected.get(slot).id} must forbid React Native support claims`);
+  }
 
   for (const item of deferred.values()) {
     assert.equal(item.sourceKind, "deferred");


### PR DESCRIPTION
## Summary

- Add an RN component semantics readiness gate to the frontend domain fixture expectations.
- Mark selected RN fixture slots as `supportClaim: "none"`, `evidenceScope: "rn-component-semantics-readiness-only"`, and `fallbackReasonScope: "current-boundary-reason-only"`.
- Add `FlatList` as interaction/list evidence in the synthetic RN interaction fixture and lock it with regression tests.

## Boundary

This PR does **not** add React Native support, detector/runtime/extractor behavior changes, new dependencies, or large-corpus validation. The existing `unsupported-react-native-webview-boundary` reason is framed as the current shared fallback boundary reason only, not a permanent RN domain model.

## Verification

- `git diff --check`
- targeted `node --test --test-name-pattern "react native|rn-|frontend domain|fixture expectation|pre-read treats React Native" test/fooks.test.mjs test/domain-detector.test.mjs` — PASS 8/8
- `npm run build` — PASS
- `npm run lint` — PASS
- `npm test` — PASS 291/291
- Architect verification — APPROVE
- Deslop pass — no extra edits; post-deslop reverify PASS
