### PR TITLE
Keep the next RN fixture gap narrow

### DIFF
--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -56,6 +56,14 @@ The RN fixture lane is a readiness gate, not a support promise. `F1` is the firs
 
 Execution for later RN gates should prefer strengthening docs, manifest metadata, and regression tests around existing RN fixture slots before adding new synthetic fixtures. This first gate is intentionally limited to `F1`; `F2`, `F9`, and `F10` remain fallback/readiness-only.
 
+### RN F1-adjacent fixture gap gate
+
+The next RN fixture gap should stay adjacent to `F1` before any broader RN lane work begins. An acceptable F1-adjacent gap varies exactly one primitive/input axis from the existing `F1` fixture family, such as an alternate primitive press/input component or prop shape, while preserving the same narrow purpose: local RN primitive/input payload evidence only.
+
+An F1-adjacent gap must not introduce `StyleSheet.create`, `Platform.select`, navigation hooks, `FlatList`, `PanResponder`, image/layout primitives, WebView bridge markers, TUI/Ink imports, or React Web DOM/form evidence. If a candidate needs any of those signals, it belongs to `F2`, `F9`, `F10`, WebView, TUI, or React Web planning instead of the F1-adjacent lane.
+
+Before adding an F1-adjacent fixture file or promoting any runtime behavior, the plan must name the specific missing primitive/input acceptance check, state whether the expected pre-read outcome remains fallback or uses the existing `rn-primitive-input-narrow-payload` policy, and keep `supportClaim: "none"`. Without a named failing or missing acceptance check, the correct result is a no-op audit rather than invented implementation.
+
 ## Manifest shape guard
 
 Selected fixtures must not carry deferred-only fields such as `deferReason` or `doesNotBlockBaseline`. Deferred fixtures must not carry executable fixture paths, expected outcomes, fallback reasons, required signals, or verification instructions. This keeps the manifest from describing the same slot as both selected and deferred while later RN/WebView/TUI/React Web work is split across branches.

--- a/docs/frontend-fixture-boundary-regression-map.md
+++ b/docs/frontend-fixture-boundary-regression-map.md
@@ -22,4 +22,6 @@ This is the compact review map for the RN/WebView/TUI fixture boundary. It does 
 - Keep WebView slots `F3`, `F4`, and `F6` at `evidenceScope: "fallback-boundary-evidence-only"`.
 - Keep TUI slot `F5` at `evidenceScope: "syntax-evidence-only"`.
 - Keep only RN slot `F1` on `payloadPolicy: "rn-primitive-input-narrow-payload"`; the other selected RN slots stay readiness-only fallback evidence.
+- Keep any future RN F1-adjacent fixture gap limited to one primitive/input axis; do not mix in `F2`, `F9`, `F10`, WebView, TUI, or React Web signals.
+- Require a named missing primitive/input acceptance check before adding an F1-adjacent fixture file or changing runtime behavior; otherwise record a no-op audit.
 - Do not add support, setup-eligibility, runtime-token, provider-token, billing, performance, terminal-safety, bridge-safety, or default compact-extraction claims from these fixtures.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4667,10 +4667,17 @@ test("frontend domain fixture docs mirror manifest slot expectations", () => {
   assert.match(docs, /`F7` remains deferred for broad non-Ink terminal renderer semantics/);
   assert.match(docs, /pre-read must continue to fallback with `unsupported-frontend-domain-profile`/i);
   assert.match(docs, /must not construct a compact payload by default/);
+  assert.match(docs, /RN F1-adjacent fixture gap gate/);
+  assert.match(docs, /varies exactly one primitive\/input axis/);
+  assert.match(docs, /must not introduce `StyleSheet\.create`, `Platform\.select`, navigation hooks, `FlatList`, `PanResponder`, image\/layout primitives, WebView bridge markers, TUI\/Ink imports, or React Web DOM\/form evidence/);
+  assert.match(docs, /name the specific missing primitive\/input acceptance check/);
+  assert.match(docs, /Without a named failing or missing acceptance check, the correct result is a no-op audit/);
   assert.match(docs, /Selected fixtures must not carry deferred-only fields/);
   assert.match(docs, /Deferred fixtures must not carry executable fixture paths/);
   assert.match(docs, /\[frontend fixture boundary regression map\]\(frontend-fixture-boundary-regression-map\.md\)/);
   assert.match(boundaryMap, /## Regression map/);
+  assert.match(boundaryMap, /future RN F1-adjacent fixture gap limited to one primitive\/input axis/);
+  assert.match(boundaryMap, /Require a named missing primitive\/input acceptance check before adding an F1-adjacent fixture file or changing runtime behavior/);
   assert.match(docs, /\[WebView bridge boundary plan\]\(webview-bridge-boundary-plan\.md\)/);
   assert.match(webviewBridgePlan, /`F4` \(`webview-bridge-pair`\) as \*\*selected fallback-boundary evidence\*\*/);
   assert.match(webviewBridgePlan, /checkout\.submit/);


### PR DESCRIPTION
## Summary
- lock the next RN F1-adjacent fixture gap to exactly one primitive/input axis
- require a named missing primitive/input acceptance check before adding a fixture or changing runtime behavior
- add regression assertions so the docs/map boundary cannot drift into broad RN/WebView/TUI/React Web claims

## Verification
- `node --test --test-name-pattern "frontend domain fixture docs mirror manifest slot expectations|frontend fixture boundary regression map keeps RN WebView TUI claim boundaries compact" test/fooks.test.mjs`
- `npm run lint`
- `git diff --check`
- `npm test` — 315 pass, 0 fail

## Boundaries
- No runtime detector or pre-read behavior change
- No new fixture file
- No React Native support claim
