### PR TITLE
docs: clarify bounded R4 evidence scope

### DIFF
--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -112,7 +112,8 @@ A bounded live rerun used the repeated R4 applied-code path with
 `requiredAccepted=5`, `maxPairs=8`, Codex provider mode, and model
 `gpt-5.4-mini`. It attempted seven matched vanilla/fooks pairs and accepted
 five pairs, but the summary classification remained `diagnostic-only` because
-the candidate threshold was not met.
+regression outliers kept stable claimability false, not because the accepted-pair
+denominator was missing.
 
 Accepted-pair medians were directionally positive: fooks supplied an 86.4%
 smaller prompt, CLI-reported runtime tokens were 22.4% lower, and latency was

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4681,6 +4681,18 @@ test("docs give first-run users a clear support and diagnosis path", () => {
   assert.match(combined, /no universal read interception|Universal file-read interception/);
 });
 
+test("docs keep bounded R4 rerun diagnostic reason tied to claimability failures", () => {
+  const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
+  const benchmarkEvidence = fs.readFileSync(path.join(repoRoot, "docs", "benchmark-evidence.md"), "utf8");
+  const combined = `${release}\n${benchmarkEvidence}`;
+
+  assert.match(combined, /2026-04-25 bounded rerun accepted 5\/7 pairs/);
+  assert.match(combined, /one severe runtime-token regression remained/);
+  assert.match(combined, /stable claimability flags stayed false/);
+  assert.match(benchmarkEvidence, /not because the accepted-pair\s+denominator was missing/);
+  assert.doesNotMatch(benchmarkEvidence, /diagnostic-only` because\s+the candidate threshold was not met/);
+});
+
 test("docs keep direct runtime benchmark regressions out of public win claims", () => {
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
   const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");


### PR DESCRIPTION
Pain point: release/benchmark evidence can drift from diagnostic R4 evidence into broader readiness claims. This keeps the R4 wording explicitly bounded and adds regression coverage for that claim boundary.\n\nChanges:\n- Clarify that bounded R4 evidence remains diagnostic.\n- Add regression coverage that prevents wording drift into support/readiness claims.\n\nVerification:\n- npm run build\n- node --test test/fooks.test.mjs\n- npm run typecheck -- --pretty false