### PR TITLE
Tighten CI success burst triage

### DIFF
--- a/docs/ci-alert-triage.md
+++ b/docs/ci-alert-triage.md
@@ -6,9 +6,12 @@ triage report.
 
 For clawhip bursts that replay many historical green CI URLs after a merge,
 compact mode keeps the current `main` head run visible and records the stale
-historical replay count in `alertSummary.staleReplayCount`. The omitted-count
-maps (`byEvidence`, `byConclusion`) provide evidence that the collapsed rows
-were stale successes rather than new failures.
+historical replay count in `alertSummary.staleReplayCount`. It also reports
+`alertSummary.actionableAlertCount` and `alertSummary.staleSuccessReplayCount`
+so all-green bursts can show zero evidence needing inspection while still
+counting the omitted historical successes. The omitted-count maps (`byEvidence`,
+`byConclusion`) provide evidence that the collapsed rows were stale successes
+rather than new failures.
 
 When the pasted alert is the current completed `main` CI success (for example a
 `git:fooks@main` notice followed by `CI passed · fooks` for the same head run),

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -251,7 +251,10 @@ function alertSummaryFields(allEvidence, focusBranch) {
     currentHeadCount: currentHeadRunIds.length,
     currentHeadRunIds,
     currentMainEchoCount: allEvidence.filter((alert) => alert.echo).length,
+    verificationOnlyCount: allEvidence.filter((alert) => alert.disposition === "verification-only").length,
+    actionableAlertCount: allEvidence.filter((alert) => alert.disposition === "inspect").length,
     staleReplayCount: allEvidence.filter((alert) => alert.replay).length,
+    staleSuccessReplayCount: allEvidence.filter((alert) => alert.replay && alert.conclusion === "success").length,
   };
 }
 
@@ -450,6 +453,9 @@ Use this report to collapse replayed GitHub Actions alert buffers: inspect only 
 - Pasted alert URLs inspected: ${result.alertSummary?.total ?? result.alerts?.length ?? 0}
 - Pasted alert evidence shown: ${result.alertSummary?.shown ?? result.alerts?.length ?? 0}
 - Pasted alert evidence omitted: ${result.alertSummary?.omitted ?? 0}
+- Pasted alert evidence needing inspection: ${result.alertSummary?.actionableAlertCount ?? 0}
+- Verification-only current-main echoes: ${result.alertSummary?.verificationOnlyCount ?? 0}
+- Stale success replay evidence: ${result.alertSummary?.staleSuccessReplayCount ?? 0}
 
 ${alertEvidenceTable(result.alerts, result.alertSummary)}## Actionable / watch
 

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -549,9 +549,14 @@ test("CI alert triage collapses success-heavy clawhip bursts to current head plu
     assert.equal(result.alertSummary.omitted, 20);
     assert.equal(result.alertSummary.currentHeadCount, 1);
     assert.deepEqual(result.alertSummary.currentHeadRunIds, ["700"]);
+    assert.equal(result.alertSummary.actionableAlertCount, 0);
+    assert.equal(result.alertSummary.verificationOnlyCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 20);
+    assert.equal(result.alertSummary.staleSuccessReplayCount, 20);
     assert.equal(result.alertSummary.byEvidence.stale, 20);
     assert.equal(result.alertSummary.byConclusion.success, 20);
+    assert.equal(result.counts.actionable ?? 0, 0);
+    assert.equal(result.counts.watch ?? 0, 0);
     assert.equal(result.alerts.length, 1);
     assert.equal(result.alerts[0].alertedRunId, "700");
     assert.equal(result.alerts[0].evidence, "current");


### PR DESCRIPTION
## Summary
- add explicit pasted-alert summary counters for evidence needing inspection, verification-only echoes, and stale success replays
- tighten the success-heavy clawhip burst regression so all-green historical replay produces zero actionable/watch evidence while keeping only the current main echo
- document the new CI alert triage counters for green replay bursts

## Tests
- `node --test test/ci-alert-triage.test.mjs`
- `npm run build`

Closes #367

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
