### PR TITLE
Expose narrow React Web payload facts

### DIFF
--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -15,6 +15,12 @@ export type ReactWebDomainPayload = {
   facts: {
     domTags?: string[];
     jsxAttributes?: string[];
+    componentName?: string;
+    exports?: Pick<ExtractionResult["exports"][number], "name" | "kind" | "type">[];
+    hooks?: string[];
+    jsxDepth?: number;
+    hasSideEffects?: boolean;
+    hasStyleBranching?: boolean;
     formControls?: Pick<FormControlSignal, "tag" | "name" | "type" | "handlers">[];
     eventHandlers?: string[];
     styleSystem?: Exclude<StyleSystem, "unknown">;
@@ -26,6 +32,16 @@ export type DomainPayload = ReactWebDomainPayload;
 
 function uniqueSorted(values: Iterable<string>): string[] {
   return [...new Set(values)].sort();
+}
+
+function compactExports(exportItems: ExtractionResult["exports"]): ReactWebDomainPayload["facts"]["exports"] {
+  if (exportItems.length === 0) return undefined;
+
+  return exportItems.map((item) => ({
+    name: item.name,
+    kind: item.kind,
+    ...(item.type ? { type: item.type } : {}),
+  }));
 }
 
 function compactFormControls(controls: FormControlSignal[] | undefined): ReactWebDomainPayload["facts"]["formControls"] {
@@ -58,6 +74,8 @@ export function buildReactWebDomainPayload(
   const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
   const formControls = compactFormControls(result.behavior?.formSurface?.controls);
   const styleSystem = result.style?.system && result.style.system !== "unknown" ? result.style.system : undefined;
+  const exportFacts = compactExports(result.exports);
+  const hooks = uniqueSorted(result.behavior?.hooks ?? []);
 
   return {
     schemaVersion: DOMAIN_PAYLOAD_SCHEMA_VERSION,
@@ -68,6 +86,12 @@ export function buildReactWebDomainPayload(
     claimBoundary: "react-web-measured-extraction",
     evidence: uniqueSorted(reactWebEvidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`)),
     facts: {
+      ...(result.componentName ? { componentName: result.componentName } : {}),
+      ...(exportFacts && exportFacts.length > 0 ? { exports: exportFacts } : {}),
+      ...(hooks.length > 0 ? { hooks } : {}),
+      ...(typeof result.structure?.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
+      ...(typeof result.behavior?.hasSideEffects === "boolean" ? { hasSideEffects: result.behavior.hasSideEffects } : {}),
+      ...(typeof result.style?.hasStyleBranching === "boolean" ? { hasStyleBranching: result.style.hasStyleBranching } : {}),
       ...(domTags.length > 0 ? { domTags } : {}),
       ...(jsxAttributes.length > 0 ? { jsxAttributes } : {}),
       ...(formControls && formControls.length > 0 ? { formControls } : {}),

--- a/test/react-web-domain-payload-expansion.test.mjs
+++ b/test/react-web-domain-payload-expansion.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+
+function cleanupRuntimeSessions(prefix) {
+  const root = path.join(repoRoot, ".fooks", "state", "codex-runtime");
+  if (!fs.existsSync(root)) return;
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith(prefix)) {
+      fs.rmSync(path.join(root, entry.name), { force: true });
+    }
+  }
+
+  if (fs.existsSync(root) && fs.readdirSync(root).length === 0) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function repeatedPayloadFor(relativeFile, sessionSuffix) {
+  const sessionId = `react-web-payload-expansion-${sessionSuffix}-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${relativeFile}`,
+    },
+    repoRoot,
+  );
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again inspect ${relativeFile}`,
+    },
+    repoRoot,
+  );
+
+  assert.equal(first.action, "record");
+  assert.equal(second.action, "inject");
+  assert.equal(second.debug.decision.payload.domainPayload.domain, "react-web");
+  return second.debug.decision.payload.domainPayload.facts;
+}
+
+function assertNoNonWhitelistedDetails(facts) {
+  for (const forbiddenKey of ["rawText", "snippets", "loc", "componentLoc", "effectSignals", "callbackSignals", "stateSummary"]) {
+    assert.equal(forbiddenKey in facts, false, `${forbiddenKey} must not be added to React Web domainPayload facts`);
+  }
+}
+
+test.after(() => {
+  cleanupRuntimeSessions("react-web-payload-expansion-");
+});
+
+test("React Web runtime payload exposes only whitelisted compact facts", () => {
+  const formFacts = repeatedPayloadFor("fixtures/compressed/FormSection.tsx", "form-section");
+
+  assert.equal(formFacts.componentName, "FormSection");
+  assert.deepEqual(formFacts.exports, [{ name: "FormSection", kind: "named", type: "function" }]);
+  assert.equal(formFacts.jsxDepth, 4);
+  assert.equal(formFacts.hasSideEffects, false);
+  assert.equal(formFacts.hasStyleBranching, false);
+  assert.equal(formFacts.styleSystem, "tailwind");
+  assert.ok(formFacts.domTags.includes("input"));
+  assertNoNonWhitelistedDetails(formFacts);
+
+  const hookFacts = repeatedPayloadFor("fixtures/compressed/HookEffectPanel.tsx", "hook-effect-panel");
+
+  assert.equal(hookFacts.componentName, "HookEffectPanel");
+  assert.deepEqual(hookFacts.exports, [{ name: "HookEffectPanel", kind: "named", type: "function" }]);
+  assert.deepEqual(hookFacts.hooks, ["useCallback", "useEffect", "useMemo", "useState"]);
+  assert.equal(hookFacts.jsxDepth, 3);
+  assert.equal(hookFacts.hasSideEffects, true);
+  assert.equal(hookFacts.hasStyleBranching, false);
+  assert.ok(hookFacts.eventHandlers.includes("onClick"));
+  assertNoNonWhitelistedDetails(hookFacts);
+});


### PR DESCRIPTION
## Summary\n- expand the React Web domain payload with whitelisted compact facts from existing ExtractionResult data\n- include component/export/hooks/jsxDepth/side-effect/style-branching facts without detector or runtime seam changes\n- add a focused runtime payload regression test for the whitelist and detail-leak exclusions\n\n## Scope boundaries\n- fooks repo only\n- React Web current supported lane only\n- no RN/WebView/TUI changes\n- no detector, pre-read, runtime hook, schema, or model-facing seam changes\n- no broad frontend/domain-parallel support claims\n\n## Verification\n- npm run typecheck\n- npm run build\n- node --test test/runtime-bridge-contract.test.mjs test/react-web-domain-payload-expansion.test.mjs test/fooks.test.mjs test/domain-detector.test.mjs test/react-web-runtime-evidence-claim-boundary.test.mjs test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs\n- npm test\n- Architect verification: APPROVE\n