### PR TITLE
Keep launch evidence wording tool agnostic

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -183,8 +183,8 @@ Before opening a true domain-parallel wave, use the frontend-domain contract's l
 - allowed write sets and forbidden shared seams;
 - PR order;
 - verification matrix;
-- Build preflight evidence;
-- Ownership replay evidence;
+- build/typecheck preflight evidence;
+- ownership/scope evidence;
 - stop rules.
 
 Planning-only launch-contract work remains docs/regression-only and does not authorize runtime/source changes, fixture expansion, domain implementation, support claims, or team/worktree execution by itself.

--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -163,8 +163,8 @@ Every PR wave must carry a small **PR wave contract** before worktree, team, or 
 9. **Merge-order note** — records which shared-policy branch must land first and which domain branches wait.
 10. **Disjoint-file proof** — lists each lane's owned files and proves they do not overlap shared seams.
 11. **Required verification command** — names the targeted command proving fallback/deferred/support boundaries did not weaken.
-12. **Build preflight evidence** — records the local build/typecheck command that ran before any worker prompt, inbox, or implementation handoff for lanes that depend on generated artifacts.
-13. **Ownership replay evidence** — records that each lane task owner, branch/worktree name, and review inbox target matched the launch contract before any domain work started.
+12. **build/typecheck preflight evidence** — records the local build/typecheck command that ran before any lane prompt, review inbox, or implementation handoff for lanes that depend on generated artifacts.
+13. **ownership/scope evidence** — records that each lane task owner, branch/worktree name, and review inbox target matched the launch contract before any domain work started.
 14. **Claim-boundary audit** — records the forbidden broad-support/domain-parallel wording check for the lane.
 15. **Worktree/team launch status** — states whether this is only a planning contract or names the separate approved launch plan; absence of that plan means no domain implementation worktree is authorized.
 16. **Contradiction check** — states that full domain writer parallelism against shared runtime/shared-seam files remains forbidden, docs/claim-boundary lanes cannot freely change shared support policy, and single runtime writer lanes serialize instead of running parallel.
@@ -183,8 +183,8 @@ The launch contract must include:
 6. **Shared-seam owner** — either `none` or one named branch that owns the shared seam for the wave.
 7. **PR order** — which PR lands first, which PRs wait, and which PRs must rebase after the shared-policy owner lands.
 8. **Verification matrix** — targeted command per lane plus the aggregate command the leader runs after integration.
-9. **Build preflight** — local build/typecheck evidence for any lane whose tests, package entrypoints, or scripts depend on generated artifacts before worker prompt or inbox delivery.
-10. **Ownership replay** — evidence that task owner, branch/worktree name, and review inbox target are aligned for every participating lane before domain work starts.
+9. **build/typecheck preflight evidence** — local build/typecheck evidence for any lane whose tests, package entrypoints, or scripts depend on generated artifacts before lane prompt or review inbox delivery.
+10. **ownership/scope evidence** — evidence that task owner, branch/worktree name, and review inbox target are aligned for every participating lane before domain work starts.
 11. **Stop rules** — shared-file conflict, support-claim drift, fixture sprawl, runtime seam expansion, missing build preflight, ownership mismatch, or failing verification stops the wave and returns to planning.
 12. **No-launch marker for planning-only work** — states `planning-only` when the current PR only writes docs/regression tests and does not authorize team/worktree execution.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -64,4 +64,4 @@ The following remain unresolved until a human-approved publish step:
 - Keep Codex wording scoped to supported repeated-file hook behavior through `fooks setup`.
 - Keep Claude wording scoped to project-local `SessionStart` / `UserPromptSubmit` context hooks; do not claim Claude `Read` interception.
 - Keep opencode wording scoped to the prepared tool/slash-command bridge; do not claim automatic `read` interception or automatic runtime-token savings.
