### PR TITLE
Extract pre-read final payload outcome phase

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -154,6 +154,55 @@ function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayload
   return { payload, readiness, debug };
 }
 
+type PreReadDecisionFromPayloadPlanInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  extension: string;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: NonNullable<PreReadDecision["debug"]>;
+};
+
+function buildPreReadDecisionFromPayloadPlan(input: PreReadDecisionFromPayloadPlanInput): PreReadDecision {
+  if (input.readiness.ready) {
+    const profileGate = assessFrontendProfilePayloadReuse(
+      input.extension,
+      input.domainDetection,
+      input.payload,
+      input.frontendPayloadPolicy,
+    );
+    if (profileGate.allowed) {
+      return buildPreReadPayloadDecision({
+        runtime: input.runtime,
+        filePath: input.filePath,
+        payload: input.payload,
+        readiness: input.readiness,
+        debug: input.debug,
+      });
+    }
+
+    return buildPreReadFallbackDecision({
+      runtime: input.runtime,
+      filePath: input.filePath,
+      eligible: true,
+      reasons: [profileGate.reason],
+      readiness: input.readiness,
+      debug: input.debug,
+    });
+  }
+
+  return buildPreReadFallbackDecision({
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: true,
+    reasons: input.readiness.reasons,
+    readiness: input.readiness,
+    debug: input.debug,
+  });
+}
+
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
   const domainDetection = detectDomainFromSource(sourceText);
   return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
@@ -213,33 +262,13 @@ export function decidePreRead(
     frontendPayloadPolicy,
   });
 
-  if (readiness.ready) {
-    const profileGate = assessFrontendProfilePayloadReuse(extension, domainDetection, payload, frontendPayloadPolicy);
-    if (profileGate.allowed) {
-      return buildPreReadPayloadDecision({
-        runtime,
-        filePath: outputPath,
-        payload,
-        readiness,
-        debug,
-      });
-    }
-
-    return buildPreReadFallbackDecision({
-      runtime,
-      filePath: outputPath,
-      eligible: true,
-      reasons: [profileGate.reason],
-      readiness,
-      debug,
-    });
-  }
-
-  return buildPreReadFallbackDecision({
+  return buildPreReadDecisionFromPayloadPlan({
     runtime,
     filePath: outputPath,
-    eligible: true,
-    reasons: readiness.reasons,
+    extension,
+    domainDetection,
+    frontendPayloadPolicy,
+    payload,
     readiness,
     debug,
   });

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -30,6 +30,12 @@ test("pre-read centralizes payload preparation phase", () => {
   assert.doesNotMatch(preReadSource, /const result = extractFile\(resolvedPath\);[\s\S]*?const readiness = assessPayloadReadiness\(result, payload\);/);
 });
 
+test("pre-read centralizes payload plan outcome decision", () => {
+  assert.match(preReadSource, /function buildPreReadDecisionFromPayloadPlan\(/);
+  assert.match(preReadSource, /return buildPreReadDecisionFromPayloadPlan\(\{/);
+  assert.doesNotMatch(preReadSource, /if \(readiness\.ready\) \{[\s\S]*?const profileGate = assessFrontendProfilePayloadReuse\(extension, domainDetection, payload, frontendPayloadPolicy\);/);
+});
+
 test("pre-read payload builder preserves React Web payload success envelope", () => {
   const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
     includeEditGuidance: true,


### PR DESCRIPTION
## Summary
- Add local `buildPreReadDecisionFromPayloadPlan` in `pre-read.ts`.
- Move the post-plan readiness/profile-gate payload-vs-fallback branch into that final outcome helper.
- Keep existing payload and fallback envelope builders unchanged.
- Extend focused pre-read tests to guard final outcome centralization.

## Scope boundary
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No runtime bridge behavior changes.
- No module extraction in this cut.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/payload-policy/runtime tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
