### PR TITLE
Guard WebView source-shape pre-read fallbacks

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -203,6 +203,14 @@ function buildPreReadDecisionFromPayloadPlan(input: PreReadDecisionFromPayloadPl
   });
 }
 
+function hasWebViewSourceShapeBoundary(domainDetection: DomainDetectionResult): boolean {
+  return (
+    domainDetection.outcome === "fallback" &&
+    domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
+    domainDetection.evidence.some((item) => item.domain === "webview" && item.signal === "source-shape")
+  );
+}
+
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
   const domainDetection = detectDomainFromSource(sourceText);
   return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
@@ -230,6 +238,16 @@ export function decidePreRead(
   const sourceText = fs.readFileSync(resolvedPath, "utf8");
   const domainDetection = detectDomainFromSource(sourceText, resolvedPath);
   const frontendPayloadPolicy = assessFrontendPayloadPolicy(domainDetection);
+  if (hasWebViewSourceShapeBoundary(domainDetection) && domainDetection.classification !== "react-native") {
+    return buildPreReadFallbackDecision({
+      runtime,
+      filePath: outputPath,
+      eligible: true,
+      reasons: [REACT_NATIVE_WEBVIEW_BOUNDARY_REASON],
+      debug: frontendDebug(domainDetection, frontendPayloadPolicy),
+    });
+  }
+
   if (
     domainDetection.outcome === "fallback" &&
     domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&

--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -36,6 +36,43 @@ test("pre-read fallback builder preserves ineligible extension decisions", () =>
   });
 });
 
+test("pre-read source-shape boundary guard skips payload planning", () => {
+  assert.match(preReadSource, /function hasWebViewSourceShapeBoundary\(/);
+  assert.match(preReadSource, /if \(hasWebViewSourceShapeBoundary\(domainDetection\) && domainDetection\.classification !== "react-native"\) \{/);
+  const sourceShapeGuardIndex = preReadSource.indexOf('if (hasWebViewSourceShapeBoundary(domainDetection)');
+  const payloadPlanIndex = preReadSource.indexOf('const { payload, readiness, debug } = buildPreReadPayloadPlan({');
+  assert.ok(sourceShapeGuardIndex >= 0);
+  assert.ok(payloadPlanIndex > sourceShapeGuardIndex);
+
+  const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-source-shape-"));
+  try {
+    const filePath = path.join(tempDir, "CheckoutWebView.tsx");
+    fs.writeFileSync(
+      filePath,
+      `import { WebView } from "react-native-webview";
+export function CheckoutWebView() {
+  return <WebView source={{ uri: "https://example.test/checkout" }} onMessage={() => {}} />;
+}
+`,
+    );
+
+    const decision = preRead.decidePreRead(filePath, tempDir, "codex", { includeEditGuidance: true });
+
+    assert.equal(decision.decision, "fallback");
+    assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
+    assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
+    assert.equal("payload" in decision, false);
+    assert.equal("readiness" in decision, false);
+    assert.equal("mode" in decision.debug, false);
+    assert.equal("complexityScore" in decision.debug, false);
+    assert.equal(decision.debug.domainDetection.classification, "webview");
+    assert.equal(decision.debug.domainDetection.profile.claimStatus, "fallback-boundary");
+    assert.ok(decision.debug.domainDetection.signals.includes("webview:source-shape:uri"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("pre-read fallback debug remains domain and policy shaped", () => {
   const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-debug-"));
   try {


### PR DESCRIPTION
## Summary
- Add an explicit `hasWebViewSourceShapeBoundary` guard in `pre-read.ts`.
- Short-circuit WebView source-shape boundary files before payload planning.
- Preserve the existing `unsupported-react-native-webview-boundary` fallback reason.
- Add focused regression coverage proving no payload/readiness/extraction debug state is produced on the source-shape boundary path.

## Scope boundary
- No module extraction.
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- Existing broader RN/WebView boundary fallback behavior remains intact.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/runtime/payload-policy tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
