### PR TITLE
Classify archived stale branch audits

### DIFF
--- a/scripts/audit-remote-branches.mjs
+++ b/scripts/audit-remote-branches.mjs
@@ -94,12 +94,60 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Usage: node scripts/audit-remote-branches.mjs [options]\n\nAudits remote branches against a base ref and classifies branches that can add\nstale-branch noise after main has absorbed equivalent work.\n\nOptions:\n  --base <ref>      Base ref to compare against (default: origin/main)\n  --remote <name>   Remote namespace to audit (default: origin)\n  --no-fetch        Use local remote-tracking refs without fetching first\n  --json            Emit machine-readable JSON instead of markdown\n  --markdown        Emit markdown (default)\n  --output <path>   Write output to a file instead of stdout\n  -h, --help        Show this help\n\nClassification:\n  redundant-merged            branch has no commits ahead of base\n  redundant-patch-equivalent  branch commits are patch-equivalent to base\n  valid-candidate             branch has unique patch commits and no open PR\n  open-pr                     branch has an open PR and is not stale-branch noise
+  console.log(`Usage: node scripts/audit-remote-branches.mjs [options]\n\nAudits remote branches against a base ref and classifies branches that can add\nstale-branch noise after main has absorbed equivalent work.\n\nOptions:\n  --base <ref>      Base ref to compare against (default: origin/main)\n  --remote <name>   Remote namespace to audit (default: origin)\n  --no-fetch        Use local remote-tracking refs without fetching first\n  --json            Emit machine-readable JSON instead of markdown\n  --markdown        Emit markdown (default)\n  --output <path>   Write output to a file instead of stdout\n  -h, --help        Show this help\n\nClassification:\n  redundant-merged            branch has no commits ahead of base\n  redundant-patch-equivalent  branch commits are patch-equivalent to base\n  valid-candidate             branch has unique patch commits, no open PR, and no archive doc\n  archived-stale              branch has unique patch commits but is already archived in docs\n  open-pr                     branch has an open PR and is not stale-branch noise
 
 Next-action shortlist:
   Markdown and JSON include a read-only Discord-friendly valid-candidate
   shortlist for operator triage. It does not recommend deleting branches or
   merging code.`);
