### PR TITLE
Treat new-to-merged PR alerts as echoes

### DIFF
--- a/docs/pr-alert-disambiguation.md
+++ b/docs/pr-alert-disambiguation.md
@@ -4,6 +4,7 @@ Clawhip/relay-style alert text can describe a `fooks#NNN` close/comment as PR wo
 
 - `pull_request` present: safe to continue PR-specific handling.
 - `pull_request` absent: stop PR recovery and treat it as an issue event.
+- Alert says `PR fooks#NNN <new> -> merged` and GitHub already reports the PR as merged: treat it as a verification-only echo, not fresh actionable PR recovery.
 
 The guard is read-only. It never comments, closes, reopens, deletes branches, or changes worktrees.
 
@@ -23,4 +24,4 @@ For issue-only payloads like `fooks#226`, expect `kind: "issue"` and `prHandling
 npm run --silent pr:guard -- --repo minislively/fooks --alerts /tmp/alerts.txt
 ```
 
-This invokes `gh api repos/<owner>/<repo>/issues/<number>` for each matching alert reference and prints a small markdown report. Use rows with `prHandling=skip` as a hard stop before any PR recovery workflow.
+This invokes `gh api repos/<owner>/<repo>/issues/<number>` for each matching alert reference and prints a small markdown report. Use rows with `prHandling=skip` as a hard stop before any PR recovery workflow. Use `prHandling=echo` rows only to verify the already-merged GitHub state; do not start fresh PR recovery from that alert.

--- a/scripts/guard-pr-alerts.mjs
+++ b/scripts/guard-pr-alerts.mjs
@@ -104,8 +104,28 @@ function fetchIssue(ref) {
   return JSON.parse(stdout);
 }
 
-function classifyIssue(ref, issue) {
+function alertLooksLikeNewToMergedEcho(alertText, ref) {
+  if (!/<new>\s*->\s*merged/i.test(alertText)) return false;
+  const refPatterns = [
+    new RegExp(`\\b${escapeRegExp(ref.repo)}#${ref.number}\\b`, "i"),
+    new RegExp(`\\b${escapeRegExp(ref.owner)}/${escapeRegExp(ref.repo)}#${ref.number}\\b`, "i"),
+    new RegExp(`github\\.com/${escapeRegExp(ref.owner)}/${escapeRegExp(ref.repo)}/(?:issues|pull)/${ref.number}\\b`, "i"),
+  ];
+  return refPatterns.some((pattern) => pattern.test(alertText));
+}
+
+function githubStateIsMerged(issue) {
+  return Boolean(issue?.pull_request) && (
+    Boolean(issue.pull_request.merged_at) ||
+    Boolean(issue.merged_at) ||
+    issue.pull_request.merged === true ||
+    issue.merged === true
+  );
+}
+
+function classifyIssue(ref, issue, alertText) {
   const isPullRequest = Boolean(issue?.pull_request);
+  const isNewToMergedEcho = isPullRequest && githubStateIsMerged(issue) && alertLooksLikeNewToMergedEcho(alertText, ref);
   return {
     repo: `${ref.owner}/${ref.repo}`,
     number: ref.number,
@@ -114,8 +134,10 @@ function classifyIssue(ref, issue) {
     state: issue?.state ?? "unknown",
     htmlUrl: issue?.html_url ?? `https://github.com/${ref.owner}/${ref.repo}/issues/${ref.number}`,
     kind: isPullRequest ? "pull_request" : "issue",
-    prHandling: isPullRequest ? "allow" : "skip",
-    reason: isPullRequest ? "GitHub issue API response includes pull_request" : "GitHub issue API response has no pull_request field",
+    prHandling: isNewToMergedEcho ? "echo" : isPullRequest ? "allow" : "skip",
+    reason: isNewToMergedEcho
+      ? "Alert reports <new> -> merged and GitHub state is already merged; verification-only echo"
+      : isPullRequest ? "GitHub issue API response includes pull_request" : "GitHub issue API response has no pull_request field",
   };
 }
 
@@ -125,7 +147,7 @@ function buildReport(options) {
   const eventFixtures = readEvents(options.eventsInput);
   const rows = refs.map((ref) => {
     const issue = eventFixtures.get(String(ref.number)) ?? fetchIssue(ref);
-    return classifyIssue(ref, issue);
+    return classifyIssue(ref, issue, alertText);
   });
 
   const counts = rows.reduce((acc, row) => {
@@ -164,6 +186,7 @@ function renderMarkdown(result) {
     `- Issues: ${result.counts.issue ?? 0}`,
     `- PR handling allowed: ${result.counts.allow ?? 0}`,
     `- PR handling skipped: ${result.counts.skip ?? 0}`,
+    `- Verification-only echoes: ${result.counts.echo ?? 0}`,
     "",
     "## Rows",
     "",

--- a/test/pr-alert-guard.test.mjs
+++ b/test/pr-alert-guard.test.mjs
@@ -93,3 +93,49 @@ test("PR alert guard allows pull requests when GitHub issue payload has pull_req
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("PR alert guard treats new-to-merged alerts for already merged PRs as verification-only echo", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-echo-"));
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const eventsPath = path.join(tempDir, "events.json");
+
+  fs.writeFileSync(alertsPath, "clawhip: PR fooks#348 <new> -> merged");
+  fs.writeFileSync(eventsPath, JSON.stringify({
+    number: 348,
+    title: "Already merged PR",
+    state: "closed",
+    html_url: "https://github.com/minislively/fooks/pull/348",
+    pull_request: {
+      url: "https://api.github.com/repos/minislively/fooks/pulls/348",
+      html_url: "https://github.com/minislively/fooks/pull/348",
+      merged_at: "2026-05-02T09:00:00Z",
+    },
+  }));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      guardScript,
+      "--repo",
+      "minislively/fooks",
+      "--alerts",
+      alertsPath,
+      "--events",
+      eventsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.totalRefs, 1);
+    assert.equal(result.counts.pull_request, 1);
+    assert.equal(result.counts.echo, 1);
+    assert.equal(result.rows[0].kind, "pull_request");
+    assert.equal(result.rows[0].prHandling, "echo");
+    assert.equal(result.rows[0].reason, "Alert reports <new> -> merged and GitHub state is already merged; verification-only echo");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #348

## Summary
- classify `PR fooks#N <new> -> merged` alerts as `prHandling: echo` when GitHub already reports the PR merged
- keep normal PR alerts actionable and issue-only refs skipped
- document echo handling in the PR alert disambiguation runbook

## Verification
- `node --test test/pr-alert-guard.test.mjs`
- `npm run --silent pr:alerts -- --repo minislively/fooks --alerts <temp alerts> --events <temp merged-pr fixture> --json`