### PR TITLE
Expose React Web JSX component payload facts

### DIFF
--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -15,6 +15,7 @@ export type ReactWebDomainPayload = {
   facts: {
     domTags?: string[];
     jsxAttributes?: string[];
+    jsxComponents?: string[];
     componentName?: string;
     exports?: Pick<ExtractionResult["exports"][number], "name" | "kind" | "type">[];
     hooks?: string[];
@@ -43,6 +44,10 @@ type ReactWebPayloadPlan = {
 
 function uniqueSorted(values: Iterable<string>): string[] {
   return [...new Set(values)].sort();
+}
+
+function collectJsxComponents(sections: string[] | undefined): string[] {
+  return uniqueSorted((sections ?? []).filter((section) => /^[A-Z][A-Za-z0-9_$]*$/.test(section)));
 }
 
 function compactExports(exportItems: ExtractionResult["exports"]): ReactWebDomainPayload["facts"]["exports"] {
@@ -103,6 +108,7 @@ function buildReactWebPayloadFacts(
   const styleSystem = result.style?.system && result.style.system !== "unknown" ? result.style.system : undefined;
   const exportFacts = compactExports(result.exports);
   const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+  const jsxComponents = collectJsxComponents(result.structure?.sections);
 
   return {
     ...(result.componentName ? { componentName: result.componentName } : {}),
@@ -113,6 +119,7 @@ function buildReactWebPayloadFacts(
     ...(typeof result.style?.hasStyleBranching === "boolean" ? { hasStyleBranching: result.style.hasStyleBranching } : {}),
     ...(evidenceFacts.domTags.length > 0 ? { domTags: evidenceFacts.domTags } : {}),
     ...(evidenceFacts.jsxAttributes.length > 0 ? { jsxAttributes: evidenceFacts.jsxAttributes } : {}),
+    ...(jsxComponents.length > 0 ? { jsxComponents } : {}),
     ...(formControls && formControls.length > 0 ? { formControls } : {}),
     ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
     ...(styleSystem ? { styleSystem } : {}),

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -188,12 +188,32 @@ test("runtime bridge preserves React Web custom-wrapper domainPayload parity for
       path: "test/fixtures/frontend-domain-expectations/react-web/custom-design-system-card.tsx",
       componentName: "BillingPlanCard",
       requiredEvidence: ["react-web:jsx-attribute:className"],
+      expectedJsxComponents: [
+        "Badge",
+        "Button",
+        "Card",
+        "CardContent",
+        "CardDescription",
+        "CardHeader",
+        "CardTitle",
+        "StatRow",
+      ],
     },
     {
       label: "custom-form-shell",
       path: "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx",
       componentName: "ProfileSettingsShell",
       requiredEvidence: ["react-web:jsx-attribute:className", "react-web:jsx-attribute:htmlFor"],
+      expectedJsxComponents: [
+        "Button",
+        "ButtonGroup",
+        "ErrorText",
+        "Field",
+        "FieldControl",
+        "FieldLabel",
+        "HelperText",
+        "TextField",
+      ],
     },
   ];
 
@@ -261,6 +281,7 @@ test("runtime bridge preserves React Web custom-wrapper domainPayload parity for
     assert.equal(runtimePayload.claimStatus, "current-supported-lane");
     assert.equal(runtimePayload.claimBoundary, "react-web-measured-extraction");
     assert.equal(runtimePayload.facts.componentName, fixture.componentName);
+    assert.deepEqual(runtimePayload.facts.jsxComponents, fixture.expectedJsxComponents);
     for (const evidence of fixture.requiredEvidence) {
       assert.ok(runtimePayload.evidence.includes(evidence), `${fixture.label} should include ${evidence}`);
     }
@@ -268,6 +289,7 @@ test("runtime bridge preserves React Web custom-wrapper domainPayload parity for
       assert.equal(forbiddenKey in runtimePayload.facts, false, `${fixture.label} must not emit ${forbiddenKey}`);
     }
     assert.equal("formControls" in runtimePayload.facts, false, `${fixture.label} must not infer DOM form controls from custom components`);
+    assert.equal("customComponentSemantics" in runtimePayload.facts, false, `${fixture.label} must keep custom components structural only`);
   }
 });
 


### PR DESCRIPTION
## Summary

- add additive React Web `domainPayload.facts.jsxComponents` from existing `result.structure.sections`
- keep custom component tags structural only; no form/control/event semantic inference
- lock F11/F12 wrapper runtime parity expectations for the new fact

## Scope boundaries

- No detector changes
- No pre-read policy changes
- No RN/WebView/TUI promotion
- No support/readiness claim changes
- No broad fixture corpus changes

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅
- `node --test test/react-web-domain-payload-expansion.test.mjs test/runtime-bridge-contract.test.mjs` ✅ 6/6
- claim-boundary focused suite ✅
- `npm test` ✅ 326/326
- post-deslop `npm run lint` ✅
- post-deslop `npm test` ✅ 326/326
