### PR TITLE
Separate RN narrow payload policy seam

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -9,6 +9,10 @@ import {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
 } from "../core/payload-policy/react-web";
+import {
+  assessReactNativePayloadPolicy,
+  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+} from "../core/payload-policy/react-native";
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
 import { assessWebViewPayloadPolicy, WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
 import type { PreReadDecision } from "../core/schema";
@@ -19,37 +23,11 @@ const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
   WEBVIEW_BOUNDARY_FALLBACK_POLICY,
 };
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
-export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
-const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
-  "react-native:primitive:View",
-  "react-native:primitive:Text",
-  "react-native:primitive:TextInput",
-  "react-native:primitive:Pressable",
-  "react-native:jsx-prop:onChangeText",
-  "react-native:jsx-prop:onPress",
-];
-const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = [
-  "webview:",
-  "tui-ink:",
-  "react-native:navigation-",
-  "react-native:api-call:Dimensions.",
-  "react-native:api-call:PanResponder.",
-];
-const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
-  "react-native:primitive:FlatList",
-  "react-native:primitive:Image",
-  "react-native:primitive:ScrollView",
-  "react-native:primitive:TouchableOpacity",
-  "react-native:style-factory:StyleSheet.create",
-  "react-native:platform-select:Platform.select",
-  "react-native:style-prop:resizeMode",
-  "react-native:jsx-prop:activeOpacity",
-  "react-native:jsx-prop:pagingEnabled",
-];
 
 export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance">;
 export type { FrontendPayloadPolicyDecision };
@@ -86,14 +64,6 @@ function assessFrontendProfilePayloadReuse(
   return { allowed: false, reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON };
 }
 
