### PR TITLE
Separate TUI evidence-only payload policy seam

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -13,6 +13,10 @@ import {
   assessReactNativePayloadPolicy,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
 } from "../core/payload-policy/react-native";
+import {
+  assessTuiInkPayloadPolicy,
+  TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
+} from "../core/payload-policy/tui-ink";
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
 import { assessWebViewPayloadPolicy, WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
 import type { PreReadDecision } from "../core/schema";
@@ -24,6 +28,7 @@ export {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+  TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
   WEBVIEW_BOUNDARY_FALLBACK_POLICY,
 };
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
@@ -80,6 +85,9 @@ export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResu
 
   const webViewPolicy = assessWebViewPayloadPolicy(domainDetection);
   if (webViewPolicy) return webViewPolicy;
+
+  const tuiInkPolicy = assessTuiInkPayloadPolicy(domainDetection);
+  if (tuiInkPolicy) return tuiInkPolicy;
 
   return assessReactNativePayloadPolicy(domainDetection);
 }

--- a/src/core/payload-policy/tui-ink.ts
+++ b/src/core/payload-policy/tui-ink.ts
@@ -1,0 +1,20 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import type { FrontendPayloadPolicyDecision } from "./types";
+
+export const TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY = "tui-ink-evidence-only-payload";
+export const TUI_INK_EVIDENCE_ONLY_REASON = "tui-ink-evidence-only";
+
+function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: string): boolean {
+  return domainDetection.signals.some((signal) => signal.startsWith(prefix));
+}
+
+export function assessTuiInkPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
+  if (domainDetection.classification !== "tui-ink") return undefined;
+  if (!hasAnySignalWithPrefix(domainDetection, "tui-ink:")) return undefined;
+
+  return {
+    name: TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
+    allowed: false,
+    reason: TUI_INK_EVIDENCE_ONLY_REASON,
+  };
+}

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const {
+  assessTuiInkPayloadPolicy,
+  TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
+  TUI_INK_EVIDENCE_ONLY_REASON,
+} = require(path.join(repoRoot, "dist", "core", "payload-policy", "tui-ink.js"));
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+
+const forbiddenSupportClaims = /TUI support is available|TUI is supported today|TUI\/Ink is supported today|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|TUI performance improvement is available|default TUI compact extraction is enabled/i;
+
+function detect(source, filePath = "Cli.tsx") {
+  return detectDomainFromSource(source, filePath);
+}
+
+function tuiInkSource() {
+  return `import React from "react";
+    import { Box, Text, useInput } from "ink";
+    export function Cli() {
+      useInput(() => null);
+      return <Box><Text>Ready</Text></Box>;
+    }`;
+}
+
+function expectedTuiEvidenceOnlyPolicy() {
+  return {
+    name: TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
+    allowed: false,
+    reason: TUI_INK_EVIDENCE_ONLY_REASON,
+  };
+}
+
+test("TUI/Ink payload policy returns evidence-only denied decision for Ink evidence", () => {
+  const domainDetection = detect(tuiInkSource(), "Cli.tsx");
+
+  assert.equal(domainDetection.classification, "tui-ink");
+  assert.equal(domainDetection.profile.claimStatus, "evidence-only");
+  assert.ok(domainDetection.signals.some((signal) => signal.startsWith("tui-ink:")));
+  assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), expectedTuiEvidenceOnlyPolicy());
+});
+
+test("TUI/Ink payload policy does not authorize non-TUI domains", () => {
+  const samples = [
+    detect(`export function Form() { return <form><input name="email" /></form>; }`, "Form.tsx"),
+    detect(`import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`, "Native.tsx"),
+    detect(`import { WebView } from "react-native-webview"; export function Preview() { return <WebView source={{ uri: "https://example.com" }} />; }`, "Preview.tsx"),
+    detect(`import { Box } from "ink"; import { View } from "react-native"; export function Mixed() { return <Box><View /></Box>; }`, "Mixed.tsx"),
+    detect(`export const answer = 42;`, "utility.ts"),
+  ];
+
+  for (const domainDetection of samples) {
+    assert.equal(
+      assessTuiInkPayloadPolicy(domainDetection),
+      undefined,
+      `${domainDetection.classification}:${domainDetection.reason ?? "no-reason"} must not get TUI/Ink policy`,
+    );
+  }
+});
+
+test("pre-read compatibility entrypoint delegates TUI/Ink decisions to the policy seam", () => {
+  const domainDetection = detect(tuiInkSource(), "Cli.tsx");
+
+  assert.deepEqual(preRead.assessFrontendPayloadPolicy(domainDetection), assessTuiInkPayloadPolicy(domainDetection));
+  assert.equal(preRead.TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY, TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY);
+});
+
+test("TUI/Ink pre-read stays fallback-only even with an explicit denied policy", () => {
+  const fixturePath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "tui-ink-basic.tsx");
+  const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
+
+  assert.equal(decision.eligible, true);
+  assert.equal(decision.decision, "fallback");
+  assert.deepEqual(decision.reasons, [preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON]);
+  assert.equal(decision.fallback.reason, preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+  assert.equal(decision.debug.domainDetection.classification, "tui-ink");
+  assert.deepEqual(decision.debug.frontendPayloadPolicy, expectedTuiEvidenceOnlyPolicy());
+  assert.equal("payload" in decision, false);
+});
+
+test("TUI/Ink policy seam source avoids broad terminal support claims", () => {
+  for (const relativePath of [path.join("src", "core", "payload-policy", "tui-ink.ts")]) {
+    assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
+  }
+});


### PR DESCRIPTION
## Summary
- Add `src/core/payload-policy/tui-ink.ts` as the explicit TUI/Ink evidence-only payload-policy seam.
- Route `pre-read.ts` through the new seam while preserving fallback-only behavior.
- Add focused TUI/Ink policy tests for denied evidence, non-TUI denial, pre-read delegation, fallback behavior, and support-claim boundaries.

## Scope boundary
- No TUI/Ink compact extraction.
- No terminal correctness, UX safety, token-savings, or support claim expansion.
- No detector/profile/runtime payload shape changes.
- No RN/WebView behavior changes.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/claim-boundary/fooks tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
