### PR TITLE
Move frontend profile reuse gating into payload policy

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -9,6 +9,7 @@ import {
   UNKNOWN_FRONTEND_DEFERRED_PAYLOAD_POLICY,
   UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
 } from "../core/payload-policy/fallback";
+import { assessFrontendProfilePayloadReuse } from "../core/payload-policy/profile-gate";
 import { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 import {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
@@ -22,7 +23,6 @@ import type { PreReadDecision } from "../core/schema";
 
 const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
-const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 export {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
@@ -46,29 +46,6 @@ function eligibleExtensions(runtime: PreReadDecision["runtime"]): ReadonlySet<st
 function relativePath(filePath: string, cwd: string): string {
   const relative = path.relative(cwd, filePath);
   return relative || path.basename(filePath);
-}
-
-function assessFrontendProfilePayloadReuse(
-  extension: string,
-  domainDetection: DomainDetectionResult,
-  payload: ReturnType<typeof toModelFacingPayload>,
-  frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
-): { allowed: true } | { allowed: false; reason: string } {
-  if (!FRONTEND_PROFILE_GATE_EXTENSIONS.has(extension)) {
-    return { allowed: true };
-  }
-
-  if (domainDetection.profile.lane === "react-web" && domainDetection.profile.claimStatus === "current-supported-lane") {
-    return payload.domainPayload?.domain === "react-web" && payload.domainPayload.plannerDecision === "compact-safe"
-      ? { allowed: true }
-      : { allowed: false, reason: "missing-react-web-domain-payload" };
-  }
-
-  if (frontendPayloadPolicy?.allowed === true) {
-    return { allowed: true };
-  }
-
-  return { allowed: false, reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON };
 }
 
 function frontendDebug(

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -1,0 +1,32 @@
+import type { DomainDetectionResult } from "../domain-detector";
+import type { ModelFacingPayload } from "../schema";
+import { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } from "./fallback";
+import type { FrontendPayloadPolicyDecision } from "./types";
+
+const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
+export const MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON = "missing-react-web-domain-payload";
+
+export type FrontendProfilePayloadReuseDecision = { allowed: true } | { allowed: false; reason: string };
+
+export function assessFrontendProfilePayloadReuse(
+  extension: string,
+  domainDetection: DomainDetectionResult,
+  payload: ModelFacingPayload,
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
+): FrontendProfilePayloadReuseDecision {
+  if (!FRONTEND_PROFILE_GATE_EXTENSIONS.has(extension)) {
+    return { allowed: true };
+  }
+
+  if (domainDetection.profile.lane === "react-web" && domainDetection.profile.claimStatus === "current-supported-lane") {
+    return payload.domainPayload?.domain === "react-web" && payload.domainPayload.plannerDecision === "compact-safe"
+      ? { allowed: true }
+      : { allowed: false, reason: MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON };
+  }
+
+  if (frontendPayloadPolicy?.allowed === true) {
+    return { allowed: true };
+  }
+
+  return { allowed: false, reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON };
+}

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -1,0 +1,87 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
+const {
+  assessFrontendProfilePayloadReuse,
+  MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON,
+} = require(path.join(repoRoot, "dist", "core", "payload-policy", "profile-gate.js"));
+const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
+const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
+const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+
+function payloadForSource(source, fileName, options = {}) {
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-profile-gate-"));
+  try {
+    const filePath = path.join(tempDir, fileName);
+    fs.writeFileSync(filePath, source);
+    const domainDetection = detectDomainFromSource(source, filePath);
+    const policy = assessFrontendPayloadPolicy(domainDetection);
+    const payload = toModelFacingPayload(extractFile(filePath), tempDir, {
+      includeEditGuidance: false,
+      ...toFrontendPayloadBuildOptions(policy),
+      ...options,
+    });
+    return { domainDetection, policy, payload };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("frontend profile gate bypasses non-frontend-profile extensions", () => {
+  const source = `export function double(value: number): number { return value * 2; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "math.ts");
+
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".ts", domainDetection, payload, policy), { allowed: true });
+});
+
+test("frontend profile gate requires React Web domain payload for current React Web lane", () => {
+  const source = `export function Form() { return <form><input name="email" /></form>; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Form.tsx");
+  const withoutDomainPayload = { ...payload };
+  delete withoutDomainPayload.domainPayload;
+
+  assert.equal(domainDetection.classification, "react-web");
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutDomainPayload, policy), {
+    allowed: false,
+    reason: MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON,
+  });
+});
+
+test("frontend profile gate allows narrow allowed non-web frontend policies", () => {
+  const source = `import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Native.tsx");
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.equal(policy.allowed, true);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+});
+
+test("frontend profile gate denies unsupported frontend profile reuse", () => {
+  const source = `import { Box } from "ink"; export function Cli() { return <Box />; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Cli.tsx");
+
+  assert.equal(domainDetection.classification, "tui-ink");
+  assert.equal(policy.allowed, false);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), {
+    allowed: false,
+    reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  });
+});
+
+test("pre-read adapter delegates frontend profile reuse gate to payload-policy seam", () => {
+  assert.match(preReadSource, /import \{ assessFrontendProfilePayloadReuse \} from "\.\.\/core\/payload-policy\/profile-gate"/);
+  assert.doesNotMatch(preReadSource, /function assessFrontendProfilePayloadReuse\(/);
+  assert.doesNotMatch(preReadSource, /FRONTEND_PROFILE_GATE_EXTENSIONS/);
+});


### PR DESCRIPTION
## Summary
- Add `src/core/payload-policy/profile-gate.ts` as the frontend profile payload reuse gate seam.
- Thin `pre-read.ts` by delegating post-readiness profile reuse checks to the payload-policy layer.
- Add focused profile-gate tests for non-frontend bypass, React Web domainPayload consistency, RN narrow allowed reuse, unsupported profile denial, and adapter delegation.

## Scope boundary
- No support claim expansion.
- No detector/profile/runtime payload shape changes.
- No domain maturity promotion.
- Existing payload/fallback outcomes preserved.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- targeted payload/domain/runtime/fooks tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`

## Note
- Full local verification passed with 379 tests in `npm test`.
