### PR TITLE
Keep launch readiness tied to preflight evidence

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -183,6 +183,8 @@ Before opening a true domain-parallel wave, use the frontend-domain contract's l
 - allowed write sets and forbidden shared seams;
 - PR order;
 - verification matrix;
+- Build preflight evidence;
+- Ownership replay evidence;
 - stop rules.
 
 Planning-only launch-contract work remains docs/regression-only and does not authorize runtime/source changes, fixture expansion, domain implementation, support claims, or team/worktree execution by itself.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -64,4 +64,4 @@ The following remain unresolved until a human-approved publish step:
 - Keep Codex wording scoped to supported repeated-file hook behavior through `fooks setup`.
 - Keep Claude wording scoped to project-local `SessionStart` / `UserPromptSubmit` context hooks; do not claim Claude `Read` interception.
 - Keep opencode wording scoped to the prepared tool/slash-command bridge; do not claim automatic `read` interception or automatic runtime-token savings.
-- Domain-parallel worktree/team/PR wave readiness remains planning-only unless a launch contract lists the required fields, including `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Stop rules`, and `No-launch marker`.
+- Domain-parallel worktree/team/PR wave readiness remains planning-only unless a launch contract lists the required fields, including `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Build preflight`, `Ownership replay`, `Stop rules`, and `No-launch marker`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,7 +21,7 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
-Release-facing readiness docs must also stay tied to the domain-parallel launch contract gate. Any domain-parallel worktree/team/PR wave readiness wording must cite a launch contract with `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Stop rules`, and a `No-launch marker`, or else state that the work is planning-only and no implementation worktree is authorized.
+Release-facing readiness docs must also stay tied to the domain-parallel launch contract gate. Any domain-parallel worktree/team/PR wave readiness wording must cite a launch contract with `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Build preflight`, `Ownership replay`, `Stop rules`, and a `No-launch marker`, or else state that the work is planning-only and no implementation worktree is authorized.
 
 The opencode boundary is intentional. The current bridge may steer users toward
 `fooks_extract`, but it must not be described as automatic `read` interception.
@@ -139,7 +139,7 @@ Automated local checks now covered by `npm run release:smoke`:
 - [x] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
 - [x] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.
 - [x] packed CLI `fooks compare <file> --json` smoke keeps local estimated payload comparison separate from provider usage/billing-token, invoice/dashboard, or charged-cost claims.
-- [x] release-facing docs/tests keep domain-parallel worktree/team/PR wave readiness tied to a launch contract with the required fields or to the planning-only/no-launch boundary.
+- [x] release-facing docs/tests keep domain-parallel worktree/team/PR wave readiness tied to a launch contract with the required fields, including Build preflight and Ownership replay evidence, or to the planning-only/no-launch boundary.
 
 Authority-gated checks before any real publish:
 

--- a/scripts/release-claim-guards.mjs
+++ b/scripts/release-claim-guards.mjs
@@ -10,7 +10,8 @@ export function assertNoForbiddenPublicClaims(label, text) {
   const negatedClaimBoundary = /(?:not|no|without|nor|never|does not prove|do not claim|must not claim|cannot support|blocks?|excluded?|out of scope|is not|stayed false|claimability flags stayed false)[^\n]{0,160}$/i;
   const domainParallelLaunchReadiness = /\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b[^\n]{0,120}\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,100}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b|\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,120}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b[^\n]{0,100}\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b/i;
   const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
