### PR TITLE
Derive domain payload build options from policy routing

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -9,7 +9,7 @@ import {
   UNKNOWN_FRONTEND_DEFERRED_PAYLOAD_POLICY,
   UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
 } from "../core/payload-policy/fallback";
-import { assessFrontendPayloadPolicy } from "../core/payload-policy/registry";
+import { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 import {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
@@ -23,7 +23,7 @@ import type { PreReadDecision } from "../core/schema";
 const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
-export { assessFrontendPayloadPolicy } from "../core/payload-policy/registry";
+export { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 export {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
@@ -149,10 +149,10 @@ export function decidePreRead(
   }
 
   const result = extractFile(resolvedPath);
+  const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
   const payload = toModelFacingPayload(result, cwd, {
     includeEditGuidance: options.includeEditGuidance === true,
-    includeDomainPayload: frontendPayloadPolicy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
-    domainPayloadPolicy: frontendPayloadPolicy?.name,
+    ...payloadBuildOptions,
   });
   const readiness = assessPayloadReadiness(result, payload);
   const debug = {

--- a/src/core/payload-policy/registry.ts
+++ b/src/core/payload-policy/registry.ts
@@ -1,7 +1,7 @@
 import type { DomainDetectionResult } from "../domain-detector";
 import { assessFallbackPayloadPolicy } from "./fallback";
 import { assessReactNativePayloadPolicy } from "./react-native";
-import { assessReactWebPayloadPolicy } from "./react-web";
+import { assessReactWebPayloadPolicy, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY } from "./react-web";
 import { assessTuiInkPayloadPolicy } from "./tui-ink";
 import type { FrontendPayloadPolicyDecision } from "./types";
 import { assessWebViewPayloadPolicy } from "./webview";
@@ -9,6 +9,11 @@ import { assessWebViewPayloadPolicy } from "./webview";
 export type FrontendPayloadPolicyAssessor = (
   domainDetection: DomainDetectionResult,
 ) => FrontendPayloadPolicyDecision | undefined;
+
+export type FrontendPayloadBuildOptions = {
+  includeDomainPayload: boolean;
+  domainPayloadPolicy?: string;
+};
 
 export type FrontendPayloadPolicyRegistryEntry = {
   name: string;
@@ -33,4 +38,13 @@ export function assessFrontendPayloadPolicy(
   }
 
   return undefined;
+}
+
+export function toFrontendPayloadBuildOptions(
+  policy: FrontendPayloadPolicyDecision | undefined,
+): FrontendPayloadBuildOptions {
+  return {
+    includeDomainPayload: policy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+    ...(policy?.name ? { domainPayloadPolicy: policy.name } : {}),
+  };
 }

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -66,15 +66,37 @@ test("pre-read compatibility entrypoint uses the core policy registry", () => {
   }
 });
 
+test("frontend payload build options include domain payload only for React Web policy", () => {
+  const reactWebPolicy = registry.assessFrontendPayloadPolicy(samples["react-web"]);
+
+  assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactWebPolicy), {
+    includeDomainPayload: true,
+    domainPayloadPolicy: reactWebPolicy.name,
+  });
+
+  for (const lane of ["webview", "tui-ink", "react-native", "mixed", "unknown"]) {
+    const policy = registry.assessFrontendPayloadPolicy(samples[lane]);
+    assert.deepEqual(
+      registry.toFrontendPayloadBuildOptions(policy),
+      { includeDomainPayload: false, domainPayloadPolicy: policy.name },
+      lane,
+    );
+  }
+
+  assert.deepEqual(registry.toFrontendPayloadBuildOptions(undefined), { includeDomainPayload: false });
+});
+
 test("pre-read adapter no longer owns hardcoded policy assessment order", () => {
   const source = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
 
-  assert.match(source, /import \{ assessFrontendPayloadPolicy \} from "\.\.\/core\/payload-policy\/registry"/);
+  assert.match(source, /import \{ assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions \} from "\.\.\/core\/payload-policy\/registry"/);
   assert.doesNotMatch(source, /assessReactWebPayloadPolicy\(domainDetection\)/);
   assert.doesNotMatch(source, /assessWebViewPayloadPolicy\(domainDetection\)/);
   assert.doesNotMatch(source, /assessTuiInkPayloadPolicy\(domainDetection\)/);
   assert.doesNotMatch(source, /assessReactNativePayloadPolicy\(domainDetection\)/);
   assert.doesNotMatch(source, /assessFallbackPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(source, /includeDomainPayload:\s*frontendPayloadPolicy\?\.name ===/);
+  assert.match(source, /toFrontendPayloadBuildOptions\(frontendPayloadPolicy\)/);
 });
 
 test("payload policy registry source avoids broad support claims", () => {


### PR DESCRIPTION
## Summary
- Add `toFrontendPayloadBuildOptions()` to the payload-policy registry seam.
- Replace `pre-read.ts` inline `includeDomainPayload` policy-name comparison with policy-derived build options.
- Extend registry tests to lock React Web-only domainPayload inclusion and non-Web exclusion.

## Scope boundary
- No domainPayload support expansion beyond the current React Web policy.
- No detector/profile/runtime payload shape changes.
- No maturity promotion for RN/WebView/TUI/mixed/unknown.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/fooks tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`

## Note
- One full `npm test` attempt hit the known transient `layer2-applied-validation` Codex wrapper assertion; isolated rerun passed and the subsequent full `npm test` passed with 374/374 tests.
