### PR TITLE
Extract pre-read payload debug construction

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -105,6 +105,23 @@ function frontendDebug(
   };
 }
 
+type PreReadPayloadDebugInput = {
+  result: ReturnType<typeof extractFile>;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+};
+
+function buildPreReadPayloadDebug(input: PreReadPayloadDebugInput): NonNullable<PreReadDecision["debug"]> {
+  return {
+    mode: input.result.mode,
+    complexityScore: input.result.meta.complexityScore,
+    decideReason: input.result.meta.decideReason,
+    decideConfidence: input.result.meta.decideConfidence,
+    language: input.result.language,
+    ...frontendDebug(input.domainDetection, input.frontendPayloadPolicy),
+  };
+}
+
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
   const domainDetection = detectDomainFromSource(sourceText);
   return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
@@ -163,15 +180,11 @@ export function decidePreRead(
     ...payloadBuildOptions,
   });
   const readiness = assessPayloadReadiness(result, payload);
-  const debug = {
-    mode: result.mode,
-    complexityScore: result.meta.complexityScore,
-    decideReason: result.meta.decideReason,
-    decideConfidence: result.meta.decideConfidence,
-    language: result.language,
+  const debug = buildPreReadPayloadDebug({
+    result,
     domainDetection,
-    ...(frontendPayloadPolicy ? { frontendPayloadPolicy } : {}),
-  };
+    frontendPayloadPolicy,
+  });
 
   if (readiness.ready) {
     const profileGate = assessFrontendProfilePayloadReuse(extension, domainDetection, payload, frontendPayloadPolicy);

--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -35,3 +35,18 @@ test("pre-read fallback builder preserves ineligible extension decisions", () =>
     },
   });
 });
+
+test("pre-read fallback debug remains domain and policy shaped", () => {
+  const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-debug-"));
+  try {
+    const filePath = path.join(tempDir, "Cli.tsx");
+    fs.writeFileSync(filePath, `import { Box } from "ink"; export function Cli() { return <Box />; }`);
+    const decision = preRead.decidePreRead(filePath, tempDir, "codex");
+
+    assert.equal(decision.decision, "fallback");
+    assert.equal(decision.debug.domainDetection.classification, "tui-ink");
+    assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -18,6 +18,12 @@ test("pre-read centralizes payload success decision construction", () => {
   assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "payload",[\s\S]*?payload,[\s\S]*?readiness,/);
 });
 
+test("pre-read centralizes payload debug construction", () => {
+  assert.match(preReadSource, /function buildPreReadPayloadDebug\(/);
+  assert.match(preReadSource, /const debug = buildPreReadPayloadDebug\(\{/);
+  assert.doesNotMatch(preReadSource, /const debug = \{\s*\n\s*mode: result\.mode,[\s\S]*?language: result\.language,[\s\S]*?domainDetection,/);
+});
+
 test("pre-read payload builder preserves React Web payload success envelope", () => {
   const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
     includeEditGuidance: true,
@@ -30,6 +36,11 @@ test("pre-read payload builder preserves React Web payload success envelope", ()
   assert.deepEqual(decision.reasons, []);
   assert.equal(decision.readiness.ready, true);
   assert.ok(decision.payload);
+  assert.equal(decision.debug.mode, "compressed");
+  assert.equal(typeof decision.debug.complexityScore, "number");
+  assert.deepEqual(decision.debug.decideReason, ["repeated-rendering"]);
+  assert.equal(decision.debug.decideConfidence, "medium");
+  assert.equal(decision.debug.language, "tsx");
   assert.equal(decision.debug.domainDetection.classification, "react-web");
   assert.equal(decision.debug.frontendPayloadPolicy.allowed, true);
 });


### PR DESCRIPTION
## Summary
- Add local `buildPreReadPayloadDebug` in `pre-read.ts`.
- Replace the inline payload-path debug object with the helper while preserving returned debug fields.
- Extend focused pre-read tests to guard debug centralization plus representative payload and fallback debug shape.

## Scope boundary
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No fallback or payload decision behavior changes.
- No debug field rename/removal/addition.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/payload-policy/runtime tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
