### PR TITLE
Thread frontend domain profile metadata

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -51,7 +51,7 @@ This issue does not migrate the manifest schema. The current schema remains the 
 
 ## Next detector/profile promotion gate
 
-The next detector/profile PR may start only after this contract is green in docs and tests. That later PR must be explicitly scoped and must include, before source behavior changes:
+The next detector/profile PR may start only after this contract is green in docs and tests. Evidence lanes do not approve detector/profile implementation by themselves. That later PR must be explicitly scoped and must include, before source behavior changes:
 
 - fixture-backed domain classification rules for React Web, React Native, WebView, TUI-Ink, Mixed, and Unknown;
 - pass/fail expectations for each promoted fixture;
@@ -59,5 +59,29 @@ The next detector/profile PR may start only after this contract is green in docs
 - wording boundaries that avoid RN/WebView/TUI support claims beyond measured evidence;
 - regression coverage proving the manifest remains a pre-detector/profile gate;
 - a stated non-goal for package/lockfile changes, setup/CLI changes, runtime/pre-read broadening, manifest schema migration, and domain sharding unless a separate issue explicitly opens one of those lanes.
+
+### Detector promotion readiness checklist
+
+A promotion candidate must pass every gate below before it changes runtime detector, extractor, or pre-read behavior. A failed gate keeps the current fallback/deferred contract in place.
+
+| Gate | Required proof before promotion | Blocks promotion when |
+| --- | --- | --- |
+| Domain coverage | Classification evidence and expected outcome are named for React Web, React Native, WebView, TUI-Ink, Mixed, and Unknown. | Any selected domain relies on syntax evidence without an explicit `extract`, `fallback`, or `deferred` expectation. |
+| Fixture manifest alignment | `test/fixtures/frontend-domain-expectations/manifest.json`, fixture docs, and contract wording agree on lane, outcome, reason, and support-claim boundary. | The manifest schema must change without a separate migration plan, or docs/tests disagree on the current schema. |
+| Fallback safety | WebView and mixed-boundary cases keep fallback-first behavior unless a later approved security/boundary plan narrows the scope. | A change implies WebView bridge safety, compact-payload reuse, or fallback removal without that later approval. |
+| Runtime-change approval | The PR names the exact detector/profile behavior that will change and the regression proof for it. | Runtime detector, extractor, or pre-read behavior changes are introduced from evidence-lane docs alone. |
+| Claim wording | Public/user-facing wording remains limited to measured evidence and current supported lane. | RN, WebView, or TUI evidence is described as support, terminal correctness, bridge safety, or broad compact extraction. |
+| Source-reading reason boundary | `unsupported-react-native-webview-boundary` remains the current source-reading boundary reason until a later semantic model is approved. | The fallback reason is treated as a permanent RN/WebView/TUI semantic model or reused to claim domain support. |
+
+### Domain readiness matrix
+
+| Domain | Promotion-ready evidence required | Current stop condition |
+| --- | --- | --- |
+| React Web | Existing supported React Web fixtures stay green while any new detector rule proves no regression to current form/DOM extraction behavior. | React Web evidence is used to imply RN, WebView, TUI, Mixed, or Unknown support. |
+| React Native | RN primitive, interaction/list, style/platform/navigation, and fallback-reason expectations are fixture-backed and documented as measured evidence only, not a final RN semantic model. | RN primitives are mapped to DOM controls, or `unsupported-react-native-webview-boundary` is treated as a final RN semantic model instead of the current boundary reason. |
+| WebView | WebView source/HTML/bridge fixtures stay fallback-first with explicit bridge-boundary wording. | The change claims WebView bridge safety, enables compact-payload reuse, or weakens fallback-first behavior. |
+| TUI-Ink | Ink syntax fixtures prove only local TSX traversal and measured fixture outcomes. | The change claims broad TUI support, terminal behavior correctness, runtime-token savings, or default TUI compact extraction. |
+| Mixed | Mixed signals select the strongest safety boundary and document why fallback/deferred wins. | The change promotes Mixed by choosing the most convenient single domain. |
+| Unknown | Weak or absent signals remain deferred or generic only under existing eligibility rules. | Unknown is treated as implicit React Web, RN, WebView, or TUI support. |
 
 Promotion stops at the first failed gate. Until that later gate passes, this contract is documentation and regression protection only.

