### PR TITLE
Keep React Web payload seams behavior-stable

### DIFF
--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -30,6 +30,17 @@ export type ReactWebDomainPayload = {
 
 export type DomainPayload = ReactWebDomainPayload;
 
+type ReactWebPayloadEvidenceFacts = {
+  evidence: string[];
+  domTags: string[];
+  jsxAttributes: string[];
+};
+
+type ReactWebPayloadPlan = {
+  result: ExtractionResult;
+  evidenceFacts: ReactWebPayloadEvidenceFacts;
+};
+
 function uniqueSorted(values: Iterable<string>): string[] {
   return [...new Set(values)].sort();
 }
@@ -55,27 +66,66 @@ function compactFormControls(controls: FormControlSignal[] | undefined): ReactWe
   }));
 }
 
-export function buildReactWebDomainPayload(
+function collectReactWebPayloadEvidence(domainDetection: DomainDetectionResult): ReactWebPayloadEvidenceFacts | undefined {
+  const reactWebEvidence = domainDetection.evidence.filter((item) => item.domain === "react-web");
+  if (reactWebEvidence.length === 0) return undefined;
+
+  return {
+    evidence: uniqueSorted(reactWebEvidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`)),
+    domTags: uniqueSorted(reactWebEvidence.filter((item) => item.signal === "dom-tag").map((item) => item.detail)),
+    jsxAttributes: uniqueSorted(reactWebEvidence.filter((item) => item.signal === "jsx-attribute").map((item) => item.detail)),
+  };
+}
+
+function planReactWebPayload(
   result: ExtractionResult,
-  domainDetection: DomainDetectionResult | undefined = result.domainDetection,
-  policy = REACT_WEB_DOMAIN_PAYLOAD_POLICY,
-): ReactWebDomainPayload | undefined {
+  domainDetection: DomainDetectionResult | undefined,
+  policy: string,
+): ReactWebPayloadPlan | undefined {
   if (policy !== REACT_WEB_DOMAIN_PAYLOAD_POLICY) return undefined;
   if (!domainDetection) return undefined;
   if (domainDetection.classification !== "react-web") return undefined;
   if (domainDetection.profile.claimStatus !== "current-supported-lane") return undefined;
   if (domainDetection.profile.claimBoundary !== "react-web-measured-extraction") return undefined;
 
-  const reactWebEvidence = domainDetection.evidence.filter((item) => item.domain === "react-web");
-  if (reactWebEvidence.length === 0) return undefined;
+  const evidenceFacts = collectReactWebPayloadEvidence(domainDetection);
+  if (!evidenceFacts) return undefined;
 
-  const domTags = uniqueSorted(reactWebEvidence.filter((item) => item.signal === "dom-tag").map((item) => item.detail));
-  const jsxAttributes = uniqueSorted(reactWebEvidence.filter((item) => item.signal === "jsx-attribute").map((item) => item.detail));
+  return { result, evidenceFacts };
+}
+
+function buildReactWebPayloadFacts(
+  result: ExtractionResult,
+  evidenceFacts: ReactWebPayloadEvidenceFacts,
+): ReactWebDomainPayload["facts"] {
   const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
   const formControls = compactFormControls(result.behavior?.formSurface?.controls);
   const styleSystem = result.style?.system && result.style.system !== "unknown" ? result.style.system : undefined;
   const exportFacts = compactExports(result.exports);
   const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+
+  return {
+    ...(result.componentName ? { componentName: result.componentName } : {}),
+    ...(exportFacts && exportFacts.length > 0 ? { exports: exportFacts } : {}),
+    ...(hooks.length > 0 ? { hooks } : {}),
+    ...(typeof result.structure?.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
+    ...(typeof result.behavior?.hasSideEffects === "boolean" ? { hasSideEffects: result.behavior.hasSideEffects } : {}),
+    ...(typeof result.style?.hasStyleBranching === "boolean" ? { hasStyleBranching: result.style.hasStyleBranching } : {}),
+    ...(evidenceFacts.domTags.length > 0 ? { domTags: evidenceFacts.domTags } : {}),
+    ...(evidenceFacts.jsxAttributes.length > 0 ? { jsxAttributes: evidenceFacts.jsxAttributes } : {}),
+    ...(formControls && formControls.length > 0 ? { formControls } : {}),
+    ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
+    ...(styleSystem ? { styleSystem } : {}),
+  };
+}
+
+export function buildReactWebDomainPayload(
+  result: ExtractionResult,
+  domainDetection: DomainDetectionResult | undefined = result.domainDetection,
+  policy = REACT_WEB_DOMAIN_PAYLOAD_POLICY,
+): ReactWebDomainPayload | undefined {
+  const plan = planReactWebPayload(result, domainDetection, policy);
+  if (!plan) return undefined;
 
   return {
     schemaVersion: DOMAIN_PAYLOAD_SCHEMA_VERSION,
@@ -84,20 +134,8 @@ export function buildReactWebDomainPayload(
     plannerDecision: "compact-safe",
     claimStatus: "current-supported-lane",
     claimBoundary: "react-web-measured-extraction",
-    evidence: uniqueSorted(reactWebEvidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`)),
-    facts: {
-      ...(result.componentName ? { componentName: result.componentName } : {}),
-      ...(exportFacts && exportFacts.length > 0 ? { exports: exportFacts } : {}),
-      ...(hooks.length > 0 ? { hooks } : {}),
-      ...(typeof result.structure?.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
-      ...(typeof result.behavior?.hasSideEffects === "boolean" ? { hasSideEffects: result.behavior.hasSideEffects } : {}),
-      ...(typeof result.style?.hasStyleBranching === "boolean" ? { hasStyleBranching: result.style.hasStyleBranching } : {}),
-      ...(domTags.length > 0 ? { domTags } : {}),
-      ...(jsxAttributes.length > 0 ? { jsxAttributes } : {}),
-      ...(formControls && formControls.length > 0 ? { formControls } : {}),
-      ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
-      ...(styleSystem ? { styleSystem } : {}),
-    },
+    evidence: plan.evidenceFacts.evidence,
+    facts: buildReactWebPayloadFacts(plan.result, plan.evidenceFacts),
     warnings: [
       "React Web current supported lane only; this payload does not imply React Native, WebView, TUI, Mixed, or Unknown support.",
       "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",

--- a/test/react-web-domain-payload-expansion.test.mjs
+++ b/test/react-web-domain-payload-expansion.test.mjs
@@ -9,6 +9,11 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 
+const reactWebWarnings = [
+  "React Web current supported lane only; this payload does not imply React Native, WebView, TUI, Mixed, or Unknown support.",
+  "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",
+];
+
 function cleanupRuntimeSessions(prefix) {
   const root = path.join(repoRoot, ".fooks", "state", "codex-runtime");
   if (!fs.existsSync(root)) return;
@@ -48,7 +53,12 @@ function repeatedPayloadFor(relativeFile, sessionSuffix) {
   assert.equal(first.action, "record");
   assert.equal(second.action, "inject");
   assert.equal(second.debug.decision.payload.domainPayload.domain, "react-web");
-  return second.debug.decision.payload.domainPayload.facts;
+  return second.debug.decision.payload.domainPayload;
+}
+
+function assertExactPayload(actual, expected) {
+  assert.deepEqual(actual, expected);
+  assert.equal(JSON.stringify(actual), JSON.stringify(expected), "domainPayload property order must remain stable");
 }
 
 function assertNoNonWhitelistedDetails(facts) {
@@ -61,26 +71,64 @@ test.after(() => {
   cleanupRuntimeSessions("react-web-payload-expansion-");
 });
 
-test("React Web runtime payload exposes only whitelisted compact facts", () => {
-  const formFacts = repeatedPayloadFor("fixtures/compressed/FormSection.tsx", "form-section");
+test("React Web runtime payload preserves the full compact domainPayload contract", () => {
+  const formPayload = repeatedPayloadFor("fixtures/compressed/FormSection.tsx", "form-section");
 
-  assert.equal(formFacts.componentName, "FormSection");
-  assert.deepEqual(formFacts.exports, [{ name: "FormSection", kind: "named", type: "function" }]);
-  assert.equal(formFacts.jsxDepth, 4);
-  assert.equal(formFacts.hasSideEffects, false);
-  assert.equal(formFacts.hasStyleBranching, false);
-  assert.equal(formFacts.styleSystem, "tailwind");
-  assert.ok(formFacts.domTags.includes("input"));
-  assertNoNonWhitelistedDetails(formFacts);
+  assertExactPayload(formPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:dom-tag:button",
+      "react-web:dom-tag:div",
+      "react-web:dom-tag:input",
+      "react-web:dom-tag:label",
+      "react-web:dom-tag:span",
+      "react-web:jsx-attribute:className",
+    ],
+    facts: {
+      componentName: "FormSection",
+      exports: [{ name: "FormSection", kind: "named", type: "function" }],
+      jsxDepth: 4,
+      hasSideEffects: false,
+      hasStyleBranching: false,
+      domTags: ["button", "div", "input", "label", "span"],
+      jsxAttributes: ["className"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(formPayload.facts);
 
-  const hookFacts = repeatedPayloadFor("fixtures/compressed/HookEffectPanel.tsx", "hook-effect-panel");
+  const hookPayload = repeatedPayloadFor("fixtures/compressed/HookEffectPanel.tsx", "hook-effect-panel");
 
-  assert.equal(hookFacts.componentName, "HookEffectPanel");
-  assert.deepEqual(hookFacts.exports, [{ name: "HookEffectPanel", kind: "named", type: "function" }]);
-  assert.deepEqual(hookFacts.hooks, ["useCallback", "useEffect", "useMemo", "useState"]);
-  assert.equal(hookFacts.jsxDepth, 3);
-  assert.equal(hookFacts.hasSideEffects, true);
-  assert.equal(hookFacts.hasStyleBranching, false);
-  assert.ok(hookFacts.eventHandlers.includes("onClick"));
-  assertNoNonWhitelistedDetails(hookFacts);
+  assertExactPayload(hookPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:dom-tag:button",
+      "react-web:jsx-attribute:className",
+    ],
+    facts: {
+      componentName: "HookEffectPanel",
+      exports: [{ name: "HookEffectPanel", kind: "named", type: "function" }],
+      hooks: ["useCallback", "useEffect", "useMemo", "useState"],
+      jsxDepth: 3,
+      hasSideEffects: true,
+      hasStyleBranching: false,
+      domTags: ["button"],
+      jsxAttributes: ["className"],
+      eventHandlers: ["handleRefresh", "onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(hookPayload.facts);
 });


### PR DESCRIPTION
## Summary
- Split the React Web domain payload path into internal evidence/planner/facts-builder helpers while preserving the exported API.
- Strengthen the focused runtime regression to compare the full `domainPayload`, including property order.
- Keep detector/runtime/RN/WebView/TUI/support-claim behavior unchanged.

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/react-web-domain-payload-expansion.test.mjs test/runtime-bridge-contract.test.mjs test/fooks.test.mjs test/domain-detector.test.mjs test/react-web-runtime-evidence-claim-boundary.test.mjs test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs`
- `npm test`
- post-deslop targeted regression rerun: `npm run typecheck` and targeted runtime/claim-boundary tests

## Boundaries
- No detector/runtime hook changes.
- No RN/WebView/TUI/Mixed/Unknown changes.
- No new payload facts or support claims.
