### PR TITLE
Replace provider-cost manual review gates

### DIFF
--- a/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
+++ b/benchmarks/layer2-frontend-task/PROVIDER_COST_IMPORT_RUNBOOK.md
@@ -105,6 +105,20 @@ Live OpenAI campaign template:
 
 This template predeclares 3 task classes × 5 matched pairs. It is the live path for estimated API cost evidence, but it requires an OpenAI credential and explicit spend caps. The default auth mode is `auto`: `OPENAI_API_KEY`/`OPEN_AI_APIKEY` first, then Codex OAuth from `$FOOKS_CODEX_HOME/auth.json`, `$CODEX_HOME/auth.json`, or `~/.codex/auth.json`. Use `--auth-mode=codex-oauth --transport=codex-exec` when validating the common Codex/ChatGPT sign-in path; that transport shells out to `codex exec --json` and reads the `turn.completed.usage` event instead of requiring a platform API key. Without credentials, the runner records a local blocker artifact and makes no request.
 
+Its task quality gates are imported-artifact gates, not manual-review
+instructions. The recorded gate command is:
+
+```bash
+npm run bench:layer2:provider-cost:repeated -- \
+  --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json \
+  --run-id=provider-cost-import-kit-smoke
+```
+
+That command validates the local provider-cost import kit, including evidence
+shape, source provenance, denominator accounting, and recorded quality-gate
+pass/fail status. It is intentionally mechanics-scoped; semantic product
+mechanism proof remains the corrected real-payload campaign lane below.
+
 Corrected real-payload campaign builder:
 
 - `build-provider-cost-corrected-manifest.js`

--- a/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/campaign-manifest.json
+++ b/benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/campaign-manifest.json
@@ -16,27 +16,27 @@
       "id": "frontend-component-summary",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "artifact-shape-and-output-review",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual/imported artifact gate"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       }
     },
     {
       "id": "frontend-refactor-plan",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "artifact-shape-and-output-review",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual/imported artifact gate"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       }
     },
     {
       "id": "frontend-type-extraction",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "artifact-shape-and-output-review",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual/imported artifact gate"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       }
     }
   ],

--- a/benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json
+++ b/benchmarks/layer2-frontend-task/provider-cost-live-campaign-tasks.json
@@ -8,9 +8,9 @@
       "id": "frontend-component-summary",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "applied-validation",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual review: baseline and fooks answers must both correctly summarize responsibilities and extraction boundaries"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       },
       "baselinePrompt": "Summarize the responsibilities of a React combobox component and list likely extraction boundaries. Include accessibility, keyboard handling, option rendering, and state management concerns.",
       "fooksPrompt": "Using a compact prepared context for a React combobox, summarize responsibilities and extraction boundaries: accessibility, keyboard handling, option rendering, state management."
@@ -19,9 +19,9 @@
       "id": "frontend-refactor-plan",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "applied-validation",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual review: baseline and fooks answers must both provide an actionable TSX refactor plan"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       },
       "baselinePrompt": "Draft a concise refactor plan for splitting a large TypeScript React form section into components, hooks, utilities, and types. Include migration steps, test coverage, and rollback strategy.",
       "fooksPrompt": "Using compact prepared context for a large TS React form section, draft a concise split plan: components, hooks, utilities, types, tests, rollback."
@@ -30,12 +30,16 @@
       "id": "frontend-test-strategy",
       "targetPairCount": 5,
       "qualityGate": {
-        "id": "applied-validation",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual review: baseline and fooks answers must both identify behavior-preserving tests and risk coverage"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       },
       "baselinePrompt": "Create a behavior-preserving test strategy for extracting frontend utilities from a mixed React component. Cover unit tests, integration tests, snapshot risks, edge cases, and acceptance criteria.",
       "fooksPrompt": "Using compact prepared context for frontend utility extraction, create a behavior-preserving test strategy: unit, integration, snapshot risks, edge cases, acceptance criteria."
     }
+  ],
+  "nonGoals": [
+    "The synthetic live campaign template does not replace corrected real-payload campaigns for product-mechanism proof.",
+    "The imported-artifact gate validates provider-cost evidence shape, provenance, denominator, and recorded pass/fail gate status; it is not a human semantic review process."
   ]
 }