--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -5,6 +5,12 @@ import ts from "typescript";
 export type DomainLabel = "react-web" | "react-native" | "webview" | "tui-ink" | "mixed" | "unknown";
 export type FrontendDomainClassification = DomainLabel;
 export type FrontendDomainOutcome = "extract" | "fallback" | "deferred" | "unsupported";
+export type FrontendDomainProfileClaimStatus = "current-supported-lane" | "evidence-only" | "fallback-boundary" | "deferred";
+export type FrontendDomainProfileClaimBoundary =
+  | "react-web-measured-extraction"
+  | "domain-evidence-only"
+  | "source-reading-boundary"
+  | "unknown-deferred";
 
 export const FRONTEND_DOMAIN_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 
@@ -14,12 +20,22 @@ export type FrontendDomainEvidence = {
   detail: string;
 };
 
+export type FrontendDomainProfileMetadata = {
+  lane: DomainLabel;
+  outcome: FrontendDomainOutcome;
+  claimStatus: FrontendDomainProfileClaimStatus;
+  fallbackFirst: boolean;
+  boundaryReason?: string;
+  claimBoundary: FrontendDomainProfileClaimBoundary;
+};
+
 export type DomainDetectionResult = {
   classification: FrontendDomainClassification;
   /** @deprecated Use classification. */
   domain: DomainLabel;
   outcome: FrontendDomainOutcome;
   reason?: string;
+  profile: FrontendDomainProfileMetadata;
   evidence: FrontendDomainEvidence[];
   /** @deprecated Use evidence. */
   signals: string[];
@@ -87,6 +103,50 @@ function outcomeForClassification(classification: DomainLabel): Pick<DomainDetec
   }
 }
 
+function profileForClassification(
+  classification: DomainLabel,
+  outcome: FrontendDomainOutcome,
+  reason?: string,
+): FrontendDomainProfileMetadata {
+  switch (classification) {
+    case "react-web":
+      return {
+        lane: classification,
+        outcome,
+        claimStatus: "current-supported-lane",
+        fallbackFirst: false,
+        claimBoundary: "react-web-measured-extraction",
+      };
+    case "react-native":
+    case "webview":
+    case "mixed":
+      return {
+        lane: classification,
+        outcome,
+        claimStatus: "fallback-boundary",
+        fallbackFirst: true,
+        boundaryReason: reason,
+        claimBoundary: "source-reading-boundary",
+      };
+    case "tui-ink":
+      return {
+        lane: classification,
+        outcome,
+        claimStatus: "evidence-only",
+        fallbackFirst: false,
+        claimBoundary: "domain-evidence-only",
+      };
+    case "unknown":
+      return {
+        lane: classification,
+        outcome,
+        claimStatus: "deferred",
+        fallbackFirst: false,
+        claimBoundary: "unknown-deferred",
+      };
+  }
+}
+
 function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): DomainDetectionResult {
   const domainEvidence = ["react-native", "webview", "tui-ink"] as const;
   const matched = domainEvidence.filter((domain) => hasEvidence(evidence, domain));
@@ -101,10 +161,12 @@ function classify(evidence: FrontendDomainEvidence[], hasWebDom: boolean): Domai
     classification = "unknown";
   }
 
+  const outcome = outcomeForClassification(classification);
   return {
     classification,
     domain: classification,
-    ...outcomeForClassification(classification),
+    ...outcome,
+    profile: profileForClassification(classification, outcome.outcome, outcome.reason),
     evidence,
     signals: signalList(evidence),
   };

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -22,6 +22,19 @@ function assertSignals(result, expectedSignals) {
   }
 }
 
