### PR TITLE
Keep WebView boundary evidence fallback-only

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -32,6 +32,8 @@ The WebView fixture lane is fallback-first even when pre-read edit guidance is r
 
 Mixed DOM plus WebView snippets must choose the safety fallback over the React Web current-supported lane. Bare `<WebView>` snippets without an import are also treated as WebView boundary evidence so embedded HTML strings and bridge markers do not accidentally unlock React Web payload reuse.
 
+WebView hardening is a serialized shared-policy owner lane whenever it updates manifest, shared docs, or regression tests. That PR must carry the merge-order note and must keep `F3`, `F4`, and `F6` at `supportClaim: "none"` with `fallback-boundary-evidence-only` scope. Each selected WebView boundary fixture must forbid all three claims together: WebView support, bridge safety, and compact-payload reuse.
+
 
 ## RN component semantics readiness gate
 

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -104,9 +104,12 @@
       ],
       "forbiddenClaims": [
         "No WebView support claim",
-        "No WebView compact payload reuse"
+        "No WebView compact payload reuse",
+        "No bridge safety claim"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary and docs/tests forbid WebView support, bridge-safety, and compact-payload reuse claims",
+      "supportClaim": "none",
+      "evidenceScope": "fallback-boundary-evidence-only"
     },
     {
       "slot": "F4",
@@ -130,7 +133,7 @@
       "forbiddenClaims": [
         "No WebView support claim",
         "No bridge safety claim",
-        "No compact payload reuse"
+        "No WebView compact payload reuse"
       ],
       "supportClaim": "none",
       "evidenceScope": "fallback-boundary-evidence-only",
@@ -178,10 +181,13 @@
         "onMessage"
       ],
       "forbiddenClaims": [
-        "No compact payload reuse",
-        "No bridge safety claim"
+        "No WebView compact payload reuse",
+        "No bridge safety claim",
+        "No WebView support claim"
       ],
-      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary"
+      "verification": "decidePreRead returns fallback with unsupported-react-native-webview-boundary and docs/tests forbid WebView support, bridge-safety, and compact-payload reuse claims",
+      "supportClaim": "none",
+      "evidenceScope": "fallback-boundary-evidence-only"
     },
     {
       "slot": "F9",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4220,11 +4220,17 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.equal(selected.get("negative-rn-webview-boundary").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("webview-bridge-pair").expectedOutcome, "fallback");
   assert.equal(selected.get("webview-bridge-pair").expectedReason, "unsupported-react-native-webview-boundary");
-  assert.equal(selected.get("webview-bridge-pair").supportClaim, "none");
-  assert.equal(selected.get("webview-bridge-pair").evidenceScope, "fallback-boundary-evidence-only");
   assert.deepEqual(selected.get("webview-bridge-pair").relatedSourcePaths, [
     "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html",
   ]);
+  for (const webviewId of ["webview-boundary-basic", "webview-bridge-pair", "negative-rn-webview-boundary"]) {
+    const item = selected.get(webviewId);
+    assert.equal(item.supportClaim, "none", `${webviewId} must not claim WebView support`);
+    assert.equal(item.evidenceScope, "fallback-boundary-evidence-only", `${webviewId} must stay fallback-boundary evidence only`);
+    for (const forbidden of ["No WebView support claim", "No bridge safety claim", "No WebView compact payload reuse"]) {
+      assert.ok(item.forbiddenClaims.includes(forbidden), `${webviewId} must forbid ${forbidden}`);
+    }
+  }
   assert.equal(deferred.get("webview-bridge-pair"), undefined);
   assert.equal(selected.get("tui-ink-basic").supportClaim, "none");
   assert.equal(selected.get("tui-ink-basic").evidenceScope, "syntax-evidence-only");
@@ -4324,8 +4330,6 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F4").id, "webview-bridge-pair");
   assert.equal(selected.get("F4").expectedOutcome, "fallback");
   assert.equal(selected.get("F4").expectedReason, "unsupported-react-native-webview-boundary");
-  assert.equal(selected.get("F4").supportClaim, "none");
-  assert.equal(selected.get("F4").evidenceScope, "fallback-boundary-evidence-only");
   assert.deepEqual(selected.get("F4").relatedSourcePaths, [
     "test/fixtures/frontend-domain-expectations/webview/checkout-bridge-web.html",
   ]);
@@ -4358,6 +4362,16 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(selected.get(slot).preReadExpectedReason, preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON, `${selected.get(slot).id} must declare pre-read profile fallback separately`);
     assert.doesNotMatch(selected.get(slot).verification, /decidePreRead returns fallback with unsupported-react-native-webview-boundary/);
     assert.ok(selected.get(slot).forbiddenClaims.some((claim) => /No React Native support claim/.test(claim)), `${selected.get(slot).id} must forbid React Native support claims`);
+  }
+
+  for (const slot of ["F3", "F4", "F6"]) {
+    const item = selected.get(slot);
+    assert.equal(item.supportClaim, "none", `${item.id} must not claim WebView support`);
+    assert.equal(item.evidenceScope, "fallback-boundary-evidence-only", `${item.id} must stay fallback-boundary evidence only`);
+    for (const forbidden of ["No WebView support claim", "No bridge safety claim", "No WebView compact payload reuse"]) {
+      assert.ok(item.forbiddenClaims.includes(forbidden), `${item.id} must forbid ${forbidden}`);
+    }
+    assert.doesNotMatch(item.verification, /payload reuse is enabled|bridge safety is guaranteed|WebView is supported/i);
   }
 
   for (const item of deferred.values()) {
@@ -4496,6 +4510,9 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /WebView boundary hardening gate/);
   assert.match(docs, /`F3`, `F4`, and `F6` must return the `unsupported-react-native-webview-boundary` fallback without constructing a compact payload/);
   assert.match(docs, /Mixed DOM plus WebView snippets must choose the safety fallback/);
+  assert.match(docs, /WebView hardening is a serialized shared-policy owner lane/);
+  assert.match(docs, /keep `F3`, `F4`, and `F6` at `supportClaim: "none"` with `fallback-boundary-evidence-only` scope/);
+  assert.match(docs, /forbid all three claims together: WebView support, bridge safety, and compact-payload reuse/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);


### PR DESCRIPTION
## Summary
- mark F3/F4/F6 WebView boundary fixtures as `supportClaim: none` and `fallback-boundary-evidence-only`
- require all selected WebView boundary fixtures to forbid WebView support, bridge-safety, and WebView compact-payload reuse claims
- document this pass as serialized shared-policy owner work when manifest/shared docs/regression tests are updated
- add regression assertions that lock those fixture and docs boundaries

## Shared-policy owner note
This PR is the WebView boundary hardening shared-policy owner for this PR wave because it updates manifest, shared docs, and regression tests. Other domain branches should not edit these same shared policy surfaces until this lands or is abandoned.

## Boundaries
- no `src/core/domain-detector.ts` change
- no `src/adapters/pre-read.ts` change
- no `src/core/schema.ts` change
- no WebView support claim
- no WebView bridge-safety claim
- no WebView compact-payload reuse claim

## Verification
- `node --test --test-name-pattern "WebView|webview|frontend domain contract|frontend domain fixture" test/domain-detector.test.mjs test/fooks.test.mjs`
- `git diff --check && npm run lint && npm test`
- architect verification: APPROVE
