### PR TITLE
Lock TUI edit-guidance fallback

### DIFF
--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1277,6 +1277,19 @@ export function CustomOnlyForm() {
   assert.notEqual(tui.debug.frontendPayloadPolicy?.allowed, true);
   assert.equal("payload" in tui, false);
 
+  const tuiWithEditGuidance = decideCodexPreRead(
+    path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "tui-ink-basic.tsx"),
+    repoRoot,
+    { includeEditGuidance: true },
+  );
+  assert.equal(tuiWithEditGuidance.eligible, true);
+  assert.equal(tuiWithEditGuidance.decision, "fallback");
+  assert.deepEqual(tuiWithEditGuidance.reasons, [unsupportedFrontendProfile]);
+  assert.equal(tuiWithEditGuidance.fallback.reason, unsupportedFrontendProfile);
+  assert.equal(tuiWithEditGuidance.debug.domainDetection.classification, "tui-ink");
+  assert.equal(tuiWithEditGuidance.debug.domainDetection.profile.claimStatus, "evidence-only");
+  assert.equal("payload" in tuiWithEditGuidance, false);
+
   const moduleTs = decideCodexPreRead(path.join(repoRoot, "fixtures", "ts-js-beta", "module-utils.ts"), repoRoot);
   assert.equal(moduleTs.eligible, true);
   assert.equal(moduleTs.decision, "payload");


### PR DESCRIPTION
## Summary
- Add a regression assertion that TUI/Ink pre-read still falls back when `includeEditGuidance: true` is requested.
- Keep TUI evidence-only: no compact payload, no runtime promotion, no support claim.

## Verification
- `node --test --test-name-pattern "codex pre-read chooses payload" test/fooks.test.mjs` — PASS 1
- `node --test --test-name-pattern "TUI|tui|Ink|frontend domain contract|frontend domain fixture|codex pre-read chooses payload" test/domain-detector.test.mjs test/fooks.test.mjs` — PASS 8
- `node --test test/claim-boundary-doc-audit.test.mjs` — PASS 5
- `git diff --check` — PASS
- `npm run lint` — PASS
- `npm test` — PASS 312/312

## Boundary
- No `src/` runtime behavior changes.
- No TUI compact payload promotion.
- No TUI/Ink support, terminal correctness, token/cost/performance claim.