+function assertProfile(result, expected) {
+  assert.equal(result.profile.lane, result.classification);
+  assert.equal(result.profile.outcome, result.outcome);
+  assert.equal(result.profile.claimStatus, expected.claimStatus);
+  assert.equal(result.profile.fallbackFirst, expected.fallbackFirst);
+  assert.equal(result.profile.claimBoundary, expected.claimBoundary);
+  if (expected.boundaryReason !== undefined) {
+    assert.equal(result.profile.boundaryReason, expected.boundaryReason);
+  } else {
+    assert.equal(result.profile.boundaryReason, undefined);
+  }
+}
+
 function expectedClassificationForLane(lane) {
   if (lane === "react-web") return "react-web";
   if (lane === "tui-ink") return "tui-ink";
@@ -32,12 +45,26 @@ function expectedClassificationForLane(lane) {
   throw new Error(`No detector classification expectation for lane: ${lane}`);
 }
 
+
+test("detects React Web profile metadata for the current supported lane", () => {
+  const result = detectDomain(path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"));
+  assert.equal(result.classification, "react-web");
+  assert.equal(result.outcome, "extract");
+  assertProfile(result, {
+    claimStatus: "current-supported-lane",
+    fallbackFirst: false,
+    claimBoundary: "react-web-measured-extraction",
+  });
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+});
+
 test("detects React Native evidence signals without support wording", () => {
   const primitive = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
   assert.equal(primitive.classification, "react-native");
   assert.equal(primitive.domain, "react-native");
   assert.equal(primitive.outcome, "fallback");
   assert.equal(primitive.reason, "unsupported-react-native-webview-boundary");
+  assertProfile(primitive, { claimStatus: "fallback-boundary", fallbackFirst: true, claimBoundary: "source-reading-boundary", boundaryReason: "unsupported-react-native-webview-boundary" });
   assertSignals(primitive, [
     "react-native:import:react-native",
     "react-native:primitive:View",
@@ -70,6 +97,7 @@ test("detects WebView evidence signals without support wording", () => {
   assert.equal(result.classification, "webview");
   assert.equal(result.outcome, "fallback");
   assert.equal(result.reason, "unsupported-react-native-webview-boundary");
+  assertProfile(result, { claimStatus: "fallback-boundary", fallbackFirst: true, claimBoundary: "source-reading-boundary", boundaryReason: "unsupported-react-native-webview-boundary" });
   assertSignals(result, [
     "webview:import:react-native-webview",
     "webview:component:WebView",
@@ -84,6 +112,7 @@ test("detects TUI Ink evidence signals without support wording", () => {
   const result = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
   assert.equal(result.classification, "tui-ink");
   assert.equal(result.outcome, "extract");
+  assertProfile(result, { claimStatus: "evidence-only", fallbackFirst: false, claimBoundary: "domain-evidence-only" });
   assertSignals(result, ["tui-ink:import:ink", "tui-ink:primitive:Box", "tui-ink:primitive:Text", "tui-ink:hook:useInput"]);
   assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });
@@ -93,12 +122,14 @@ test("classifies mixed and unknown fallback cases", () => {
   assert.equal(mixed.classification, "mixed");
   assert.equal(mixed.outcome, "fallback");
   assert.equal(mixed.reason, "unsupported-react-native-webview-boundary");
+  assertProfile(mixed, { claimStatus: "fallback-boundary", fallbackFirst: true, claimBoundary: "source-reading-boundary", boundaryReason: "unsupported-react-native-webview-boundary" });
   assert.ok(mixed.signals.some((signal) => signal.startsWith("react-native:")));
   assert.ok(mixed.signals.some((signal) => signal.startsWith("webview:")));
 
   const unknown = detectDomainFromSource("export const answer = 42;", "utility.ts");
   assert.equal(unknown.classification, "unknown");
   assert.equal(unknown.outcome, "deferred");
+  assertProfile(unknown, { claimStatus: "deferred", fallbackFirst: false, claimBoundary: "unknown-deferred" });
   assert.deepEqual(unknown.evidence, []);
 
   assert.doesNotMatch(JSON.stringify([mixed, unknown]), forbiddenSupportClaims);
@@ -157,6 +188,8 @@ test("selected fixture manifest stays aligned with detector classifications and 
     assert.equal(result.classification, expectedClassificationForLane(item.lane), `${item.id} classification must match manifest lane`);
     assert.equal(result.domain, result.classification, `${item.id} deprecated domain alias must mirror classification`);
     assert.equal(result.outcome, item.expectedOutcome, `${item.id} detector outcome must match manifest`);
+    assert.equal(result.profile.lane, result.classification, `${item.id} profile lane must mirror classification`);
+    assert.equal(result.profile.outcome, result.outcome, `${item.id} profile outcome must mirror detector outcome`);
 
     if (item.expectedReason !== undefined) {
       assert.equal(result.reason, item.expectedReason, `${item.id} detector fallback reason must match manifest`);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3990,8 +3990,26 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(contract, /fixture expectation manifest at `test\/fixtures\/frontend-domain-expectations\/manifest\.json` is the pre-detector\/profile gate/);
   assert.match(contract, /This issue does not migrate the manifest schema/);
   assert.match(contract, /Next detector\/profile promotion gate/);
+  assert.match(contract, /Evidence lanes do not approve detector\/profile implementation by themselves/);
+  assert.match(contract, /Detector promotion readiness checklist/);
+  assert.match(contract, /Domain readiness matrix/);
+  assert.match(contract, /runtime detector, extractor, or pre-read behavior/);
+  assert.match(contract, /manifest schema must change without a separate migration plan/);
+  assert.match(contract, /WebView bridge safety, compact-payload reuse, or fallback removal/);
+  assert.match(contract, /RN, WebView, or TUI evidence is described as support/);
+  assert.match(contract, /`unsupported-react-native-webview-boundary` remains the current source-reading boundary reason/);
+  assert.match(contract, /not a final RN semantic model/);
   assert.match(contract, /Promotion stops at the first failed gate/);
   assert.match(contract, /documentation and regression protection only/);
+
+  const readinessMatrixStart = contract.indexOf("### Domain readiness matrix");
+  assert.notEqual(readinessMatrixStart, -1, "Domain readiness matrix section must exist");
+  const readinessMatrixEnd = contract.indexOf("\n\nPromotion stops", readinessMatrixStart);
+  assert.notEqual(readinessMatrixEnd, -1, "Domain readiness matrix must end before the promotion stop rule");
+  const readinessMatrix = contract.slice(readinessMatrixStart, readinessMatrixEnd);
+  for (const domain of ["React Web", "React Native", "WebView", "TUI-Ink", "Mixed", "Unknown"]) {
+    assert.ok(readinessMatrix.includes(`| ${domain} |`), `${domain} readiness matrix row must exist`);
+  }
 
   assert.equal(expectations.schemaVersion, 1);
   assert.equal(selected.get("react-web-regression-form-controls").lane, "react-web");

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1071,24 +1071,38 @@ test("extract output includes domainDetection for frontend fixtures", () => {
   assert.ok(rn.domainDetection);
   assert.equal(rn.domainDetection.classification, "react-native");
   assert.ok(rn.domainDetection.signals.includes("react-native:primitive:View"));
+  assert.deepEqual(rn.domainDetection.profile, {
+    lane: "react-native",
+    outcome: "fallback",
+    claimStatus: "fallback-boundary",
+    fallbackFirst: true,
+    boundaryReason: "unsupported-react-native-webview-boundary",
+    claimBoundary: "source-reading-boundary",
+  });
 
   const webview = extractFile(path.join(fixtureRoot, "webview-boundary-basic.tsx"));
   assert.ok(webview.domainDetection);
   assert.equal(webview.domainDetection.classification, "webview");
   assert.ok(webview.domainDetection.signals.includes("webview:component:WebView"));
+  assert.equal(webview.domainDetection.profile.claimStatus, "fallback-boundary");
+  assert.equal(webview.domainDetection.profile.fallbackFirst, true);
 
   const tui = extractFile(path.join(fixtureRoot, "tui-ink-basic.tsx"));
   assert.ok(tui.domainDetection);
   assert.equal(tui.domainDetection.classification, "tui-ink");
   assert.ok(tui.domainDetection.signals.includes("tui-ink:primitive:Box"));
+  assert.equal(tui.domainDetection.profile.claimStatus, "evidence-only");
+  assert.equal(tui.domainDetection.profile.claimBoundary, "domain-evidence-only");
 
   const mixed = extractFile(path.join(fixtureRoot, "negative-rn-webview-boundary.tsx"));
   assert.ok(mixed.domainDetection);
   assert.equal(mixed.domainDetection.classification, "mixed");
+  assert.equal(mixed.domainDetection.profile.claimStatus, "fallback-boundary");
 
   const unknown = extractFile(path.join(repoRoot, "package.json"));
   assert.ok(unknown.domainDetection);
   assert.equal(unknown.domainDetection.classification, "unknown");
+  assert.equal(unknown.domainDetection.profile.claimStatus, "deferred");
 });
 
 test("frontend domain detector and pre-read debug avoid RN WebView TUI support wording", () => {
@@ -1107,6 +1121,8 @@ test("frontend domain detector and pre-read debug avoid RN WebView TUI support w
     assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
     assert.ok(Array.isArray(result.evidence), "detector result must carry evidence");
     assert.equal(typeof result.classification, "string");
+    assert.equal(result.profile.lane, result.classification);
+    assert.equal(result.profile.outcome, result.outcome);
   }
 
   const changedSource = [
@@ -1132,6 +1148,8 @@ test("pre-read uses frontend domain detector for bare WebView fallback boundarie
   assert.deepEqual(result.reasons, ["unsupported-react-native-webview-boundary"]);
   assert.equal(result.debug.domainDetection.classification, "webview");
   assert.equal(result.debug.domainDetection.outcome, "fallback");
+  assert.equal(result.debug.domainDetection.profile.claimStatus, "fallback-boundary");
+  assert.equal(result.debug.domainDetection.profile.boundaryReason, "unsupported-react-native-webview-boundary");
   assert.ok(result.debug.domainDetection.signals.includes("webview:component:WebView"));
 });
 


### PR DESCRIPTION
## Summary

- define the detector promotion readiness checklist in the existing frontend domain contract
- add typed `DomainDetectionResult.profile` metadata derived from existing detector classification/outcome/reason
- verify profile metadata through detector, extract, and pre-read debug paths without changing RN/WebView/TUI fallback behavior

## Boundaries

- No RN extract promotion
- No WebView compact-payload reuse
- No WebView bridge-safety claim
- No TUI support / terminal-correctness claim
- No manifest schema/package/lockfile/dependency changes
- No CLI inspect-domain or default model-facing payload expansion

## Verification

- [x] `git diff --check`
- [x] `npm run build`
- [x] `node --test test/domain-detector.test.mjs`
- [x] `node --test --test-name-pattern "domainDetection|frontend domain|pre-read|React Native|WebView|TUI|support claim" test/fooks.test.mjs test/domain-detector.test.mjs`
- [x] `npm run lint`
- [x] `npm test` — 292 pass
- [x] Architect verification — APPROVE
- [x] ai-slop-cleaner/deslop pass + post-deslop reverify

## Notes

This is the first implementation slice after the docs/test readiness gates. It intentionally exposes profile metadata through existing internal detector/debug paths before any later behavior promotion.