--- a/benchmarks/layer2-frontend-task/provider-cost-tasks.json
+++ b/benchmarks/layer2-frontend-task/provider-cost-tasks.json
@@ -6,9 +6,9 @@
       "id": "frontend-component-summary",
       "targetPairCount": 1,
       "qualityGate": {
-        "id": "provider-cost-import-smoke",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual review or imported artifact gate"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       },
       "baselinePrompt": "Summarize the responsibilities of a React combobox component and list likely extraction boundaries.",
       "fooksPrompt": "Using a compact prepared context, summarize the responsibilities of a React combobox component and list likely extraction boundaries."
@@ -17,12 +17,15 @@
       "id": "frontend-refactor-plan",
       "targetPairCount": 1,
       "qualityGate": {
-        "id": "provider-cost-import-smoke",
+        "id": "provider-cost-imported-artifact-gate",
         "version": "v1",
-        "command": "manual review or imported artifact gate"
+        "command": "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke"
       },
       "baselinePrompt": "Draft a concise refactor plan for splitting a large TSX form section into components, hooks, utils, and types.",
       "fooksPrompt": "Using a compact prepared context, draft a concise refactor plan for splitting a large TSX form section into components, hooks, utils, and types."
     }
+  ],
+  "nonGoals": [
+    "The capped smoke manifest validates imported provider-cost evidence mechanics only; it is not launch-grade positive cost evidence by itself."
   ]
 }

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -222,6 +222,12 @@ without a resolved OpenAI credential writes a local blocker artifact under
 still requires explicit spend caps. Auth resolution is `--auth-mode=auto` by
 default: environment API key first, then Codex OAuth from
 `$FOOKS_CODEX_HOME/auth.json`, `$CODEX_HOME/auth.json`, or `~/.codex/auth.json`.
+The task manifest quality gates point at the imported-artifact mechanics gate:
+`npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke`.
+That gate validates the provider-cost evidence import shape, provenance,
+denominator, and recorded pass/fail quality-gate status; it is not a manual
+semantic-review path and does not replace the corrected real-payload campaign
+needed for product-mechanism proof.
 Use `--auth-mode=codex-oauth --transport=codex-exec` to force the common
 Codex/ChatGPT sign-in path. That transport shells out to `codex exec --json`
 and parses the `turn.completed.usage` event instead of requiring a platform API

--- a/test/provider-cost-evidence.test.mjs
+++ b/test/provider-cost-evidence.test.mjs
@@ -1446,7 +1446,11 @@ test("provider cost repeated CLI live mode without credentials writes controlled
       tasks: ["component", "refactor", "tests"].map((id) => ({
         id,
         targetPairCount: 5,
-        qualityGate: { id: "applied-validation", version: "v1", command: "manual review" },
+        qualityGate: {
+          id: "provider-cost-imported-artifact-gate",
+          version: "v1",
+          command: "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke",
+        },
       })),
     }));
     const stdout = execFileSync(process.execPath, [
@@ -1473,6 +1477,30 @@ test("provider cost repeated CLI live mode without credentials writes controlled
     assert.equal(ledger.plannedPairCount, 15);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider cost task manifests use concrete imported-artifact gates instead of manual review commands", () => {
+  const manifestPaths = [
+    path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-cost-live-campaign-tasks.json"),
+    path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-cost-tasks.json"),
+    path.join(repoRoot, "benchmarks", "layer2-frontend-task", "fixtures", "provider-cost-import-kit", "campaign-manifest.json"),
+  ];
+
+  for (const manifestPath of manifestPaths) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    const tasks = manifest.tasks || manifest.taskClasses || [];
+    assert.ok(tasks.length > 0, `${manifestPath} should declare provider-cost tasks`);
+
+    for (const task of tasks) {
+      const gate = task.qualityGate || {};
+      assert.equal(gate.id, "provider-cost-imported-artifact-gate");
+      assert.match(gate.command || "", /^npm run bench:layer2:provider-cost:repeated -- --import-manifest=/);
+      assert.match(gate.command || "", /fixtures\/provider-cost-import-kit\/import-manifest\.json/);
+      assert.doesNotMatch(gate.command || "", /manual review|manual\/imported/i);
+    }
+
+    assert.doesNotMatch(JSON.stringify(manifest), /manual review|manual\/imported/i);
   }
 });
 


### PR DESCRIPTION
## Summary
- Replaced provider-cost task manifest quality gate commands that referenced manual review with a concrete imported-artifact gate command.
- Added manifest non-goals documenting that smoke/synthetic gates are mechanics-scoped and do not replace corrected real-payload product-mechanism proof.
- Updated the provider-cost runbook/docs and added regression coverage to keep manual-review wording out of provider-cost task manifests.

## Verification
- `npm ci`
- `npm run build && node --test test/provider-cost-evidence.test.mjs`
- `npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke-344`

Closes #344.

— Codex