-  const domainParallelLaunchBoundary = /\b(?:does not authorize runtime source changes|docs\/tests-only by default|worktree launch needs a separate plan|separate approved launch plan|no domain implementation worktree is authorized|planning-only|must serialize|shared seams? must serialize)\b/i;
+  const launchPreflightOwnershipEvidence = /(?=.*\b(?:Build preflight|build\/typecheck evidence|local build\/typecheck evidence)\b)(?=.*\b(?:Ownership replay|ownership replay evidence|task owner|branch\/worktree name|review inbox target)\b)/i;
+  const domainParallelLaunchBoundary = /\b(?:does not authorize runtime source changes|docs\/tests-only by default|worktree launch needs a separate plan|separate approved launch plan|no (?:domain )?implementation worktree is authorized|planning-only|must serialize|shared seams? must serialize)\b/i;
 
   let previousLine = "";
   for (const line of text.split(/\r?\n/)) {
@@ -29,8 +30,8 @@ export function assertNoForbiddenPublicClaims(label, text) {
     }
     if (domainParallelLaunchReadiness.test(line)) {
       assertClaimBoundary(
-        launchContractEvidence.test(line) || domainParallelLaunchBoundary.test(line),
-        `${label} contains domain-parallel launch readiness claim without launch-contract evidence: ${line}`,
+        (launchContractEvidence.test(line) && launchPreflightOwnershipEvidence.test(line)) || domainParallelLaunchBoundary.test(line),
+        `${label} contains domain-parallel launch readiness claim without launch-contract and preflight/ownership evidence: ${line}`,
       );
     }
     previousLine = line;

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -110,8 +110,9 @@ const forbiddenDomainParallelLaunchReadinessClaims = [
 ];
 
 const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
+const launchPreflightOwnershipEvidence = /(?=.*\b(?:Build preflight|build\/typecheck evidence|local build\/typecheck evidence)\b)(?=.*\b(?:Ownership replay|ownership replay evidence|task owner|branch\/worktree name|review inbox target)\b)/i;
 
-const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden|shared seams? must serialize|worktree launch needs a separate plan|separate approved launch plan|no domain implementation worktree is authorized)\b/i;
+const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden|shared seams? must serialize|worktree launch needs a separate plan|separate approved launch plan|no (?:domain )?implementation worktree is authorized)\b/i;
 
 function collectMarkdownFiles(entry) {
   const absolute = path.join(repoRoot, entry);
@@ -158,7 +159,11 @@ function findDomainParallelLaunchReadinessClaims(text, relativePath) {
     const normalized = line.replace(/\s+/g, " ").trim();
     if (!normalized) continue;
     for (const rule of forbiddenDomainParallelLaunchReadinessClaims) {
-      if (rule.pattern.test(normalized) && !launchContractEvidence.test(normalized) && !domainParallelBoundary.test(normalized)) {
+      if (
+        rule.pattern.test(normalized)
+        && !(launchContractEvidence.test(normalized) && launchPreflightOwnershipEvidence.test(normalized))
+        && !domainParallelBoundary.test(normalized)
+      ) {
         findings.push(`${relativePath}:${index + 1} [${rule.label}] ${normalized}`);
         break;
       }
@@ -311,6 +316,9 @@ test("claim-boundary doc audit rejects broad domain-parallel examples but allows
   assert.deepEqual(findDomainParallelLaunchReadinessClaims("Domain-parallel worktree launch is ready for implementation.", "synthetic.md"), [
     "synthetic.md:1 [domain-parallel-launch-readiness-without-contract] Domain-parallel worktree launch is ready for implementation.",
   ]);
-  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.", "synthetic.md"), []);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.", "synthetic.md"), [
+    "synthetic.md:1 [domain-parallel-launch-readiness-without-contract] A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.",
+  ]);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, Build preflight evidence, and Ownership replay evidence.", "synthetic.md"), []);
   assert.deepEqual(findDomainParallelLaunchReadinessClaims("Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.", "synthetic.md"), []);
 });

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -69,12 +69,12 @@ test("release public surface guard reports the offending surface label", () => {
 test("release claim guard requires launch-contract evidence for domain-parallel launch readiness", () => {
   assertGuardRejects(
     "Domain-parallel worktree launch is ready for implementation.",
-    /domain-parallel launch readiness claim without launch-contract evidence/,
+    /domain-parallel launch readiness claim without launch-contract and preflight\/ownership evidence/,
   );
   assertNoForbiddenPublicClaims(
     "bounded domain-parallel launch surface",
     [
-      "A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.",
+      "A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, Build preflight evidence, and Ownership replay evidence.",
       "Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.",
     ].join("\n"),
   );
@@ -105,5 +105,5 @@ test("release-facing docs keep domain-parallel launch readiness tied to launch c
 
   assertPublicSurfaceClaimBoundaries(surfaces);
   assert.match(surfaces["docs/release.md"], /domain-parallel worktree\/team\/PR wave readiness wording must cite a launch contract/);
-  assert.match(surfaces["docs/release-readiness.md"], /Domain-parallel worktree\/team\/PR wave readiness remains planning-only unless a launch contract lists the required fields/);
+  assert.match(surfaces["docs/release-readiness.md"], /Domain-parallel worktree\/team\/PR wave readiness remains planning-only unless a launch contract lists the required fields[^\n]*`Build preflight`[^\n]*`Ownership replay`/);
 });


### PR DESCRIPTION
Closes #290

## Delta
- ties domain-parallel launch/readiness wording to Build preflight and Ownership replay evidence
- updates release-facing docs and claim guards without broadening runtime readiness claims

## Verification
- `node --test test/release-claim-guards.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`