### PR TITLE
Harden WebView boundary fallback evidence

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -26,6 +26,12 @@ The machine-readable fixture expectation manifest at `test/fixtures/frontend-dom
 
 The selected baseline does not require a schema migration. `F2` is selected because today's expected behavior is a fallback boundary; its richer platform/navigation meaning remains outside the current support and extraction scope. `F4` is selected only as paired fallback-boundary evidence under the [WebView bridge boundary plan](webview-bridge-boundary-plan.md): its native fixture is the primary `path`, and its paired web fixture is recorded in `relatedSourcePaths`. `F11` and `F12` are selected React Web runtime-gate fixtures: they are local synthetic design-system-style components used to prove the current supported lane handles custom JSX components with web-specific attributes before any RN/WebView/TUI lane is promoted.
 
+## WebView boundary hardening gate
+
+The WebView fixture lane is fallback-first even when pre-read edit guidance is requested. `F3`, `F4`, and `F6` must return the `unsupported-react-native-webview-boundary` fallback without constructing a compact payload. Detector evidence may record boundary facts such as WebView `source` object shape, `injectedJavaScript`, `onMessage`, and native/web `postMessage` markers, but those facts remain diagnosis evidence only.
+
+Mixed DOM plus WebView snippets must choose the safety fallback over the React Web current-supported lane. Bare `<WebView>` snippets without an import are also treated as WebView boundary evidence so embedded HTML strings and bridge markers do not accidentally unlock React Web payload reuse.
+
 
 ## RN component semantics readiness gate
 

--- a/docs/webview-bridge-boundary-plan.md
+++ b/docs/webview-bridge-boundary-plan.md
@@ -14,6 +14,12 @@ WebView bridge code is not just frontend TSX. A bridge pair can combine native R
 
 `F4` therefore provides fallback evidence only. It names a narrow fixture pair and proves that fallback-first behavior is still preserved.
 
+## Pre-read boundary behavior
+
+Pre-read must stop at fallback for `F3`, `F4`, and `F6` before compact payload construction, including calls that request edit guidance. The WebView detector can expose source-shape and bridge-marker evidence to explain the fallback, but that evidence must not be reused as an extraction profile.
+
+Bare `<WebView>` source snippets and mixed DOM plus WebView snippets are part of the same hardening gate. They stay fallback-first so HTML strings, injected JavaScript, `onMessage`, and `postMessage` boundaries are visible as source-reading boundaries rather than React Web payload eligibility.
+
 ## Fixture pair
 
 The current `F4` pair uses only local or synthetic-local fixtures:
@@ -38,6 +44,6 @@ Promotion from fallback evidence to extraction may happen only after all gates a
 - No WebView compact-payload reuse.
 - No bridge safety claim.
 - No automatic extraction across native/web message boundaries.
-- No detector, extractor, runtime, pre-read, setup, or CLI behavior change in the paired-fixture evidence PR.
+- No extractor, runtime, setup, or CLI behavior change. Detector evidence and pre-read guard tests may harden the existing fallback boundary, but they must not create WebView payload eligibility.
 - No public repository vendoring or live fetch.
 - No manifest schema migration.

--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -46,6 +46,10 @@ const RN_MODULE = "react-native";
 const RN_NAVIGATION_MODULE = "@react-navigation/native";
 const WEBVIEW_MODULE = "react-native-webview";
 const INK_MODULE = "ink";
+const WEBVIEW_BRIDGE_MARKERS = [
+  ["ReactNativeWebView.postMessage", "ReactNativeWebView.postMessage"],
+  ["window.ReactNativeWebView", "window.ReactNativeWebView"],
+] as const;
 const RN_PRIMITIVES = new Set([
   "View",
   "Text",
@@ -96,6 +100,32 @@ function hasEvidence(evidence: FrontendDomainEvidence[], domain: FrontendDomainE
 
 function signalList(evidence: FrontendDomainEvidence[]): string[] {
   return evidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`);
