### PR TITLE
Centralize pre-read payload decision construction

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -74,6 +74,27 @@ function buildPreReadFallbackDecision(input: PreReadFallbackDecisionInput): PreR
   };
 }
 
+type PreReadPayloadDecisionInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: PreReadDecision["debug"];
+};
+
+function buildPreReadPayloadDecision(input: PreReadPayloadDecisionInput): PreReadDecision {
+  return {
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: true,
+    decision: "payload",
+    reasons: [],
+    payload: input.payload,
+    readiness: input.readiness,
+    debug: input.debug,
+  };
+}
+
 function frontendDebug(
   domainDetection: DomainDetectionResult,
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
@@ -155,16 +176,13 @@ export function decidePreRead(
   if (readiness.ready) {
     const profileGate = assessFrontendProfilePayloadReuse(extension, domainDetection, payload, frontendPayloadPolicy);
     if (profileGate.allowed) {
-      return {
+      return buildPreReadPayloadDecision({
         runtime,
         filePath: outputPath,
-        eligible: true,
-        decision: "payload",
-        reasons: [],
         payload,
         readiness,
         debug,
-      };
+      });
     }
 
     return buildPreReadFallbackDecision({

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -1,0 +1,35 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+
+test("pre-read centralizes payload success decision construction", () => {
+  assert.match(preReadSource, /function buildPreReadPayloadDecision\(/);
+  assert.match(preReadSource, /return buildPreReadPayloadDecision\(\{/);
+  assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "payload",[\s\S]*?payload,[\s\S]*?readiness,/);
+});
+
+test("pre-read payload builder preserves React Web payload success envelope", () => {
+  const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
+    includeEditGuidance: true,
+  });
+
+  assert.equal(decision.runtime, "codex");
+  assert.equal(decision.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(decision.eligible, true);
+  assert.equal(decision.decision, "payload");
+  assert.deepEqual(decision.reasons, []);
+  assert.equal(decision.readiness.ready, true);
+  assert.ok(decision.payload);
+  assert.equal(decision.debug.domainDetection.classification, "react-web");
+  assert.equal(decision.debug.frontendPayloadPolicy.allowed, true);
+});


### PR DESCRIPTION
## Summary
- Add a local `buildPreReadPayloadDecision` seam inside `pre-read.ts`.
- Replace the inline successful payload return with the helper while preserving readiness, debug, and payload policy control flow.
- Add focused regression coverage that keeps payload success construction centralized and verifies a representative React Web payload envelope.

## Scope boundary
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No fallback behavior changes.
- No debug construction changes in this cut.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/payload-policy/runtime tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