-function hasSignal(domainDetection: DomainDetectionResult, signal: string): boolean {
-  return domainDetection.signals.includes(signal);
-}
-
-function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: string): boolean {
-  return domainDetection.signals.some((signal) => signal.startsWith(prefix));
-}
-
 function frontendDebug(
   domainDetection: DomainDetectionResult,
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
@@ -111,29 +81,7 @@ export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResu
   const webViewPolicy = assessWebViewPayloadPolicy(domainDetection);
   if (webViewPolicy) return webViewPolicy;
 
-  if (domainDetection.classification !== "react-native") return undefined;
-
-  const forbiddenSignal =
-    RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS.find((signal) => hasSignal(domainDetection, signal)) ??
-    RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.find((prefix) => hasAnySignalWithPrefix(domainDetection, prefix));
-  if (forbiddenSignal) {
-    return {
-      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
-      allowed: false,
-      reason: `forbidden-signal:${forbiddenSignal}`,
-    };
-  }
-
-  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
-  if (missingSignal) {
-    return {
-      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
-      allowed: false,
-      reason: `missing-signal:${missingSignal}`,
-    };
-  }
-
-  return { name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY, allowed: true };
+  return assessReactNativePayloadPolicy(domainDetection);
 }
 
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {

--- a/src/core/payload-policy/react-native.ts
+++ b/src/core/payload-policy/react-native.ts
@@ -1,0 +1,67 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import type { FrontendPayloadPolicyDecision } from "./types";
+
+export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
+
+const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
+  "react-native:primitive:View",
+  "react-native:primitive:Text",
+  "react-native:primitive:TextInput",
+  "react-native:primitive:Pressable",
+  "react-native:jsx-prop:onChangeText",
+  "react-native:jsx-prop:onPress",
+];
+const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = [
+  "webview:",
+  "tui-ink:",
+  "react-native:navigation-",
+  "react-native:api-call:Dimensions.",
+  "react-native:api-call:PanResponder.",
+];
+const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
+  "react-native:primitive:FlatList",
+  "react-native:primitive:Image",
+  "react-native:primitive:ScrollView",
+  "react-native:primitive:TouchableOpacity",
+  "react-native:style-factory:StyleSheet.create",
+  "react-native:platform-select:Platform.select",
+  "react-native:style-prop:resizeMode",
+  "react-native:jsx-prop:activeOpacity",
+  "react-native:jsx-prop:pagingEnabled",
+];
+
+function hasSignal(domainDetection: DomainDetectionResult, signal: string): boolean {
+  return domainDetection.signals.includes(signal);
+}
+
+function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: string): boolean {
+  return domainDetection.signals.some((signal) => signal.startsWith(prefix));
+}
+
+export function assessReactNativePayloadPolicy(
+  domainDetection: DomainDetectionResult,
+): FrontendPayloadPolicyDecision | undefined {
+  if (domainDetection.classification !== "react-native") return undefined;
+
+  const forbiddenSignal =
+    RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS.find((signal) => hasSignal(domainDetection, signal)) ??
+    RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.find((prefix) => hasAnySignalWithPrefix(domainDetection, prefix));
+  if (forbiddenSignal) {
+    return {
+      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+      allowed: false,
+      reason: `forbidden-signal:${forbiddenSignal}`,
+    };
+  }
+
+  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
+  if (missingSignal) {
+    return {
+      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+      allowed: false,
+      reason: `missing-signal:${missingSignal}`,
+    };
+  }
+
+  return { name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY, allowed: true };
+}

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -1,0 +1,105 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const {
+  assessReactNativePayloadPolicy,
+  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+} = require(path.join(repoRoot, "dist", "core", "payload-policy", "react-native.js"));
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+
+const forbiddenSupportClaims = /React Native support is available|React Native is supported today|React Native support will ship|broad React Native support|default React Native compact extraction is enabled/i;
+
+function detect(source, filePath = "Native.tsx") {
+  return detectDomainFromSource(source, filePath);
+}
+
+function rnPrimitiveInputSource(extraJsx = "") {
+  return `import { View, Text, TextInput, Pressable } from "react-native";
+    export function NativeInput() {
+      return <View><Text>Email</Text><TextInput value="" onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable>${extraJsx}</View>;
+    }`;
+}
+
+test("React Native payload policy allows the measured primitive/input signal set only", () => {
+  const domainDetection = detect(rnPrimitiveInputSource(), "NativeInput.tsx");
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.deepEqual(assessReactNativePayloadPolicy(domainDetection), {
+    name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    allowed: true,
+  });
+});
+
+test("React Native payload policy denies missing required primitive/input signals with stable reasons", () => {
+  const domainDetection = detect(
+    `import { View, Text, TextInput } from "react-native";
+     export function IncompleteNativeInput() {
+       return <View><Text>Email</Text><TextInput value="" onChangeText={() => null} /></View>;
+     }`,
+    "IncompleteNativeInput.tsx",
+  );
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.deepEqual(assessReactNativePayloadPolicy(domainDetection), {
+    name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    allowed: false,
+    reason: "missing-signal:react-native:primitive:Pressable",
+  });
+});
+
+test("React Native payload policy denies richer RN signals before allowing the narrow gate", () => {
+  const domainDetection = detect(
+    `import { View, Text, TextInput, Pressable, FlatList } from "react-native";
+     export function NativeList() {
+       return <View><Text>Email</Text><TextInput value="" onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable><FlatList data={[]} renderItem={() => <Text>Item</Text>} /></View>;
+     }`,
+    "NativeList.tsx",
+  );
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.deepEqual(assessReactNativePayloadPolicy(domainDetection), {
+    name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    allowed: false,
+    reason: "forbidden-signal:react-native:primitive:FlatList",
+  });
+});
+
+test("React Native payload policy does not authorize non-RN domains", () => {
+  const samples = [
+    detect(`export function Form() { return <form><input name="email" /></form>; }`, "Form.tsx"),
+    detect(`import { WebView } from "react-native-webview"; export function Preview() { return <WebView source={{ uri: "https://example.com" }} />; }`, "Preview.tsx"),
+    detect(`import { Box } from "ink"; export function Cli() { return <Box />; }`, "Cli.tsx"),
+    detect(`import { View } from "react-native"; export function Mixed() { return <div><View /></div>; }`, "Mixed.tsx"),
+    detect(`export const answer = 42;`, "utility.ts"),
+  ];
+
+  for (const domainDetection of samples) {
+    assert.equal(
+      assessReactNativePayloadPolicy(domainDetection),
+      undefined,
+      `${domainDetection.classification}:${domainDetection.reason ?? "no-reason"} must not get RN narrow policy`,
+    );
+  }
+});
+
+test("pre-read compatibility entrypoint delegates RN primitive/input decisions to the policy seam", () => {
+  const domainDetection = detect(rnPrimitiveInputSource(), "NativeInput.tsx");
+
+  assert.deepEqual(preRead.assessFrontendPayloadPolicy(domainDetection), assessReactNativePayloadPolicy(domainDetection));
+  assert.equal(preRead.RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+});
+
+test("React Native policy seam source avoids broad React Native support claims", () => {
+  for (const relativePath of [path.join("src", "core", "payload-policy", "react-native.ts")]) {
+    assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
+  }
+});


### PR DESCRIPTION
## Summary
- Extract the existing RN primitive/input narrow payload policy into `src/core/payload-policy/react-native.ts`.
- Keep `pre-read.ts` as the central policy router while preserving compatibility exports and exact policy reasons.
- Add focused RN policy seam tests for allowed primitive/input behavior, missing required signal denial, richer RN denial, non-RN denial, delegation compatibility, and claim-boundary wording.

## Scope boundary
- No broad React Native support.
- No RN payload promotion beyond the existing measured primitive/input gate.
- No WebView/TUI behavior changes.
- No detector/profile/runtime payload shape changes.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/claim-boundary/fooks tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