-- Domain-parallel worktree/team/PR wave readiness remains planning-only unless a launch contract lists the required fields, including `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Build preflight`, `Ownership replay`, `Stop rules`, and `No-launch marker`.
+- Domain-parallel worktree/team/PR wave readiness remains planning-only unless a launch contract lists the required fields, including `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `build/typecheck preflight evidence`, `ownership/scope evidence`, `Stop rules`, and `No-launch marker`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,7 +21,7 @@ Before a public release, keep the public claim surface aligned to this matrix:
 | Claude | Project-local context hooks for `SessionStart` / `UserPromptSubmit`; the first eligible explicit frontend-file prompt is recorded/prepared and a repeated same-file prompt may receive bounded context; manual/shared handoff fallback prepared by `fooks setup` when possible | `Read` interception, full prompt interception parity, or runtime-token savings |
 | opencode | Manual/semi-automatic custom tool and slash command prepared by `fooks setup` when possible | Read interception or automatic runtime-token savings |
 
-Release-facing readiness docs must also stay tied to the domain-parallel launch contract gate. Any domain-parallel worktree/team/PR wave readiness wording must cite a launch contract with `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `Build preflight`, `Ownership replay`, `Stop rules`, and a `No-launch marker`, or else state that the work is planning-only and no implementation worktree is authorized.
+Release-facing readiness docs must also stay tied to the domain-parallel launch contract gate. Any domain-parallel worktree/team/PR wave readiness wording must cite a launch contract with `Launch base`, `Lane table`, `Allowed write set`, `Forbidden write set`, `Shared-seam owner`, `PR order`, `Verification matrix`, `build/typecheck preflight evidence`, `ownership/scope evidence`, `Stop rules`, and a `No-launch marker`, or else state that the work is planning-only and no implementation worktree is authorized.
 
 The opencode boundary is intentional. The current bridge may steer users toward
 `fooks_extract`, but it must not be described as automatic `read` interception.
@@ -139,7 +139,7 @@ Automated local checks now covered by `npm run release:smoke`:
 - [x] isolated `fooks setup` smoke test passes without mutating the real user Codex config.
 - [x] isolated `fooks setup` smoke test covers a fresh public-style repo without requiring `FOOKS_ACTIVE_ACCOUNT`.
 - [x] packed CLI `fooks compare <file> --json` smoke keeps local estimated payload comparison separate from provider usage/billing-token, invoice/dashboard, or charged-cost claims.
-- [x] release-facing docs/tests keep domain-parallel worktree/team/PR wave readiness tied to a launch contract with the required fields, including Build preflight and Ownership replay evidence, or to the planning-only/no-launch boundary.
+- [x] release-facing docs/tests keep domain-parallel worktree/team/PR wave readiness tied to a launch contract with the required fields, including build/typecheck preflight evidence and ownership/scope evidence, or to the planning-only/no-launch boundary.
 
 Authority-gated checks before any real publish:
 

--- a/scripts/release-claim-guards.mjs
+++ b/scripts/release-claim-guards.mjs
@@ -10,7 +10,7 @@ export function assertNoForbiddenPublicClaims(label, text) {
   const negatedClaimBoundary = /(?:not|no|without|nor|never|does not prove|do not claim|must not claim|cannot support|blocks?|excluded?|out of scope|is not|stayed false|claimability flags stayed false)[^\n]{0,160}$/i;
   const domainParallelLaunchReadiness = /\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b[^\n]{0,120}\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,100}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b|\b(?:worktree|team|multi-agent|launch|PR wave|wave)\b[^\n]{0,120}\b(?:ready|readiness|authorized|permitted|allowed|enabled|safe|available|may proceed|can proceed|may launch|can launch)\b[^\n]{0,100}\b(?:domain[-\s]parallel|parallel domain|domain lanes?|frontend domain lanes?)\b/i;
   const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
-  const launchPreflightOwnershipEvidence = /(?=.*\b(?:Build preflight|build\/typecheck evidence|local build\/typecheck evidence)\b)(?=.*\b(?:Ownership replay|ownership replay evidence|task owner|branch\/worktree name|review inbox target)\b)/i;
+  const launchPreflightOwnershipEvidence = /(?=.*\b(?:build\/typecheck preflight evidence|local build\/typecheck evidence)\b)(?=.*\bownership\/scope evidence\b)/i;
   const domainParallelLaunchBoundary = /\b(?:does not authorize runtime source changes|docs\/tests-only by default|worktree launch needs a separate plan|separate approved launch plan|no (?:domain )?implementation worktree is authorized|planning-only|must serialize|shared seams? must serialize)\b/i;
 
   let previousLine = "";
