### PR TITLE
Keep TUI evidence syntax-only

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -35,6 +35,14 @@ Mixed DOM plus WebView snippets must choose the safety fallback over the React W
 WebView hardening is a serialized shared-policy owner lane whenever it updates manifest, shared docs, or regression tests. That PR must carry the merge-order note and must keep `F3`, `F4`, and `F6` at `supportClaim: "none"` with `fallback-boundary-evidence-only` scope. Each selected WebView boundary fixture must forbid all three claims together: WebView support, bridge safety, and compact-payload reuse.
 
 
+## TUI evidence hardening gate
+
+The TUI/Ink fixture lane is syntax evidence only. `F5` may prove that the current TSX/JSX extractor can traverse a small local Ink-like component and its paired local evidence fixture, but it must not be described as TUI/Ink support, terminal correctness, terminal UX safety, runtime-token savings, provider-token savings, billing savings, performance improvement, or default compact extraction.
+
+TUI evidence hardening is a serialized shared-policy owner lane whenever it updates manifest, shared docs, or regression tests. That PR must carry the merge-order note and must keep `F5` at `supportClaim: "none"` with `syntax-evidence-only` scope. `F7` remains deferred for broad non-Ink terminal renderer semantics and must not gain executable fixture paths in this evidence gate.
+
+Pre-read behavior must stay conservative for TUI/Ink: `F5` can remain extractable syntax evidence through `extractFile`, but Codex pre-read must continue to fallback with `unsupported-frontend-domain-profile` and must not construct a compact payload by default.
+
 ## RN component semantics readiness gate
 
 The RN fixture lane is a readiness gate, not a support promise. `F1` is the first narrow runtime candidate and is limited to primitive/input payload reuse through `rn-primitive-input-narrow-payload`; it is not broad React Native support. Other selected RN fixtures stay fallback/evidence-only until a later detector/profile promotion plan explicitly changes runtime behavior. The current fallback reason, `unsupported-react-native-webview-boundary`, is still the shared source-reading boundary reason for detector evidence and WebView/mixed boundaries; it must not be treated as a permanent domain model for every RN semantic.
@@ -67,6 +75,7 @@ This baseline must not imply any of the following support promotions:
 - React Native availability or current support.
 - WebView availability or current support.
 - TUI availability or current support.
+- TUI terminal correctness, terminal UX safety, runtime-token/provider-token/billing/performance/cost, or default compact extraction promotion.
 - WebView compact-payload reuse or bridge safety promotion.
 
 ## Promotion boundary

--- a/test/fixtures/frontend-domain-expectations/manifest.json
+++ b/test/fixtures/frontend-domain-expectations/manifest.json
@@ -155,10 +155,13 @@
         "terminal layout"
       ],
       "forbiddenClaims": [
-        "No broad TUI support claim",
+        "No TUI/Ink support claim",
+        "No terminal correctness claim",
+        "No runtime-token/provider-token/billing/performance/cost claim",
+        "No default TUI compact extraction",
         "No RN/WebView fallback boundary implied"
       ],
