### PR TITLE
Keep release readiness behind launch contracts

### DIFF
--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -13,6 +13,8 @@ This snapshot records the current pre-public release posture after the #172 LSP 
 - `package.json` — package metadata, `bin` mapping, `files` allowlist, and npm scripts.
 - `docs/release-note-v0.1.0.md` — release-note wording and conservative evidence boundary.
 - `docs/release.md` — public release checklist, residual risks, pre-publish blockers, and verification commands.
+- `docs/frontend-domain-contract.md` — domain-parallel launch contract gate and planning-only/no-launch boundary.
+- `scripts/release-claim-guards.mjs` and release claim tests — release-facing claim guard coverage for benchmark, provider, `.omx`, and domain-parallel launch wording.
 
 ## Current package and CLI boundary
 
@@ -62,3 +64,4 @@ The following remain unresolved until a human-approved publish step:
 - Keep Codex wording scoped to supported repeated-file hook behavior through `fooks setup`.
 - Keep Claude wording scoped to project-local `SessionStart` / `UserPromptSubmit` context hooks; do not claim Claude `Read` interception.
 - Keep opencode wording scoped to the prepared tool/slash-command bridge; do not claim automatic `read` interception or automatic runtime-token savings.
+- Domain-parallel worktree/team/PR wave readiness remains planning-only unless a launch contract lists the required fields, including `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Stop rules`, and `No-launch marker`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,6 +21,8 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
+Release-facing readiness docs must also stay tied to the domain-parallel launch contract gate. Any domain-parallel worktree/team/PR wave readiness wording must cite a launch contract with `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Stop rules`, and a `No-launch marker`, or else state that the work is planning-only and no implementation worktree is authorized.
+
 The opencode boundary is intentional. The current bridge may steer users toward
 `fooks_extract`, but it must not be described as automatic `read` interception.
 A future project-local `read` shadow would need to preserve opencode's native
@@ -137,6 +139,7 @@ Automated local checks now covered by `npm run release:smoke`:
 - [x] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
 - [x] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.
 - [x] packed CLI `fooks compare <file> --json` smoke keeps local estimated payload comparison separate from provider usage/billing-token, invoice/dashboard, or charged-cost claims.
+- [x] release-facing docs/tests keep domain-parallel worktree/team/PR wave readiness tied to a launch contract with the required fields or to the planning-only/no-launch boundary.
 
 Authority-gated checks before any real publish:
 

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -146,6 +146,7 @@ assertPublicSurfaceClaimBoundaries({
   "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
   "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
   "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+  "docs/release-readiness.md": fs.readFileSync(path.join(repoRoot, "docs", "release-readiness.md"), "utf8"),
   "docs/benchmark-evidence.md": fs.readFileSync(path.join(repoRoot, "docs", "benchmark-evidence.md"), "utf8"),
   "docs/roadmap.md": fs.readFileSync(path.join(repoRoot, "docs", "roadmap.md"), "utf8"),
   "docs/internal/live-hook-smoke-checklist.md": fs.existsSync(path.join(repoRoot, "docs", "internal", "live-hook-smoke-checklist.md"))

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -3,10 +3,14 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import {
   assertNoForbiddenPublicClaims,
   assertPublicSurfaceClaimBoundaries,
 } from "../scripts/release-claim-guards.mjs";
+
+const repoRoot = process.cwd();
 
 function assertGuardRejects(text, expectedMessage) {
   assert.throws(
@@ -73,4 +77,15 @@ test("release claim guard requires launch-contract evidence for domain-parallel 
       "Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.",
     ].join("\n"),
   );
+});
+
+test("release-facing docs keep domain-parallel launch readiness tied to launch contracts", () => {
+  const surfaces = {
+    "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+    "docs/release-readiness.md": fs.readFileSync(path.join(repoRoot, "docs", "release-readiness.md"), "utf8"),
+  };
+
+  assertPublicSurfaceClaimBoundaries(surfaces);
+  assert.match(surfaces["docs/release.md"], /domain-parallel worktree\/team\/PR wave readiness wording must cite a launch contract/);
+  assert.match(surfaces["docs/release-readiness.md"], /Domain-parallel worktree\/team\/PR wave readiness remains planning-only unless a launch contract lists the required fields/);
 });


### PR DESCRIPTION
Refs #284

Delta:
- Adds release-facing doc/smoke guard coverage tying domain-parallel launch readiness to launch contracts.

Verification:
- node --test test/release-claim-guards.test.mjs test/claim-boundary-doc-audit.test.mjs (13/13 pass)
- npm run typecheck -- --pretty false
- npm run release:smoke