### PR TITLE
Expose React Web payload gate as runtime evidence

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -11,6 +11,7 @@ const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
+export const REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY = "react-web-current-supported-lane";
 export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
 const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
   "react-native:primitive:View",
@@ -94,6 +95,10 @@ function frontendDebug(
 }
 
 export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
+  if (domainDetection.classification === "react-web" && domainDetection.profile.claimStatus === "current-supported-lane") {
+    return { name: REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY, allowed: true };
+  }
+
   if (domainDetection.classification !== "react-native") return undefined;
 
   const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1226,6 +1226,8 @@ export function CustomOnlyForm() {
   assert.equal(customReactWeb.decision, "payload");
   assert.equal(customReactWeb.debug.domainDetection.classification, "react-web");
   assert.equal(customReactWeb.debug.domainDetection.profile.claimStatus, "current-supported-lane");
+  assert.equal(customReactWeb.debug.frontendPayloadPolicy.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
+  assert.equal(customReactWeb.debug.frontendPayloadPolicy.allowed, true);
   assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"));
   assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:htmlFor"));
 
@@ -1264,6 +1266,7 @@ export function CustomOnlyForm() {
   assert.equal(tui.fallback.reason, unsupportedFrontendProfile);
   assert.equal(tui.debug.domainDetection.classification, "tui-ink");
   assert.equal(tui.debug.domainDetection.profile.claimStatus, "evidence-only");
+  assert.notEqual(tui.debug.frontendPayloadPolicy?.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   assert.notEqual(tui.debug.frontendPayloadPolicy?.allowed, true);
   assert.equal("payload" in tui, false);
 
@@ -1273,6 +1276,7 @@ export function CustomOnlyForm() {
   assert.equal(moduleTs.debug.language, "ts");
   assert.equal(moduleTs.debug.domainDetection.classification, "unknown");
   assert.equal(moduleTs.debug.domainDetection.profile.claimStatus, "deferred");
+  assert.notEqual(moduleTs.debug.frontendPayloadPolicy?.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   assert.ok(moduleTs.payload.structure.moduleDeclarations?.length);
   assert.equal("editGuidance" in moduleTs.payload, false);
 
@@ -4433,6 +4437,12 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(decision.decision, "payload", `${item.id} should reuse payload as React Web current lane`);
     assert.equal(decision.debug.domainDetection.classification, "react-web", `${item.id} should classify as React Web`);
     assert.equal(decision.debug.domainDetection.profile.claimStatus, "current-supported-lane", `${item.id} should stay in the current supported lane`);
+    assert.equal(
+      decision.debug.frontendPayloadPolicy.name,
+      preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+      `${item.id} should expose the React Web current-supported payload policy marker`,
+    );
+    assert.equal(decision.debug.frontendPayloadPolicy.allowed, true, `${item.id} should allow the React Web current-supported payload policy`);
     assert.ok(decision.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"), `${item.id} should carry className evidence`);
     assert.equal("fallback" in decision, false, `${item.id} must not fall back after React Web evidence`);
   }
@@ -4466,6 +4476,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(decision.decision, "fallback", `${item.id} should stay outside the RN primitive/input narrow payload gate`);
     assert.deepEqual(decision.reasons, [preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON]);
     assert.equal(decision.fallback.reason, preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+    assert.notEqual(decision.debug.frontendPayloadPolicy.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
     assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
   }
 
@@ -4475,6 +4486,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(decision.decision, "fallback", `${item.id} should stay WebView fallback-first`);
     assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
     assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
+    assert.notEqual(decision.debug.frontendPayloadPolicy?.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   }
 
   for (const slot of ["F3", "F4", "F6"]) {
@@ -4487,6 +4499,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal("payload" in decision, false, `${item.id} must not build a compact payload across the WebView boundary`);
     assert.equal(decision.debug.domainDetection.profile.claimStatus, "fallback-boundary");
     assert.equal(decision.debug.domainDetection.profile.boundaryReason, "unsupported-react-native-webview-boundary");
+    assert.notEqual(decision.debug.frontendPayloadPolicy?.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   }
 });
 


### PR DESCRIPTION
## Summary
- Add a narrow React Web pre-read payload policy marker: `react-web-current-supported-lane`
- Expose the marker only for React Web `current-supported-lane` decisions
- Add regression coverage that F11/F12 receive the marker and RN/WebView/TUI/Unknown do not

## Scope boundaries
- No `src/core/domain-detector.ts` changes
- No schema migration
- No RN/WebView/TUI/Mixed/Unknown promotion
- No support, performance, token, billing, or cost claims

## Verification
- `npm run build && node --test --test-name-pattern "React Web|react-web|F11|F12|frontend domain contract|frontend domain fixture|pre-read" test/domain-detector.test.mjs test/fooks.test.mjs` — 13/13 pass
- `git diff --check && npm run lint && npm test` — 297/297 pass
- Architect review — APPROVE

## Not tested
- Real-world large React Native/WebView/TUI corpora beyond existing fixtures
