### PR TITLE
Classify replayed CI alert evidence

### DIFF
--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -138,6 +138,19 @@ function alertEvidenceState(row) {
   return "current";
 }
 
+function isHistoricalReplayEvidence(row, isStaleAttempt) {
+  if (isStaleAttempt) return true;
+  if (!row || row.bucket !== "stale") return false;
+  return row.latestRunId !== null && row.id !== null && String(row.latestRunId) !== String(row.id);
+}
+
+function alertDisposition(evidence, replay) {
+  if (evidence === "actionable" || evidence === "watch") return "inspect";
+  if (replay) return "suppress-replay";
+  if (evidence === "stale") return "suppress-stale";
+  return "review";
+}
+
 function buildAlertEvidence(alertRefs, rows) {
   if (alertRefs.length === 0) return [];
 
@@ -146,15 +159,21 @@ function buildAlertEvidence(alertRefs, rows) {
     const row = rowsById.get(ref.id);
     const currentAttempt = row?.attempt ?? null;
     const isStaleAttempt = ref.alertedAttempt !== null && currentAttempt !== null && ref.alertedAttempt < currentAttempt;
+    const replay = isHistoricalReplayEvidence(row, isStaleAttempt);
+    const evidence = isStaleAttempt ? "stale" : alertEvidenceState(row);
+    const reason = isStaleAttempt
+      ? `superseded by attempt ${currentAttempt}`
+      : row?.reason ?? "run URL was not present in the inspected gh run list window";
     return {
       alertedRunId: ref.id,
       alertedAttempt: ref.alertedAttempt,
       alertedUrl: ref.url,
       appearances: ref.appearances,
-      evidence: isStaleAttempt ? "stale" : alertEvidenceState(row),
-      reason: isStaleAttempt
-        ? `superseded by attempt ${currentAttempt}`
-        : row?.reason ?? "run URL was not present in the inspected gh run list window",
+      evidence,
+      replay,
+      disposition: alertDisposition(evidence, replay),
+      reason,
+      replayReason: replay ? `historical replay of ${reason}` : "",
       currentRunId: row?.latestRunId ?? null,
       currentAttempt,
       workflow: row?.workflow ?? "",
@@ -243,8 +262,8 @@ function alertEvidenceTable(alerts) {
   const lines = [
     "## Pasted alert URL evidence",
     "",
-    "| Evidence | Alerted run | Alerted attempt | Current run | Current attempt | Workflow | Branch | Status | Conclusion | Reason | Seen |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    "| Evidence | Disposition | Replay | Alerted run | Alerted attempt | Current run | Current attempt | Workflow | Branch | Status | Conclusion | Reason | Seen |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
   ];
 
   for (const alert of alerts) {
@@ -252,7 +271,9 @@ function alertEvidenceTable(alerts) {
     const currentRun = alert.currentRunId ? `\`${alert.currentRunId}\`` : "-";
     const alertedAttempt = alert.alertedAttempt ?? "-";
     const currentAttempt = alert.currentAttempt ?? "-";
-    lines.push(`| ${alert.evidence} | ${alertedRun} | ${alertedAttempt} | ${currentRun} | ${currentAttempt} | ${escapeMarkdown(alert.workflow || "-")} | \`${escapeMarkdown(alert.branch || "-")}\` | ${escapeMarkdown(alert.status || "-")} | ${escapeMarkdown(alert.conclusion || "-")} | ${escapeMarkdown(alert.reason)} | ${alert.appearances} |`);
+    const replay = alert.replay ? "historical replay" : "-";
+    const reason = alert.replayReason || alert.reason;
+    lines.push(`| ${alert.evidence} | ${alert.disposition} | ${replay} | ${alertedRun} | ${alertedAttempt} | ${currentRun} | ${currentAttempt} | ${escapeMarkdown(alert.workflow || "-")} | \`${escapeMarkdown(alert.branch || "-")}\` | ${escapeMarkdown(alert.status || "-")} | ${escapeMarkdown(alert.conclusion || "-")} | ${escapeMarkdown(reason)} | ${alert.appearances} |`);
   }
 
   return `${lines.join("\n")}\n\n`;
@@ -261,7 +282,7 @@ function alertEvidenceTable(alerts) {
 function renderMarkdown(result) {
   const actionable = result.rows.filter((row) => row.bucket === "actionable" || row.bucket === "watch");
   const stale = result.rows.filter((row) => row.bucket === "stale");
-  return `# CI alert replay triage\n\nGenerated: ${result.generatedAt}\n\nUse this report to collapse replayed GitHub Actions alert buffers: inspect only \`actionable\` and \`watch\` rows, and treat \`stale\` rows as already superseded/cancelled unless a new run appears.\n\n## Summary\n\n- Total runs inspected: ${result.totalRuns}\n- Actionable latest failures: ${result.counts.actionable ?? 0}\n- Latest runs still in flight: ${result.counts.watch ?? 0}\n- Stale replay rows: ${result.counts.stale ?? 0}\n- Informational successes/neutral rows: ${result.counts.informational ?? 0}\n- Pasted alert URLs inspected: ${result.alerts?.length ?? 0}\n\n${alertEvidenceTable(result.alerts)}## Actionable / watch\n\n${markdownTable(actionable)}\n## Stale replay rows\n\n${markdownTable(stale)}`;
+  return `# CI alert replay triage\n\nGenerated: ${result.generatedAt}\n\nUse this report to collapse replayed GitHub Actions alert buffers: inspect only \`actionable\` and \`watch\` rows, suppress alert evidence marked \`suppress-replay\`, and treat \`stale\` rows as already superseded/cancelled unless a new run appears.\n\n## Summary\n\n- Total runs inspected: ${result.totalRuns}\n- Actionable latest failures: ${result.counts.actionable ?? 0}\n- Latest runs still in flight: ${result.counts.watch ?? 0}\n- Stale replay rows: ${result.counts.stale ?? 0}\n- Informational successes/neutral rows: ${result.counts.informational ?? 0}\n- Pasted alert URLs inspected: ${result.alerts?.length ?? 0}\n\n${alertEvidenceTable(result.alerts)}## Actionable / watch\n\n${markdownTable(actionable)}\n## Stale replay rows\n\n${markdownTable(stale)}`;
 }
 
 function main() {

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -266,3 +266,142 @@ test("CI alert triage keeps explicit rerun attempt evidence distinct", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("CI alert triage identifies replayed historical main alerts for suppression", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-replay-storm-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 404,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-04-30T20:12:00Z",
+      updatedAt: "2026-04-30T20:14:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/404",
+    },
+    {
+      databaseId: 403,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "cancelled",
+      createdAt: "2026-04-30T19:40:00Z",
+      updatedAt: "2026-04-30T19:42:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/403",
+    },
+    {
+      databaseId: 402,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-04-30T19:20:00Z",
+      updatedAt: "2026-04-30T19:24:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/402",
+    },
+    {
+      databaseId: 401,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "failure",
+      createdAt: "2026-04-30T19:00:00Z",
+      updatedAt: "2026-04-30T19:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/401",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "20:14 UTC replayed old success https://github.com/minislively/fooks/actions/runs/402",
+    "20:14 UTC replayed old cancelled https://github.com/minislively/fooks/actions/runs/403",
+    "20:14 UTC replayed old failure now superseded https://github.com/minislively/fooks/actions/runs/401",
+    "current green main evidence https://github.com/minislively/fooks/actions/runs/404",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const byAlertId = new Map(result.alerts.map((alert) => [alert.alertedRunId, alert]));
+
+    for (const id of ["401", "402", "403"]) {
+      assert.equal(byAlertId.get(id).evidence, "stale");
+      assert.equal(byAlertId.get(id).replay, true);
+      assert.equal(byAlertId.get(id).disposition, "suppress-replay");
+      assert.match(byAlertId.get(id).replayReason, /historical replay/);
+      assert.equal(byAlertId.get(id).currentRunId, 404);
+    }
+
+    assert.equal(byAlertId.get("404").evidence, "current");
+    assert.equal(byAlertId.get("404").replay, false);
+    assert.equal(byAlertId.get("404").disposition, "review");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage does not call a latest cancelled alert a historical replay", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-replay-negative-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 501,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "cancelled",
+      createdAt: "2026-04-30T20:00:00Z",
+      updatedAt: "2026-04-30T20:01:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/501",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, "latest cancelled alert https://github.com/minislively/fooks/actions/runs/501\n");
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.alerts[0].evidence, "stale");
+    assert.equal(result.alerts[0].reason, "completed cancelled");
+    assert.equal(result.alerts[0].replay, false);
+    assert.equal(result.alerts[0].disposition, "suppress-stale");
+    assert.equal(result.alerts[0].replayReason, "");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #319.

## Summary
- Adds explicit replay metadata for pasted GitHub Actions alert URLs that resolve to historical stale evidence superseded by a newer same workflow/branch/event run.
- Emits `disposition: suppress-replay` and a historical replay reason for those alert URLs while preserving existing `actionable` / `watch` behavior.
- Updates markdown output to make replay suppression visible to fooks channel triage operators.
- Leaves external notification routing/clawhip behavior unchanged; this is a fooks-side reporting/triage classification only.

## Validation
- `node --test test/ci-alert-triage.test.mjs`
- `npm test`