### PR TITLE
Centralize pre-read fallback decision construction

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -48,6 +48,32 @@ function relativePath(filePath: string, cwd: string): string {
   return relative || path.basename(filePath);
 }
 
+type PreReadFallbackDecisionInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  eligible: boolean;
+  reasons: string[];
+  readiness?: PreReadDecision["readiness"];
+  debug?: PreReadDecision["debug"];
+  fallbackReason?: string;
+};
+
+function buildPreReadFallbackDecision(input: PreReadFallbackDecisionInput): PreReadDecision {
+  return {
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: input.eligible,
+    decision: "fallback",
+    reasons: input.reasons,
+    ...(input.readiness ? { readiness: input.readiness } : {}),
+    debug: input.debug ?? {},
+    fallback: {
+      action: "full-read",
+      reason: input.fallbackReason ?? input.reasons[0] ?? "missing-structure",
+    },
+  };
+}
+
 function frontendDebug(
   domainDetection: DomainDetectionResult,
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
@@ -74,18 +100,12 @@ export function decidePreRead(
   const extension = path.extname(resolvedPath).toLowerCase();
 
   if (!eligibleExtensions(runtime).has(extension)) {
-    return {
+    return buildPreReadFallbackDecision({
       runtime,
       filePath: outputPath,
       eligible: false,
-      decision: "fallback",
       reasons: ["ineligible-extension"],
-      debug: {},
-      fallback: {
-        action: "full-read",
-        reason: "ineligible-extension",
-      },
-    };
+    });
   }
 
   const sourceText = fs.readFileSync(resolvedPath, "utf8");
@@ -96,33 +116,23 @@ export function decidePreRead(
     domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
     domainDetection.classification !== "react-native"
   ) {
-    return {
+    return buildPreReadFallbackDecision({
       runtime,
       filePath: outputPath,
       eligible: true,
-      decision: "fallback",
       reasons: [REACT_NATIVE_WEBVIEW_BOUNDARY_REASON],
       debug: frontendDebug(domainDetection, frontendPayloadPolicy),
-      fallback: {
-        action: "full-read",
-        reason: REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
-      },
-    };
+    });
   }
 
   if (domainDetection.classification === "react-native" && frontendPayloadPolicy?.allowed !== true) {
-    return {
+    return buildPreReadFallbackDecision({
       runtime,
       filePath: outputPath,
       eligible: true,
-      decision: "fallback",
       reasons: [UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON],
       debug: frontendDebug(domainDetection, frontendPayloadPolicy),
-      fallback: {
-        action: "full-read",
-        reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
-      },
-    };
+    });
   }
 
   const result = extractFile(resolvedPath);
@@ -157,32 +167,22 @@ export function decidePreRead(
       };
     }
 
-    return {
+    return buildPreReadFallbackDecision({
       runtime,
       filePath: outputPath,
       eligible: true,
-      decision: "fallback",
       reasons: [profileGate.reason],
       readiness,
       debug,
-      fallback: {
-        action: "full-read",
-        reason: profileGate.reason,
-      },
-    };
+    });
   }
 
-  return {
+  return buildPreReadFallbackDecision({
     runtime,
     filePath: outputPath,
     eligible: true,
-    decision: "fallback",
     reasons: readiness.reasons,
     readiness,
     debug,
-    fallback: {
-      action: "full-read",
-      reason: readiness.reasons[0] ?? "missing-structure",
-    },
-  };
+  });
 }

--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -1,0 +1,37 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+
+test("pre-read centralizes full-read fallback envelope construction", () => {
+  assert.match(preReadSource, /function buildPreReadFallbackDecision\(/);
+  const fallbackEnvelopeConstructions = preReadSource.match(/fallback:\s*{\s*\n\s*action:\s*"full-read"/g) ?? [];
+  assert.equal(fallbackEnvelopeConstructions.length, 1);
+  assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "fallback",[\s\S]*?fallback: \{\s*\n\s*action: "full-read"/);
+});
+
+test("pre-read fallback builder preserves ineligible extension decisions", () => {
+  const decision = preRead.decidePreRead(path.join(repoRoot, "not-a-source.md"), repoRoot, "codex");
+
+  assert.deepEqual(decision, {
+    runtime: "codex",
+    filePath: "not-a-source.md",
+    eligible: false,
+    decision: "fallback",
+    reasons: ["ineligible-extension"],
+    debug: {},
+    fallback: {
+      action: "full-read",
+      reason: "ineligible-extension",
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- Add a local `buildPreReadFallbackDecision` seam inside `pre-read.ts`.
- Replace repeated full-read fallback return envelopes with the helper while preserving branch-owned reasons, eligibility, readiness, and debug data.
- Add focused regression coverage that keeps fallback envelope construction centralized and verifies the ineligible-extension fallback shape.

## Scope boundary
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No runtime payload shape changes for payload decisions.
- Fallback reasons and existing branch behavior preserved.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/payload-policy/runtime tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
