### PR TITLE
Isolate pre-read helper stack for safer adapter flow

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -1,0 +1,190 @@
+import { detectDomainFromSource, type DomainDetectionResult } from "../core/domain-detector";
+import { extractFile } from "../core/extract";
+import { toModelFacingPayload } from "../core/payload/model-facing";
+import { assessPayloadReadiness } from "../core/payload/readiness";
+import { assessFrontendProfilePayloadReuse } from "../core/payload-policy/profile-gate";
+import { toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
+import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
+import type { PreReadDecision } from "../core/schema";
+
+export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
+
+export type PreReadFallbackDecisionInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  eligible: boolean;
+  reasons: string[];
+  readiness?: PreReadDecision["readiness"];
+  debug?: PreReadDecision["debug"];
+  fallbackReason?: string;
+};
+
+export function buildPreReadFallbackDecision(input: PreReadFallbackDecisionInput): PreReadDecision {
+  return {
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: input.eligible,
+    decision: "fallback",
+    reasons: input.reasons,
+    ...(input.readiness ? { readiness: input.readiness } : {}),
+    debug: input.debug ?? {},
+    fallback: {
+      action: "full-read",
+      reason: input.fallbackReason ?? input.reasons[0] ?? "missing-structure",
+    },
+  };
+}
+
+export type PreReadPayloadDecisionInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: PreReadDecision["debug"];
+};
+
+export function buildPreReadPayloadDecision(input: PreReadPayloadDecisionInput): PreReadDecision {
+  return {
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: true,
+    decision: "payload",
+    reasons: [],
+    payload: input.payload,
+    readiness: input.readiness,
+    debug: input.debug,
+  };
+}
+
+export function frontendDebug(
+  domainDetection: DomainDetectionResult,
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
+): NonNullable<PreReadDecision["debug"]> {
+  return {
+    domainDetection,
+    ...(frontendPayloadPolicy ? { frontendPayloadPolicy } : {}),
+  };
+}
+
+export type PreReadPayloadDebugInput = {
+  result: ReturnType<typeof extractFile>;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+};
+
+export function buildPreReadPayloadDebug(input: PreReadPayloadDebugInput): NonNullable<PreReadDecision["debug"]> {
+  return {
+    mode: input.result.mode,
+    complexityScore: input.result.meta.complexityScore,
+    decideReason: input.result.meta.decideReason,
+    decideConfidence: input.result.meta.decideConfidence,
+    language: input.result.language,
+    ...frontendDebug(input.domainDetection, input.frontendPayloadPolicy),
+  };
+}
+
+export type PreReadPayloadPlanInput = {
+  resolvedPath: string;
+  cwd: string;
+  includeEditGuidance: boolean;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+};
+
+export type PreReadPayloadPlan = {
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: NonNullable<PreReadDecision["debug"]>;
+};
+
+export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
+  const { frontendPayloadPolicy } = input;
+  const result = extractFile(input.resolvedPath);
+  const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
+  const payload = toModelFacingPayload(result, input.cwd, {
+    includeEditGuidance: input.includeEditGuidance,
+    ...payloadBuildOptions,
+  });
+  const readiness = assessPayloadReadiness(result, payload);
+  const debug = buildPreReadPayloadDebug({
+    result,
+    domainDetection: input.domainDetection,
+    frontendPayloadPolicy,
+  });
+
+  return { payload, readiness, debug };
+}
+
+export type PreReadDecisionFromPayloadPlanInput = {
+  runtime: PreReadDecision["runtime"];
+  filePath: string;
+  extension: string;
+  domainDetection: DomainDetectionResult;
+  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
+  payload: NonNullable<PreReadDecision["payload"]>;
+  readiness: NonNullable<PreReadDecision["readiness"]>;
+  debug: NonNullable<PreReadDecision["debug"]>;
+};
+
+export function buildPreReadDecisionFromPayloadPlan(input: PreReadDecisionFromPayloadPlanInput): PreReadDecision {
+  if (input.readiness.ready) {
+    const profileGate = assessFrontendProfilePayloadReuse(
+      input.extension,
+      input.domainDetection,
+      input.payload,
+      input.frontendPayloadPolicy,
+    );
+    if (profileGate.allowed) {
+      return buildPreReadPayloadDecision({
+        runtime: input.runtime,
+        filePath: input.filePath,
+        payload: input.payload,
+        readiness: input.readiness,
+        debug: input.debug,
+      });
+    }
+
+    return buildPreReadFallbackDecision({
+      runtime: input.runtime,
+      filePath: input.filePath,
+      eligible: true,
+      reasons: [profileGate.reason],
+      readiness: input.readiness,
+      debug: input.debug,
+    });
+  }
+
+  return buildPreReadFallbackDecision({
+    runtime: input.runtime,
+    filePath: input.filePath,
+    eligible: true,
+    reasons: input.readiness.reasons,
+    readiness: input.readiness,
+    debug: input.debug,
+  });
+}
+
+export function hasWebViewSourceShapeBoundary(domainDetection: DomainDetectionResult): boolean {
+  return (
+    domainDetection.outcome === "fallback" &&
+    domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
+    domainDetection.evidence.some((item) => item.domain === "webview" && item.signal === "source-shape")
+  );
+}
+
+export function shouldUseReactNativeWebViewBoundaryFallback(domainDetection: DomainDetectionResult): boolean {
+  if (domainDetection.classification === "react-native") {
+    return false;
+  }
+
+  if (hasWebViewSourceShapeBoundary(domainDetection)) {
+    return true;
+  }
+
+  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
+}
+
+export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
+  const domainDetection = detectDomainFromSource(sourceText);
+  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
+}

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -1,15 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import { extractFile } from "../core/extract";
-import { detectDomainFromSource, type DomainDetectionResult } from "../core/domain-detector";
-import { toModelFacingPayload, type ModelFacingPayloadOptions } from "../core/payload/model-facing";
-import { assessPayloadReadiness } from "../core/payload/readiness";
+import { detectDomainFromSource } from "../core/domain-detector";
+import type { ModelFacingPayloadOptions } from "../core/payload/model-facing";
 import {
   MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
   UNKNOWN_FRONTEND_DEFERRED_PAYLOAD_POLICY,
   UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
 } from "../core/payload-policy/fallback";
