### PR TITLE
Make React Web runtime payload evidence concrete

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { extractFile } from "../core/extract";
 import { detectDomainFromSource, type DomainDetectionResult } from "../core/domain-detector";
 import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/payload/model-facing";
+import { REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "../core/payload/domain-payload";
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import type { PreReadDecision } from "../core/schema";
 
@@ -11,7 +12,7 @@ const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
-export const REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY = "react-web-current-supported-lane";
+export const REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY = REACT_WEB_DOMAIN_PAYLOAD_POLICY;
 export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
 export const WEBVIEW_BOUNDARY_FALLBACK_POLICY = "webview-boundary-fallback";
 const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
@@ -60,6 +61,7 @@ function relativePath(filePath: string, cwd: string): string {
 function assessFrontendProfilePayloadReuse(
   extension: string,
   domainDetection: DomainDetectionResult,
+  payload: ReturnType<typeof toModelFacingPayload>,
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
 ): { allowed: true } | { allowed: false; reason: string } {
   if (!FRONTEND_PROFILE_GATE_EXTENSIONS.has(extension)) {
@@ -67,7 +69,9 @@ function assessFrontendProfilePayloadReuse(
   }
 
   if (domainDetection.profile.lane === "react-web" && domainDetection.profile.claimStatus === "current-supported-lane") {
-    return { allowed: true };
+    return payload.domainPayload?.domain === "react-web" && payload.domainPayload.plannerDecision === "compact-safe"
+      ? { allowed: true }
+      : { allowed: false, reason: "missing-react-web-domain-payload" };
   }
 
   if (frontendPayloadPolicy?.allowed === true) {
@@ -206,6 +210,8 @@ export function decidePreRead(
   const result = extractFile(resolvedPath);
   const payload = toModelFacingPayload(result, cwd, {
     includeEditGuidance: options.includeEditGuidance === true,
+    includeDomainPayload: frontendPayloadPolicy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+    domainPayloadPolicy: frontendPayloadPolicy?.name,
   });
   const readiness = assessPayloadReadiness(result, payload);
   const debug = {
@@ -219,7 +225,7 @@ export function decidePreRead(
   };
 
   if (readiness.ready) {
-    const profileGate = assessFrontendProfilePayloadReuse(extension, domainDetection, frontendPayloadPolicy);
+    const profileGate = assessFrontendProfilePayloadReuse(extension, domainDetection, payload, frontendPayloadPolicy);
     if (profileGate.allowed) {
       return {
         runtime,

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -1,0 +1,82 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import type { ExtractionResult, FormControlSignal, StyleSystem } from "../schema";
+
+export const DOMAIN_PAYLOAD_SCHEMA_VERSION = "domain-payload.v1";
+export const REACT_WEB_DOMAIN_PAYLOAD_POLICY = "react-web-current-supported-lane";
+
+export type ReactWebDomainPayload = {
+  schemaVersion: typeof DOMAIN_PAYLOAD_SCHEMA_VERSION;
+  domain: "react-web";
+  policy: typeof REACT_WEB_DOMAIN_PAYLOAD_POLICY;
+  plannerDecision: "compact-safe";
+  claimStatus: "current-supported-lane";
+  claimBoundary: "react-web-measured-extraction";
+  evidence: string[];
+  facts: {
+    domTags?: string[];
+    jsxAttributes?: string[];
+    formControls?: Pick<FormControlSignal, "tag" | "name" | "type" | "handlers">[];
+    eventHandlers?: string[];
+    styleSystem?: Exclude<StyleSystem, "unknown">;
+  };
+  warnings: string[];
+};
+
+export type DomainPayload = ReactWebDomainPayload;
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort();
+}
+
+function compactFormControls(controls: FormControlSignal[] | undefined): ReactWebDomainPayload["facts"]["formControls"] {
+  if (!controls || controls.length === 0) return undefined;
+
+  return controls.map((control) => ({
+    tag: control.tag,
+    ...(control.name ? { name: control.name } : {}),
+    ...(control.type ? { type: control.type } : {}),
+    ...(control.handlers && control.handlers.length > 0 ? { handlers: control.handlers } : {}),
+  }));
+}
+
+export function buildReactWebDomainPayload(
+  result: ExtractionResult,
+  domainDetection: DomainDetectionResult | undefined = result.domainDetection,
+  policy = REACT_WEB_DOMAIN_PAYLOAD_POLICY,
+): ReactWebDomainPayload | undefined {
+  if (policy !== REACT_WEB_DOMAIN_PAYLOAD_POLICY) return undefined;
+  if (!domainDetection) return undefined;
+  if (domainDetection.classification !== "react-web") return undefined;
+  if (domainDetection.profile.claimStatus !== "current-supported-lane") return undefined;
+  if (domainDetection.profile.claimBoundary !== "react-web-measured-extraction") return undefined;
+
+  const reactWebEvidence = domainDetection.evidence.filter((item) => item.domain === "react-web");
+  if (reactWebEvidence.length === 0) return undefined;
+
+  const domTags = uniqueSorted(reactWebEvidence.filter((item) => item.signal === "dom-tag").map((item) => item.detail));
+  const jsxAttributes = uniqueSorted(reactWebEvidence.filter((item) => item.signal === "jsx-attribute").map((item) => item.detail));
+  const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
+  const formControls = compactFormControls(result.behavior?.formSurface?.controls);
+  const styleSystem = result.style?.system && result.style.system !== "unknown" ? result.style.system : undefined;
+
+  return {
+    schemaVersion: DOMAIN_PAYLOAD_SCHEMA_VERSION,
+    domain: "react-web",
+    policy: REACT_WEB_DOMAIN_PAYLOAD_POLICY,
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: uniqueSorted(reactWebEvidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`)),
+    facts: {
+      ...(domTags.length > 0 ? { domTags } : {}),
+      ...(jsxAttributes.length > 0 ? { jsxAttributes } : {}),
+      ...(formControls && formControls.length > 0 ? { formControls } : {}),
+      ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
+      ...(styleSystem ? { styleSystem } : {}),
+    },
+    warnings: [
+      "React Web current supported lane only; this payload does not imply React Native, WebView, TUI, Mixed, or Unknown support.",
+      "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",
+    ],
+  };
+}

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { deriveDesignReviewMetadata } from "../design-review-metadata";
+import { buildReactWebDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
 import type { EditGuidance, ExtractionResult, ModelFacingPayload, PatchTarget, PatchTargetKind, SourceFingerprint, SourceRange } from "../schema";
 
 const PATCH_TARGET_LIMIT = 12;
@@ -13,6 +14,8 @@ const EDIT_GUIDANCE_INSTRUCTIONS = [
 export type ModelFacingPayloadOptions = {
   includeEditGuidance?: boolean;
   includeDesignReviewMetadata?: boolean;
+  includeDomainPayload?: boolean;
+  domainPayloadPolicy?: string;
 };
 
 function supportsEditGuidance(result: ExtractionResult): boolean {
@@ -125,12 +128,17 @@ function buildEditGuidance(result: ExtractionResult, freshness: SourceFingerprin
 }
 
 export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd(), options: ModelFacingPayloadOptions = {}): ModelFacingPayload {
+  const domainPayload = options.includeDomainPayload
+    ? buildReactWebDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
+    : undefined;
+
   if (result.useOriginal && result.mode === "raw" && result.rawText) {
     return {
       mode: result.mode,
       filePath: toRelativePath(result.filePath, cwd),
       useOriginal: true,
       rawText: result.rawText,
+      ...(domainPayload ? { domainPayload } : {}),
     };
   }
 
@@ -199,6 +207,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
     ...(fingerprint ? { sourceFingerprint: fingerprint } : {}),
     ...(editGuidance ? { editGuidance } : {}),
     ...(designReviewMetadata ? { designReviewMetadata } : {}),
+    ...(domainPayload ? { domainPayload } : {}),
     ...(result.exports.length > 0 ? { exports: result.exports } : {}),
     ...(contract ? { contract } : {}),
     ...(behavior ? { behavior } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,6 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
 import type { DomainDetectionResult } from "./domain-detector";
+import type { DomainPayload } from "./payload/domain-payload";
 
 export type OutputMode = "raw" | "compressed" | "hybrid";
 export type Language = "tsx" | "jsx" | "ts" | "js";
@@ -187,6 +188,7 @@ export type ModelFacingPayload = {
   snippets?: ExtractionResult["snippets"];
   editGuidance?: EditGuidance;
   designReviewMetadata?: DesignReviewMetadataV0;
+  domainPayload?: DomainPayload;
 };
 
 export type PayloadReadiness = {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1186,6 +1186,13 @@ test("codex pre-read chooses payload for eligible tsx/jsx and fallback otherwise
   assert.equal("editGuidance" in compressed.payload, false);
   assert.equal("domainDetection" in compressed.payload, false);
   assert.equal("profile" in compressed.payload, false);
+  assert.equal(compressed.payload.domainPayload.domain, "react-web");
+  assert.equal(compressed.payload.domainPayload.schemaVersion, "domain-payload.v1");
+  assert.equal(compressed.payload.domainPayload.policy, preReadModule.REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
+  assert.equal(compressed.payload.domainPayload.plannerDecision, "compact-safe");
+  assert.equal(compressed.payload.domainPayload.claimBoundary, "react-web-measured-extraction");
+  assert.ok(compressed.payload.domainPayload.evidence.some((signal) => signal.startsWith("react-web:")));
+  assert.match(compressed.payload.domainPayload.warnings.join("\n"), /current supported lane only/);
   assert.equal(compressed.debug.domainDetection.classification, "react-web");
   assert.equal(compressed.debug.domainDetection.profile.lane, "react-web");
   assert.equal(compressed.debug.domainDetection.profile.claimStatus, "current-supported-lane");
@@ -1236,6 +1243,8 @@ export function CustomOnlyForm() {
   assert.equal(customReactWeb.debug.frontendPayloadPolicy.allowed, true);
   assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"));
   assert.ok(customReactWeb.debug.domainDetection.signals.includes("react-web:jsx-attribute:htmlFor"));
+  assert.equal(customReactWeb.payload.domainPayload.domain, "react-web");
+  assert.deepEqual(customReactWeb.payload.domainPayload.facts.jsxAttributes, ["className", "htmlFor"]);
 
   const unsupportedFrontendProfile = preReadModule.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON;
   const rnPrimitive = decideCodexPreRead(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-primitive-basic.tsx"), repoRoot);
@@ -1247,6 +1256,7 @@ export function CustomOnlyForm() {
   assert.equal(rnPrimitive.readiness.ready, true);
   assert.equal(rnPrimitive.readiness.signals.hasContract, true);
   assert.ok(rnPrimitive.payload.contract.propsName);
+  assert.equal("domainPayload" in rnPrimitive.payload, false);
 
   for (const rnFixture of [
     "rn-style-platform-navigation.tsx",
@@ -4556,6 +4566,8 @@ test("frontend domain fixture expectations keep exact local outcomes", () => {
     );
     assert.equal(decision.debug.frontendPayloadPolicy.allowed, true, `${item.id} should allow the React Web current-supported payload policy`);
     assert.ok(decision.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"), `${item.id} should carry className evidence`);
+    assert.equal(decision.payload.domainPayload.domain, "react-web", `${item.id} should emit the React Web domain payload slice`);
+    assert.equal(decision.payload.domainPayload.plannerDecision, "compact-safe", `${item.id} should use the compact-safe React Web planner decision`);
     assert.equal("fallback" in decision, false, `${item.id} must not fall back after React Web evidence`);
   }
 

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -63,6 +63,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(firstInject.action, "record");
   assert.equal(secondInject.action, "inject");
   assert.match(secondInject.additionalContext, /^fooks: reused pre-read \(compressed\)/);
+  assert.match(secondInject.additionalContext, /"domainPayload"/);
+  assert.equal(secondInject.debug.decision.payload.domainPayload.domain, "react-web");
   assert.equal(secondInject.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(secondInject.additionalContext.includes("\"editGuidance\""), true);
   assert.ok(secondInject.reasons.includes("edit-guidance-opt-in"));
@@ -186,6 +188,8 @@ test("claude runtime bridge follows record-then-inject repeated same-file contra
   assert.match(second.additionalContext, /fixtures\/compressed\/FormSection\.tsx/);
   assert.match(second.additionalContext, /does not intercept Claude Read or claim runtime-token savings/);
   assert.equal(second.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(second.additionalContext.includes("\"domainPayload\""), true);
+  assert.equal(second.debug.decision.payload.domainPayload.domain, "react-web");
   assert.deepEqual(second.debug.decision.payload.editGuidance.freshness, second.debug.decision.payload.sourceFingerprint);
   assert.doesNotMatch(second.additionalContext, /Claude Read interception is enabled/i);
   assert.equal(second.debug.repeatedFile, true);


### PR DESCRIPTION
## Summary
- add the first concrete React Web runtime domain payload slice
- wire adapter/runtime evidence so domain payload architecture is no longer docs-only
- add tests for the React Web payload evidence path

Fixes #270

## Verification
- npm run typecheck -- --pretty false
- npm test

Commit: bb46579