### PR TITLE
docs: map frontend fixture claim boundaries

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -8,7 +8,7 @@ Selected first-pass fixtures are limited to `existing-local` or `synthetic-local
 
 ## Selected fixture expectations
 
-The machine-readable fixture expectation manifest at `test/fixtures/frontend-domain-expectations/manifest.json` is the source of truth for selected and deferred slots. This table mirrors that manifest so parallel domain work does not reinterpret selected fixtures differently.
+The machine-readable fixture expectation manifest at `test/fixtures/frontend-domain-expectations/manifest.json` is the source of truth for selected and deferred slots. This table mirrors that manifest so parallel domain work does not reinterpret selected fixtures differently. For a compact cross-fixture claim-boundary view, use the [frontend fixture boundary regression map](frontend-fixture-boundary-regression-map.md).
 
 | Slot | ID | Lane | Source kind | Path | Expected outcome | Required proof |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/frontend-fixture-boundary-regression-map.md
+++ b/docs/frontend-fixture-boundary-regression-map.md
@@ -1,0 +1,25 @@
+# Frontend fixture boundary regression map
+
+This is the compact review map for the RN/WebView/TUI fixture boundary. It does **not** add or broaden platform support. Use it when editing `test/fixtures/frontend-domain-expectations/manifest.json`, fixture files, or fixture-boundary tests so evidence does not drift into support wording.
+
+## Regression map
+
+| Slot | Lane | Boundary label | Detector expectation | Pre-read expectation | Must not claim | Review cue |
+| --- | --- | --- | --- | --- | --- | --- |
+| `F1` | RN primitive/input | measured narrow payload | `fallback`, `unsupported-react-native-webview-boundary` | `payload` only through `rn-primitive-input-narrow-payload` | React Native support, DOM/form inference, broad RN payload reuse | If this payload gate changes, prove it remains primitive/input-only and does not cover `F2`, `F9`, or `F10`. |
+| `F2` | RN style/platform/navigation | readiness evidence only | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-frontend-domain-profile` | React Native support, navigation runtime guarantee, DOM/form inference | `StyleSheet`, `Platform`, and navigation markers are evidence only. |
+| `F9` | RN interaction/list | readiness evidence only | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-frontend-domain-profile` | React Native support, gesture safety, list virtualization support | Touchable/list/gesture markers must not inherit the `F1` payload policy. |
+| `F10` | RN media/layout | readiness evidence only | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-frontend-domain-profile` | React Native support, image loading safety, layout support | Image/ScrollView/Dimensions markers are evidence only. |
+| `F3` | WebView boundary | fallback-only boundary | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-react-native-webview-boundary` | WebView support, bridge safety, compact-payload reuse | Edit-guidance requests must still stop before payload construction. |
+| `F4` | WebView bridge pair | fallback-only boundary | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-react-native-webview-boundary` | WebView support, bridge safety, compact-payload reuse | Native/web paired evidence stays local and diagnostic-only. |
+| `F6` | RN + WebView negative boundary | fallback-only boundary | `fallback`, `unsupported-react-native-webview-boundary` | `fallback`, `unsupported-react-native-webview-boundary` | WebView support, bridge safety, compact-payload reuse | Mixed RN/WebView evidence must choose the boundary fallback over any compact payload. |
+| `F5` | TUI/Ink | syntax-only evidence | extractable TSX syntax evidence | `fallback`, `unsupported-frontend-domain-profile` | TUI/Ink support, terminal correctness, terminal UX safety, token/cost/performance savings, default compact extraction | Extraction proves parser traversal only; pre-read must not build a default TUI payload. |
+| `F7` | TUI non-Ink | deferred | no executable fixture path | no executable fixture path | broad terminal renderer support | Keep deferred until a separate non-Ink terminal semantics plan exists. |
+
+## Review checklist
+
+- Keep every RN/WebView/TUI selected fixture at `supportClaim: "none"`.
+- Keep WebView slots `F3`, `F4`, and `F6` at `evidenceScope: "fallback-boundary-evidence-only"`.
+- Keep TUI slot `F5` at `evidenceScope: "syntax-evidence-only"`.
+- Keep only RN slot `F1` on `payloadPolicy: "rn-primitive-input-narrow-payload"`; the other selected RN slots stay readiness-only fallback evidence.
+- Do not add support, setup-eligibility, runtime-token, provider-token, billing, performance, terminal-safety, bridge-safety, or default compact-extraction claims from these fixtures.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4498,6 +4498,7 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
     fs.readFileSync(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json"), "utf8"),
   );
   const docs = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
+  const boundaryMap = fs.readFileSync(path.join(repoRoot, "docs", "frontend-fixture-boundary-regression-map.md"), "utf8");
   const webviewBridgePlan = fs.readFileSync(path.join(repoRoot, "docs", "webview-bridge-boundary-plan.md"), "utf8");
   const selectedRows = parseMarkdownTableRows(docs, "Selected fixture expectations");
   const deferredRows = parseMarkdownTableRows(docs, "Deferred fixture slots");
