### PR TITLE
Open React Web runtime profile gate

### DIFF
--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -59,6 +59,7 @@ const RN_PRIMITIVES = new Set([
   "TouchableWithoutFeedback",
 ]);
 const WEB_DOM_TAGS = new Set(["div", "span", "form", "input", "button", "select", "textarea", "label"]);
+const WEB_REACT_ATTRIBUTES = new Set(["className", "htmlFor"]);
 const WEBVIEW_PROPS = new Set(["source", "injectedJavaScript", "onMessage"]);
 const TUI_PRIMITIVES = new Set(["Box", "Text"]);
 const TUI_HOOKS = new Set(["useInput"]);
@@ -180,7 +181,7 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
   const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
   const importedNamesByModule = new Map<string, Set<string>>();
   const evidence: FrontendDomainEvidence[] = [];
-  let hasWebDom = false;
+  let hasReactWebEvidence = false;
 
   function rememberImportedName(moduleName: string, name: string): void {
     const names = importedNamesByModule.get(moduleName) ?? new Set<string>();
@@ -231,12 +232,22 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
         if (RN_PRIMITIVES.has(tag) && hasImportedName(RN_MODULE, tag)) addEvidence(evidence, "react-native", "primitive", tag);
         if (tag === "WebView") addEvidence(evidence, "webview", "component", tag);
         if (TUI_PRIMITIVES.has(tag) && hasImportedName(INK_MODULE, tag)) addEvidence(evidence, "tui-ink", "primitive", tag);
-        if (WEB_DOM_TAGS.has(tag)) hasWebDom = true;
+        if (WEB_DOM_TAGS.has(tag)) {
+          hasReactWebEvidence = true;
+          addEvidence(evidence, "react-web", "dom-tag", tag);
+        }
       }
     }
 
-    if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name) && WEBVIEW_PROPS.has(node.name.text) && hasEvidence(evidence, "webview")) {
-      addEvidence(evidence, "webview", "prop", node.name.text);
+    if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name)) {
+      const attributeName = node.name.text;
+      if (WEB_REACT_ATTRIBUTES.has(attributeName)) {
+        hasReactWebEvidence = true;
+        addEvidence(evidence, "react-web", "jsx-attribute", attributeName);
+      }
+      if (WEBVIEW_PROPS.has(attributeName) && hasEvidence(evidence, "webview")) {
+        addEvidence(evidence, "webview", "prop", attributeName);
+      }
     }
 
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
@@ -258,7 +269,7 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
   }
 
   visit(sourceFile);
-  return classify(evidence, hasWebDom);
+  return classify(evidence, hasReactWebEvidence);
 }
 
 export function detectDomain(filePath: string): DomainDetectionResult {

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -58,6 +58,26 @@ test("detects React Web profile metadata for the current supported lane", () => 
   assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });
 
+test("detects React Web custom-component className evidence for the current supported lane", () => {
+  const result = detectDomainFromSource(
+    `import { Button, FieldLabel } from "@/components/ui";
+     export function CustomOnlyForm() {
+       return <Button className="rounded px-3"><FieldLabel htmlFor="email">Email</FieldLabel></Button>;
+     }`,
+    "CustomOnlyForm.tsx",
+  );
+
+  assert.equal(result.classification, "react-web");
+  assert.equal(result.outcome, "extract");
+  assertProfile(result, {
+    claimStatus: "current-supported-lane",
+    fallbackFirst: false,
+    claimBoundary: "react-web-measured-extraction",
+  });
+  assertSignals(result, ["react-web:jsx-attribute:className", "react-web:jsx-attribute:htmlFor"]);
+  assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
+});
+
 test("detects React Native evidence signals without support wording", () => {
   const primitive = detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx"));
   assert.equal(primitive.classification, "react-native");
@@ -169,7 +189,18 @@ test("classifies web DOM mixed with non-web frontend signals as fallback", () =>
   assert.ok(tuiDom.signals.includes("tui-ink:import:ink"));
   assert.ok(tuiDom.signals.includes("tui-ink:primitive:Box"));
 
-  assert.doesNotMatch(JSON.stringify([rnDom, webviewDom, tuiDom]), forbiddenSupportClaims);
+  const rnClassName = detectDomainFromSource(
+    `import { View } from "react-native";
+     export function NativeWithClassName() { return <View className="p-2" />; }`,
+    "NativeWithClassName.tsx",
+  );
+  assert.equal(rnClassName.classification, "mixed");
+  assert.equal(rnClassName.outcome, "fallback");
+  assert.equal(rnClassName.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(rnClassName.signals.includes("react-native:primitive:View"));
+  assert.ok(rnClassName.signals.includes("react-web:jsx-attribute:className"));
+
+  assert.doesNotMatch(JSON.stringify([rnDom, webviewDom, tuiDom, rnClassName]), forbiddenSupportClaims);
 });
 
 test("treats bare WebView JSX as a fallback-first boundary signal", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1189,6 +1189,29 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.ok(jsx.payload.contract);
   assert.equal("editGuidance" in jsx.payload, false);
 
+  const customReactWebDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-profile-"));
+  const customReactWebPath = path.join(customReactWebDir, "CustomOnlyForm.tsx");
+  fs.writeFileSync(
+    customReactWebPath,
+    `import { Button, FieldLabel } from "@/components/ui";
+
+export function CustomOnlyForm() {
+  return (
+    <Button className="rounded px-3" onClick={() => undefined}>
+      <FieldLabel htmlFor="email">Email</FieldLabel>
+    </Button>
+  );
+}
+`,
+  );
+  const customReactWeb = decideCodexPreRead(customReactWebPath, customReactWebDir);
+  assert.equal(customReactWeb.eligible, true);
+  assert.equal(customReactWeb.decision, "payload");
+  assert.equal(customReactWeb.debug.domainDetection.classification, "react-web");
+  assert.equal(customReactWeb.debug.domainDetection.profile.claimStatus, "current-supported-lane");
+  assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"));
+  assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:htmlFor"));
+
   const unsupportedFrontendProfile = preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON;
   const tui = decideCodexPreRead(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "tui-ink-basic.tsx"), repoRoot);
   assert.equal(tui.eligible, true);


### PR DESCRIPTION
## Summary
- Add React Web evidence for custom-component JSX that uses web-specific `className` / `htmlFor` attributes.
- Keep the existing pre-read profile gate unchanged: payload reuse is still only allowed for `react-web` + `current-supported-lane`.
- Add regression coverage proving RN/WebView/TUI/Mixed boundaries do not loosen when web-specific JSX attributes appear with non-web evidence.

## Verification
- `npm run build`
- `node --test --test-name-pattern "React Web custom-component|codex pre-read chooses payload|classifies web DOM mixed" test/domain-detector.test.mjs test/fooks.test.mjs`
- `git diff --check`
- `npm run lint`
- `npm test` — 293 pass

## Boundaries
- No RN compact extraction or support claim.
- No WebView compact extraction, bridge-safety claim, or fallback removal.
- No TUI/Ink support or runtime-token savings claim.
- No manifest schema, dependency, or lockfile changes.
