### PR TITLE
Classify current main CI pass echoes

### DIFF
--- a/docs/ci-alert-triage.md
+++ b/docs/ci-alert-triage.md
@@ -10,6 +10,15 @@ historical replay count in `alertSummary.staleReplayCount`. The omitted-count
 maps (`byEvidence`, `byConclusion`) provide evidence that the collapsed rows
 were stale successes rather than new failures.
 
+When the pasted alert is the current completed `main` CI success (for example a
+`git:fooks@main` notice followed by `CI passed · fooks` for the same head run),
+the alert evidence remains `current` and gains `verdict: "current-main-echo"`,
+`echo: true`, and `disposition: "verification-only"`. Treat that as a merge
+verification echo: record it as the current main verdict, but do not re-open a
+fresh development investigation unless a newer actionable/watch run appears.
+Historical success URLs in the same paste stay bounded by compact mode and are
+noise-counted as stale replay rows.
+
 Offline verification example:
 
 ```sh

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -156,32 +156,51 @@ function isHistoricalReplayEvidence(row, isStaleAttempt) {
   return row.latestRunId !== null && row.id !== null && String(row.latestRunId) !== String(row.id);
 }
 
-function alertDisposition(evidence, replay) {
+function isCurrentMainSuccessEcho(row, focusBranch) {
+  return row
+    && row.bucket === "informational"
+    && row.branch === focusBranch
+    && row.status === "completed"
+    && row.conclusion === "success"
+    && row.latestRunId !== null
+    && row.id !== null
+    && String(row.latestRunId) === String(row.id);
+}
+
+function alertDisposition(evidence, replay, echo = false) {
   if (evidence === "actionable" || evidence === "watch") return "inspect";
+  if (echo) return "verification-only";
   if (replay) return "suppress-replay";
   if (evidence === "stale") return "suppress-stale";
   return "review";
 }
 
-function buildRawAlertEvidence(alertRefs, rows) {
+function buildRawAlertEvidence(alertRefs, rows, options = {}) {
   const rowsById = new Map(rows.map((row) => [String(row.id), row]));
+  const focusBranch = options.branch || "main";
   return alertRefs.map((ref) => {
     const row = rowsById.get(ref.id);
     const currentAttempt = row?.attempt ?? null;
     const isStaleAttempt = ref.alertedAttempt !== null && currentAttempt !== null && ref.alertedAttempt < currentAttempt;
     const replay = isHistoricalReplayEvidence(row, isStaleAttempt);
+    const echo = !isStaleAttempt && isCurrentMainSuccessEcho(row, focusBranch);
     const evidence = isStaleAttempt ? "stale" : alertEvidenceState(row);
+    const verdict = echo ? "current-main-echo" : evidence;
     const reason = isStaleAttempt
       ? `superseded by attempt ${currentAttempt}`
-      : row?.reason ?? "run URL was not present in the inspected gh run list window";
+      : echo
+        ? `verification-only current ${focusBranch} success echo`
+        : row?.reason ?? "run URL was not present in the inspected gh run list window";
     return {
       alertedRunId: ref.id,
       alertedAttempt: ref.alertedAttempt,
       alertedUrl: ref.url,
       appearances: ref.appearances,
       evidence,
+      verdict,
+      echo,
       replay,
-      disposition: alertDisposition(evidence, replay),
+      disposition: alertDisposition(evidence, replay, echo),
       reason,
       replayReason: replay ? `historical replay of ${reason}` : "",
       currentRunId: row?.latestRunId ?? null,
@@ -223,7 +242,7 @@ function alertSummaryFields(allEvidence, focusBranch) {
   const currentHeadRunIds = [
     ...new Set(
       allEvidence
-        .filter((alert) => alert.evidence === "current" && alert.branch === focusBranch)
+        .filter((alert) => alert.echo || (alert.evidence === "current" && alert.branch === focusBranch))
         .map((alert) => alert.alertedRunId),
     ),
   ];
@@ -231,13 +250,14 @@ function alertSummaryFields(allEvidence, focusBranch) {
   return {
     currentHeadCount: currentHeadRunIds.length,
     currentHeadRunIds,
+    currentMainEchoCount: allEvidence.filter((alert) => alert.echo).length,
     staleReplayCount: allEvidence.filter((alert) => alert.replay).length,
   };
 }
 
 function buildAlertEvidence(alertRefs, rows, options = {}) {
-  const allEvidence = buildRawAlertEvidence(alertRefs, rows);
   const focusBranch = options.branch || "main";
+  const allEvidence = buildRawAlertEvidence(alertRefs, rows, { branch: focusBranch });
   const limit = options.alertEvidenceLimit || DEFAULT_ALERT_EVIDENCE_LIMIT;
   const summaryFields = alertSummaryFields(allEvidence, focusBranch);
 
@@ -383,7 +403,7 @@ function formatCountMap(map) {
 function alertEvidenceTable(alerts, summary) {
   if (!alerts || alerts.length === 0) return "";
   const currentHeadVerdict = summary?.currentHeadRunIds?.length
-    ? ` Current-head verdict${summary.currentHeadRunIds.length === 1 ? "" : "s"}: ${summary.currentHeadRunIds.map((id) => `\`${escapeMarkdown(id)}\``).join(", ")}. Stale historical replay count: ${summary.staleReplayCount ?? 0}.`
+    ? ` Current-head verdict${summary.currentHeadRunIds.length === 1 ? "" : "s"}: ${summary.currentHeadRunIds.map((id) => `\`${escapeMarkdown(id)}\``).join(", ")}. Current-main echo count: ${summary.currentMainEchoCount ?? 0}. Stale historical replay count: ${summary.staleReplayCount ?? 0}.`
     : "";
   const compactNote = summary?.mode === "compact"
     ? `Compact mode: showing ${summary.shown}/${summary.total} pasted alert URLs for focus branch \`${escapeMarkdown(summary.focusBranch)}\`; omitted ${summary.omitted} low-signal historical replay rows (${escapeMarkdown(formatCountMap(summary.byConclusion))}).${currentHeadVerdict}`
