### PR TITLE
Recognize pasted CI job URLs as run alerts

### DIFF
--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -86,7 +86,7 @@ function readAlertText(alertsInput) {
 
 function extractAlertRunRefs(alertText) {
   const refsById = new Map();
-  const urlPattern = /https:\/\/github\.com\/[^\s<>)\]]+\/actions\/runs\/(\d+)(?:[^\s<>)\]]*)?/gi;
+  const urlPattern = /https:\/\/github\.com\/[^\s<>)\]]+\/actions\/runs\/(\d+)(?:\/(?:attempts|job|jobs)\/\d+)?(?:[?#][^\s<>)\]]*)?/gi;
 
   for (const match of alertText.matchAll(urlPattern)) {
     const id = match[1];

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -130,8 +130,8 @@ test("CI alert triage turns pasted GitHub Actions URLs into evidence", () => {
   ]));
   fs.writeFileSync(alertsPath, [
     "Discord alert: https://github.com/minislively/fooks/actions/runs/204",
-    "clawhip replay https://github.com/minislively/fooks/actions/runs/203/attempts/1",
-    "duplicate https://github.com/minislively/fooks/actions/runs/204",
+    "clawhip replay job URL https://github.com/minislively/fooks/actions/runs/203/job/987654321",
+    "duplicate job URL https://github.com/minislively/fooks/actions/runs/204/job/123456789",
     "outside inspected window https://github.com/minislively/fooks/actions/runs/999",
   ].join("\n"));
 
@@ -157,6 +157,7 @@ test("CI alert triage turns pasted GitHub Actions URLs into evidence", () => {
     assert.equal(byAlertId.get("204").reason, "superseded by run 205");
     assert.equal(byAlertId.get("204").appearances, 2);
     assert.equal(byAlertId.get("203").evidence, "actionable");
+    assert.equal(byAlertId.get("203").alertedUrl, "https://github.com/minislively/fooks/actions/runs/203/job/987654321");
     assert.equal(byAlertId.get("999").evidence, "missing");
     assert.equal(byAlertId.get("999").reason, "run URL was not present in the inspected gh run list window");
   } finally {


### PR DESCRIPTION
## Summary
- make `ci:alerts --alerts` recognize pasted GitHub Actions job URLs as parent run alerts
- preserve existing run URL parsing and de-duplication
- add regression coverage for mixed run/job URL paste

Fixes #257

## Verification
- node --check scripts/triage-ci-alerts.mjs
- node --test test/ci-alert-triage.test.mjs
- npm run typecheck -- --pretty false

Commit: 6dca098