### PR TITLE
Serialize shared frontend domain policy edits

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -90,6 +90,31 @@ A promotion candidate must pass every gate below before it changes runtime detec
 
 This matrix enables future multi-branch domain work, but it is not itself runtime behavior change, domain promotion, support claim expansion, or a shared-file free-for-all. Domain lanes may proceed in parallel only when they stay inside their primary owned surfaces. Changes to serialized shared surfaces require one named owner and a merge-order note for that PR wave.
 
+#### Serialized shared surfaces
+
+The files below are shared policy surfaces. A PR wave that changes any of them must name one shared-policy owner, include a merge-order note, and keep other domain branches from editing the same file until the owner branch lands or is abandoned.
+
+- `src/core/domain-detector.ts`
+- `src/adapters/pre-read.ts`
+- `src/core/schema.ts`
+- `test/fooks.test.mjs`
+- `test/domain-detector.test.mjs`
+- `test/fixtures/frontend-domain-expectations/manifest.json`
+- `docs/frontend-domain-contract.md`
+- `docs/frontend-domain-fixture-expectations.md`
+
+#### Domain-owned parallel surfaces
+
+The paths below may be edited in parallel when the branch stays inside its domain and does not change serialized shared surfaces:
+
+- React Web fixture-only work under `test/fixtures/frontend-domain-expectations/react-web/`
+- React Native fixture-only work under `test/fixtures/frontend-domain-expectations/rn-*.tsx`
+- WebView fixture-only work under `test/fixtures/frontend-domain-expectations/webview*/`
+- TUI/Ink fixture-only work under `test/fixtures/frontend-domain-expectations/tui-*`
+- Domain-specific docs that do not change shared support, detector, pre-read, or manifest policy
+
+Parallel branches that need a serialized shared surface are no longer independent domain branches for that PR wave; they must serialize behind the named shared-policy owner.
+
 | Lane | Primary owned surfaces | Serialized shared surfaces | Merge-order rule | Verification minimum | Claim boundary |
 | --- | --- | --- | --- | --- | --- |
 | React Web | React Web fixtures, React Web readiness/payload tests, and React Web docs under the current supported lane. | `src/core/domain-detector.ts`, `src/adapters/pre-read.ts`, `test/fooks.test.mjs`, `test/fixtures/frontend-domain-expectations/manifest.json`. | Merge before non-web lanes only when it changes shared profile policy; otherwise keep independent React Web-only changes separate. | React Web pre-read/readiness targeted tests plus full frontend-domain contract tests. | Current supported lane only; do not imply RN, WebView, TUI, Mixed, or Unknown support. |

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4136,15 +4136,31 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(contract, /not a final RN semantic model/);
   assert.match(contract, /Promotion stops at the first failed gate/);
   assert.match(contract, /documentation and regression protection only/);
-  assert.match(contract, /Parallel domain ownership matrix/);
   assert.match(contract, /not itself runtime behavior change, domain promotion, support claim expansion, or a shared-file free-for-all/);
+  assert.match(contract, /### Parallel domain ownership matrix/);
+  assert.match(contract, /#### Serialized shared surfaces/);
+  assert.match(contract, /#### Domain-owned parallel surfaces/);
+  assert.match(contract, /Parallel branches that need a serialized shared surface are no longer independent domain branches/);
   for (const sharedFile of [
     "src/core/domain-detector.ts",
     "src/adapters/pre-read.ts",
+    "src/core/schema.ts",
     "test/fooks.test.mjs",
+    "test/domain-detector.test.mjs",
     "test/fixtures/frontend-domain-expectations/manifest.json",
+    "docs/frontend-domain-contract.md",
+    "docs/frontend-domain-fixture-expectations.md",
   ]) {
     assert.ok(contract.includes(sharedFile), `${sharedFile} must be marked as serialized shared surface`);
+  }
+  for (const domainSurface of [
+    "test/fixtures/frontend-domain-expectations/react-web/",
+    "test/fixtures/frontend-domain-expectations/rn-*.tsx",
+    "test/fixtures/frontend-domain-expectations/webview*/",
+    "test/fixtures/frontend-domain-expectations/tui-*",
+    "Domain-specific docs that do not change shared support, detector, pre-read, or manifest policy",
+  ]) {
+    assert.ok(contract.includes(domainSurface), `${domainSurface} must be marked as domain-owned parallel surface`);
   }
 
   const readinessMatrixStart = contract.indexOf("### Domain readiness matrix");
@@ -4161,6 +4177,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   const ownershipMatrixEnd = contract.indexOf("\n\nPromotion stops", ownershipMatrixStart);
   assert.notEqual(ownershipMatrixEnd, -1, "Parallel domain ownership matrix must end before the promotion stop rule");
   const ownershipMatrix = contract.slice(ownershipMatrixStart, ownershipMatrixEnd);
+  assert.match(ownershipMatrix, /must name one shared-policy owner, include a merge-order note/);
+  assert.match(ownershipMatrix, /may be edited in parallel when the branch stays inside its domain/);
   for (const lane of ["React Web", "React Native", "WebView", "TUI/Ink", "Mixed/Unknown/shared policy"]) {
     assert.ok(ownershipMatrix.includes(`| ${lane} |`), `${lane} ownership matrix row must exist`);
   }


### PR DESCRIPTION
## Summary
- add a serialized shared-surface gate for frontend domain policy files
- define domain-owned fixture/doc surfaces that can be edited in parallel when they avoid shared policy files
- lock the ownership wording and surface lists in the frontend domain contract regression test

## Verification
- npm run build
- node --test --test-name-pattern "frontend domain contract|frontend domain fixture|React Native|RN|WebView|webview|TUI|parallel" test/domain-detector.test.mjs test/fooks.test.mjs
- git diff --check && npm run lint && npm test
- architect verification: APPROVE

## Boundaries
- docs/tests only
- no runtime detector, pre-read, or schema behavior changes
- no RN/WebView/TUI support or WebView bridge-safety claim