### PR TITLE
Make domain-parallel work safe to split

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -96,6 +96,9 @@ The files below are shared policy surfaces. A PR wave that changes any of them m
 
 - `src/core/domain-detector.ts`
 - `src/adapters/pre-read.ts`
+- `src/core/payload/readiness.ts`
+- `src/adapters/*-runtime-hook.ts`
+- `src/adapters/*-hook-preset.ts`
 - `src/core/schema.ts`
 - `test/fooks.test.mjs`
 - `test/domain-detector.test.mjs`
@@ -114,6 +117,46 @@ The paths below may be edited in parallel when the branch stays inside its domai
 - Domain-specific docs that do not change shared support, detector, pre-read, or manifest policy
 
 Parallel branches that need a serialized shared surface are no longer independent domain branches for that PR wave; they must serialize behind the named shared-policy owner.
+
+#### Domain parallel safety layer
+
+The parallel safety layer is an execution contract for future multi-agent or multi-worktree domain work. It is docs/tests-only by default and does not authorize runtime source changes. A safety-layer PR must include a changed-file guard: the final diff may contain only the selected frontend-domain contract doc(s), focused contract regression test(s), and OMX planning/state artifacts needed for workflow bookkeeping. If `src/core/domain-detector.ts`, `src/adapters/pre-read.ts`, `src/core/payload/readiness.ts`, runtime hooks, hook presets, schema files, or manifest policy must change, the work stops and reruns planning/review as a serialized shared-policy owner branch.
+
+Safe lane types are limited to:
+
+- read-only investigation;
+- fixture-only lane;
+- disjoint domain test lane;
+- docs/claim-boundary lane, only when it avoids shared support-policy expansion or names the shared-policy owner;
+- single runtime writer lane, explicitly serialized and never parallel with other shared-seam/runtime writers;
+- verifier lane.
+
+Unsafe lane types are not parallel-safe and must serialize:
+
+- multiple branches editing detector, pre-read, readiness, runtime hooks, hook presets, schema, shared tests, or manifest policy in the same PR wave;
+- domain branches changing shared support wording without a named shared-policy owner;
+- WebView payload or bridge reuse while WebView is fallback-first;
+- RN or TUI support wording based only on syntax traversal evidence;
+- Mixed or Unknown promotion by choosing the most convenient domain;
+- full domain writer parallelism against shared runtime/shared-seam files.
+
+Execution handoff checklist for any future domain-parallel PR wave:
+
+1. **Named shared-policy owner** — required for any PR wave touching serialized shared surfaces.
+2. **Merge-order note** — records which shared-policy branch must land first and which domain branches wait.
+3. **Disjoint-file proof** — lists each lane's owned files and proves they do not overlap shared seams.
+4. **Verifier command** — names the targeted command proving fallback/deferred/support boundaries did not weaken.
+5. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
+
+Shared fallback reasons and denial markers are boundary evidence, not support claims. In particular, `unsupported-react-native-webview-boundary`, `unsupported-frontend-domain-profile`, `webview-boundary-fallback`, and domain-specific payload policy strings must not be reused as React Native, WebView, TUI/Ink, Mixed, or Unknown support wording.
+
+Domain promotion must follow this ordered ladder and stop at the first failed gate:
+
+1. evidence-only;
+2. readiness gate;
+3. denial/current marker;
+4. narrow runtime gate;
+5. narrow payload gate.
 
 | Lane | Primary owned surfaces | Serialized shared surfaces | Merge-order rule | Verification minimum | Claim boundary |
 | --- | --- | --- | --- | --- | --- |

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4193,6 +4193,9 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   for (const sharedFile of [
     "src/core/domain-detector.ts",
     "src/adapters/pre-read.ts",
+    "src/core/payload/readiness.ts",
+    "src/adapters/*-runtime-hook.ts",
+    "src/adapters/*-hook-preset.ts",
     "src/core/schema.ts",
     "test/fooks.test.mjs",
     "test/domain-detector.test.mjs",
@@ -4228,6 +4231,42 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   const ownershipMatrix = contract.slice(ownershipMatrixStart, ownershipMatrixEnd);
   assert.match(ownershipMatrix, /must name one shared-policy owner, include a merge-order note/);
   assert.match(ownershipMatrix, /may be edited in parallel when the branch stays inside its domain/);
+  assert.match(ownershipMatrix, /#### Domain parallel safety layer/);
+  assert.match(ownershipMatrix, /docs\/tests-only by default and does not authorize runtime source changes/);
+  assert.match(ownershipMatrix, /changed-file guard/);
+  assert.match(ownershipMatrix, /read-only investigation/);
+  assert.match(ownershipMatrix, /fixture-only lane/);
+  assert.match(ownershipMatrix, /disjoint domain test lane/);
+  assert.match(ownershipMatrix, /docs\/claim-boundary lane, only when it avoids shared support-policy expansion or names the shared-policy owner/);
+  assert.match(ownershipMatrix, /single runtime writer lane, explicitly serialized and never parallel with other shared-seam\/runtime writers/);
+  assert.match(ownershipMatrix, /verifier lane/);
+  assert.match(ownershipMatrix, /Unsafe lane types are not parallel-safe and must serialize/);
+  assert.match(ownershipMatrix, /full domain writer parallelism against shared runtime\/shared-seam files/);
+  assert.match(ownershipMatrix, /Execution handoff checklist/);
+  for (const handoffItem of [
+    "Named shared-policy owner",
+    "Merge-order note",
+    "Disjoint-file proof",
+    "Verifier command",
+    "Contradiction check",
+  ]) {
+    assert.ok(ownershipMatrix.includes(handoffItem), `${handoffItem} must stay in the execution handoff checklist`);
+  }
+  assert.match(ownershipMatrix, /Shared fallback reasons and denial markers are boundary evidence, not support claims/);
+  assert.match(ownershipMatrix, /`unsupported-react-native-webview-boundary`/);
+  assert.match(ownershipMatrix, /`unsupported-frontend-domain-profile`/);
+  assert.match(ownershipMatrix, /`webview-boundary-fallback`/);
+  assert.match(ownershipMatrix, /must not be reused as React Native, WebView, TUI\/Ink, Mixed, or Unknown support wording/);
+  assert.match(ownershipMatrix, /Domain promotion must follow this ordered ladder and stop at the first failed gate/);
+  for (const ladderStep of [
+    "1. evidence-only",
+    "2. readiness gate",
+    "3. denial/current marker",
+    "4. narrow runtime gate",
+    "5. narrow payload gate",
+  ]) {
+    assert.ok(ownershipMatrix.includes(ladderStep), `${ladderStep} must stay in the domain promotion ladder`);
+  }
   for (const lane of ["React Web", "React Native", "WebView", "TUI/Ink", "Mixed/Unknown/shared policy"]) {
     assert.ok(ownershipMatrix.includes(`| ${lane} |`), `${lane} ownership matrix row must exist`);
   }


### PR DESCRIPTION
## Summary
- harden the frontend domain contract with a docs/tests-only Domain Parallel Safety Layer
- serialize shared seams for detector, pre-read, readiness, runtime hooks, hook presets, schema, manifest, and shared tests
- regression-lock safe/unsafe lane types, execution handoff checklist, fallback-reason boundaries, and promotion ladder ordering

## Verification
- `npm test -- test/fooks.test.mjs --test-name-pattern 'frontend domain contract locks taxonomy'` (project script ran 310 tests)
- `git diff --check`
- `npm run lint`
- `npm test` (310 pass / 0 fail)
- Architect verification: APPROVE / CLEAR
- ai-slop-cleaner changed-files-only pass: no cleanup edits needed; post-deslop regression stayed green

## Notes
- No runtime source files changed.
- Shared fallback reasons and denial markers remain boundary evidence, not support claims.
- This prepares future domain-specific parallel work; it does not itself promote RN/WebView/TUI support.