### PR TITLE
Normalize pre-read boundary fallback gating

### DIFF
--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -211,6 +211,18 @@ function hasWebViewSourceShapeBoundary(domainDetection: DomainDetectionResult): 
   );
 }
 
+function shouldUseReactNativeWebViewBoundaryFallback(domainDetection: DomainDetectionResult): boolean {
+  if (domainDetection.classification === "react-native") {
+    return false;
+  }
+
+  if (hasWebViewSourceShapeBoundary(domainDetection)) {
+    return true;
+  }
+
+  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
+}
+
 export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
   const domainDetection = detectDomainFromSource(sourceText);
   return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
@@ -238,21 +250,7 @@ export function decidePreRead(
   const sourceText = fs.readFileSync(resolvedPath, "utf8");
   const domainDetection = detectDomainFromSource(sourceText, resolvedPath);
   const frontendPayloadPolicy = assessFrontendPayloadPolicy(domainDetection);
-  if (hasWebViewSourceShapeBoundary(domainDetection) && domainDetection.classification !== "react-native") {
-    return buildPreReadFallbackDecision({
-      runtime,
-      filePath: outputPath,
-      eligible: true,
-      reasons: [REACT_NATIVE_WEBVIEW_BOUNDARY_REASON],
-      debug: frontendDebug(domainDetection, frontendPayloadPolicy),
-    });
-  }
-
-  if (
-    domainDetection.outcome === "fallback" &&
-    domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
-    domainDetection.classification !== "react-native"
-  ) {
+  if (shouldUseReactNativeWebViewBoundaryFallback(domainDetection)) {
     return buildPreReadFallbackDecision({
       runtime,
       filePath: outputPath,

--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -12,6 +12,16 @@ const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
 const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
 
+function assertFallbackOnlyDecision(decision, reason) {
+  assert.equal(decision.decision, "fallback");
+  assert.deepEqual(decision.reasons, [reason]);
+  assert.equal(decision.fallback.reason, reason);
+  assert.equal("payload" in decision, false);
+  assert.equal("readiness" in decision, false);
+  assert.equal("mode" in decision.debug, false);
+  assert.equal("complexityScore" in decision.debug, false);
+}
+
 test("pre-read centralizes full-read fallback envelope construction", () => {
   assert.match(preReadSource, /function buildPreReadFallbackDecision\(/);
   const fallbackEnvelopeConstructions = preReadSource.match(/fallback:\s*{\s*\n\s*action:\s*"full-read"/g) ?? [];
@@ -38,11 +48,14 @@ test("pre-read fallback builder preserves ineligible extension decisions", () =>
 
 test("pre-read source-shape boundary guard skips payload planning", () => {
   assert.match(preReadSource, /function hasWebViewSourceShapeBoundary\(/);
-  assert.match(preReadSource, /if \(hasWebViewSourceShapeBoundary\(domainDetection\) && domainDetection\.classification !== "react-native"\) \{/);
-  const sourceShapeGuardIndex = preReadSource.indexOf('if (hasWebViewSourceShapeBoundary(domainDetection)');
+  assert.match(preReadSource, /function shouldUseReactNativeWebViewBoundaryFallback\(/);
+  assert.match(preReadSource, /if \(shouldUseReactNativeWebViewBoundaryFallback\(domainDetection\)\) \{/);
+  const sourceShapeGuardIndex = preReadSource.indexOf("function shouldUseReactNativeWebViewBoundaryFallback(");
+  const boundaryGuardIndex = preReadSource.indexOf("if (shouldUseReactNativeWebViewBoundaryFallback(domainDetection))");
   const payloadPlanIndex = preReadSource.indexOf('const { payload, readiness, debug } = buildPreReadPayloadPlan({');
   assert.ok(sourceShapeGuardIndex >= 0);
-  assert.ok(payloadPlanIndex > sourceShapeGuardIndex);
+  assert.ok(boundaryGuardIndex > sourceShapeGuardIndex);
+  assert.ok(payloadPlanIndex > boundaryGuardIndex);
 
   const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-source-shape-"));
   try {
@@ -58,16 +71,33 @@ export function CheckoutWebView() {
 
     const decision = preRead.decidePreRead(filePath, tempDir, "codex", { includeEditGuidance: true });
 
-    assert.equal(decision.decision, "fallback");
-    assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
-    assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
-    assert.equal("payload" in decision, false);
-    assert.equal("readiness" in decision, false);
-    assert.equal("mode" in decision.debug, false);
-    assert.equal("complexityScore" in decision.debug, false);
+    assertFallbackOnlyDecision(decision, "unsupported-react-native-webview-boundary");
     assert.equal(decision.debug.domainDetection.classification, "webview");
     assert.equal(decision.debug.domainDetection.profile.claimStatus, "fallback-boundary");
     assert.ok(decision.debug.domainDetection.signals.includes("webview:source-shape:uri"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read unsupported RN fallback skips payload planning", () => {
+  const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-rn-unsupported-"));
+  try {
+    const filePath = path.join(tempDir, "UnsupportedScreen.tsx");
+    fs.writeFileSync(
+      filePath,
+      `import { ScrollView, View } from "react-native";
+export function UnsupportedScreen() {
+  return <ScrollView><View /></ScrollView>;
+}
+`,
+    );
+
+    const decision = preRead.decidePreRead(filePath, tempDir, "codex", { includeEditGuidance: true });
+
+    assertFallbackOnlyDecision(decision, "unsupported-frontend-domain-profile");
+    assert.equal(decision.debug.domainDetection.classification, "react-native");
+    assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Normalize RN/WebView boundary fallback selection into one explicit pre-read predicate.
- Preserve source-shape fallback ordering before payload planning.
- Keep existing fallback reason and broader RN/WebView boundary behavior intact.
- Strengthen fallback tests around boundary guard ordering and absence of payload planning artifacts.

## Scope boundary
- No helper module extraction.
- No support claim expansion.
- No detector/profile/payload-policy semantic changes.
- No runtime behavior change intended.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/runtime/payload-policy tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
