### PR TITLE
Route frontend payload policy through a core registry

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -5,31 +5,25 @@ import { detectDomainFromSource, type DomainDetectionResult } from "../core/doma
 import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/payload/model-facing";
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import {
-  assessFallbackPayloadPolicy,
   MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
   UNKNOWN_FRONTEND_DEFERRED_PAYLOAD_POLICY,
   UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
 } from "../core/payload-policy/fallback";
+import { assessFrontendPayloadPolicy } from "../core/payload-policy/registry";
 import {
-  assessReactWebPayloadPolicy,
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
 } from "../core/payload-policy/react-web";
-import {
-  assessReactNativePayloadPolicy,
-  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
-} from "../core/payload-policy/react-native";
-import {
-  assessTuiInkPayloadPolicy,
-  TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
-} from "../core/payload-policy/tui-ink";
+import { RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY } from "../core/payload-policy/react-native";
+import { TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY } from "../core/payload-policy/tui-ink";
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
-import { assessWebViewPayloadPolicy, WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
+import { WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
 import type { PreReadDecision } from "../core/schema";
 
 const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+export { assessFrontendPayloadPolicy } from "../core/payload-policy/registry";
 export {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
@@ -85,22 +79,6 @@ function frontendDebug(
     domainDetection,
     ...(frontendPayloadPolicy ? { frontendPayloadPolicy } : {}),
   };
-}
-
-export function assessFrontendPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
-  const reactWebPolicy = assessReactWebPayloadPolicy(domainDetection);
-  if (reactWebPolicy) return reactWebPolicy;
-
-  const webViewPolicy = assessWebViewPayloadPolicy(domainDetection);
-  if (webViewPolicy) return webViewPolicy;
-
-  const tuiInkPolicy = assessTuiInkPayloadPolicy(domainDetection);
-  if (tuiInkPolicy) return tuiInkPolicy;
-
-  const reactNativePolicy = assessReactNativePayloadPolicy(domainDetection);
-  if (reactNativePolicy) return reactNativePolicy;
-
-  return assessFallbackPayloadPolicy(domainDetection);
 }
 
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {

--- a/src/core/payload-policy/registry.ts
+++ b/src/core/payload-policy/registry.ts
@@ -1,0 +1,36 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import { assessFallbackPayloadPolicy } from "./fallback";
+import { assessReactNativePayloadPolicy } from "./react-native";
+import { assessReactWebPayloadPolicy } from "./react-web";
+import { assessTuiInkPayloadPolicy } from "./tui-ink";
+import type { FrontendPayloadPolicyDecision } from "./types";
+import { assessWebViewPayloadPolicy } from "./webview";
+
+export type FrontendPayloadPolicyAssessor = (
+  domainDetection: DomainDetectionResult,
+) => FrontendPayloadPolicyDecision | undefined;
+
+export type FrontendPayloadPolicyRegistryEntry = {
+  name: string;
+  lane: "react-web" | "webview" | "tui-ink" | "react-native" | "fallback";
+  assess: FrontendPayloadPolicyAssessor;
+};
+
+export const FRONTEND_PAYLOAD_POLICY_REGISTRY: readonly FrontendPayloadPolicyRegistryEntry[] = [
+  { name: "react-web-current-supported", lane: "react-web", assess: assessReactWebPayloadPolicy },
+  { name: "webview-boundary", lane: "webview", assess: assessWebViewPayloadPolicy },
+  { name: "tui-ink-evidence-only", lane: "tui-ink", assess: assessTuiInkPayloadPolicy },
+  { name: "react-native-primitive-input", lane: "react-native", assess: assessReactNativePayloadPolicy },
+  { name: "mixed-unknown-fallback", lane: "fallback", assess: assessFallbackPayloadPolicy },
+] as const;
+
+export function assessFrontendPayloadPolicy(
+  domainDetection: DomainDetectionResult,
+): FrontendPayloadPolicyDecision | undefined {
+  for (const entry of FRONTEND_PAYLOAD_POLICY_REGISTRY) {
+    const decision = entry.assess(domainDetection);
+    if (decision) return decision;
+  }
+
+  return undefined;
+}

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -1,0 +1,85 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const registry = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
+const { assessReactWebPayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "react-web.js"));
+const { assessWebViewPayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "webview.js"));
+const { assessTuiInkPayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "tui-ink.js"));
+const { assessReactNativePayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "react-native.js"));
+const { assessFallbackPayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+
+const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|mixed frontend support is available|unknown frontend support is available|terminal correctness is guaranteed|bridge safety is guaranteed|default WebView compact extraction is enabled|default TUI compact extraction is enabled/i;
+
+function detect(source, filePath = "Component.tsx") {
+  return detectDomainFromSource(source, filePath);
+}
+
+const samples = {
+  "react-web": detect(`export function Form() { return <form><input name="email" /></form>; }`, "Form.tsx"),
+  webview: detect(`import { WebView } from "react-native-webview"; export function Preview() { return <WebView source={{ uri: "https://example.com" }} />; }`, "Preview.tsx"),
+  "tui-ink": detect(`import { Box } from "ink"; export function Cli() { return <Box />; }`, "Cli.tsx"),
+  "react-native": detect(`import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`, "Native.tsx"),
+  mixed: detect(`import { Box, Text } from "ink"; export function MixedCliWeb() { return <div><Box><Text>Ready</Text></Box></div>; }`, "MixedCliWeb.tsx"),
+  unknown: detect(`export function PlainUnknown() { return null; }`, "PlainUnknown.tsx"),
+};
+
+test("frontend payload policy registry preserves explicit policy precedence", () => {
+  assert.deepEqual(
+    registry.FRONTEND_PAYLOAD_POLICY_REGISTRY.map((entry) => entry.lane),
+    ["react-web", "webview", "tui-ink", "react-native", "fallback"],
+  );
+
+  assert.deepEqual(
+    registry.FRONTEND_PAYLOAD_POLICY_REGISTRY.map((entry) => typeof entry.assess),
+    ["function", "function", "function", "function", "function"],
+  );
+});
+
+test("frontend payload policy registry returns the same decisions as lane-owned seams", () => {
+  const expectedByLane = {
+    "react-web": assessReactWebPayloadPolicy(samples["react-web"]),
+    webview: assessWebViewPayloadPolicy(samples.webview),
+    "tui-ink": assessTuiInkPayloadPolicy(samples["tui-ink"]),
+    "react-native": assessReactNativePayloadPolicy(samples["react-native"]),
+    mixed: assessFallbackPayloadPolicy(samples.mixed),
+    unknown: assessFallbackPayloadPolicy(samples.unknown),
+  };
+
+  for (const [lane, domainDetection] of Object.entries(samples)) {
+    assert.deepEqual(registry.assessFrontendPayloadPolicy(domainDetection), expectedByLane[lane], lane);
+  }
+});
+
+test("pre-read compatibility entrypoint uses the core policy registry", () => {
+  for (const [lane, domainDetection] of Object.entries(samples)) {
+    assert.deepEqual(preRead.assessFrontendPayloadPolicy(domainDetection), registry.assessFrontendPayloadPolicy(domainDetection), lane);
+  }
+});
+
+test("pre-read adapter no longer owns hardcoded policy assessment order", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+
+  assert.match(source, /import \{ assessFrontendPayloadPolicy \} from "\.\.\/core\/payload-policy\/registry"/);
+  assert.doesNotMatch(source, /assessReactWebPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(source, /assessWebViewPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(source, /assessTuiInkPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(source, /assessReactNativePayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(source, /assessFallbackPayloadPolicy\(domainDetection\)/);
+});
+
+test("payload policy registry source avoids broad support claims", () => {
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(repoRoot, "src", "core", "payload-policy", "registry.ts"), "utf8"),
+    forbiddenSupportClaims,
+  );
+});


### PR DESCRIPTION
## Summary
- Add `src/core/payload-policy/registry.ts` as the ordered frontend payload-policy router.
- Thin `pre-read.ts` by delegating policy assessment to the core registry while preserving compatibility exports.
- Add focused registry tests for precedence, lane-owned decision parity, pre-read compatibility, and support-claim boundaries.

## Scope boundary
- No support claim expansion.
- No detector/profile/runtime payload shape changes.
- No maturity promotion for RN/WebView/TUI/mixed/unknown.
- Existing policy precedence preserved: React Web -> WebView -> TUI/Ink -> React Native -> fallback.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/fooks tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`

## Note
- One full `npm test` run had a transient failure in `test/layer2-applied-validation.test.mjs`; the isolated test passed immediately, and the subsequent full `npm test` passed with 373/373 tests.
