### PR TITLE
Require explicit contracts before domain-parallel waves

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -142,11 +142,22 @@ Unsafe lane types are not parallel-safe and must serialize:
 
 Execution handoff checklist for any future domain-parallel PR wave:
 
-1. **Named shared-policy owner** — required for any PR wave touching serialized shared surfaces.
-2. **Merge-order note** — records which shared-policy branch must land first and which domain branches wait.
-3. **Disjoint-file proof** — lists each lane's owned files and proves they do not overlap shared seams.
-4. **Verifier command** — names the targeted command proving fallback/deferred/support boundaries did not weaken.
-5. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
+Every PR wave must carry a small **PR wave contract** before worktree, team, or multi-agent launch. The contract is operational bookkeeping only: it is docs/tests-only unless a separate serialized runtime plan names a single shared-seam owner. Required fields are:
+
+1. **Base branch or base commit prerequisite** — records the exact `main` tip, merged prerequisite PR, or branch that every lane must start from.
+2. **Lane name** — names the domain lane, for example `react-web`, `react-native`, `webview-boundary`, `tui-ink`, `mixed-unknown`, or `shared-policy`.
+3. **Lane type** — chooses exactly one safe lane type from the list above; runtime writer lanes are single-writer and serialized, not a parallel default.
+4. **Lane owner** — names the branch or agent responsible for the lane's owned files.
+5. **Allowed files** — lists the lane-owned docs, fixtures, or tests that may change.
+6. **Disallowed files** — repeats the serialized shared surfaces that this lane must not edit without stopping for shared-policy planning.
+7. **Shared-seam lock status** — states either `none` or the exact serialized shared seam under lock.
+8. **Named shared-policy owner** — required for any PR wave touching serialized shared surfaces.
+9. **Merge-order note** — records which shared-policy branch must land first and which domain branches wait.
+10. **Disjoint-file proof** — lists each lane's owned files and proves they do not overlap shared seams.
+11. **Required verification command** — names the targeted command proving fallback/deferred/support boundaries did not weaken.
+12. **Claim-boundary audit** — records the forbidden broad-support/domain-parallel wording check for the lane.
+13. **Worktree/team launch status** — states whether this is only a planning contract or names the separate approved launch plan; absence of that plan means no domain implementation worktree is authorized.
+14. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
 
 Shared fallback reasons and denial markers are boundary evidence, not support claims. In particular, `unsupported-react-native-webview-boundary`, `unsupported-frontend-domain-profile`, `webview-boundary-fallback`, and domain-specific payload policy strings must not be reused as React Native, WebView, TUI/Ink, Mixed, or Unknown support wording.
 

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -76,7 +76,7 @@ const forbiddenBroadDomainParallelClaims = [
   },
 ];
 
-const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden)\b/i;
+const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden|shared seams? must serialize|worktree launch needs a separate plan|separate approved launch plan|no domain implementation worktree is authorized)\b/i;
 
 function collectMarkdownFiles(entry) {
   const absolute = path.join(repoRoot, entry);
@@ -193,6 +193,13 @@ test("claim-boundary doc audit rejects broad domain-parallel examples but allows
   assert.deepEqual(findBroadDomainParallelClaims("Safe to split means runtime support is enabled for domain-parallel source changes.", "synthetic.md"), [
     "synthetic.md:1 [domain-parallel-runtime-support] Safe to split means runtime support is enabled for domain-parallel source changes.",
   ]);
+  assert.deepEqual(findBroadDomainParallelClaims("The PR wave contract says domain-parallel runtime support is authorized for source changes.", "synthetic.md"), [
+    "synthetic.md:1 [domain-parallel-runtime-support] The PR wave contract says domain-parallel runtime support is authorized for source changes.",
+  ]);
+  assert.deepEqual(findBroadDomainParallelClaims("The PR wave contract is docs/tests-only unless a shared-seam owner says domain-parallel runtime support is authorized.", "synthetic.md"), [
+    "synthetic.md:1 [domain-parallel-runtime-support] The PR wave contract is docs/tests-only unless a shared-seam owner says domain-parallel runtime support is authorized.",
+  ]);
   assert.deepEqual(findBroadDomainParallelClaims("The parallel safety layer is docs/tests-only by default and does not authorize runtime source changes.", "synthetic.md"), []);
   assert.deepEqual(findBroadDomainParallelClaims("Domain lanes may proceed in parallel only when each lane has a disjoint-file proof and shared seams must serialize.", "synthetic.md"), []);
+  assert.deepEqual(findBroadDomainParallelClaims("The PR wave contract is docs/tests-only; shared seams must serialize behind a named owner and worktree launch needs a separate plan.", "synthetic.md"), []);
 });

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4244,15 +4244,28 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(ownershipMatrix, /Unsafe lane types are not parallel-safe and must serialize/);
   assert.match(ownershipMatrix, /full domain writer parallelism against shared runtime\/shared-seam files/);
   assert.match(ownershipMatrix, /Execution handoff checklist/);
+  assert.match(ownershipMatrix, /PR wave contract/);
+  assert.match(ownershipMatrix, /before worktree, team, or multi-agent launch/);
+  assert.match(ownershipMatrix, /docs\/tests-only unless a separate serialized runtime plan names a single shared-seam owner/);
   for (const handoffItem of [
+    "Base branch or base commit prerequisite",
+    "Lane name",
+    "Lane type",
+    "Lane owner",
+    "Allowed files",
+    "Disallowed files",
+    "Shared-seam lock status",
     "Named shared-policy owner",
     "Merge-order note",
     "Disjoint-file proof",
-    "Verifier command",
+    "Required verification command",
+    "Claim-boundary audit",
+    "Worktree/team launch status",
     "Contradiction check",
   ]) {
-    assert.ok(ownershipMatrix.includes(handoffItem), `${handoffItem} must stay in the execution handoff checklist`);
+    assert.ok(ownershipMatrix.includes(handoffItem), `${handoffItem} must stay in the PR wave contract checklist`);
   }
+  assert.match(ownershipMatrix, /absence of that plan means no domain implementation worktree is authorized/);
   assert.match(ownershipMatrix, /Shared fallback reasons and denial markers are boundary evidence, not support claims/);
   assert.match(ownershipMatrix, /`unsupported-react-native-webview-boundary`/);
   assert.match(ownershipMatrix, /`unsupported-frontend-domain-profile`/);


### PR DESCRIPTION
## Summary
- expand the frontend domain contract with an explicit PR wave contract checklist before worktree/team/multi-agent launches
- lock required lane fields: base prerequisite, lane name/type/owner, allowed/disallowed files, shared-seam lock status, verification, claim-boundary audit, and launch status
- tighten claim-boundary regression coverage so broad domain-parallel runtime/support authorization remains rejected even when phrased as a conditional contract

## Boundaries
- Docs/tests-only.
- No runtime, detector, pre-read, readiness, hook, schema, or manifest behavior changes.
- This does not authorize RN/WebView/TUI/React Web implementation lanes by itself; each later lane still needs a filled PR wave contract and shared-seam ownership when applicable.

## Verification
- `node --test test/claim-boundary-doc-audit.test.mjs`
- `node --test test/fooks.test.mjs --test-name-pattern "frontend domain contract|domain-parallel|fixture boundary"`
- `npm run lint`
- `npm test`
- `git diff --check`
- docs diff forbidden-claim grep audit

## Remaining risk
- The next implementation wave still needs lane-by-lane contracts before parallel work starts.
