### PR TITLE
Keep domain-parallel shared locks complete

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -102,9 +102,11 @@ The files below are shared policy surfaces. A PR wave that changes any of them m
 - `src/core/schema.ts`
 - `test/fooks.test.mjs`
 - `test/domain-detector.test.mjs`
+- `test/claim-boundary-doc-audit.test.mjs`
 - `test/fixtures/frontend-domain-expectations/manifest.json`
 - `docs/frontend-domain-contract.md`
 - `docs/frontend-domain-fixture-expectations.md`
+- `docs/frontend-fixture-boundary-regression-map.md`
 
 #### Domain-owned parallel surfaces
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4213,9 +4213,11 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
     "src/core/schema.ts",
     "test/fooks.test.mjs",
     "test/domain-detector.test.mjs",
+    "test/claim-boundary-doc-audit.test.mjs",
     "test/fixtures/frontend-domain-expectations/manifest.json",
     "docs/frontend-domain-contract.md",
     "docs/frontend-domain-fixture-expectations.md",
+    "docs/frontend-fixture-boundary-regression-map.md",
   ]) {
     assert.ok(contract.includes(sharedFile), `${sharedFile} must be marked as serialized shared surface`);
   }


### PR DESCRIPTION
## Summary
- add the boundary regression map to the serialized shared surfaces list
- add the claim-boundary doc audit test to the serialized shared surfaces list
- extend the frontend-domain contract regression assertions for both shared-lock paths

## Verification
- `node --test --test-name-pattern "frontend domain contract locks taxonomy and pre-detector promotion gates|current docs do not make broad domain-parallel execution claims|claim-boundary doc audit rejects broad domain-parallel examples" test/fooks.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `git diff --check`
- `npm run lint`
- `npm test` — 315 pass, 0 fail

## Boundaries
- No runtime detector/pre-read/extractor behavior change
- No new fixtures or manifest edits
- No RN/WebView/TUI support claim
- No domain-parallel implementation/team launch
