### PR TITLE
Collapse CI success alert bursts

### DIFF
--- a/docs/ci-alert-triage.md
+++ b/docs/ci-alert-triage.md
@@ -1,0 +1,19 @@
+# CI alert replay triage
+
+`npm run --silent ci:alerts -- --alerts <file> --branch main` is read-only. It
+only reads pasted alert text and GitHub Actions run metadata, then prints a
+triage report.
+
+For clawhip bursts that replay many historical green CI URLs after a merge,
+compact mode keeps the current `main` head run visible and records the stale
+historical replay count in `alertSummary.staleReplayCount`. The omitted-count
+maps (`byEvidence`, `byConclusion`) provide evidence that the collapsed rows
+were stale successes rather than new failures.
+
+Offline verification example:
+
+```sh
+gh run list --limit 100 --json attempt,databaseId,status,conclusion,createdAt,updatedAt,headBranch,event,name,workflowName,url > /tmp/runs.json
+pbpaste > /tmp/clawhip-alerts.txt
+npm run --silent ci:alerts -- --input /tmp/runs.json --alerts /tmp/clawhip-alerts.txt --branch main --json
+```

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -215,10 +215,31 @@ function summarizeOmittedAlerts(omitted) {
   return { byEvidence, byConclusion };
 }
 
+function alertKey(alert) {
+  return `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`;
+}
+
+function alertSummaryFields(allEvidence, focusBranch) {
+  const currentHeadRunIds = [
+    ...new Set(
+      allEvidence
+        .filter((alert) => alert.evidence === "current" && alert.branch === focusBranch)
+        .map((alert) => alert.alertedRunId),
+    ),
+  ];
+
+  return {
+    currentHeadCount: currentHeadRunIds.length,
+    currentHeadRunIds,
+    staleReplayCount: allEvidence.filter((alert) => alert.replay).length,
+  };
+}
+
 function buildAlertEvidence(alertRefs, rows, options = {}) {
   const allEvidence = buildRawAlertEvidence(alertRefs, rows);
   const focusBranch = options.branch || "main";
   const limit = options.alertEvidenceLimit || DEFAULT_ALERT_EVIDENCE_LIMIT;
+  const summaryFields = alertSummaryFields(allEvidence, focusBranch);
 
   if (allEvidence.length <= limit) {
     return {
@@ -229,6 +250,7 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
         shown: allEvidence.length,
         omitted: 0,
         focusBranch,
+        ...summaryFields,
       },
     };
   }
@@ -236,7 +258,7 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
   const kept = [];
   const keptKeys = new Set();
   const keep = (alert, sampled = false) => {
-    const key = `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`;
+    const key = alertKey(alert);
     if (keptKeys.has(key)) return;
     keptKeys.add(key);
     kept.push(sampled ? { ...alert, sampled: true } : alert);
@@ -261,8 +283,8 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
     return rightTime - leftTime || Number(right.appearances) - Number(left.appearances);
   });
 
-  const keptKeySet = new Set(kept.map((alert) => `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`));
-  const omitted = allEvidence.filter((alert) => !keptKeySet.has(`${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`));
+  const keptKeySet = new Set(kept.map(alertKey));
+  const omitted = allEvidence.filter((alert) => !keptKeySet.has(alertKey(alert)));
 
   return {
     alerts: kept,
@@ -273,6 +295,7 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
       omitted: omitted.length,
       focusBranch,
       staleSampleLimit: STALE_ALERT_SAMPLE_LIMIT,
+      ...summaryFields,
       ...summarizeOmittedAlerts(omitted),
     },
   };
@@ -359,9 +382,12 @@ function formatCountMap(map) {
 
 function alertEvidenceTable(alerts, summary) {
   if (!alerts || alerts.length === 0) return "";
+  const currentHeadVerdict = summary?.currentHeadRunIds?.length
+    ? ` Current-head verdict${summary.currentHeadRunIds.length === 1 ? "" : "s"}: ${summary.currentHeadRunIds.map((id) => `\`${escapeMarkdown(id)}\``).join(", ")}. Stale historical replay count: ${summary.staleReplayCount ?? 0}.`
+    : "";
   const compactNote = summary?.mode === "compact"
-    ? `Compact mode: showing ${summary.shown}/${summary.total} pasted alert URLs for focus branch \`${escapeMarkdown(summary.focusBranch)}\`; omitted ${summary.omitted} low-signal historical replay rows (${escapeMarkdown(formatCountMap(summary.byConclusion))}).`
-    : `Full mode: showing all ${summary?.shown ?? alerts.length} pasted alert URLs.`;
+    ? `Compact mode: showing ${summary.shown}/${summary.total} pasted alert URLs for focus branch \`${escapeMarkdown(summary.focusBranch)}\`; omitted ${summary.omitted} low-signal historical replay rows (${escapeMarkdown(formatCountMap(summary.byConclusion))}).${currentHeadVerdict}`
+    : `Full mode: showing all ${summary?.shown ?? alerts.length} pasted alert URLs.${currentHeadVerdict}`;
   const lines = [
     "## Pasted alert URL evidence",
     "",

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -484,3 +484,77 @@ test("CI alert triage compacts bulk replay URLs around current main and cancelle
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("CI alert triage collapses success-heavy clawhip bursts to current head plus stale count", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-green-burst-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  const currentRun = {
+    databaseId: 700,
+    workflowName: "CI",
+    name: "Validate",
+    headBranch: "main",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    createdAt: "2026-05-01T12:00:00Z",
+    updatedAt: "2026-05-01T12:05:00Z",
+    url: "https://github.com/minislively/fooks/actions/runs/700",
+  };
+  const historicalRuns = Array.from({ length: 20 }, (_, index) => {
+    const id = 600 + index;
+    return {
+      databaseId: id,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: `2026-04-30T${String(index).padStart(2, "0")}:00:00Z`,
+      updatedAt: `2026-04-30T${String(index).padStart(2, "0")}:05:00Z`,
+      url: `https://github.com/minislively/fooks/actions/runs/${id}`,
+    };
+  });
+
+  fs.writeFileSync(runsPath, JSON.stringify([currentRun, ...historicalRuns]));
+  fs.writeFileSync(alertsPath, [
+    ...historicalRuns.map((run) => `clawhip green replay https://github.com/minislively/fooks/actions/runs/${run.databaseId}`),
+    "current main-head green verdict https://github.com/minislively/fooks/actions/runs/700",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "main",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.alertSummary.mode, "compact");
+    assert.equal(result.alertSummary.total, 21);
+    assert.equal(result.alertSummary.shown, 1);
+    assert.equal(result.alertSummary.omitted, 20);
+    assert.equal(result.alertSummary.currentHeadCount, 1);
+    assert.deepEqual(result.alertSummary.currentHeadRunIds, ["700"]);
+    assert.equal(result.alertSummary.staleReplayCount, 20);
+    assert.equal(result.alertSummary.byEvidence.stale, 20);
+    assert.equal(result.alertSummary.byConclusion.success, 20);
+    assert.equal(result.alerts.length, 1);
+    assert.equal(result.alerts[0].alertedRunId, "700");
+    assert.equal(result.alerts[0].evidence, "current");
+    assert.equal(result.alerts[0].conclusion, "success");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add current-head and stale replay counts to ci:alerts pasted URL summaries
- cover success-heavy clawhip bursts collapsing to one current main-head verdict
- document read-only offline verification for replayed CI alert bursts

Closes #346

## Verification
- `node --check scripts/triage-ci-alerts.mjs`
- `node --test test/ci-alert-triage.test.mjs`
- `npm run typecheck -- --pretty false`