### PR TITLE
Require preflight evidence before domain-parallel launch

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -163,9 +163,11 @@ Every PR wave must carry a small **PR wave contract** before worktree, team, or 
 9. **Merge-order note** — records which shared-policy branch must land first and which domain branches wait.
 10. **Disjoint-file proof** — lists each lane's owned files and proves they do not overlap shared seams.
 11. **Required verification command** — names the targeted command proving fallback/deferred/support boundaries did not weaken.
-12. **Claim-boundary audit** — records the forbidden broad-support/domain-parallel wording check for the lane.
-13. **Worktree/team launch status** — states whether this is only a planning contract or names the separate approved launch plan; absence of that plan means no domain implementation worktree is authorized.
-14. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
+12. **Build preflight evidence** — records the local build/typecheck command that ran before any worker prompt, inbox, or implementation handoff for lanes that depend on generated artifacts.
+13. **Ownership replay evidence** — records that each lane task owner, branch/worktree name, and review inbox target matched the launch contract before any domain work started.
+14. **Claim-boundary audit** — records the forbidden broad-support/domain-parallel wording check for the lane.
+15. **Worktree/team launch status** — states whether this is only a planning contract or names the separate approved launch plan; absence of that plan means no domain implementation worktree is authorized.
+16. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
 
 #### Domain-parallel launch contract
 
@@ -181,8 +183,10 @@ The launch contract must include:
 6. **Shared-seam owner** — either `none` or one named branch that owns the shared seam for the wave.
 7. **PR order** — which PR lands first, which PRs wait, and which PRs must rebase after the shared-policy owner lands.
 8. **Verification matrix** — targeted command per lane plus the aggregate command the leader runs after integration.
-9. **Stop rules** — shared-file conflict, support-claim drift, fixture sprawl, runtime seam expansion, or failing verification stops the wave and returns to planning.
-10. **No-launch marker for planning-only work** — states `planning-only` when the current PR only writes docs/regression tests and does not authorize team/worktree execution.
+9. **Build preflight** — local build/typecheck evidence for any lane whose tests, package entrypoints, or scripts depend on generated artifacts before worker prompt or inbox delivery.
+10. **Ownership replay** — evidence that task owner, branch/worktree name, and review inbox target are aligned for every participating lane before domain work starts.
+11. **Stop rules** — shared-file conflict, support-claim drift, fixture sprawl, runtime seam expansion, missing build preflight, ownership mismatch, or failing verification stops the wave and returns to planning.
+12. **No-launch marker for planning-only work** — states `planning-only` when the current PR only writes docs/regression tests and does not authorize team/worktree execution.
 
 Allowed launch statuses are:
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4288,6 +4288,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(ownershipMatrix, /Shared-seam owner/);
   assert.match(ownershipMatrix, /PR order/);
   assert.match(ownershipMatrix, /Verification matrix/);
+  assert.match(ownershipMatrix, /Build preflight/);
+  assert.match(ownershipMatrix, /Ownership replay/);
   assert.match(ownershipMatrix, /Stop rules/);
   assert.match(ownershipMatrix, /No-launch marker for planning-only work/);
   for (const launchStatus of ["planning-only", "verifier-only", "single-shared-owner", "disjoint-domain-writers"]) {
@@ -4306,6 +4308,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
     "Merge-order note",
     "Disjoint-file proof",
     "Required verification command",
+    "Build preflight evidence",
+    "Ownership replay evidence",
     "Claim-boundary audit",
     "Worktree/team launch status",
     "Contradiction check",
@@ -4313,6 +4317,10 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
     assert.ok(ownershipMatrix.includes(handoffItem), `${handoffItem} must stay in the PR wave contract checklist`);
   }
   assert.match(ownershipMatrix, /absence of that plan means no domain implementation worktree is authorized/);
+  assert.match(ownershipMatrix, /before any worker prompt, inbox, or implementation handoff/);
+  assert.match(ownershipMatrix, /before worker prompt or inbox delivery/);
+  assert.match(ownershipMatrix, /task owner, branch\/worktree name, and review inbox target/);
+  assert.match(ownershipMatrix, /missing build preflight, ownership mismatch/);
   assert.match(ownershipMatrix, /Shared fallback reasons and denial markers are boundary evidence, not support claims/);
   assert.match(ownershipMatrix, /`unsupported-react-native-webview-boundary`/);
   assert.match(ownershipMatrix, /`unsupported-frontend-domain-profile`/);


### PR DESCRIPTION
## Summary
- require domain-parallel PR wave contracts to record build/typecheck preflight before worker prompt/inbox handoff
- require ownership replay evidence tying task owner, branch/worktree name, and review inbox target to the launch contract
- extend the frontend-domain contract regression so these launch gates cannot silently disappear

## Verification
- `node --test test/fooks.test.mjs test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs`
- `git diff --check`

## Notes
This keeps the fooks domain-parallel path planning-only until the project contract proves generated-artifact readiness and lane ownership alignment. It does not claim broad domain-parallel runtime support.
