### PR TITLE
Make cache status failures actionable

### DIFF
--- a/src/core/cache-monitor.ts
+++ b/src/core/cache-monitor.ts
@@ -32,9 +32,10 @@ export class CacheMonitor {
 
     const backupAvailable = existsSync(backupPath) && this.readIndexHealth(backupPath).valid;
     const corruptionEvents = this.metrics.corruptionEvents;
+    const status = this.resolveHealthStatus({ indexExists, indexValid, corruptionEvents });
 
-    return {
-      status: this.resolveHealthStatus({ indexExists, indexValid, corruptionEvents }),
+    const report = {
+      status,
       indexExists,
       indexValid,
       entryCount,
@@ -42,6 +43,7 @@ export class CacheMonitor {
       backupAvailable,
       lastCheck: new Date().toISOString(),
     };
+    return { ...report, recommendation: this.generateRecommendation(report) };
   }
 
   private readIndexHealth(indexPath: string): { valid: boolean; entryCount: number } {
@@ -119,7 +121,7 @@ export class CacheMonitor {
     return report.corruptionEvents > 0 ? "recovered" : "healthy";
   }
 
-  private generateRecommendation(report: CacheHealthReport): string {
+  private generateRecommendation(report: Pick<CacheHealthReport, "status" | "backupAvailable" | "corruptionEvents">): string {
     if (report.status === "empty") {
       return "Initialize cache with first scan";
     }
@@ -168,6 +170,7 @@ interface CacheHealthReport {
   entryCount: number;
   corruptionEvents: number;
   backupAvailable: boolean;
+  recommendation: string;
   lastCheck: string;
 }
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4885,6 +4885,19 @@ test("status cache reports healthy after scan builds the cache index", () => {
   assert.ok(status.entryCount >= 5);
 });
 
+test("status cache reports an actionable recommendation for corrupted indexes", () => {
+  const tempDir = makeTempProject();
+  fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, ".fooks", "index.json"), "{ invalid json");
+
+  const status = run(["status", "cache"], tempDir);
+
+  assert.equal(status.status, "corrupted");
+  assert.equal(status.indexExists, true);
+  assert.equal(status.indexValid, false);
+  assert.match(status.recommendation, /rerun scan to regenerate/i);
+});
+
 test("attach codex proves contract and runtime under minislively account context", () => {
   const tempDir = makeTempProject();
   const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-codex-home-"));


### PR DESCRIPTION
## Summary
- surface the existing cache monitor recovery recommendation in `fooks status cache` failure output
- add regression coverage for corrupted cache index guidance

## Verification
- npm run build && node --test --test-name-pattern "status cache" test/fooks.test.mjs

Commit: 3a694160695bf7d642347828cfa66b5dfbf924e4