@@ -31,7 +31,7 @@ export function assertNoForbiddenPublicClaims(label, text) {
     if (domainParallelLaunchReadiness.test(line)) {
       assertClaimBoundary(
         (launchContractEvidence.test(line) && launchPreflightOwnershipEvidence.test(line)) || domainParallelLaunchBoundary.test(line),
-        `${label} contains domain-parallel launch readiness claim without launch-contract and preflight/ownership evidence: ${line}`,
+        `${label} contains domain-parallel launch readiness claim without launch-contract and build/typecheck preflight and ownership/scope evidence: ${line}`,
       );
     }
     previousLine = line;

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -110,7 +110,7 @@ const forbiddenDomainParallelLaunchReadinessClaims = [
 ];
 
 const launchContractEvidence = /\b(?:named launch contract|launch contract)\b[^\n]{0,220}\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b|\b(?:Launch base|Lane table|Branch\/worktree name|Allowed write set|Forbidden write set|Shared-seam owner|PR order|Verification matrix|Stop rules|No-launch marker|planning-only|verifier-only|single-shared-owner|disjoint-domain-writers|required fields|lists the required fields)\b[^\n]{0,220}\b(?:named launch contract|launch contract)\b/i;
-const launchPreflightOwnershipEvidence = /(?=.*\b(?:Build preflight|build\/typecheck evidence|local build\/typecheck evidence)\b)(?=.*\b(?:Ownership replay|ownership replay evidence|task owner|branch\/worktree name|review inbox target)\b)/i;
+const launchPreflightOwnershipEvidence = /(?=.*\b(?:build\/typecheck preflight evidence|local build\/typecheck evidence)\b)(?=.*\bownership\/scope evidence\b)/i;
 
 const domainParallelBoundary = /\b(?:not itself runtime behavior change|does not authorize runtime source changes|docs\/tests-only by default|shared-file free-for-all|must name one shared-policy owner|merge-order note|disjoint-file proof|changed-file guard|must serialize|not parallel-safe|only when it avoids shared support-policy expansion|single runtime writer lane|full domain writer parallelism[^\n]{0,80}forbidden|remains forbidden|shared seams? must serialize|worktree launch needs a separate plan|separate approved launch plan|no (?:domain )?implementation worktree is authorized)\b/i;
 
@@ -319,6 +319,6 @@ test("claim-boundary doc audit rejects broad domain-parallel examples but allows
   assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.", "synthetic.md"), [
     "synthetic.md:1 [domain-parallel-launch-readiness-without-contract] A domain-parallel team wave may launch when the launch contract lists the required fields and status disjoint-domain-writers.",
   ]);
-  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, Build preflight evidence, and Ownership replay evidence.", "synthetic.md"), []);
+  assert.deepEqual(findDomainParallelLaunchReadinessClaims("A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, build/typecheck preflight evidence, and ownership/scope evidence.", "synthetic.md"), []);
   assert.deepEqual(findDomainParallelLaunchReadinessClaims("Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.", "synthetic.md"), []);
 });

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4288,8 +4288,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
   assert.match(ownershipMatrix, /Shared-seam owner/);
   assert.match(ownershipMatrix, /PR order/);
   assert.match(ownershipMatrix, /Verification matrix/);