+}
+
+
+function listBranchArchiveDocs() {
+  const docsDir = path.join(repoRoot, "docs");
+  try {
+    return fs.readdirSync(docsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /branch-archive.*\.md$/i.test(entry.name))
+      .map((entry) => path.join(docsDir, entry.name))
+      .sort((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+function addArchivedBranch(archives, branchName, docPath, remote) {
+  const normalized = branchName
+    .replace(/^refs\/remotes\//, "")
+    .replace(new RegExp(`^${remote.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/`), "");
+  if (!normalized || normalized === "HEAD" || normalized === "main") return;
+  const relativeDoc = path.relative(repoRoot, docPath);
+  const docs = archives.get(normalized) ?? [];
+  if (!docs.includes(relativeDoc)) docs.push(relativeDoc);
+  archives.set(normalized, docs);
+}
+
+function getArchivedBranchDocs(remote) {
+  const archives = new Map();
+  for (const docPath of listBranchArchiveDocs()) {
+    const content = fs.readFileSync(docPath, "utf8");
+
+    for (const match of content.matchAll(/Branch inspected:\s*`([^`]+)`/gi)) {
+      const ref = match[1].trim();
+      if (ref.startsWith(`${remote}/`)) addArchivedBranch(archives, ref, docPath, remote);
+    }
+
+    for (const match of content.matchAll(/Archive rationale for\s+`([^`]+)`/gi)) {
+      addArchivedBranch(archives, match[1].trim(), docPath, remote);
+    }
+
+    for (const match of content.matchAll(/`([^`]+)`/g)) {
+      const ref = match[1].trim();
+      if (ref.startsWith(`${remote}/`) && !ref.includes("..") && !/\s/.test(ref)) {
+        addArchivedBranch(archives, ref, docPath, remote);
+      }
+    }
+  }
+  return archives;
 }
 
 function getOpenPullRequestHeads(remote) {
@@ -192,7 +240,7 @@ function formatCurrentTreeRisk(impact) {
   return `destructive-stale-tree (${impact.deletedFiles} current-file deletes${evidence})`;
 }
 
-function branchAudit(branch, options, openPrHeads) {
+function branchAudit(branch, options, openPrHeads, archivedBranchDocs) {
   const branchName = branch.slice(`${options.remote}/`.length);
   const [baseOnly, branchOnly] = run("git", ["rev-list", "--left-right", "--count", `${options.base}...${branch}`])
     .split(/\s+/)
@@ -203,6 +251,7 @@ function branchAudit(branch, options, openPrHeads) {
   const uniquePatchCommits = cherryLines.filter((line) => line.startsWith("+")).length;
   const patchEquivalentCommits = cherryLines.filter((line) => line.startsWith("-")).length;
   const hasOpenPr = openPrHeads.has(branchName);
+  const archiveDocs = archivedBranchDocs.get(branchName) ?? [];
   const lastCommitDate = run("git", ["log", "-1", "--format=%cs", branch]);
   const lastSubject = run("git", ["log", "-1", "--format=%s", branch]);
   const lastSha = run("git", ["rev-parse", "--short=12", branch]);
@@ -215,6 +264,7 @@ function branchAudit(branch, options, openPrHeads) {
   if (hasOpenPr) classification = "open-pr";
   else if (branchOnly === 0) classification = "redundant-merged";
   else if (uniquePatchCommits === 0) classification = "redundant-patch-equivalent";
+  else if (archiveDocs.length > 0) classification = "archived-stale";
 
   return {
     branch: branchName,
@@ -227,6 +277,7 @@ function branchAudit(branch, options, openPrHeads) {
     lastCommitDate,
     lastSha,
     lastSubject,
+    archiveDocs,
     currentTreeImpact,
   };
 }
@@ -253,11 +304,12 @@ function markdownTable(rows, classification) {
   if (filtered.length === 0) return `No ${classification} branches.\n`;
 
   const lines = [
-    "| Branch | Ahead | Behind | Unique patches | Patch-equivalent | Current-tree impact | Current-tree risk | Last commit | Tip | Subject |",
-    "| --- | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+    "| Branch | Ahead | Behind | Unique patches | Patch-equivalent | Current-tree impact | Current-tree risk | Archive docs | Last commit | Tip | Subject |",
+    "| --- | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- |",
   ];
   for (const row of filtered) {
-    lines.push(`| \`${row.branch}\` | ${row.aheadOfBaseCommits} | ${row.behindBaseCommits} | ${row.uniquePatchCommits} | ${row.patchEquivalentCommits} | ${escapeMarkdown(formatCurrentTreeImpact(row.currentTreeImpact))} | ${escapeMarkdown(formatCurrentTreeRisk(row.currentTreeImpact))} | ${row.lastCommitDate} | \`${row.lastSha}\` | ${escapeMarkdown(row.lastSubject)} |`);
+    const archiveDocs = row.archiveDocs.length > 0 ? row.archiveDocs.map((doc) => `\`${doc}\``).join(", ") : "—";
+    lines.push(`| \`${row.branch}\` | ${row.aheadOfBaseCommits} | ${row.behindBaseCommits} | ${row.uniquePatchCommits} | ${row.patchEquivalentCommits} | ${escapeMarkdown(formatCurrentTreeImpact(row.currentTreeImpact))} | ${escapeMarkdown(formatCurrentTreeRisk(row.currentTreeImpact))} | ${archiveDocs} | ${row.lastCommitDate} | \`${row.lastSha}\` | ${escapeMarkdown(row.lastSubject)} |`);
   }
   return `${lines.join("\n")}\n`;
 }
@@ -284,7 +336,7 @@ function renderDiscordNextActionShortlist(shortlist) {
 function renderMarkdown(result) {
   const { summary, branches } = result;
   const redundantTotal = (summary.counts["redundant-merged"] ?? 0) + (summary.counts["redundant-patch-equivalent"] ?? 0);
-  return `# Remote branch stale-work audit\n\nGenerated: ${summary.generatedAt}\n\nBase: \`${summary.base}\`\n\nRemote: \`${summary.remote}\`\nGitHub open PR check: ${summary.githubPullRequestsChecked ? `yes (${summary.openPullRequests} open PRs in ${summary.githubRepository})` : "unavailable"}\n\nRegenerate this report with \`npm run --silent branch:audit -- --output docs/remote-branch-audit.md\`. Use \`--json\` for automation.\n\n## Summary\n\n- Total remote branches audited: ${summary.totalBranches}\n- Redundant branches: ${redundantTotal}\n  - Fully merged by commit: ${summary.counts["redundant-merged"] ?? 0}\n  - Patch-equivalent to base: ${summary.counts["redundant-patch-equivalent"] ?? 0}\n- Valid candidates needing human review: ${summary.counts["valid-candidate"] ?? 0}\n- Branches with open PRs: ${summary.counts["open-pr"] ?? 0}\n\n## Discord-friendly valid-candidate next-action shortlist\n\n${renderDiscordNextActionShortlist(result.discordNextActionShortlist)}\n## Valid candidates without open PRs\n\nThese branches still have unique patch commits relative to \`${summary.base}\`. This audit is read-only and does not recommend deleting branches or merging code.\n\n${markdownTable(branches, "valid-candidate")}\n## Redundant: fully merged by commit\n\n${markdownTable(branches, "redundant-merged")}\n## Redundant: patch-equivalent to base\n\nThese branches still have commits ahead of the base ref, but \`git cherry\` reports their patches as already present in \`${summary.base}\`.\n\n${markdownTable(branches, "redundant-patch-equivalent")}\n## Open PR branches\n\n${markdownTable(branches, "open-pr")}`;
+  return `# Remote branch stale-work audit\n\nGenerated: ${summary.generatedAt}\n\nBase: \`${summary.base}\`\n\nRemote: \`${summary.remote}\`\nGitHub open PR check: ${summary.githubPullRequestsChecked ? `yes (${summary.openPullRequests} open PRs in ${summary.githubRepository})` : "unavailable"}\n\nRegenerate this report with \`npm run --silent branch:audit -- --output docs/remote-branch-audit.md\`. Use \`--json\` for automation.\n\n## Summary\n\n- Total remote branches audited: ${summary.totalBranches}\n- Redundant branches: ${redundantTotal}\n  - Fully merged by commit: ${summary.counts["redundant-merged"] ?? 0}\n  - Patch-equivalent to base: ${summary.counts["redundant-patch-equivalent"] ?? 0}\n- Valid candidates needing human review: ${summary.counts["valid-candidate"] ?? 0}\n- Archived stale branches already documented: ${summary.counts["archived-stale"] ?? 0}\n- Branches with open PRs: ${summary.counts["open-pr"] ?? 0}\n\n## Discord-friendly valid-candidate next-action shortlist\n\n${renderDiscordNextActionShortlist(result.discordNextActionShortlist)}\n## Valid candidates without open PRs\n\nThese branches still have unique patch commits relative to \`${summary.base}\`. This audit is read-only and does not recommend deleting branches or merging code.\n\n${markdownTable(branches, "valid-candidate")}\n## Archived stale branches\n\nThese branches still have unique patch commits, but existing \`docs/*branch-archive*.md\` evidence already records a stale-branch archive decision. They are kept out of the fresh valid-candidate shortlist.\n\n${markdownTable(branches, "archived-stale")}\n## Redundant: fully merged by commit\n\n${markdownTable(branches, "redundant-merged")}\n## Redundant: patch-equivalent to base\n\nThese branches still have commits ahead of the base ref, but \`git cherry\` reports their patches as already present in \`${summary.base}\`.\n\n${markdownTable(branches, "redundant-patch-equivalent")}\n## Open PR branches\n\n${markdownTable(branches, "open-pr")}`;
 }
 
 function main() {
@@ -295,14 +347,16 @@ function main() {
 
   run("git", ["rev-parse", "--verify", options.base]);
   const prInfo = getOpenPullRequestHeads(options.remote);
+  const archivedBranchDocs = getArchivedBranchDocs(options.remote);
   const branches = listRemoteBranches(options.remote, options.base)
-    .map((branch) => branchAudit(branch, options, prInfo.heads))
+    .map((branch) => branchAudit(branch, options, prInfo.heads, archivedBranchDocs))
     .sort((left, right) => {
       const classOrder = {
         "valid-candidate": 0,
         "open-pr": 1,
-        "redundant-merged": 2,
-        "redundant-patch-equivalent": 3,
+        "archived-stale": 2,
+        "redundant-merged": 3,
+        "redundant-patch-equivalent": 4,
       };
       return classOrder[left.classification] - classOrder[right.classification]
         || right.lastCommitDate.localeCompare(left.lastCommitDate)

--- a/test/audit-remote-branches.test.mjs
+++ b/test/audit-remote-branches.test.mjs
@@ -113,3 +113,108 @@ printf '%s\n' '[]'
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("remote branch audit classifies branch archive docs outside fresh candidates", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-branch-audit-"));
+  const binDir = path.join(tempDir, "bin");
+  const archiveDoc = path.join(repoRoot, "docs", "zz-test-branch-archive-315.md");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeExecutable(path.join(binDir, "git"), `#!/bin/sh
+args="$*"
+case "$args" in
+  "remote get-url origin")
+    printf '%s\n' 'https://github.com/minislively/fooks.git'
+    ;;
+  "fetch --prune origin")
+    exit 0
+    ;;
+  "rev-parse --verify origin/main")
+    printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    ;;
+  "branch -r --format=%(refname:short)")
+    printf '%s\n' 'origin/main' 'origin/already-archived' 'origin/fresh-candidate'
+    ;;
+  "rev-list --left-right --count origin/main...origin/already-archived"|"rev-list --left-right --count origin/main...origin/fresh-candidate")
+    printf '%s\n' '0 1'
+    ;;
+  "cherry origin/main origin/already-archived")
+    printf '%s\n' '+ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    ;;
+  "cherry origin/main origin/fresh-candidate")
+    printf '%s\n' '+ cccccccccccccccccccccccccccccccccccccccc'
+    ;;
+  "log -1 --format=%cs origin/already-archived"|"log -1 --format=%cs origin/fresh-candidate")
+    printf '%s\n' '2026-04-27'
+    ;;
+  "log -1 --format=%s origin/already-archived")
+    printf '%s\n' 'Archived branch fixture'
+    ;;
+  "log -1 --format=%s origin/fresh-candidate")
+    printf '%s\n' 'Fresh branch fixture'
+    ;;
+  "rev-parse --short=12 origin/already-archived")
+    printf '%s\n' 'bbbbbbbbbbbb'
+    ;;
+  "rev-parse --short=12 origin/fresh-candidate")
+    printf '%s\n' 'cccccccccccc'
+    ;;
+  "diff --name-status origin/main origin/already-archived"|"diff --name-status origin/main origin/fresh-candidate")
+    printf '%s\n' 'M	README.md'
+    ;;
+  "diff --shortstat origin/main origin/already-archived"|"diff --shortstat origin/main origin/fresh-candidate")
+    printf '%s\n' '1 file changed, 1 insertion(+)'
+    ;;
+  *)
+    printf 'unexpected git args: %s\n' "$args" >&2
+    exit 64
+    ;;
+esac
+`);
+
+  writeExecutable(path.join(binDir, "gh"), `#!/bin/sh
+printf '%s\n' '[]'
+`);
+
+  fs.writeFileSync(archiveDoc, `# Archive rationale for \`already-archived\` (#315)
+
+Branch inspected: \`origin/already-archived\`
+
+## Decision
+
+Archive the stale branch instead of replaying it.
+`);
+
+  try {
+    const stdout = execFileSync(process.execPath, [auditScript, "--json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const archivedBranch = result.branches.find((branch) => branch.branch === "already-archived");
+    const freshBranch = result.branches.find((branch) => branch.branch === "fresh-candidate");
+
+    assert.equal(archivedBranch.classification, "archived-stale");
+    assert.deepEqual(archivedBranch.archiveDocs, ["docs/zz-test-branch-archive-315.md"]);
+    assert.equal(freshBranch.classification, "valid-candidate");
+    assert.deepEqual(
+      result.discordNextActionShortlist.map((item) => item.branch),
+      ["fresh-candidate"],
+    );
+
+    const markdown = execFileSync(process.execPath, [auditScript, "--markdown"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    assert.match(markdown, /## Archived stale branches/);
+    assert.match(markdown, /`already-archived`/);
+    assert.match(markdown, /docs\/zz-test-branch-archive-315\.md/);
+  } finally {
+    fs.rmSync(archiveDoc, { force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- classify documented archive branches as archived-stale before valid-candidate fallback
- suppress archived-stale branches from Discord valid-candidate shortlist
- add regression coverage for branch archive docs outside fresh candidates

## Verification
- node --check scripts/audit-remote-branches.mjs
- node --test test/audit-remote-branches.test.mjs
- npm run typecheck -- --pretty false

Refs #315
