### PR TITLE
Guard RN F1 runtime payload boundary

### DIFF
--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -208,6 +208,24 @@ test("codex runtime activates React Web payload semantics only for the React Web
   assert.equal("domainPayload" in rnPrimitive.second.debug.decision.payload, false);
   assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), false);
 
+  for (const [label, fixture, forbiddenSignal] of [
+    ["rn-style-platform", "rn-style-platform-navigation.tsx", "react-native:primitive:ScrollView"],
+    ["rn-interaction", "rn-interaction-gesture.tsx", "react-native:primitive:FlatList"],
+    ["rn-image-scrollview", "rn-image-scrollview.tsx", "react-native:primitive:Image"],
+  ]) {
+    const { second } = runRepeatedPrompt(label, `inspect test/fixtures/frontend-domain-expectations/${fixture}`);
+    assert.equal(second.action, "fallback", `${label} should not inherit the RN F1 narrow payload`);
+    assert.equal(second.contextModeReason, UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+    assert.equal(second.debug.decision.debug.domainDetection.classification, "react-native");
+    assert.equal(second.debug.decision.fallback.reason, UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+    assert.equal(second.debug.decision.debug.frontendPayloadPolicy.name, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+    assert.equal(second.debug.decision.debug.frontendPayloadPolicy.allowed, false);
+    assert.match(second.debug.decision.debug.frontendPayloadPolicy.reason, new RegExp(`^forbidden-signal:${forbiddenSignal.replaceAll(".", "\\.")}`));
+    assert.equal("payload" in second.debug.decision, false);
+    assert.notEqual(second.debug.decision.debug.frontendPayloadPolicy.name, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
+    assert.equal(second.additionalContext, undefined);
+  }
+
   for (const [label, prompt, classification, reason, policyName] of [
     ["webview", "inspect test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx", "webview", REACT_NATIVE_WEBVIEW_BOUNDARY_REASON, WEBVIEW_BOUNDARY_FALLBACK_POLICY],
     ["tui", "inspect test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx", "tui-ink", UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON, undefined],
@@ -236,6 +254,41 @@ test("codex runtime activates React Web payload semantics only for the React Web
     assert.notEqual(unknown.debug.decision.debug.frontendPayloadPolicy?.name, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   } finally {
     fs.rmSync(unknownDir, { recursive: true, force: true });
+  }
+});
+
+test("claude runtime keeps RN F1 narrow payload separate from broader RN domains", () => {
+  const runRepeatedPrompt = (label, prompt) => {
+    const sessionId = `bridge-contract-claude-rn-domain-${label}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+    const first = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt }, repoRoot);
+    const second = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Again, ${prompt}` }, repoRoot);
+    return { first, second };
+  };
+
+  const rnPrimitive = runRepeatedPrompt("rn-primitive", "inspect test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx");
+  assert.equal(rnPrimitive.first.action, "record");
+  assert.equal(rnPrimitive.second.action, "inject");
+  assert.equal(rnPrimitive.second.contextModeReason, "repeated-exact-file-narrow-payload");
+  assert.equal(rnPrimitive.second.debug.decision.debug.domainDetection.classification, "react-native");
+  assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.name, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+  assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.allowed, true);
+  assert.equal("domainPayload" in rnPrimitive.second.debug.decision.payload, false);
+  assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), false);
+
+  for (const [label, fixture] of [
+    ["rn-style-platform", "rn-style-platform-navigation.tsx"],
+    ["rn-interaction", "rn-interaction-gesture.tsx"],
+    ["rn-image-scrollview", "rn-image-scrollview.tsx"],
+  ]) {
+    const { second } = runRepeatedPrompt(label, `inspect test/fixtures/frontend-domain-expectations/${fixture}`);
+    assert.equal(second.action, "fallback", `${label} should not inherit the RN F1 narrow payload`);
+    assert.equal(second.contextModeReason, UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+    assert.equal(second.fallback.reason, UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+    assert.equal(second.additionalContext.includes(UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON), true);
+    assert.equal(second.additionalContext.includes('"domainPayload"'), false);
+    assert.equal(second.debug.repeatedFile, true);
+    assert.equal(second.debug.bounded, true);
   }
 });
 


### PR DESCRIPTION
## Summary

- Added Codex runtime contract coverage proving only `rn-primitive-basic.tsx` receives the RN F1 `rn-primitive-input-narrow-payload` path.
- Added broader RN fixture checks for `rn-style-platform-navigation.tsx`, `rn-interaction-gesture.tsx`, and `rn-image-scrollview.tsx` so they remain `unsupported-frontend-domain-profile` full-read fallbacks.
- Added Claude runtime coverage for the same RN F1-vs-broader-RN boundary without changing runtime policy.

## Audit result

The runtime policy was already narrow in `src/adapters/pre-read.ts`: broader RN fixtures are denied by forbidden React Native signals before payload construction. The concrete gap was executable runtime-hook coverage for broader RN domains, so this PR adds the smallest test-only guard in `test/runtime-bridge-contract.test.mjs`.

## Verification

- `npm run build && node --test test/runtime-bridge-contract.test.mjs`
- `npm run typecheck -- --pretty false`
- `npm test` (320/320 pass)

Closes #283

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