@@ -393,8 +413,8 @@ function alertEvidenceTable(alerts, summary) {
     "",
     compactNote,
     "",
-    "| Evidence | Disposition | Replay | Alerted run | Alerted attempt | Current run | Current attempt | Workflow | Branch | Status | Conclusion | Reason | Seen |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    "| Evidence | Verdict | Disposition | Replay | Alerted run | Alerted attempt | Current run | Current attempt | Workflow | Branch | Status | Conclusion | Reason | Seen |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
   ];
 
   for (const alert of alerts) {
@@ -405,7 +425,7 @@ function alertEvidenceTable(alerts, summary) {
     const evidence = alert.sampled ? `${alert.evidence} sample` : alert.evidence;
     const replay = alert.replay ? "historical replay" : "-";
     const reason = alert.replayReason || alert.reason;
-    lines.push(`| ${evidence} | ${alert.disposition} | ${replay} | ${alertedRun} | ${alertedAttempt} | ${currentRun} | ${currentAttempt} | ${escapeMarkdown(alert.workflow || "-")} | \`${escapeMarkdown(alert.branch || "-")}\` | ${escapeMarkdown(alert.status || "-")} | ${escapeMarkdown(alert.conclusion || "-")} | ${escapeMarkdown(reason)} | ${alert.appearances} |`);
+    lines.push(`| ${evidence} | ${escapeMarkdown(alert.verdict || alert.evidence || "-")} | ${alert.disposition} | ${replay} | ${alertedRun} | ${alertedAttempt} | ${currentRun} | ${currentAttempt} | ${escapeMarkdown(alert.workflow || "-")} | \`${escapeMarkdown(alert.branch || "-")}\` | ${escapeMarkdown(alert.status || "-")} | ${escapeMarkdown(alert.conclusion || "-")} | ${escapeMarkdown(reason)} | ${alert.appearances} |`);
   }
 
   return `${lines.join("\n")}\n\n`;

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -256,7 +256,7 @@ test("CI alert triage keeps explicit rerun attempt evidence distinct", () => {
     assert.equal(current301.appearances, 2);
     assert.equal(current301.currentAttempt, 2);
     assert.equal(current301.evidence, "current");
-    assert.equal(current301.reason, "not failing");
+    assert.equal(current301.reason, "verification-only current main success echo");
 
     assert.equal(missingCurrentAttempt.alertedUrl, "https://github.com/minislively/fooks/actions/runs/302/attempts/1");
     assert.equal(missingCurrentAttempt.currentAttempt, null);
@@ -354,8 +354,10 @@ test("CI alert triage identifies replayed historical main alerts for suppression
     }
 
     assert.equal(byAlertId.get("404").evidence, "current");
+    assert.equal(byAlertId.get("404").verdict, "current-main-echo");
+    assert.equal(byAlertId.get("404").echo, true);
     assert.equal(byAlertId.get("404").replay, false);
-    assert.equal(byAlertId.get("404").disposition, "review");
+    assert.equal(byAlertId.get("404").disposition, "verification-only");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -473,7 +475,7 @@ test("CI alert triage compacts bulk replay URLs around current main and cancelle
     const byAlertId = new Map(result.alerts.map((alert) => [alert.alertedRunId, alert]));
     assert.equal(byAlertId.get("500").evidence, "current");
     assert.equal(byAlertId.get("500").branch, "main");
-    assert.equal(byAlertId.get("500").reason, "not failing");
+    assert.equal(byAlertId.get("500").reason, "verification-only current main success echo");
 
     const cancelledSamples = result.alerts.filter((alert) => alert.conclusion === "cancelled");
     assert.equal(cancelledSamples.length, 2);
@@ -553,7 +555,82 @@ test("CI alert triage collapses success-heavy clawhip bursts to current head plu
     assert.equal(result.alerts.length, 1);
     assert.equal(result.alerts[0].alertedRunId, "700");
     assert.equal(result.alerts[0].evidence, "current");
+    assert.equal(result.alerts[0].verdict, "current-main-echo");
+    assert.equal(result.alerts[0].echo, true);
+    assert.equal(result.alerts[0].disposition, "verification-only");
     assert.equal(result.alerts[0].conclusion, "success");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage classifies pasted current main CI success as verification-only echo", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-main-pass-echo-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 850,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-02T09:00:00Z",
+      updatedAt: "2026-05-02T09:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/850",
+    },
+    {
+      databaseId: 849,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-02T08:00:00Z",
+      updatedAt: "2026-05-02T08:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/849",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "git:fooks@main",
+    "CI passed · fooks https://github.com/minislively/fooks/actions/runs/850/job/1234567890",
+    "historical green replay https://github.com/minislively/fooks/actions/runs/849",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "main",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const byAlertId = new Map(result.alerts.map((alert) => [alert.alertedRunId, alert]));
+
+    assert.equal(byAlertId.get("850").evidence, "current");
+    assert.equal(byAlertId.get("850").verdict, "current-main-echo");
+    assert.equal(byAlertId.get("850").echo, true);
+    assert.equal(byAlertId.get("850").disposition, "verification-only");
+    assert.equal(byAlertId.get("850").reason, "verification-only current main success echo");
+    assert.equal(byAlertId.get("850").currentRunId, 850);
+    assert.equal(byAlertId.get("849").evidence, "stale");
+    assert.equal(byAlertId.get("849").replay, true);
+    assert.equal(byAlertId.get("849").disposition, "suppress-replay");
+    assert.equal(result.alertSummary.currentHeadRunIds.includes("850"), true);
+    assert.equal(result.alertSummary.currentMainEchoCount, 1);
+    assert.equal(result.alertSummary.staleReplayCount, 1);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- classify pasted current `main` CI success URLs as verification-only `current-main-echo` alert evidence
- keep historical success URLs bounded/noise-counted through the existing compact replay summary
- document the operator flow for `git:fooks@main` followed by `CI passed · fooks`

## Verification
- `node --test test/ci-alert-triage.test.mjs`
- `npm run build && node --test test/ci-alert-triage.test.mjs`
- `npm test`
- manual fixture: `node scripts/triage-ci-alerts.mjs --input <runs.json> --alerts <alerts.txt> --branch main --json` confirmed current run `850` => `current-main-echo` / `verification-only`, historical run `849` => `suppress-replay`

Closes #350