-      "verification": "extractFile returns a non-empty TSX extraction result",
+      "verification": "extractFile returns a non-empty TSX extraction result; decidePreRead remains fallback with unsupported-frontend-domain-profile; docs/tests forbid TUI/Ink support, terminal correctness, runtime-token/provider-token/billing/performance/cost, and default compact extraction claims",
       "supportClaim": "none",
       "evidenceScope": "syntax-evidence-only",
       "relatedSourcePaths": [

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1120,7 +1120,7 @@ test("extract output includes domainDetection for frontend fixtures", () => {
 });
 
 test("frontend domain detector and pre-read debug avoid RN WebView TUI support wording", () => {
-  const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|default WebView compact extraction is enabled/i;
+  const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|TUI performance improvement is available|default WebView compact extraction is enabled|default TUI compact extraction is enabled/i;
   const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
   const results = [
     detectDomain(path.join(fixtureRoot, "rn-primitive-basic.tsx")),
@@ -1264,6 +1264,7 @@ export function CustomOnlyForm() {
   assert.equal(tui.fallback.reason, unsupportedFrontendProfile);
   assert.equal(tui.debug.domainDetection.classification, "tui-ink");
   assert.equal(tui.debug.domainDetection.profile.claimStatus, "evidence-only");
+  assert.notEqual(tui.debug.frontendPayloadPolicy?.allowed, true);
   assert.equal("payload" in tui, false);
 
   const moduleTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"), repoRoot);
@@ -4234,6 +4235,15 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.equal(deferred.get("webview-bridge-pair"), undefined);
   assert.equal(selected.get("tui-ink-basic").supportClaim, "none");
   assert.equal(selected.get("tui-ink-basic").evidenceScope, "syntax-evidence-only");
+  for (const forbidden of [
+    "No TUI/Ink support claim",
+    "No terminal correctness claim",
+    "No runtime-token/provider-token/billing/performance/cost claim",
+    "No default TUI compact extraction",
+  ]) {
+    assert.ok(selected.get("tui-ink-basic").forbiddenClaims.includes(forbidden), `tui-ink-basic must forbid ${forbidden}`);
+  }
+  assert.doesNotMatch(selected.get("tui-ink-basic").verification, /TUI\/Ink is supported|terminal correctness is guaranteed|runtime-token savings are available|default TUI compact extraction is enabled/i);
 
   assert.doesNotMatch(contract, /React Native support is available/i);
   assert.doesNotMatch(contract, /WebView support is available/i);
@@ -4336,6 +4346,15 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
   assert.equal(selected.get("F5").expectedOutcome, "extract");
   assert.equal(selected.get("F5").supportClaim, "none");
   assert.equal(selected.get("F5").evidenceScope, "syntax-evidence-only");
+  for (const forbidden of [
+    "No TUI/Ink support claim",
+    "No terminal correctness claim",
+    "No runtime-token/provider-token/billing/performance/cost claim",
+    "No default TUI compact extraction",
+  ]) {
+    assert.ok(selected.get("F5").forbiddenClaims.includes(forbidden), `F5 must forbid ${forbidden}`);
+  }
+  assert.doesNotMatch(selected.get("F5").verification, /TUI\/Ink is supported|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|performance improvement is available|default TUI compact extraction is enabled/i);
   assert.equal(selected.get("F6").expectedOutcome, "fallback");
   assert.equal(selected.get("F6").expectedReason, "unsupported-react-native-webview-boundary");
   assert.equal(selected.get("F9").expectedOutcome, "fallback");
@@ -4433,7 +4452,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(extracted.language, "tsx", `${evidencePath} must remain TSX syntax evidence`);
     assert.ok(["compressed", "hybrid", "raw"].includes(extracted.mode), `${evidencePath} must be extractable`);
     assert.doesNotMatch(source, /github\.com|https?:\/\/|public-snapshot|live-fetch|vendor-external/i);
-    assert.doesNotMatch(source, /TUI support is available|TUI\/Ink is supported today|default TUI compact extraction is enabled/i);
+    assert.doesNotMatch(source, /TUI support is available|TUI\/Ink is supported today|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|performance improvement is available|default TUI compact extraction is enabled/i);
   }
 
   const rnPrimitiveDecision = preReadModule.decidePreRead(path.join(repoRoot, selected.get("F1").path), repoRoot, "codex");
@@ -4513,6 +4532,13 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /WebView hardening is a serialized shared-policy owner lane/);
   assert.match(docs, /keep `F3`, `F4`, and `F6` at `supportClaim: "none"` with `fallback-boundary-evidence-only` scope/);
   assert.match(docs, /forbid all three claims together: WebView support, bridge safety, and compact-payload reuse/);
+  assert.match(docs, /TUI evidence hardening gate/);
+  assert.match(docs, /TUI\/Ink fixture lane is syntax evidence only/);
+  assert.match(docs, /TUI evidence hardening is a serialized shared-policy owner lane/);
+  assert.match(docs, /keep `F5` at `supportClaim: "none"` with `syntax-evidence-only` scope/);
+  assert.match(docs, /`F7` remains deferred for broad non-Ink terminal renderer semantics/);
+  assert.match(docs, /pre-read must continue to fallback with `unsupported-frontend-domain-profile`/i);
+  assert.match(docs, /must not construct a compact payload by default/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
@@ -4535,8 +4561,9 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(webviewBridgePlan, /No automatic extraction across native\/web message boundaries/);
   assert.doesNotMatch(docs, /React Native support is available|React Native is supported today/i);
   assert.doesNotMatch(docs, /WebView support is available|WebView is supported today/i);
-  assert.doesNotMatch(docs, /TUI support is available|TUI is supported today/i);
-  assert.doesNotMatch(docs, /default WebView compact extraction is enabled/i);
+  assert.doesNotMatch(docs, /TUI support is available|TUI is supported today|TUI\/Ink is supported today/i);
+  assert.doesNotMatch(docs, /terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|TUI performance improvement is available/i);
+  assert.doesNotMatch(docs, /default WebView compact extraction is enabled|default TUI compact extraction is enabled/i);
   assert.doesNotMatch(webviewBridgePlan, /React Native support is available|React Native is supported today/i);
   assert.doesNotMatch(webviewBridgePlan, /WebView support is available|WebView is supported today/i);
   assert.doesNotMatch(webviewBridgePlan, /WebView compact payload reuse is supported/i);


### PR DESCRIPTION
## Summary
- Lock the TUI/Ink F5 fixture as syntax-evidence-only with `supportClaim: "none"`.
- Add TUI evidence hardening docs that forbid TUI/Ink support, terminal correctness/UX safety, runtime-token/provider-token/billing/performance/cost, and default compact extraction claims.
- Strengthen regression tests so TUI pre-read remains fallback/no-payload while F7 stays deferred.

## Shared-policy owner / merge-order note
This PR is the serialized TUI shared-policy owner for this wave because it changes shared manifest/docs/regression surfaces:
- `docs/frontend-domain-fixture-expectations.md`
- `test/fixtures/frontend-domain-expectations/manifest.json`
- `test/fooks.test.mjs`

Other RN/WebView/React Web/TUI branches should not edit these shared policy files until this branch lands or is abandoned.

## Runtime boundary
No runtime detector, pre-read implementation, or schema files are changed. This PR does not add TUI support, terminal correctness, runtime-token savings, performance claims, or default compact extraction.

## Verification
- `node --test --test-name-pattern "TUI|tui|Ink|frontend domain contract|frontend domain fixture" test/domain-detector.test.mjs test/fooks.test.mjs`
- `git diff --check`
- `npm run lint`
- `npm test` → 297 passed, 0 failed

## RALPH evidence
- Architect verification: APPROVE
- Deslop pass: completed, no edits; duplicate assertions intentionally kept for independent gate failure locality
- Post-deslop verification: `git diff --check && npm run lint && npm test` passed
