### PR TITLE
Expose wrapper-lane evidence through pre-read debug

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -13,6 +13,7 @@ const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
 export const REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY = REACT_WEB_DOMAIN_PAYLOAD_POLICY;
+export const CUSTOM_WRAPPER_DOM_SIGNAL_GAP = "custom-wrapper-dom-signal-gap";
 export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
 export const WEBVIEW_BOUNDARY_FALLBACK_POLICY = "webview-boundary-fallback";
 const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
@@ -47,6 +48,7 @@ export type FrontendPayloadPolicyDecision = {
   name: string;
   allowed: boolean;
   reason?: string;
+  evidenceGates?: string[];
 };
 
 function eligibleExtensions(runtime: PreReadDecision["runtime"]): ReadonlySet<string> {
@@ -89,6 +91,18 @@ function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: 
   return domainDetection.signals.some((signal) => signal.startsWith(prefix));
 }
 
+function reactWebEvidenceGates(domainDetection: DomainDetectionResult): string[] {
+  if (domainDetection.classification !== "react-web") return [];
+  if (domainDetection.profile.claimStatus !== "current-supported-lane") return [];
+
+  const hasDomTagEvidence = domainDetection.evidence.some((item) => item.domain === "react-web" && item.signal === "dom-tag");
+  const hasWebJsxAttributeEvidence = domainDetection.evidence.some(
+    (item) => item.domain === "react-web" && item.signal === "jsx-attribute",
+  );
+
+  return !hasDomTagEvidence && hasWebJsxAttributeEvidence ? [CUSTOM_WRAPPER_DOM_SIGNAL_GAP] : [];
+}
+
 function frontendDebug(
   domainDetection: DomainDetectionResult,
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
@@ -101,7 +115,12 @@ function frontendDebug(
 
 export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
   if (domainDetection.classification === "react-web" && domainDetection.profile.claimStatus === "current-supported-lane") {
-    return { name: REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY, allowed: true };
+    const evidenceGates = reactWebEvidenceGates(domainDetection);
+    return {
+      name: REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+      allowed: true,
+      ...(evidenceGates.length > 0 ? { evidenceGates } : {}),
+    };
   }
 
   if (

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -224,6 +224,7 @@ export type PreReadDecision = {
       name: string;
       allowed: boolean;
       reason?: string;
+      evidenceGates?: string[];
     };
   };
   fallback?: {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4651,8 +4651,19 @@ test("custom-wrapper-dom-signal-gap keeps React Web wrapper fixtures in the narr
     );
     assert.equal(decision.debug.frontendPayloadPolicy.allowed, true, `${item.id} must allow only the measured React Web current lane`);
     assert.ok(
+      decision.debug.frontendPayloadPolicy.evidenceGates.includes(preReadModule.CUSTOM_WRAPPER_DOM_SIGNAL_GAP),
+      `${item.id} must expose custom-wrapper-dom-signal-gap through debug policy evidence`,
+    );
+    assert.ok(
       decision.debug.domainDetection.signals.includes("react-web:jsx-attribute:className"),
       `${item.id} must carry className evidence for custom-wrapper-dom-signal-gap`,
+    );
+
+    const cliDecision = run(["codex-pre-read", item.path]);
+    assert.deepEqual(
+      cliDecision.debug.frontendPayloadPolicy,
+      decision.debug.frontendPayloadPolicy,
+      `${item.id} must expose the same custom-wrapper-dom-signal-gap traceability through codex-pre-read CLI debug JSON`,
     );
     assert.equal("fallback" in decision, false, `${item.id} must not fall back after narrow custom wrapper React Web evidence`);
   }


### PR DESCRIPTION
## Summary
- expose the custom-wrapper-dom-signal-gap marker through pre-read debug policy evidence
- assert F11/F12 React Web wrapper fixtures expose the same traceability through codex-pre-read CLI JSON
- keep the change scoped to CLI/debug observability without runtime status wording or non-web domain changes

## Verification
- npm run lint
- npm test
- npm test -- --test-name-pattern='custom-wrapper-dom-signal-gap keeps React Web wrapper fixtures in the narrow current lane'

## Boundaries
- no broad React Web support claim
- no compact-safe promotion beyond the current measured lane
- no RN/WebView/TUI changes
- no user-facing runtime status copy change