### PR TITLE
Gate domain-parallel launch readiness claims

### DIFF
--- a/scripts/release-claim-guards.mjs
+++ b/scripts/release-claim-guards.mjs
@@ -8,6 +8,9 @@ export function assertNoForbiddenPublicClaims(label, text) {
     /automatic Claude runtime-token savings/i,
   ];
   const negatedClaimBoundary = /(?:not|no|without|nor|never|does not prove|do not claim|must not claim|cannot support|blocks?|excluded?|out of scope|is not|stayed false|claimability flags stayed false)[^\n]{0,160}$/i;
+  const domainParallelLaunchReadiness = /\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b[^\n]{0,120}\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,100}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b|\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,120}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b[^\n]{0,100}\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b/i;
+  const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
+  const domainParallelLaunchBoundary = /\b(?:does not authorize runtime source changes|docs\/tests-only by default|worktree launch needs a separate plan|separate approved launch plan|no domain implementation worktree is authorized|planning-only|must serialize|shared seams? must serialize)\b/i;
 
   let previousLine = "";
   for (const line of text.split(/\r?\n/)) {
@@ -23,6 +26,12 @@ export function assertNoForbiddenPublicClaims(label, text) {
     }
     if (/\.omx\//i.test(line) || /\.omx\/state/i.test(line)) {
       assertClaimBoundary(/internal|harness|planning/i.test(line), `${label} exposes .omx as product state: ${line}`);
+    }
+    if (domainParallelLaunchReadiness.test(line)) {
+      assertClaimBoundary(
+        launchContractEvidence.test(line) || domainParallelLaunchBoundary.test(line),
+        `${label} contains domain-parallel launch readiness claim without launch-contract evidence: ${line}`,
+      );
     }
     previousLine = line;
   }

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -98,6 +98,19 @@ const forbiddenBroadDomainParallelClaims = [
   },
 ];
 
+const forbiddenDomainParallelLaunchReadinessClaims = [
+  {
+    label: "domain-parallel-launch-readiness-without-contract",
+    pattern: /\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b[^\n]{0,120}\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,100}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b/i,
+  },
+  {
+    label: "domain-parallel-launch-readiness-without-contract",
+    pattern: /\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,120}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b[^\n]{0,100}\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b/i,
+  },
+];
+
+const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
+
 const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden|shared seams? must serialize|worktree launch needs a separate plan|separate approved launch plan|no domain implementation worktree is authorized)\b/i;
 
 function collectMarkdownFiles(entry) {
@@ -138,6 +151,21 @@ function findBroadSupportClaims(text, relativePath) {
   return findings;
 }
 
+function findDomainParallelLaunchReadinessClaims(text, relativePath) {
+  const findings = [];
+  const lines = text.split(/\r?\n/);
+  for (const [index, line] of lines.entries()) {
+    const normalized = line.replace(/\s+/g, " ").trim();
+    if (!normalized) continue;
+    for (const rule of forbiddenDomainParallelLaunchReadinessClaims) {
+      if (rule.pattern.test(normalized) && !launchContractEvidence.test(normalized) && !domainParallelBoundary.test(normalized)) {
+        findings.push(`${relativePath}:${index + 1} [${rule.label}] ${normalized}`);
+        break;
+      }
+    }
+  }
+  return findings;
+}
 
 function findSchemaEditGuidanceClaims(text, relativePath) {
   const findings = [];
@@ -188,7 +216,11 @@ test("current docs do not make broad domain-parallel execution claims", () => {
 
   const findings = markdownFiles.flatMap((file) => {
     const relativePath = path.relative(repoRoot, file);
-    return findBroadDomainParallelClaims(fs.readFileSync(file, "utf8"), relativePath);
+    const text = fs.readFileSync(file, "utf8");
+    return [
+      ...findBroadDomainParallelClaims(text, relativePath),
+      ...findDomainParallelLaunchReadinessClaims(text, relativePath),
+    ];
   });
 
   assert.deepEqual(findings, [], `forbidden broad domain-parallel claims found:\n${findings.join("\n")}`);
@@ -276,4 +308,9 @@ test("claim-boundary doc audit rejects broad domain-parallel examples but allows
   assert.deepEqual(findBroadDomainParallelClaims("The parallel safety layer is docs/tests-only by default and does not authorize runtime source changes.", "synthetic.md"), []);
   assert.deepEqual(findBroadDomainParallelClaims("Domain lanes may proceed in parallel only when each lane has a disjoint-file proof and shared seams must serialize.", "synthetic.md"), []);
   assert.deepEqual(findBroadDomainParallelClaims("The PR wave contract is docs/tests-only; shared seams must serialize behind a named owner and worktree launch needs a separate plan.", "synthetic.md"), []);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("Domain-parallel worktree launch is ready for implementation.", "synthetic.md"), [
+    "synthetic.md:1 [domain-parallel-launch-readiness-without-contract] Domain-parallel worktree launch is ready for implementation.",
+  ]);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.", "synthetic.md"), []);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.", "synthetic.md"), []);
 });

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -60,3 +60,17 @@ test("release public surface guard reports the offending surface label", () => {
     /docs\/benchmark-evidence\.md contains forbidden positive claim/,
   );
 });
+
+test("release claim guard requires launch-contract evidence for domain-parallel launch readiness", () => {
+  assertGuardRejects(
+    "Domain-parallel worktree launch is ready for implementation.",
+    /domain-parallel launch readiness claim without launch-contract evidence/,
+  );
+  assertNoForbiddenPublicClaims(
+    "bounded domain-parallel launch surface",
+    [
+      "A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.",
+      "Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.",
+    ].join("\n"),
+  );
+});


### PR DESCRIPTION
Refs #281

Delta:
- Adds release-claim guard coverage requiring launch-contract evidence before domain-parallel readiness claims.
- Keeps allowed wording scoped to safety-layer / non-goal boundaries.

Verification:
- node --test test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs (12/12 pass)
- npm run typecheck -- --pretty false