### PR TITLE
Extract pre-read payload preparation phase

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -122,6 +122,38 @@ function buildPreReadPayloadDebug(input: PreReadPayloadDebugInput): NonNullable<
   };
 }
 
+type PreReadPayloadPlanInput = {
+  resolvedPath: string;
+  cwd: string;
+  includeEditGuidance: boolean;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+};
+
+type PreReadPayloadPlan = {
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: NonNullable<PreReadDecision["debug"]>;
+};
+
+function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
+  const { frontendPayloadPolicy } = input;
+  const result = extractFile(input.resolvedPath);
+  const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
+  const payload = toModelFacingPayload(result, input.cwd, {
+    includeEditGuidance: input.includeEditGuidance,
+    ...payloadBuildOptions,
+  });
+  const readiness = assessPayloadReadiness(result, payload);
+  const debug = buildPreReadPayloadDebug({
+    result,
+    domainDetection: input.domainDetection,
+    frontendPayloadPolicy,
+  });
+
+  return { payload, readiness, debug };
+}
+
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
   const domainDetection = detectDomainFromSource(sourceText);
   return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
@@ -173,15 +205,10 @@ export function decidePreRead(
     });
   }
 
-  const result = extractFile(resolvedPath);
-  const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
-  const payload = toModelFacingPayload(result, cwd, {
+  const { payload, readiness, debug } = buildPreReadPayloadPlan({
+    resolvedPath,
+    cwd,
     includeEditGuidance: options.includeEditGuidance === true,
-    ...payloadBuildOptions,
-  });
-  const readiness = assessPayloadReadiness(result, payload);
-  const debug = buildPreReadPayloadDebug({
-    result,
     domainDetection,
     frontendPayloadPolicy,
   });

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -24,6 +24,12 @@ test("pre-read centralizes payload debug construction", () => {
   assert.doesNotMatch(preReadSource, /const debug = \{\s*\n\s*mode: result\.mode,[\s\S]*?language: result\.language,[\s\S]*?domainDetection,/);
 });
 
+test("pre-read centralizes payload preparation phase", () => {
+  assert.match(preReadSource, /function buildPreReadPayloadPlan\(/);
+  assert.match(preReadSource, /const \{ payload, readiness, debug \} = buildPreReadPayloadPlan\(\{/);
+  assert.doesNotMatch(preReadSource, /const result = extractFile\(resolvedPath\);[\s\S]*?const readiness = assessPayloadReadiness\(result, payload\);/);
+});
+
 test("pre-read payload builder preserves React Web payload success envelope", () => {
   const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
     includeEditGuidance: true,


### PR DESCRIPTION
## Summary
- Add local `buildPreReadPayloadPlan` in `pre-read.ts`.
- Move extraction, payload build options, model-facing payload construction, readiness assessment, and payload debug preparation into that phase helper.
- Keep final readiness/profile-gate payload-vs-fallback decisions unchanged.
- Extend focused pre-read tests to guard payload preparation phase centralization.

## Scope boundary
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No fallback or payload decision behavior changes.
- No module extraction in this cut.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/payload-policy/runtime tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
