### PR TITLE
Stabilize pre-read tests around behavior

### DIFF
--- a/test/pre-read-fallback-builder.test.mjs
+++ b/test/pre-read-fallback-builder.test.mjs
@@ -10,8 +10,6 @@ import { createRequire } from "node:module";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
-const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
-const preReadStackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
 
 function assertFallbackOnlyDecision(decision, reason) {
   assert.equal(decision.decision, "fallback");
@@ -22,14 +20,6 @@ function assertFallbackOnlyDecision(decision, reason) {
   assert.equal("mode" in decision.debug, false);
   assert.equal("complexityScore" in decision.debug, false);
 }
-
-test("pre-read centralizes full-read fallback envelope construction", () => {
-  assert.match(preReadStackSource, /function buildPreReadFallbackDecision\(/);
-  assert.match(preReadSource, /buildPreReadFallbackDecision/);
-  const fallbackEnvelopeConstructions = preReadStackSource.match(/fallback:\s*{\s*\n\s*action:\s*"full-read"/g) ?? [];
-  assert.equal(fallbackEnvelopeConstructions.length, 1);
-  assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "fallback",[\s\S]*?fallback: \{\s*\n\s*action: "full-read"/);
-});
 
 test("pre-read fallback builder preserves ineligible extension decisions", () => {
   const decision = preRead.decidePreRead(path.join(repoRoot, "not-a-source.md"), repoRoot, "codex");
@@ -49,30 +39,19 @@ test("pre-read fallback builder preserves ineligible extension decisions", () =>
 });
 
 test("pre-read source-shape boundary guard skips payload planning", () => {
-  assert.match(preReadStackSource, /function hasWebViewSourceShapeBoundary\(/);
-  assert.match(preReadStackSource, /function shouldUseReactNativeWebViewBoundaryFallback\(/);
-  assert.match(preReadSource, /if \(shouldUseReactNativeWebViewBoundaryFallback\(domainDetection\)\) \{/);
-  const sourceShapeGuardIndex = preReadStackSource.indexOf("function shouldUseReactNativeWebViewBoundaryFallback(");
-  const boundaryGuardIndex = preReadSource.indexOf("if (shouldUseReactNativeWebViewBoundaryFallback(domainDetection))");
-  const payloadPlanIndex = preReadSource.indexOf('const { payload, readiness, debug } = buildPreReadPayloadPlan({');
-  assert.ok(sourceShapeGuardIndex >= 0);
-  assert.ok(boundaryGuardIndex >= 0);
-  assert.ok(payloadPlanIndex > boundaryGuardIndex);
-
   const tempDir = fs.mkdtempSync(path.join(repoRoot, ".tmp-pre-read-source-shape-"));
   try {
     const filePath = path.join(tempDir, "CheckoutWebView.tsx");
-    fs.writeFileSync(
-      filePath,
-      `import { WebView } from "react-native-webview";
+    const source = `import { WebView } from "react-native-webview";
 export function CheckoutWebView() {
   return <WebView source={{ uri: "https://example.test/checkout" }} onMessage={() => {}} />;
 }
-`,
-    );
+`;
+    fs.writeFileSync(filePath, source);
 
     const decision = preRead.decidePreRead(filePath, tempDir, "codex", { includeEditGuidance: true });
 
+    assert.equal(preRead.hasReactNativeWebViewBoundaryMarker(source), true);
     assertFallbackOnlyDecision(decision, "unsupported-react-native-webview-boundary");
     assert.equal(decision.debug.domainDetection.classification, "webview");
     assert.equal(decision.debug.domainDetection.profile.claimStatus, "fallback-boundary");

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -3,41 +3,12 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
-const preReadSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read.ts"), "utf8");
-const preReadStackSource = fs.readFileSync(path.join(repoRoot, "src", "adapters", "pre-read-stack.ts"), "utf8");
-
-test("pre-read centralizes payload success decision construction", () => {
-  assert.match(preReadStackSource, /function buildPreReadPayloadDecision\(/);
-  assert.match(preReadStackSource, /function buildPreReadDecisionFromPayloadPlan\(/);
-  assert.match(preReadStackSource, /return buildPreReadPayloadDecision\(\{/);
-  assert.match(preReadSource, /buildPreReadDecisionFromPayloadPlan/);
-  assert.doesNotMatch(preReadSource, /return \{\s*\n\s*runtime,[\s\S]*?decision: "payload",[\s\S]*?payload,[\s\S]*?readiness,/);
-});
-
-test("pre-read centralizes payload debug construction", () => {
-  assert.match(preReadStackSource, /function buildPreReadPayloadDebug\(/);
-  assert.match(preReadStackSource, /const debug = buildPreReadPayloadDebug\(\{/);
-  assert.doesNotMatch(preReadSource, /const debug = \{\s*\n\s*mode: result\.mode,[\s\S]*?language: result\.language,[\s\S]*?domainDetection,/);
-});
-
-test("pre-read centralizes payload preparation phase", () => {
-  assert.match(preReadStackSource, /function buildPreReadPayloadPlan\(/);
-  assert.match(preReadSource, /const \{ payload, readiness, debug \} = buildPreReadPayloadPlan\(\{/);
-  assert.doesNotMatch(preReadSource, /const result = extractFile\(resolvedPath\);[\s\S]*?const readiness = assessPayloadReadiness\(result, payload\);/);
-});
-
-test("pre-read centralizes payload plan outcome decision", () => {
-  assert.match(preReadStackSource, /function buildPreReadDecisionFromPayloadPlan\(/);
-  assert.match(preReadSource, /return buildPreReadDecisionFromPayloadPlan\(\{/);
-  assert.doesNotMatch(preReadSource, /if \(readiness\.ready\) \{[\s\S]*?const profileGate = assessFrontendProfilePayloadReuse\(extension, domainDetection, payload, frontendPayloadPolicy\);/);
-});
 
 test("pre-read payload builder preserves React Web payload success envelope", () => {
   const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {


### PR DESCRIPTION
## Summary
- Remove source-string coupling from the pre-read fallback/payload tests.
- Keep the adapter-visible behavior checks for fallback envelopes, boundary fallback-only decisions, unsupported RN fallback, TUI fallback debug, and React Web payload success.
- Leave production code unchanged.

## Scope boundary
- Test-only change.
- No runtime hook semantic changes.
- No detector/profile/payload-policy behavior changes.
- No support claim expansion.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- focused pre-read/fooks/runtime/payload-policy tests
- `npm test`
- `git diff --check`
- support-claim grep over `docs` and `src`
