### PR TITLE
Lock shared domain payload seam boundaries

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -36,6 +36,16 @@ input file
 
 The key split is that scanner, planner, and builder must not collapse into one policy-heavy extractor. The shared syntax layer can parse TS/JS/TSX/JSX, but syntax parsing alone is not framework support.
 
+## Shared seam responsibility contract
+
+Future domain payload work must preserve a three-part contract:
+
+- **Scanner contract:** observes source-derived signals only. A scanner must not choose compact, narrow, boundary-aware, fallback, or deferred mode; must not emit model-facing payloads; and must not claim domain support.
+- **Planner contract:** consumes the domain profile plus scanner facts and chooses the safety/policy decision. A planner must not invent source facts, format final payload output, weaken WebView fallback-first behavior, broaden the measured RN `F1` narrow gate, or promote TUI, Mixed, or Unknown evidence lanes.
+- **Builder contract:** formats the model-facing packet according to the planner decision. A builder must not override planner safety decisions, decide support or promotion, or compact across a boundary the planner rejected.
+
+Shared seam changes are serialized by default. Any PR that changes detector, pre-read, model-facing payload, domain payload, schema, shared fixture manifest, or normative support-policy docs must name one shared-policy owner and a merge-order note. Domain-specific lanes may run in parallel only when they stay in disjoint fixture/docs/test surfaces and do not edit those serialized shared seams.
+
 ## Shared syntax layer
 
 The shared syntax layer owns reusable source facts:

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -258,6 +258,28 @@ test("claim-boundary doc audit preserves measured narrow evidence wording", () =
   assert.match(combined, /TUI \/ React CLI profiles[\s\S]*Future profile candidate only; no implementation or support promise/);
 });
 
+test("claim-boundary doc audit preserves shared scanner planner builder seam responsibilities", () => {
+  const architecture = fs.readFileSync(path.join(repoRoot, "docs", "domain-payload-architecture.md"), "utf8");
+
+  assert.match(architecture, /## Shared seam responsibility contract/);
+  assert.match(
+    architecture,
+    /\*\*Scanner contract:\*\* observes source-derived signals only\.[\s\S]*?must not choose compact, narrow, boundary-aware, fallback, or deferred mode[\s\S]*?must not emit model-facing payloads[\s\S]*?must not claim domain support/,
+  );
+  assert.match(
+    architecture,
+    /\*\*Planner contract:\*\* consumes the domain profile plus scanner facts and chooses the safety\/policy decision\.[\s\S]*?must not invent source facts[\s\S]*?format final payload output[\s\S]*?weaken WebView fallback-first behavior[\s\S]*?broaden the measured RN `F1` narrow gate[\s\S]*?promote TUI, Mixed, or Unknown evidence lanes/,
+  );
+  assert.match(
+    architecture,
+    /\*\*Builder contract:\*\* formats the model-facing packet according to the planner decision\.[\s\S]*?must not override planner safety decisions[\s\S]*?decide support or promotion[\s\S]*?compact across a boundary the planner rejected/,
+  );
+  assert.match(
+    architecture,
+    /Shared seam changes are serialized by default\.[\s\S]*?must name one shared-policy owner and a merge-order note[\s\S]*?Domain-specific lanes may run in parallel only when they stay in disjoint fixture\/docs\/test surfaces/,
+  );
+});
+
 test("claim-boundary doc audit rejects positive examples but allows negated or measured examples", () => {
   assert.deepEqual(findBroadSupportClaims("React Native support is available for all TSX files.", "synthetic.md"), [
     "synthetic.md:1 [react-native-support-available] React Native support is available for all TSX files.",


### PR DESCRIPTION
## Summary
- Add the shared scanner/planner/builder responsibility contract to the domain payload architecture doc.
- Lock the seam boundaries with a focused claim-boundary doc-audit regression.
- Keep the first pass docs/test-only with no runtime behavior, domain promotion, broad skeletons, or support-claim changes.

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs test/runtime-bridge-contract.test.mjs test/react-web-domain-payload-expansion.test.mjs`

## Boundaries
- No source/runtime changes.
- No source/interface extraction.
- No RN/WebView/TUI promotion.
- No broad `src/domains/**` skeleton sprawl.
- No new support claims.
