### PR TITLE
Guard debug evidence readiness claims

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -37,6 +37,10 @@ WebView files are boundary files before they are extraction candidates. `react-n
 
 React Native and TUI/Ink fixtures may be useful evidence for syntax traversal, fixture shape, and future domain-signal design. They are **not support claims**. RN primitive/input `F1` may use the measured `rn-primitive-input-narrow-payload` gate, but RN primitives must not be reinterpreted as DOM controls, React Web form semantics, or broad React Native support. TUI/Ink fixtures must not be generalized into arbitrary terminal UI support, terminal behavior correctness, or runtime-token savings.
 
+## Runtime debug evidence boundary
+
+`custom-wrapper-dom-signal-gap` is a traceability marker for the same-file React Web wrapper payload gate only. When it appears in pre-read or runtime-hook debug output such as `debug.frontendPayloadPolicy.evidenceGates`, it explains why a custom-component TSX fixture stayed inside the current React Web lane; it must not be interpreted as domain-parallel runtime readiness, setup/provider readiness, runtime promotion, or support for RN, WebView, TUI, Mixed, or Unknown lanes.
+
 ## Fixture manifest pre-detector/profile gate
 
 The fixture expectation manifest at `test/fixtures/frontend-domain-expectations/manifest.json` is the pre-detector/profile gate for this lane. Before any detector or profile promotion, a candidate change must keep the manifest and docs aligned on:

--- a/test/react-web-runtime-evidence-claim-boundary.test.mjs
+++ b/test/react-web-runtime-evidence-claim-boundary.test.mjs
@@ -26,6 +26,10 @@ const forbiddenBroadReactWebRuntimeClaims = [
     label: "react-web-runtime-savings-proof",
     pattern: /\b(?:React\s*Web|React\/Web|web\s+React)\b[^\n]{0,100}\b(?:runtime-token|runtime token|latency|billing|cost)\b[^\n]{0,80}\b(?:savings?|reduction|win|proof|guarantee)\b/i,
   },
+  {
+    label: "wrapper-debug-domain-parallel-readiness",
+    pattern: /\b(?:custom-wrapper-dom-signal-gap|wrapper(?:-lane)?|pre-read\s+runtime\s+debug\s+evidence|runtime\s+debug\s+evidence|frontendPayloadPolicy(?:\.evidenceGates)?)\b[^\n]{0,120}\b(?:proves?|guarantees?|establishes?|unlocks?|counts\s+as|interpreted\s+as)\b[^\n]{0,120}\b(?:domain-parallel|parallel\s+domain|multi-domain|cross-domain|runtime\s+readiness|runtime\s+promotion|setup\s+readiness|provider\s+readiness)\b/i,
+  },
 ];
 
 const boundedClaimBoundary = /\b(?:measured|same-file|current supported lane only|current supported lane|fixture(?:-backed)?|local synthetic|claim boundary|does not|do not|not|no|without|cannot|must not|only|fallback|deferred|narrow|before any|separate approval|not broad|not stable|not provider|not runtime-token)\b/i;
@@ -88,6 +92,8 @@ test("React Web runtime evidence audit preserves the narrow fixture boundary", (
   assert.match(combined, /F11` and `F12` are selected React Web runtime-gate fixtures/);
   assert.match(combined, /prove the current supported lane handles custom JSX components with web-specific attributes before any RN\/WebView\/TUI lane is promoted/);
   assert.match(combined, /React Web evidence is used to imply RN, WebView, TUI, Mixed, or Unknown support/);
+  assert.match(combined, /`custom-wrapper-dom-signal-gap` is a traceability marker for the same-file React Web wrapper payload gate only/);
+  assert.match(combined, /must not be interpreted as domain-parallel runtime readiness/);
 });
 
 test("React Web runtime evidence audit rejects broad examples but allows scoped examples", () => {
@@ -112,6 +118,19 @@ test("React Web runtime evidence audit rejects broad examples but allows scoped 
   );
   assert.deepEqual(
     findBroadReactWebRuntimeClaims("F11/F12 are measured same-file React Web runtime-gate fixtures only; this is not stable runtime-token proof.", "synthetic.md"),
+    [],
+  );
+  assert.deepEqual(
+    findBroadReactWebRuntimeClaims("pre-read runtime debug evidence proves domain-parallel runtime readiness.", "synthetic.md"),
+    [
+      "synthetic.md:1 [wrapper-debug-domain-parallel-readiness] pre-read runtime debug evidence proves domain-parallel runtime readiness.",
+    ],
+  );
+  assert.deepEqual(
+    findBroadReactWebRuntimeClaims(
+      "custom-wrapper-dom-signal-gap is traceability for the same-file React Web wrapper gate only; it must not be interpreted as domain-parallel runtime readiness.",
+      "synthetic.md",
+    ),
     [],
   );
 });


### PR DESCRIPTION
Refs #277

Verification:
- node --test test/react-web-runtime-evidence-claim-boundary.test.mjs (3/3 pass)
- npm ci (worktree dependency install)
- npm run typecheck -- --pretty false