### PR TITLE
Keep wrapper-heavy React Web payloads structurally measurable

### DIFF
--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -15,6 +15,7 @@ export type ReactWebDomainPayload = {
   facts: {
     domTags?: string[];
     jsxAttributes?: string[];
+    jsxComponentCount?: number;
     jsxComponents?: string[];
     componentName?: string;
     exports?: Pick<ExtractionResult["exports"][number], "name" | "kind" | "type">[];
@@ -119,6 +120,7 @@ function buildReactWebPayloadFacts(
     ...(typeof result.style?.hasStyleBranching === "boolean" ? { hasStyleBranching: result.style.hasStyleBranching } : {}),
     ...(evidenceFacts.domTags.length > 0 ? { domTags: evidenceFacts.domTags } : {}),
     ...(evidenceFacts.jsxAttributes.length > 0 ? { jsxAttributes: evidenceFacts.jsxAttributes } : {}),
+    ...(jsxComponents.length > 0 ? { jsxComponentCount: jsxComponents.length } : {}),
     ...(jsxComponents.length > 0 ? { jsxComponents } : {}),
     ...(formControls && formControls.length > 0 ? { formControls } : {}),
     ...(eventHandlers.length > 0 ? { eventHandlers } : {}),

--- a/test/react-web-domain-payload-expansion.test.mjs
+++ b/test/react-web-domain-payload-expansion.test.mjs
@@ -132,3 +132,66 @@ test("React Web runtime payload preserves the full compact domainPayload contrac
   });
   assertNoNonWhitelistedDetails(hookPayload.facts);
 });
+
+test("React Web runtime payload adds jsxComponentCount for wrapper-heavy current-lane payloads", () => {
+  const customCardPayload = repeatedPayloadFor(
+    "test/fixtures/frontend-domain-expectations/react-web/custom-design-system-card.tsx",
+    "custom-design-system-card",
+  );
+
+  assertExactPayload(customCardPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: ["react-web:jsx-attribute:className"],
+    facts: {
+      componentName: "BillingPlanCard",
+      exports: [{ name: "BillingPlanCard", kind: "named", type: "function" }],
+      jsxDepth: 3,
+      hasSideEffects: false,
+      hasStyleBranching: true,
+      jsxAttributes: ["className"],
+      jsxComponentCount: 8,
+      jsxComponents: ["Badge", "Button", "Card", "CardContent", "CardDescription", "CardHeader", "CardTitle", "StatRow"],
+      eventHandlers: ["onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(customCardPayload.facts);
+
+  const customFormPayload = repeatedPayloadFor(
+    "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx",
+    "custom-form-shell",
+  );
+
+  assertExactPayload(customFormPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:jsx-attribute:className",
+      "react-web:jsx-attribute:htmlFor",
+    ],
+    facts: {
+      componentName: "ProfileSettingsShell",
+      exports: [{ name: "ProfileSettingsShell", kind: "named", type: "function" }],
+      jsxDepth: 3,
+      hasSideEffects: false,
+      hasStyleBranching: false,
+      jsxAttributes: ["className", "htmlFor"],
+      jsxComponentCount: 8,
+      jsxComponents: ["Button", "ButtonGroup", "ErrorText", "Field", "FieldControl", "FieldLabel", "HelperText", "TextField"],
+      eventHandlers: ["onChange", "onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(customFormPayload.facts);
+});

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -281,6 +281,7 @@ test("runtime bridge preserves React Web custom-wrapper domainPayload parity for
     assert.equal(runtimePayload.claimStatus, "current-supported-lane");
     assert.equal(runtimePayload.claimBoundary, "react-web-measured-extraction");
     assert.equal(runtimePayload.facts.componentName, fixture.componentName);
+    assert.equal(runtimePayload.facts.jsxComponentCount, fixture.expectedJsxComponents.length);
     assert.deepEqual(runtimePayload.facts.jsxComponents, fixture.expectedJsxComponents);
     for (const evidence of fixture.requiredEvidence) {
       assert.ok(runtimePayload.evidence.includes(evidence), `${fixture.label} should include ${evidence}`);


### PR DESCRIPTION
## Summary
- Adds additive `facts.jsxComponentCount` to React Web domain payloads.
- Derives the count only from the existing emitted `jsxComponents` list.
- Adds focused React Web payload/runtime parity coverage for wrapper-heavy fixtures.

## Boundaries
- React Web lane only.
- No detector or pre-read policy changes.
- No RN/WebView/TUI promotion.
- No support-claim broadening.

## Verification
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `node --test test/react-web-domain-payload-expansion.test.mjs test/runtime-bridge-contract.test.mjs`
- `node --test test/react-web-runtime-evidence-claim-boundary.test.mjs test/claim-boundary-doc-audit.test.mjs test/release-claim-guards.test.mjs`

## Team pilot note
The RN F1 worker attempted a shared `src/core/extract.ts` change during the parallel pilot. That change was intentionally excluded from this PR because it crosses the RN lane ownership boundary and should be handled later through a shared-core lane.
