### PR TITLE
Guard issue-closing PR bodies

### DIFF
--- a/scripts/release-claim-guards.mjs
+++ b/scripts/release-claim-guards.mjs
@@ -37,6 +37,21 @@ export function assertNoForbiddenPublicClaims(label, text) {
   }
 }
 
+const PR_BODY_CLOSING_KEYWORD_PATTERN = /\b(?:close[sd]?|fix(?:e[sd]|ed)?|resolve[sd]?)\s*:?\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+\b/i;
+const STANDALONE_REFS_ISSUE_PATTERN = /^\s*(?:[-*]\s*)?(?:refs?|references?)\s*:?\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+(?:\s*,\s*(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+)*\s*[.!]?\s*$/i;
+
+export function assertPullRequestBodyUsesClosingIssueRefs(label, text) {
+  for (const line of text.split(/\r?\n/)) {
+    if (PR_BODY_CLOSING_KEYWORD_PATTERN.test(line)) continue;
+    if (STANDALONE_REFS_ISSUE_PATTERN.test(line)) {
+      assertClaimBoundary(
+        false,
+        `${label} uses a non-closing issue reference in a PR body: ${line.trim()}. Use Closes #N, Fixes #N, or Resolves #N when the PR should close the issue.`,
+      );
+    }
+  }
+}
+
 export function assertPublicSurfaceClaimBoundaries(surfaces) {
   for (const [label, text] of Object.entries(surfaces)) {
     assertNoForbiddenPublicClaims(label, text);

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import {
   assertNoForbiddenPublicClaims,
   assertPublicSurfaceClaimBoundaries,
+  assertPullRequestBodyUsesClosingIssueRefs,
 } from "../scripts/release-claim-guards.mjs";
 
 const repoRoot = process.cwd();
@@ -77,6 +78,23 @@ test("release claim guard requires launch-contract evidence for domain-parallel 
       "Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.",
     ].join("\n"),
   );
+});
+
+test("PR body guard rejects standalone Refs footers for issue-closing PRs", () => {
+  assert.throws(
+    () => assertPullRequestBodyUsesClosingIssueRefs("synthetic PR body", "Summary\n\nRefs #287"),
+    /non-closing issue reference.*Use Closes #N, Fixes #N, or Resolves #N/,
+  );
+  assert.throws(
+    () => assertPullRequestBodyUsesClosingIssueRefs("synthetic PR body", "- Refs: #277, #281"),
+    /non-closing issue reference/,
+  );
+});
+
+test("PR body guard allows GitHub closing keywords and contextual refs", () => {
+  assertPullRequestBodyUsesClosingIssueRefs("closing PR body", "Summary\n\nCloses #287");
+  assertPullRequestBodyUsesClosingIssueRefs("closing PR body", "Fixes: minislively/fooks#287");
+  assertPullRequestBodyUsesClosingIssueRefs("related PR body", "Refs #287 for related background only; this PR does not close it.");
 });
 
 test("release-facing docs keep domain-parallel launch readiness tied to launch contracts", () => {


### PR DESCRIPTION
Closes #287

## Delta
- adds a release-claim guard that rejects standalone issue-resolving PR body footers using bare `Refs #N`
- keeps contextual non-closing references allowed while requiring `Closes/Fixes/Resolves #N` for issue-closing intent

## Verification
- `node --test test/release-claim-guards.test.mjs`
- `npm run typecheck -- --pretty false`