### PR TITLE
Clarify domain-parallel readiness non-goals

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -124,6 +124,8 @@ Parallel branches that need a serialized shared surface are no longer independen
 
 The parallel safety layer is an execution contract for future multi-agent or multi-worktree domain work. It is docs/tests-only by default and does not authorize runtime source changes. A safety-layer PR must include a changed-file guard: the final diff may contain only the selected frontend-domain contract doc(s), focused contract regression test(s), and OMX planning/state artifacts needed for workflow bookkeeping. If `src/core/domain-detector.ts`, `src/adapters/pre-read.ts`, `src/core/payload/readiness.ts`, runtime hooks, hook presets, schema files, or manifest policy must change, the work stops and reruns planning/review as a serialized shared-policy owner branch.
 
+Readiness-layer non-goals are explicit: no runtime source change, no fixture corpus expansion, no domain implementation, no public support wording, no provider/runtime-token, cache, billing, or performance claim, and no team or worktree launch without a separate approved launch plan.
+
 Safe lane types are limited to:
 
 - read-only investigation;

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4259,6 +4259,11 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(ownershipMatrix, /may be edited in parallel when the branch stays inside its domain/);
   assert.match(ownershipMatrix, /#### Domain parallel safety layer/);
   assert.match(ownershipMatrix, /docs\/tests-only by default and does not authorize runtime source changes/);
+  assert.match(ownershipMatrix, /Readiness-layer non-goals are explicit/);
+  assert.match(ownershipMatrix, /no runtime source change, no fixture corpus expansion, no domain implementation/);
+  assert.match(ownershipMatrix, /no public support wording/);
+  assert.match(ownershipMatrix, /no provider\/runtime-token, cache, billing, or performance claim/);
+  assert.match(ownershipMatrix, /no team or worktree launch without a separate approved launch plan/);
   assert.match(ownershipMatrix, /changed-file guard/);
   assert.match(ownershipMatrix, /read-only investigation/);
   assert.match(ownershipMatrix, /fixture-only lane/);


### PR DESCRIPTION
## Summary
- clarify the frontend domain parallel readiness layer non-goals
- lock that readiness work does not imply runtime changes, fixture expansion, domain implementation, support wording, provider/runtime-token/cache/billing/performance claims, or team/worktree launch
- add regression assertions to keep the readiness contract explicit

## Verification
- npm run lint
- npm test -- --test-name-pattern='frontend domain contract locks taxonomy and pre-detector promotion gates|current docs do not make broad domain-parallel execution claims'

## Boundaries
- docs/tests only
- no runtime/source behavior changes
- no fixture corpus changes
- no domain support or token/cache claims
- no actual team/multi-worktree execution