### PR TITLE
test: make release claim guards testable offline

### DIFF
--- a/scripts/release-claim-guards.mjs
+++ b/scripts/release-claim-guards.mjs
@@ -1,0 +1,41 @@
+export function assertNoForbiddenPublicClaims(label, text) {
+  const forbidden = [
+    /provider usage\/billing-token reduction/i,
+    /billing-token savings/i,
+    /provider cost savings/i,
+    /Claude Read interception is enabled/i,
+    /Claude runtime-token savings are enabled/i,
+    /automatic Claude runtime-token savings/i,
+  ];
+  const negatedClaimBoundary = /(?:not|no|without|nor|never|does not prove|do not claim|must not claim|cannot support|blocks?|excluded?|out of scope|is not|stayed false|claimability flags stayed false)[^\n]{0,160}$/i;
+
+  let previousLine = "";
+  for (const line of text.split(/\r?\n/)) {
+    for (const pattern of forbidden) {
+      const match = pattern.exec(line);
+      if (match) {
+        const beforeMatch = `${previousLine.trim()} ${line.slice(0, match.index)}`;
+        assertClaimBoundary(negatedClaimBoundary.test(beforeMatch), `${label} contains forbidden positive claim ${pattern}: ${line}`);
+      }
+    }
+    if (/ccusage replacement/i.test(line)) {
+      assertClaimBoundary(/not (?:a )?ccusage replacement|not provider usage\/billing tokens[^.]*ccusage replacement/i.test(line), `${label} contains unbounded ccusage replacement wording: ${line}`);
+    }
+    if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
+      assertClaimBoundary(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
+    }
+    previousLine = line;
+  }
+}
+
+export function assertPublicSurfaceClaimBoundaries(surfaces) {
+  for (const [label, text] of Object.entries(surfaces)) {
+    assertNoForbiddenPublicClaims(label, text);
+  }
+}
+
+function assertClaimBoundary(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertPublicSurfaceClaimBoundaries } from "./release-claim-guards.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -30,41 +31,6 @@ function parsePackJson(stdout) {
 }
 
 
-function assertNoForbiddenPublicClaims(label, text) {
-  const forbidden = [
-    /provider usage\/billing-token reduction/i,
-    /billing-token savings/i,
-    /provider cost savings/i,
-    /Claude Read interception is enabled/i,
-    /Claude runtime-token savings are enabled/i,
-    /automatic Claude runtime-token savings/i,
-  ];
-  const negatedClaimBoundary = /(?:not|no|without|nor|never|does not prove|do not claim|must not claim|cannot support|blocks?|excluded?|out of scope|is not|stayed false|claimability flags stayed false)[^\n]{0,160}$/i;
-
-  let previousLine = "";
-  for (const line of text.split(/\r?\n/)) {
-    for (const pattern of forbidden) {
-      const match = pattern.exec(line);
-      if (match) {
-        const beforeMatch = `${previousLine.trim()} ${line.slice(0, match.index)}`;
-        assert(negatedClaimBoundary.test(beforeMatch), `${label} contains forbidden positive claim ${pattern}: ${line}`);
-      }
-    }
-    if (/ccusage replacement/i.test(line)) {
-      assert(/not (?:a )?ccusage replacement|not provider usage\/billing tokens[^.]*ccusage replacement/i.test(line), `${label} contains unbounded ccusage replacement wording: ${line}`);
-    }
-    if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
-      assert(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
-    }
-    previousLine = line;
-  }
-}
-
-function assertPublicSurfaceClaimBoundaries(surfaces) {
-  for (const [label, text] of Object.entries(surfaces)) {
-    assertNoForbiddenPublicClaims(label, text);
-  }
-}
 
 function runInstalledFooks(fooksBin, args, options = {}) {
   return execFileSync(fooksBin, args, {

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -1,0 +1,62 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  assertNoForbiddenPublicClaims,
+  assertPublicSurfaceClaimBoundaries,
+} from "../scripts/release-claim-guards.mjs";
+
+function assertGuardRejects(text, expectedMessage) {
+  assert.throws(
+    () => assertNoForbiddenPublicClaims("synthetic benchmark/provider surface", text),
+    expectedMessage,
+  );
+}
+
+test("release claim guard rejects benchmark/provider positive savings claims offline", () => {
+  assertGuardRejects(
+    "Benchmark evidence shows provider usage/billing-token reduction for users.",
+    /provider usage\/billing-token reduction/,
+  );
+  assertGuardRejects(
+    "Provider cost savings are available from this benchmark.",
+    /provider cost savings/,
+  );
+  assertGuardRejects(
+    "The result is a ccusage replacement for provider billing review.",
+    /unbounded ccusage replacement wording/,
+  );
+});
+
+test("release claim guard allows explicit benchmark/provider boundaries without broadening claims", () => {
+  assertNoForbiddenPublicClaims(
+    "bounded benchmark/provider surface",
+    [
+      "Benchmark evidence is local estimated payload evidence only; it does not prove provider usage/billing-token reduction.",
+      "This is not provider usage/billing tokens, invoices, dashboards, charged costs, or a ccusage replacement.",
+      "claimability flags stayed false: provider cost savings remain out of scope.",
+    ].join("\n"),
+  );
+});
+
+test("release claim guard keeps internal .omx state out of product surfaces", () => {
+  assertGuardRejects(
+    "Users can inspect product state in .omx/state after the benchmark run.",
+    /exposes \.omx as product state/,
+  );
+  assertNoForbiddenPublicClaims(
+    "bounded harness surface",
+    "The release harness may write internal .omx/state planning artifacts during tests.",
+  );
+});
+
+test("release public surface guard reports the offending surface label", () => {
+  assert.throws(
+    () => assertPublicSurfaceClaimBoundaries({
+      "docs/benchmark-evidence.md": "Provider cost savings are guaranteed.",
+    }),
+    /docs\/benchmark-evidence\.md contains forbidden positive claim/,
+  );
+});


### PR DESCRIPTION
## Summary
- extract release public-surface claim guards into a reusable offline module
- add focused regression coverage for benchmark/provider and .omx claim boundaries
- keep release-smoke wired to the same guard without requiring full pack/install smoke for guard-only checks

## Verification
- node --check scripts/release-claim-guards.mjs
- node --check scripts/release-smoke.mjs
- node --test test/release-claim-guards.test.mjs
- npm run build
- npm run typecheck -- --pretty false