@@ -4544,6 +4545,8 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /must not construct a compact payload by default/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
+  assert.match(docs, /\[frontend fixture boundary regression map\]\(frontend-fixture-boundary-regression-map\.md\)/);
+  assert.match(boundaryMap, /## Regression map/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
   assert.match(webviewBridgePlan, /`F4` \(`webview-bridge-pair`\) as \*\*selected fallback-boundary evidence\*\*/);
   assert.match(webviewBridgePlan, /checkout\.submit/);
@@ -4574,6 +4577,86 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.doesNotMatch(webviewBridgePlan, /WebView bridge is safe/i);
   assert.doesNotMatch(webviewBridgePlan, /compact[- ]payload reuse is (?:available|enabled|safe)/i);
   assert.doesNotMatch(webviewBridgePlan, /default WebView compact extraction is enabled/i);
+});
+
+test("frontend fixture boundary regression map keeps RN WebView TUI claim boundaries compact", () => {
+  const expectations = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json"), "utf8"),
+  );
+  const boundaryMap = fs.readFileSync(path.join(repoRoot, "docs", "frontend-fixture-boundary-regression-map.md"), "utf8");
+  const rows = parseMarkdownTableRows(boundaryMap, "Regression map");
+  const docsBySlot = new Map(
+    rows.map(([slot, lane, boundaryLabel, detectorExpectation, preReadExpectation, mustNotClaim, reviewCue]) => [
+      stripMarkdownCode(slot),
+      {
+        lane,
+        boundaryLabel,
+        detectorExpectation,
+        preReadExpectation,
+        mustNotClaim,
+        reviewCue,
+      },
+    ]),
+  );
+  const manifestBySlot = new Map([...expectations.selected, ...expectations.deferred].map((item) => [item.slot, item]));
+
+  assert.deepEqual([...docsBySlot.keys()], ["F1", "F2", "F9", "F10", "F3", "F4", "F6", "F5", "F7"]);
+
+  for (const slot of docsBySlot.keys()) {
+    assert.ok(manifestBySlot.has(slot), `${slot} boundary map row must exist in manifest`);
+  }
+
+  const rnPrimitive = docsBySlot.get("F1");
+  assert.equal(rnPrimitive.boundaryLabel, "measured narrow payload");
+  assert.match(rnPrimitive.detectorExpectation, /fallback/);
+  assert.match(rnPrimitive.detectorExpectation, /unsupported-react-native-webview-boundary/);
+  assert.match(rnPrimitive.preReadExpectation, /payload/);
+  assert.match(rnPrimitive.preReadExpectation, /rn-primitive-input-narrow-payload/);
+  assert.match(rnPrimitive.mustNotClaim, /React Native support/);
+  assert.match(rnPrimitive.reviewCue, /does not cover `F2`, `F9`, or `F10`/);
+
+  for (const slot of ["F2", "F9", "F10"]) {
+    const row = docsBySlot.get(slot);
+    assert.equal(row.boundaryLabel, "readiness evidence only", `${slot} must stay RN readiness-only`);
+    assert.match(row.detectorExpectation, /unsupported-react-native-webview-boundary/);
+    assert.match(row.preReadExpectation, /unsupported-frontend-domain-profile/);
+    assert.match(row.mustNotClaim, /React Native support/);
+    assert.doesNotMatch(row.preReadExpectation, /rn-primitive-input-narrow-payload/);
+  }
+
+  for (const slot of ["F3", "F4", "F6"]) {
+    const row = docsBySlot.get(slot);
+    assert.equal(row.boundaryLabel, "fallback-only boundary", `${slot} must stay WebView fallback-only`);
+    assert.match(row.detectorExpectation, /unsupported-react-native-webview-boundary/);
+    assert.match(row.preReadExpectation, /unsupported-react-native-webview-boundary/);
+    assert.match(row.mustNotClaim, /WebView support/);
+    assert.match(row.mustNotClaim, /bridge safety/);
+    assert.match(row.mustNotClaim, /compact-payload reuse/);
+    assert.doesNotMatch(`${row.preReadExpectation} ${row.reviewCue}`, /payload construction is allowed|payload reuse is enabled/i);
+  }
+
+  const tui = docsBySlot.get("F5");
+  assert.equal(tui.boundaryLabel, "syntax-only evidence");
+  assert.match(tui.detectorExpectation, /extractable TSX syntax evidence/);
+  assert.match(tui.preReadExpectation, /unsupported-frontend-domain-profile/);
+  assert.match(tui.mustNotClaim, /TUI\/Ink support/);
+  assert.match(tui.mustNotClaim, /terminal correctness/);
+  assert.match(tui.mustNotClaim, /token\/cost\/performance savings/);
+  assert.match(tui.mustNotClaim, /default compact extraction/);
+
+  const deferred = docsBySlot.get("F7");
+  assert.equal(deferred.boundaryLabel, "deferred");
+  assert.match(deferred.detectorExpectation, /no executable fixture path/);
+  assert.match(deferred.preReadExpectation, /no executable fixture path/);
+  assert.match(deferred.mustNotClaim, /broad terminal renderer support/);
+
+  for (const slot of ["F1", "F2", "F9", "F10", "F3", "F4", "F6", "F5"]) {
+    assert.equal(manifestBySlot.get(slot).supportClaim, "none", `${slot} must stay no-support in manifest`);
+  }
+  assert.doesNotMatch(
+    boundaryMap,
+    /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|bridge safety is guaranteed|compact[- ]payload reuse is (?:available|enabled|safe)|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|performance improvement is available|default WebView compact extraction is enabled|default TUI compact extraction is enabled/i,
+  );
 });
 
 test("docs give first-run users a clear support and diagnosis path", () => {


### PR DESCRIPTION
Pain point: recent RN primitive payload, WebView fallback-only, and TUI syntax-only gates make future review easy to overstate. This adds a compact cross-fixture claim-boundary map and regression coverage so evidence remains conservative.\n\nChanges:\n- Add docs/frontend-fixture-boundary-regression-map.md.\n- Cross-link fixture expectation docs.\n- Add regression coverage that keeps RN/WebView/TUI evidence from becoming support wording.\n\nVerification:\n- npm run build\n- node --test test/fooks.test.mjs\n- npm run typecheck -- --pretty false