### PR TITLE
Clarify RN F1 forbidden-signal fallback precedence

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -113,15 +113,6 @@ export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResu
 
   if (domainDetection.classification !== "react-native") return undefined;
 
-  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
-  if (missingSignal) {
-    return {
-      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
-      allowed: false,
-      reason: `missing-signal:${missingSignal}`,
-    };
-  }
-
   const forbiddenSignal =
     RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS.find((signal) => hasSignal(domainDetection, signal)) ??
     RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.find((prefix) => hasAnySignalWithPrefix(domainDetection, prefix));
@@ -130,6 +121,15 @@ export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResu
       name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
       allowed: false,
       reason: `forbidden-signal:${forbiddenSignal}`,
+    };
+  }
+
+  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
+  if (missingSignal) {
+    return {
+      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+      allowed: false,
+      reason: `missing-signal:${missingSignal}`,
     };
   }
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1262,6 +1262,7 @@ export function CustomOnlyForm() {
     assert.equal(rn.debug.domainDetection.profile.claimStatus, "fallback-boundary");
     assert.equal(rn.debug.frontendPayloadPolicy.name, preReadModule.RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
     assert.equal(rn.debug.frontendPayloadPolicy.allowed, false);
+    assert.match(rn.debug.frontendPayloadPolicy.reason, /^forbidden-signal:react-native:/);
     assert.equal("payload" in rn, false);
   }
 
@@ -4561,6 +4562,7 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     assert.equal(decision.fallback.reason, preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
     assert.notEqual(decision.debug.frontendPayloadPolicy.name, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
     assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
+    assert.match(decision.debug.frontendPayloadPolicy.reason, /^forbidden-signal:react-native:/);
   }
 
   for (const slot of ["F3", "F4", "F6"]) {


### PR DESCRIPTION
## Summary\n- prefer forbidden RN signals before missing required F1 signals in the RN primitive/input payload policy\n- assert F2/F9/F10 fallback denials surface forbidden RN semantics instead of looking like incomplete F1 candidates\n- keep detector/schema/hooks/manifest schema, WebView, TUI, and React Web behavior unchanged\n\n## Verification\n- node --test test/domain-detector.test.mjs\n- npm run build && node --test test/fooks.test.mjs --test-name-pattern "pre-read|frontend domain|React Native|WebView|TUI|fixture boundary"\n- npm run lint\n- npm test\n- git diff --check\n- forbidden support/token/billing/performance claim audit\n\n## Boundary\nThis is an F1-only pre-read policy hardening. It is not broad React Native support and does not promote detector/profile behavior.\n