-  assert.match(ownershipMatrix, /Build preflight/);
-  assert.match(ownershipMatrix, /Ownership replay/);
+  assert.match(ownershipMatrix, /build\/typecheck preflight evidence/);
+  assert.match(ownershipMatrix, /ownership\/scope evidence/);
   assert.match(ownershipMatrix, /Stop rules/);
   assert.match(ownershipMatrix, /No-launch marker for planning-only work/);
   for (const launchStatus of ["planning-only", "verifier-only", "single-shared-owner", "disjoint-domain-writers"]) {
@@ -4308,8 +4308,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
     "Merge-order note",
     "Disjoint-file proof",
     "Required verification command",
-    "Build preflight evidence",
-    "Ownership replay evidence",
+    "build/typecheck preflight evidence",
+    "ownership/scope evidence",
     "Claim-boundary audit",
     "Worktree/team launch status",
     "Contradiction check",
@@ -4317,8 +4317,8 @@ test("frontend domain contract locks taxonomy and pre-detector promotion gates",
     assert.ok(ownershipMatrix.includes(handoffItem), `${handoffItem} must stay in the PR wave contract checklist`);
   }
   assert.match(ownershipMatrix, /absence of that plan means no domain implementation worktree is authorized/);
-  assert.match(ownershipMatrix, /before any worker prompt, inbox, or implementation handoff/);
-  assert.match(ownershipMatrix, /before worker prompt or inbox delivery/);
+  assert.match(ownershipMatrix, /before any lane prompt, review inbox, or implementation handoff/);
+  assert.match(ownershipMatrix, /before lane prompt or review inbox delivery/);
   assert.match(ownershipMatrix, /task owner, branch\/worktree name, and review inbox target/);
   assert.match(ownershipMatrix, /missing build preflight, ownership mismatch/);
   assert.match(ownershipMatrix, /Shared fallback reasons and denial markers are boundary evidence, not support claims/);

--- a/test/release-claim-guards.test.mjs
+++ b/test/release-claim-guards.test.mjs
@@ -69,12 +69,12 @@ test("release public surface guard reports the offending surface label", () => {
 test("release claim guard requires launch-contract evidence for domain-parallel launch readiness", () => {
   assertGuardRejects(
     "Domain-parallel worktree launch is ready for implementation.",
-    /domain-parallel launch readiness claim without launch-contract and preflight\/ownership evidence/,
+    /domain-parallel launch readiness claim without launch-contract and build\/typecheck preflight and ownership\/scope evidence/,
   );
   assertNoForbiddenPublicClaims(
     "bounded domain-parallel launch surface",
     [
-      "A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, Build preflight evidence, and Ownership replay evidence.",
+      "A domain-parallel team wave may launch when the launch contract lists the required fields, status disjoint-domain-writers, build/typecheck preflight evidence, and ownership/scope evidence.",
       "Until a launch contract names one of those statuses and lists the required fields above, domain-parallel work remains planning-only and no implementation worktree is authorized.",
     ].join("\n"),
   );
@@ -105,5 +105,5 @@ test("release-facing docs keep domain-parallel launch readiness tied to launch c
 
   assertPublicSurfaceClaimBoundaries(surfaces);
   assert.match(surfaces["docs/release.md"], /domain-parallel worktree\/team\/PR wave readiness wording must cite a launch contract/);
-  assert.match(surfaces["docs/release-readiness.md"], /Domain-parallel worktree\/team\/PR wave readiness remains planning-only unless a launch contract lists the required fields[^\n]*`Build preflight`[^\n]*`Ownership replay`/);
+  assert.match(surfaces["docs/release-readiness.md"], /Domain-parallel worktree\/team\/PR wave readiness remains planning-only unless a launch contract lists the required fields[^\n]*`build\/typecheck preflight evidence`[^\n]*`ownership\/scope evidence`/);
 });


### PR DESCRIPTION
Closes #292

## Delta
- renames domain-parallel launch evidence wording from orchestrator-flavored `Build preflight` / `Ownership replay` to project-local `build/typecheck preflight evidence` and `ownership/scope evidence`
- keeps release claim guards strict: launch readiness still needs launch-contract evidence plus build/typecheck preflight evidence plus ownership/scope evidence, or an explicit planning-only/no-launch boundary
- updates release-facing docs and regression assertions without adding runtime/domain implementation

## Verification
- `node --test test/release-claim-guards.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`
- Additional sanity: `node --test test/release-claim-guards.test.mjs test/claim-boundary-doc-audit.test.mjs test/fooks.test.mjs`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
