### PR TITLE
Separate WebView fallback policy seam

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -10,16 +10,20 @@ import {
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
 } from "../core/payload-policy/react-web";
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
+import { assessWebViewPayloadPolicy, WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
 import type { PreReadDecision } from "../core/schema";
 
 const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
-export { CUSTOM_WRAPPER_DOM_SIGNAL_GAP, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY };
+export {
+  CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
+  REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+  WEBVIEW_BOUNDARY_FALLBACK_POLICY,
+};
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
 export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
-export const WEBVIEW_BOUNDARY_FALLBACK_POLICY = "webview-boundary-fallback";
 const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
   "react-native:primitive:View",
   "react-native:primitive:Text",
@@ -104,16 +108,8 @@ export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResu
   const reactWebPolicy = assessReactWebPayloadPolicy(domainDetection);
   if (reactWebPolicy) return reactWebPolicy;
 
-  if (
-    domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
-    hasAnySignalWithPrefix(domainDetection, "webview:")
-  ) {
-    return {
-      name: WEBVIEW_BOUNDARY_FALLBACK_POLICY,
-      allowed: false,
-      reason: REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
-    };
-  }
+  const webViewPolicy = assessWebViewPayloadPolicy(domainDetection);
+  if (webViewPolicy) return webViewPolicy;
 
   if (domainDetection.classification !== "react-native") return undefined;
 

--- a/src/core/payload-policy/webview.ts
+++ b/src/core/payload-policy/webview.ts
@@ -1,0 +1,21 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import { FRONTEND_DOMAIN_BOUNDARY_REASON } from "../domain-profiles/types";
+import type { FrontendPayloadPolicyDecision } from "./types";
+
+export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = FRONTEND_DOMAIN_BOUNDARY_REASON;
+export const WEBVIEW_BOUNDARY_FALLBACK_POLICY = "webview-boundary-fallback";
+
+function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: string): boolean {
+  return domainDetection.signals.some((signal) => signal.startsWith(prefix));
+}
+
+export function assessWebViewPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
+  if (domainDetection.reason !== REACT_NATIVE_WEBVIEW_BOUNDARY_REASON) return undefined;
+  if (!hasAnySignalWithPrefix(domainDetection, "webview:")) return undefined;
+
+  return {
+    name: WEBVIEW_BOUNDARY_FALLBACK_POLICY,
+    allowed: false,
+    reason: REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
+  };
+}

--- a/test/payload-policy-webview.test.mjs
+++ b/test/payload-policy-webview.test.mjs
@@ -1,0 +1,84 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const {
+  assessWebViewPayloadPolicy,
+  REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
+  WEBVIEW_BOUNDARY_FALLBACK_POLICY,
+} = require(path.join(repoRoot, "dist", "core", "payload-policy", "webview.js"));
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+
+const forbiddenSupportClaims = /WebView support is available|WebView is supported today|default WebView compact extraction is enabled|bridge safety is guaranteed/i;
+
+function detect(source, filePath = "Component.tsx") {
+  return detectDomainFromSource(source, filePath);
+}
+
+function expectedWebViewFallbackPolicy() {
+  return {
+    name: WEBVIEW_BOUNDARY_FALLBACK_POLICY,
+    allowed: false,
+    reason: REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
+  };
+}
+
+test("WebView payload policy returns fallback-only decision for WebView boundary evidence", () => {
+  const domainDetection = detect(
+    `import { WebView } from "react-native-webview";
+     export function Preview() {
+       return <WebView source={{ uri: "https://example.com" }} onMessage={() => null} />;
+     }`,
+    "Preview.tsx",
+  );
+
+  assert.equal(domainDetection.reason, REACT_NATIVE_WEBVIEW_BOUNDARY_REASON);
+  assert.ok(domainDetection.signals.some((signal) => signal.startsWith("webview:")));
+  assert.deepEqual(assessWebViewPayloadPolicy(domainDetection), expectedWebViewFallbackPolicy());
+});
+
+test("WebView payload policy does not authorize non-WebView domains", () => {
+  const samples = [
+    detect(`export function Form() { return <form><input name="email" /></form>; }`, "Form.tsx"),
+    detect(`import { View } from "react-native"; export function Native() { return <View />; }`, "Native.tsx"),
+    detect(`import { Box } from "ink"; export function Cli() { return <Box />; }`, "Cli.tsx"),
+    detect(`import { View } from "react-native"; export function Mixed() { return <div><View /></div>; }`, "Mixed.tsx"),
+    detect(`export const answer = 42;`, "utility.ts"),
+  ];
+
+  for (const domainDetection of samples) {
+    assert.equal(
+      assessWebViewPayloadPolicy(domainDetection),
+      undefined,
+      `${domainDetection.classification}:${domainDetection.reason ?? "no-reason"} must not get WebView policy`,
+    );
+  }
+});
+
+test("pre-read compatibility entrypoint delegates WebView decisions to the policy seam", () => {
+  const domainDetection = detect(
+    `import { WebView } from "react-native-webview";
+     export function Preview() {
+       return <WebView source={{ html: "<html><body><script>window.ReactNativeWebView.postMessage('ready')</script></body></html>" }} />;
+     }`,
+    "Preview.tsx",
+  );
+
+  assert.deepEqual(preRead.assessFrontendPayloadPolicy(domainDetection), assessWebViewPayloadPolicy(domainDetection));
+  assert.equal(preRead.REACT_NATIVE_WEBVIEW_BOUNDARY_REASON, REACT_NATIVE_WEBVIEW_BOUNDARY_REASON);
+  assert.equal(preRead.WEBVIEW_BOUNDARY_FALLBACK_POLICY, WEBVIEW_BOUNDARY_FALLBACK_POLICY);
+});
+
+test("WebView policy seam source avoids broad WebView support claims", () => {
+  for (const relativePath of [path.join("src", "core", "payload-policy", "webview.ts")]) {
+    assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
+  }
+});


### PR DESCRIPTION
## Summary
- Extract WebView boundary/fallback payload policy into `src/core/payload-policy/webview.ts`.
- Keep `pre-read.ts` compatibility exports while delegating only the WebView fallback decision to the new seam.
- Add focused WebView policy regression coverage for fallback-only behavior, non-WebView denial, pre-read delegation, and broad-claim boundaries.

## Scope boundary
- No WebView compact extraction.
- No RN/TUI policy migration.
- No detector/profile/runtime payload shape changes.
- No support claim expansion.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/claim-boundary tests
- `node --test test/fooks.test.mjs`
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