-import { assessFrontendProfilePayloadReuse } from "../core/payload-policy/profile-gate";
 import { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 import {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
@@ -20,6 +17,14 @@ import { TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY } from "../core/payload-policy/tui
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
 import { WEBVIEW_BOUNDARY_FALLBACK_POLICY } from "../core/payload-policy/webview";
 import type { PreReadDecision } from "../core/schema";
+import {
+  buildPreReadDecisionFromPayloadPlan,
+  buildPreReadFallbackDecision,
+  buildPreReadPayloadPlan,
+  frontendDebug,
+  REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
+  shouldUseReactNativeWebViewBoundaryFallback,
+} from "./pre-read-stack";
 
 const REACT_ELIGIBLE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
@@ -34,7 +39,7 @@ export {
   UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
   WEBVIEW_BOUNDARY_FALLBACK_POLICY,
 };
-export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
+export { hasReactNativeWebViewBoundaryMarker, REACT_NATIVE_WEBVIEW_BOUNDARY_REASON } from "./pre-read-stack";
 
 export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance">;
 export type { FrontendPayloadPolicyDecision };
@@ -46,186 +51,6 @@ function eligibleExtensions(runtime: PreReadDecision["runtime"]): ReadonlySet<st
 function relativePath(filePath: string, cwd: string): string {
   const relative = path.relative(cwd, filePath);
   return relative || path.basename(filePath);
-}
-
-type PreReadFallbackDecisionInput = {
-  runtime: PreReadDecision["runtime"];
-  filePath: string;
-  eligible: boolean;
-  reasons: string[];
-  readiness?: PreReadDecision["readiness"];
-  debug?: PreReadDecision["debug"];
-  fallbackReason?: string;
-};
-
-function buildPreReadFallbackDecision(input: PreReadFallbackDecisionInput): PreReadDecision {
-  return {
-    runtime: input.runtime,
-    filePath: input.filePath,
-    eligible: input.eligible,
-    decision: "fallback",
-    reasons: input.reasons,
-    ...(input.readiness ? { readiness: input.readiness } : {}),
-    debug: input.debug ?? {},
-    fallback: {
-      action: "full-read",
-      reason: input.fallbackReason ?? input.reasons[0] ?? "missing-structure",
-    },
-  };
-}
-
-type PreReadPayloadDecisionInput = {
-  runtime: PreReadDecision["runtime"];
-  filePath: string;
-  payload: NonNullable<PreReadDecision["payload"]>;
-  readiness: NonNullable<PreReadDecision["readiness"]>;
-  debug: PreReadDecision["debug"];
-};
-
-function buildPreReadPayloadDecision(input: PreReadPayloadDecisionInput): PreReadDecision {
-  return {
-    runtime: input.runtime,
-    filePath: input.filePath,
-    eligible: true,
-    decision: "payload",
-    reasons: [],
-    payload: input.payload,
-    readiness: input.readiness,
-    debug: input.debug,
-  };
-}
-
-function frontendDebug(
-  domainDetection: DomainDetectionResult,
-  frontendPayloadPolicy?: FrontendPayloadPolicyDecision,
-): NonNullable<PreReadDecision["debug"]> {
-  return {
-    domainDetection,
-    ...(frontendPayloadPolicy ? { frontendPayloadPolicy } : {}),
-  };
-}
-
-type PreReadPayloadDebugInput = {
-  result: ReturnType<typeof extractFile>;
-  domainDetection: DomainDetectionResult;
-  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
-};
-
-function buildPreReadPayloadDebug(input: PreReadPayloadDebugInput): NonNullable<PreReadDecision["debug"]> {
-  return {
-    mode: input.result.mode,
-    complexityScore: input.result.meta.complexityScore,
-    decideReason: input.result.meta.decideReason,
-    decideConfidence: input.result.meta.decideConfidence,
-    language: input.result.language,
-    ...frontendDebug(input.domainDetection, input.frontendPayloadPolicy),
-  };
-}
-
-type PreReadPayloadPlanInput = {
-  resolvedPath: string;
-  cwd: string;
-  includeEditGuidance: boolean;
-  domainDetection: DomainDetectionResult;
-  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
-};
-
-type PreReadPayloadPlan = {
-  payload: NonNullable<PreReadDecision["payload"]>;
-  readiness: NonNullable<PreReadDecision["readiness"]>;
-  debug: NonNullable<PreReadDecision["debug"]>;
-};
-
-function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
-  const { frontendPayloadPolicy } = input;
-  const result = extractFile(input.resolvedPath);
-  const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
-  const payload = toModelFacingPayload(result, input.cwd, {
-    includeEditGuidance: input.includeEditGuidance,
-    ...payloadBuildOptions,
-  });
-  const readiness = assessPayloadReadiness(result, payload);
-  const debug = buildPreReadPayloadDebug({
-    result,
-    domainDetection: input.domainDetection,
-    frontendPayloadPolicy,
-  });
-
-  return { payload, readiness, debug };
-}
-
-type PreReadDecisionFromPayloadPlanInput = {
-  runtime: PreReadDecision["runtime"];
-  filePath: string;
-  extension: string;
-  domainDetection: DomainDetectionResult;
-  frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
-  payload: NonNullable<PreReadDecision["payload"]>;
-  readiness: NonNullable<PreReadDecision["readiness"]>;
-  debug: NonNullable<PreReadDecision["debug"]>;
-};
-
-function buildPreReadDecisionFromPayloadPlan(input: PreReadDecisionFromPayloadPlanInput): PreReadDecision {
-  if (input.readiness.ready) {
-    const profileGate = assessFrontendProfilePayloadReuse(
-      input.extension,
-      input.domainDetection,
-      input.payload,
-      input.frontendPayloadPolicy,
-    );
-    if (profileGate.allowed) {
-      return buildPreReadPayloadDecision({
-        runtime: input.runtime,
-        filePath: input.filePath,
-        payload: input.payload,
-        readiness: input.readiness,
-        debug: input.debug,
-      });
-    }
-
-    return buildPreReadFallbackDecision({
-      runtime: input.runtime,
-      filePath: input.filePath,
-      eligible: true,
-      reasons: [profileGate.reason],
-      readiness: input.readiness,
-      debug: input.debug,
-    });
-  }
-
-  return buildPreReadFallbackDecision({
-    runtime: input.runtime,
-    filePath: input.filePath,
-    eligible: true,
-    reasons: input.readiness.reasons,
-    readiness: input.readiness,
-    debug: input.debug,
-  });
-}
-
-function hasWebViewSourceShapeBoundary(domainDetection: DomainDetectionResult): boolean {
-  return (
-    domainDetection.outcome === "fallback" &&
-    domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON &&
-    domainDetection.evidence.some((item) => item.domain === "webview" && item.signal === "source-shape")
-  );
-}
-
-function shouldUseReactNativeWebViewBoundaryFallback(domainDetection: DomainDetectionResult): boolean {
-  if (domainDetection.classification === "react-native") {
-    return false;
-  }
-
-  if (hasWebViewSourceShapeBoundary(domainDetection)) {
-    return true;
-  }
-
-  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
-}
-
-export function hasReactNativeWebViewBoundaryMarker(sourceText: string): boolean {
-  const domainDetection = detectDomainFromSource(sourceText);
-  return domainDetection.outcome === "fallback" && domainDetection.reason === REACT_NATIVE_WEBVIEW_BOUNDARY_REASON;
 }
 
 export function decidePreRead(

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4071,6 +4071,7 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   const fixtureExpectations = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-fixture-expectations.md"), "utf8");
   const webviewBridgePlan = fs.readFileSync(path.join(repoRoot, "docs", "webview-bridge-boundary-plan.md"), "utf8");
   const preRead = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+  const preReadStack = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
   const combined = `${readme}\n${roadmap}\n${release}\n${taxonomy}\n${candidates}\n${architecture}\n${domainProfiles}\n${fixtureExpectations}\n${webviewBridgePlan}`;
 
   assert.match(combined, /React Native(?:\/WebView| and embedded WebView| \/ embedded WebView)/);
@@ -4115,7 +4116,7 @@ test("docs and pre-read boundary keep React Native and WebView unsupported", () 
   assert.match(combined, /domain signal profiles/);
   assert.match(combined, /architecture direction and staged gates/);
   assert.match(combined, /not default compact extraction|not default WebView compact extraction|default WebView compact extraction/);
-  assert.match(preRead, /unsupported-react-native-webview-boundary/);
+  assert.match(`${preRead}\n${preReadStack}`, /unsupported-react-native-webview-boundary/);
   assert.doesNotMatch(combined, /React Native support is available/i);
   assert.doesNotMatch(combined, /React Native(?: \/ WebView)? is supported today/i);
   assert.doesNotMatch(combined, /default WebView compact extraction is enabled/i);

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -19,6 +19,7 @@ const {
 const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
 const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
 const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+const preReadStackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
 
 function payloadForSource(source, fileName, options = {}) {
   const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-profile-gate-"));
@@ -81,7 +82,9 @@ test("frontend profile gate denies unsupported frontend profile reuse", () => {
 });
 
 test("pre-read adapter delegates frontend profile reuse gate to payload-policy seam", () => {
-  assert.match(preReadSource, /import \{ assessFrontendProfilePayloadReuse \} from "\.\.\/core\/payload-policy\/profile-gate"/);
-  assert.doesNotMatch(preReadSource, /function assessFrontendProfilePayloadReuse\(/);
-  assert.doesNotMatch(preReadSource, /FRONTEND_PROFILE_GATE_EXTENSIONS/);
+  const combinedPreReadSource = `${preReadSource}\n${preReadStackSource}`;
+
+  assert.match(preReadStackSource, /import \{ assessFrontendProfilePayloadReuse \} from "\.\.\/core\/payload-policy\/profile-gate"/);
+  assert.doesNotMatch(combinedPreReadSource, /function assessFrontendProfilePayloadReuse\(/);
+  assert.doesNotMatch(combinedPreReadSource, /FRONTEND_PROFILE_GATE_EXTENSIONS/);
 });

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -88,15 +88,17 @@ test("frontend payload build options include domain payload only for React Web p
 
 test("pre-read adapter no longer owns hardcoded policy assessment order", () => {
   const source = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+  const stackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
+  const combinedSource = `${source}\n${stackSource}`;
 
   assert.match(source, /import \{ assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions \} from "\.\.\/core\/payload-policy\/registry"/);
-  assert.doesNotMatch(source, /assessReactWebPayloadPolicy\(domainDetection\)/);
-  assert.doesNotMatch(source, /assessWebViewPayloadPolicy\(domainDetection\)/);
-  assert.doesNotMatch(source, /assessTuiInkPayloadPolicy\(domainDetection\)/);
-  assert.doesNotMatch(source, /assessReactNativePayloadPolicy\(domainDetection\)/);
-  assert.doesNotMatch(source, /assessFallbackPayloadPolicy\(domainDetection\)/);
-  assert.doesNotMatch(source, /includeDomainPayload:\s*frontendPayloadPolicy\?\.name ===/);
-  assert.match(source, /toFrontendPayloadBuildOptions\(frontendPayloadPolicy\)/);
+  assert.doesNotMatch(combinedSource, /assessReactWebPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(combinedSource, /assessWebViewPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(combinedSource, /assessTuiInkPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(combinedSource, /assessReactNativePayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(combinedSource, /assessFallbackPayloadPolicy\(domainDetection\)/);
+  assert.doesNotMatch(combinedSource, /includeDomainPayload:\s*frontendPayloadPolicy\?\.name ===/);
+  assert.match(stackSource, /toFrontendPayloadBuildOptions\(frontendPayloadPolicy\)/);
 });
 
 test("payload policy registry source avoids broad support claims", () => {

--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -11,6 +11,7 @@ const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
 const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+const preReadStackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
 
 function assertFallbackOnlyDecision(decision, reason) {
   assert.equal(decision.decision, "fallback");
@@ -23,8 +24,9 @@ function assertFallbackOnlyDecision(decision, reason) {
 }
 
 test("pre-read centralizes full-read fallback envelope construction", () => {
-  assert.match(preReadSource, /function buildPreReadFallbackDecision\(/);
-  const fallbackEnvelopeConstructions = preReadSource.match(/fallback:\s*{\s*\n\s*action:\s*"full-read"/g) ?? [];
+  assert.match(preReadStackSource, /function buildPreReadFallbackDecision\(/);
+  assert.match(preReadSource, /buildPreReadFallbackDecision/);
+  const fallbackEnvelopeConstructions = preReadStackSource.match(/fallback:\s*{\s*\n\s*action:\s*"full-read"/g) ?? [];
   assert.equal(fallbackEnvelopeConstructions.length, 1);
   assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "fallback",[\s\S]*?fallback: \{\s*\n\s*action: "full-read"/);
 });
@@ -47,14 +49,14 @@ test("pre-read fallback builder preserves ineligible extension decisions", () =>
 });
 
 test("pre-read source-shape boundary guard skips payload planning", () => {
-  assert.match(preReadSource, /function hasWebViewSourceShapeBoundary\(/);
-  assert.match(preReadSource, /function shouldUseReactNativeWebViewBoundaryFallback\(/);
+  assert.match(preReadStackSource, /function hasWebViewSourceShapeBoundary\(/);
+  assert.match(preReadStackSource, /function shouldUseReactNativeWebViewBoundaryFallback\(/);
   assert.match(preReadSource, /if \(shouldUseReactNativeWebViewBoundaryFallback\(domainDetection\)\) \{/);
-  const sourceShapeGuardIndex = preReadSource.indexOf("function shouldUseReactNativeWebViewBoundaryFallback(");
+  const sourceShapeGuardIndex = preReadStackSource.indexOf("function shouldUseReactNativeWebViewBoundaryFallback(");
   const boundaryGuardIndex = preReadSource.indexOf("if (shouldUseReactNativeWebViewBoundaryFallback(domainDetection))");
   const payloadPlanIndex = preReadSource.indexOf('const { payload, readiness, debug } = buildPreReadPayloadPlan({');
   assert.ok(sourceShapeGuardIndex >= 0);
-  assert.ok(boundaryGuardIndex > sourceShapeGuardIndex);
+  assert.ok(boundaryGuardIndex >= 0);
   assert.ok(payloadPlanIndex > boundaryGuardIndex);
 
   const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-source-shape-"));

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -11,27 +11,30 @@ const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
 const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
+const preReadStackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
 
 test("pre-read centralizes payload success decision construction", () => {
-  assert.match(preReadSource, /function buildPreReadPayloadDecision\(/);
-  assert.match(preReadSource, /return buildPreReadPayloadDecision\(\{/);
+  assert.match(preReadStackSource, /function buildPreReadPayloadDecision\(/);
+  assert.match(preReadStackSource, /function buildPreReadDecisionFromPayloadPlan\(/);
+  assert.match(preReadStackSource, /return buildPreReadPayloadDecision\(\{/);
+  assert.match(preReadSource, /buildPreReadDecisionFromPayloadPlan/);
   assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "payload",[\s\S]*?payload,[\s\S]*?readiness,/);
 });
 
 test("pre-read centralizes payload debug construction", () => {
-  assert.match(preReadSource, /function buildPreReadPayloadDebug\(/);
-  assert.match(preReadSource, /const debug = buildPreReadPayloadDebug\(\{/);
+  assert.match(preReadStackSource, /function buildPreReadPayloadDebug\(/);
+  assert.match(preReadStackSource, /const debug = buildPreReadPayloadDebug\(\{/);
   assert.doesNotMatch(preReadSource, /const debug = \{\s*\n\s*mode: result\.mode,[\s\S]*?language: result\.language,[\s\S]*?domainDetection,/);
 });
 
 test("pre-read centralizes payload preparation phase", () => {
-  assert.match(preReadSource, /function buildPreReadPayloadPlan\(/);
+  assert.match(preReadStackSource, /function buildPreReadPayloadPlan\(/);
   assert.match(preReadSource, /const \{ payload, readiness, debug \} = buildPreReadPayloadPlan\(\{/);
   assert.doesNotMatch(preReadSource, /const result = extractFile\(resolvedPath\);[\s\S]*?const readiness = assessPayloadReadiness\(result, payload\);/);
 });
 
 test("pre-read centralizes payload plan outcome decision", () => {
-  assert.match(preReadSource, /function buildPreReadDecisionFromPayloadPlan\(/);
+  assert.match(preReadStackSource, /function buildPreReadDecisionFromPayloadPlan\(/);
   assert.match(preReadSource, /return buildPreReadDecisionFromPayloadPlan\(\{/);
   assert.doesNotMatch(preReadSource, /if \(readiness\.ready\) \{[\s\S]*?const profileGate = assessFrontendProfilePayloadReuse\(extension, domainDetection, payload, frontendPayloadPolicy\);/);
 });


### PR DESCRIPTION
## Summary
- Extract the pre-read helper stack into `src/adapters/pre-read-stack.ts`.
- Keep `decidePreRead` in `src/adapters/pre-read.ts` as the runtime orchestration boundary.
- Preserve RN/WebView boundary fallback ordering before payload planning.
- Update source-structure tests to follow the helper module rather than requiring helper definitions in `pre-read.ts`.

## Scope boundary
- No runtime hook semantic changes.
- No detector/profile/payload-policy behavior changes.
- No support claim expansion.
- No domain maturity promotion.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/runtime/payload-policy tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