+}
+
+function addWebViewSourceShapeEvidence(evidence: FrontendDomainEvidence[], initializer: ts.JsxAttribute["initializer"]): void {
+  if (!initializer || !ts.isJsxExpression(initializer) || !initializer.expression) return;
+
+  const expression = initializer.expression;
+  if (!ts.isObjectLiteralExpression(expression)) return;
+
+  for (const property of expression.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = property.name;
+    const propertyName = ts.isIdentifier(name) || ts.isStringLiteral(name) ? name.text : undefined;
+    if (propertyName === "html" || propertyName === "uri") {
+      addEvidence(evidence, "webview", "source-shape", propertyName);
+    }
+  }
+}
+
+function addWebViewBridgeMarkerEvidence(evidence: FrontendDomainEvidence[], text: string): void {
+  if (!hasEvidence(evidence, "webview")) return;
+
+  for (const [marker, detail] of WEBVIEW_BRIDGE_MARKERS) {
+    if (text.includes(marker)) {
+      addEvidence(evidence, "webview", "bridge-marker", detail);
+    }
+  }
 }
 
 function outcomeForClassification(classification: DomainLabel): Pick<DomainDetectionResult, "outcome" | "reason"> {
@@ -261,6 +291,9 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
       }
       if (WEBVIEW_PROPS.has(attributeName) && hasEvidence(evidence, "webview")) {
         addEvidence(evidence, "webview", "prop", attributeName);
+        if (attributeName === "source") {
+          addWebViewSourceShapeEvidence(evidence, node.initializer);
+        }
       }
     }
 
@@ -279,6 +312,9 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
         hasImportedName(RN_MODULE, expression.text)
       ) {
         addEvidence(evidence, "react-native", "api-call", `${expression.text}.${property}`);
+      }
+      if (hasEvidence(evidence, "webview") && property === "postMessage") {
+        addEvidence(evidence, "webview", "bridge-call", "postMessage");
       }
     }
 
@@ -309,6 +345,10 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
 
     if (ts.isIdentifier(node) && TUI_HOOKS.has(node.text) && hasImportedName(INK_MODULE, node.text)) {
       addEvidence(evidence, "tui-ink", "hook", node.text);
+    }
+
+    if (ts.isStringLiteralLike(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      addWebViewBridgeMarkerEvidence(evidence, node.text);
     }
 
     ts.forEachChild(node, visit);

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -139,8 +139,10 @@ test("detects WebView evidence signals without support wording", () => {
     "webview:import:react-native-webview",
     "webview:component:WebView",
     "webview:prop:source",
+    "webview:source-shape:uri",
     "webview:prop:injectedJavaScript",
     "webview:prop:onMessage",
+    "webview:bridge-marker:ReactNativeWebView.postMessage",
   ]);
   assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });
@@ -194,6 +196,7 @@ test("classifies web DOM mixed with non-web frontend signals as fallback", () =>
   assert.equal(webviewDom.reason, "unsupported-react-native-webview-boundary");
   assert.ok(webviewDom.signals.includes("webview:import:react-native-webview"));
   assert.ok(webviewDom.signals.includes("webview:component:WebView"));
+  assert.ok(webviewDom.signals.includes("webview:source-shape:html"));
 
   const tuiDom = detectDomainFromSource(
     `import { Box } from "ink";
@@ -221,11 +224,33 @@ test("classifies web DOM mixed with non-web frontend signals as fallback", () =>
 });
 
 test("treats bare WebView JSX as a fallback-first boundary signal", () => {
-  const result = detectDomainFromSource(`export function Preview() { return <WebView source={{ uri: "https://example.test" }} />; }`, "Preview.tsx");
+  const result = detectDomainFromSource(
+    `export function Preview() {
+       return <WebView source={{ html: "<script>window.ReactNativeWebView.postMessage('ready')</script>" }} onMessage={() => {}} />;
+     }`,
+    "Preview.tsx",
+  );
   assert.equal(result.classification, "webview");
   assert.equal(result.outcome, "fallback");
   assert.equal(result.reason, "unsupported-react-native-webview-boundary");
   assert.ok(result.signals.includes("webview:component:WebView"));
+  assert.ok(result.signals.includes("webview:prop:source"));
+  assert.ok(result.signals.includes("webview:source-shape:html"));
+  assert.ok(result.signals.includes("webview:prop:onMessage"));
+  assert.ok(result.signals.includes("webview:bridge-marker:window.ReactNativeWebView"));
+});
+
+test("keeps WebView bridge-pair evidence as fallback-only boundary facts", () => {
+  const result = detectDomain(path.join(fixtureRoot, "webview", "checkout-bridge-native.tsx"));
+  assert.equal(result.classification, "mixed");
+  assert.equal(result.outcome, "fallback");
+  assert.equal(result.reason, "unsupported-react-native-webview-boundary");
+  assert.ok(result.signals.includes("react-native:primitive:View"));
+  assert.ok(result.signals.includes("webview:component:WebView"));
+  assert.ok(result.signals.includes("webview:prop:source"));
+  assert.ok(result.signals.includes("webview:prop:injectedJavaScript"));
+  assert.ok(result.signals.includes("webview:prop:onMessage"));
+  assert.ok(result.signals.includes("webview:bridge-call:postMessage"));
 });
 
 test("selected fixture manifest stays aligned with detector classifications and outcomes", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1051,8 +1051,10 @@ test("frontend domain detector returns evidence-only classifications for Level 3
   assert.ok(webview.signals.includes("webview:import:react-native-webview"));
   assert.ok(webview.signals.includes("webview:component:WebView"));
   assert.ok(webview.signals.includes("webview:prop:source"));
+  assert.ok(webview.signals.includes("webview:source-shape:uri"));
   assert.ok(webview.signals.includes("webview:prop:injectedJavaScript"));
   assert.ok(webview.signals.includes("webview:prop:onMessage"));
+  assert.ok(webview.signals.includes("webview:bridge-marker:ReactNativeWebView.postMessage"));
 
   const tui = detectDomain(path.join(fixtureRoot, "tui-ink-basic.tsx"));
   assert.equal(tui.classification, "tui-ink");
@@ -1095,6 +1097,7 @@ test("extract output includes domainDetection for frontend fixtures", () => {
   assert.ok(webview.domainDetection);
   assert.equal(webview.domainDetection.classification, "webview");
   assert.ok(webview.domainDetection.signals.includes("webview:component:WebView"));
+  assert.ok(webview.domainDetection.signals.includes("webview:source-shape:uri"));
   assert.equal(webview.domainDetection.profile.claimStatus, "fallback-boundary");
   assert.equal(webview.domainDetection.profile.fallbackFirst, true);
 
@@ -1149,19 +1152,22 @@ test("pre-read uses frontend domain detector for bare WebView fallback boundarie
   fs.writeFileSync(
     bareWebViewPath,
     `export function BareWebView() {
-  return <WebView source={{ uri: "https://example.test" }} />;
+  return <WebView source={{ html: "<script>window.ReactNativeWebView.postMessage('ready')</script>" }} onMessage={() => {}} />;
 }
 `,
   );
 
-  const result = preReadModule.decidePreRead(bareWebViewPath, tempDir, "codex");
+  const result = preReadModule.decidePreRead(bareWebViewPath, tempDir, "codex", { includeEditGuidance: true });
   assert.equal(result.decision, "fallback");
   assert.deepEqual(result.reasons, ["unsupported-react-native-webview-boundary"]);
+  assert.equal("payload" in result, false);
   assert.equal(result.debug.domainDetection.classification, "webview");
   assert.equal(result.debug.domainDetection.outcome, "fallback");
   assert.equal(result.debug.domainDetection.profile.claimStatus, "fallback-boundary");
   assert.equal(result.debug.domainDetection.profile.boundaryReason, "unsupported-react-native-webview-boundary");
   assert.ok(result.debug.domainDetection.signals.includes("webview:component:WebView"));
+  assert.ok(result.debug.domainDetection.signals.includes("webview:source-shape:html"));
+  assert.ok(result.debug.domainDetection.signals.includes("webview:bridge-marker:window.ReactNativeWebView"));
 });
 
 test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise", () => {
@@ -4343,6 +4349,18 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
     assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
   }
+
+  for (const slot of ["F3", "F4", "F6"]) {
+    const item = selected.get(slot);
+    const decision = preReadModule.decidePreRead(path.join(repoRoot, item.path), repoRoot, "codex", { includeEditGuidance: true });
+    assert.equal(decision.eligible, true, `${item.id} should remain eligible for pre-read inspection before boundary fallback`);
+    assert.equal(decision.decision, "fallback", `${item.id} should stay fallback even when edit guidance is requested`);
+    assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
+    assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
+    assert.equal("payload" in decision, false, `${item.id} must not build a compact payload across the WebView boundary`);
+    assert.equal(decision.debug.domainDetection.profile.claimStatus, "fallback-boundary");
+    assert.equal(decision.debug.domainDetection.profile.boundaryReason, "unsupported-react-native-webview-boundary");
+  }
 });
 
 test("frontend domain fixture docs mirror manifest slot expectations", () => {
@@ -4381,6 +4399,9 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   }
 
   assert.match(docs, /F2[\s\S]*current fallback expectation[\s\S]*navigation semantics remain non-promoted/);
+  assert.match(docs, /WebView boundary hardening gate/);
+  assert.match(docs, /`F3`, `F4`, and `F6` must return the `unsupported-react-native-webview-boundary` fallback without constructing a compact payload/);
+  assert.match(docs, /Mixed DOM plus WebView snippets must choose the safety fallback/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
@@ -4390,9 +4411,12 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(webviewBridgePlan, /Web side fixture/);
   assert.match(webviewBridgePlan, /Boundary contract note/);
   assert.match(webviewBridgePlan, /Selected fallback-evidence boundary/);
+  assert.match(webviewBridgePlan, /Pre-read boundary behavior/);
+  assert.match(webviewBridgePlan, /before compact payload construction, including calls that request edit guidance/);
   assert.match(webviewBridgePlan, /synthetic bridge pair remains a separate lane/);
   assert.match(webviewBridgePlan, /expected outcome is `fallback`/);
-  assert.match(webviewBridgePlan, /detector, extractor, runtime, pre-read, setup, or CLI behavior/);
+  assert.match(webviewBridgePlan, /No extractor, runtime, setup, or CLI behavior change/);
+  assert.match(webviewBridgePlan, /Detector evidence and pre-read guard tests may harden the existing fallback boundary/);
   assert.match(webviewBridgePlan, /unsupported-react-native-webview-boundary/);
   assert.match(webviewBridgePlan, /expected outcome is `fallback`/);
   assert.match(webviewBridgePlan, /No WebView compact-payload reuse/);


### PR DESCRIPTION
## Summary
- record WebView source-shape and bridge marker/call evidence without changing fallback-first outcomes
- strengthen F3/F4/F6 pre-read assertions so edit-guidance requests still return fallback with no payload
- update fixture/bridge docs to state this is boundary hardening, not WebView support or compact-payload reuse

## Verification
- npm run build
- node --test --test-name-pattern "WebView|webview|frontend domain detector|codex pre-read chooses payload|frontend domain fixture|bridge" test/domain-detector.test.mjs test/fooks.test.mjs
- git diff --check
- npm run lint
- npm test

## Boundaries
- No WebView compact-payload reuse
- No WebView/RN/TUI support claim
- No extractor/runtime/setup/CLI behavior change
- External RN/WebView corpus remains out of scope