### PR TITLE
Guard stale tmux alert history

### DIFF
--- a/docs/ci-alert-triage.md
+++ b/docs/ci-alert-triage.md
@@ -22,6 +22,26 @@ fresh development investigation unless a newer actionable/watch run appears.
 Historical success URLs in the same paste stay bounded by compact mode and are
 noise-counted as stale replay rows.
 
+## Tmux pane-history keyword replay
+
+`ci:alerts --alerts <file>` also scans pasted tmux pane text for blocker-looking
+keyword lines such as `error`, `failed`, and `TS7006`. This scan is deliberately
+separate from GitHub Actions URL evidence: an actionable/watch run URL still
+requires inspection even if an older pane-history keyword is marked stale.
+
+Pane-history keyword suppression is conservative. A keyword line is marked
+`stale-history` with `disposition: "suppress-replay"` only when it appears at or
+before an explicit recovery/terminal marker such as `npm test passed`,
+`tests passed`, `PR #379 opened`, `ralplan terminal`, `tmux session killed`, or
+`process exited code 0`. Keyword lines after the last marker, and keyword lines
+with no marker at all, remain `current` with `disposition: "inspect"` so fresh
+errors are not hidden by scrollback cleanup.
+
+The JSON output exposes line-auditable `tmuxHistory` rows plus
+`tmuxHistorySummary` counts. Use `tmuxHistorySummary.disposition === "inspect"`
+as a hard signal that the pasted pane still contains a current blocker-looking
+line; use `suppress-replay` only for stale-only keyword evidence.
+
 Offline verification example:
 
 ```sh

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -12,6 +12,16 @@ const OMITTED_ALERT_RUN_EVIDENCE_LIMIT = 12;
 const STALE_CONCLUSIONS = new Set(["cancelled", "skipped"]);
 const ACTIONABLE_CONCLUSIONS = new Set(["failure", "timed_out", "action_required", "startup_failure"]);
 const ACTIVE_STATUSES = new Set(["queued", "in_progress", "waiting", "pending", "requested"]);
+const TMUX_BLOCKER_PATTERN = /\b(TS\d{4}|error|errors|failed|failure|exception)\b/i;
+const TMUX_NON_BLOCKER_PATTERN = /\b(?:0|zero|no)\s+errors?\b/i;
+const TMUX_RECOVERY_PATTERNS = [
+  /\bnpm\s+(?:run\s+)?test\b.*\bpass(?:ed|ing)?\b/i,
+  /\btests?\s+pass(?:ed|ing)?\b/i,
+  /\bPR\s+#?\d+\s+(?:opened|created|ready|merged)\b/i,
+  /\bralplan\s+terminal\b/i,
+  /\btmux\s+session\s+(?:killed|terminated|closed|exited)\b/i,
+  /\b(?:process\s+)?exited\s+(?:with\s+)?code\s+0\b/i,
+];
 
 function parseArgs(argv) {
   const options = {
@@ -95,6 +105,63 @@ function readAlertText(alertsInput) {
   if (!alertsInput) return "";
   if (alertsInput === "-") return fs.readFileSync(0, "utf8");
   return fs.readFileSync(path.resolve(repoRoot, alertsInput), "utf8");
+}
+
+function matchedTmuxKeyword(line) {
+  const withoutBenignErrorCounts = line.replace(TMUX_NON_BLOCKER_PATTERN, "");
+  return withoutBenignErrorCounts.match(TMUX_BLOCKER_PATTERN)?.[1] ?? "";
+}
+
+function isTmuxRecoveryLine(line) {
+  return TMUX_RECOVERY_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+function buildTmuxHistoryEvidence(alertText) {
+  const rawLines = String(alertText || "").split(/\r?\n/);
+  const lines = rawLines.map((text, index) => ({
+    line: index + 1,
+    text,
+    marker: isTmuxRecoveryLine(text),
+    matchedKeyword: matchedTmuxKeyword(text),
+  }));
+  const markerLines = lines.filter((line) => line.marker);
+  const lastRecoveryLine = markerLines.length ? markerLines.at(-1).line : null;
+  const rows = lines
+    .filter((line) => line.matchedKeyword)
+    .map((line) => {
+      const staleHistory = lastRecoveryLine !== null && line.line <= lastRecoveryLine;
+      return {
+        lineNumber: line.line,
+        excerpt: line.text.trim(),
+        matchedKeyword: line.matchedKeyword,
+        lastRecoveryMarkerLine: lastRecoveryLine,
+        evidence: staleHistory ? "stale-history" : "current",
+        verdict: staleHistory ? "tmux-history-replay" : "fresh-blocker",
+        disposition: staleHistory ? "suppress-replay" : "inspect",
+        reason: staleHistory
+          ? `blocker keyword appears before recovery/terminal marker on line ${lastRecoveryLine}`
+          : lastRecoveryLine === null
+            ? "blocker keyword has no later recovery/terminal marker in pasted pane history"
+            : `blocker keyword appears after recovery/terminal marker on line ${lastRecoveryLine}`,
+      };
+    });
+  const staleHistoryCount = rows.filter((row) => row.evidence === "stale-history").length;
+  const freshBlockerCount = rows.filter((row) => row.disposition === "inspect").length;
+
+  return {
+    rows,
+    summary: {
+      mode: alertText ? "scanned" : "empty",
+      totalLines: rawLines.length === 1 && rawLines[0] === "" ? 0 : rawLines.length,
+      recoveryMarkerCount: markerLines.length,
+      lastMarkerLine: lastRecoveryLine,
+      totalKeywordLines: rows.length,
+      staleKeywordLines: staleHistoryCount,
+      currentKeywordLines: freshBlockerCount,
+      disposition: freshBlockerCount > 0 ? "inspect" : staleHistoryCount > 0 ? "suppress-replay" : "none",
+      verdict: freshBlockerCount > 0 ? "fresh-blocker" : staleHistoryCount > 0 ? "stale-history-replay" : "no-keyword-evidence",
+    },
+  };
 }
 
 function normalizePositiveInteger(value) {
@@ -455,6 +522,24 @@ function alertEvidenceTable(alerts, summary) {
   return `${lines.join("\n")}\n\n`;
 }
 
+function tmuxHistoryTable(rows, summary) {
+  if (!summary || summary.totalKeywordLines === 0) return "";
+  const lines = [
+    "## Tmux pane history keyword evidence",
+    "",
+    `Verdict: \`${escapeMarkdown(summary.verdict)}\`; disposition: \`${escapeMarkdown(summary.disposition)}\`. Recovery/terminal markers: ${summary.recoveryMarkerCount}; last marker line: ${summary.lastMarkerLine ?? "-"}. Fresh blocker lines needing inspection: ${summary.currentKeywordLines}; stale history replay lines: ${summary.staleKeywordLines}.`,
+    "",
+    "Use `disposition=suppress-replay` only when the blocker keyword is older than the recovery/terminal marker. Lines after the marker remain `inspect` so fresh errors are not suppressed.",
+    "",
+    "| Disposition | Evidence | Line | Reason | Text |",
+    "| --- | --- | --- | --- | --- |",
+  ];
+  for (const row of rows) {
+    lines.push(`| ${row.disposition} | ${row.evidence} | ${row.lineNumber} | ${escapeMarkdown(row.reason)} | ${escapeMarkdown(row.excerpt)} |`);
+  }
+  return `${lines.join("\n")}\n\n`;
+}
+
 function renderMarkdown(result) {
   const actionable = result.rows.filter((row) => row.bucket === "actionable" || row.bucket === "watch");
   const stale = result.rows.filter((row) => row.bucket === "stale");
@@ -477,8 +562,10 @@ Use this report to collapse replayed GitHub Actions alert buffers: inspect only 
 - Pasted alert evidence needing inspection: ${result.alertSummary?.actionableAlertCount ?? 0}
 - Verification-only current-main echoes: ${result.alertSummary?.verificationOnlyCount ?? 0}
 - Stale success replay evidence: ${result.alertSummary?.staleSuccessReplayCount ?? 0}
+- Tmux pane history fresh blockers: ${result.tmuxHistorySummary?.currentKeywordLines ?? 0}
+- Tmux pane history stale replay lines: ${result.tmuxHistorySummary?.staleKeywordLines ?? 0}
 
-${alertEvidenceTable(result.alerts, result.alertSummary)}## Actionable / watch
+${alertEvidenceTable(result.alerts, result.alertSummary)}${tmuxHistoryTable(result.tmuxHistory, result.tmuxHistorySummary)}## Actionable / watch
 
 ${markdownTable(actionable)}
 ## Stale replay rows
@@ -490,11 +577,15 @@ function main() {
   const options = parseArgs(process.argv.slice(2));
   const rawRuns = readRuns(options);
   if (!Array.isArray(rawRuns)) throw new Error("Expected an array of GitHub Actions runs");
+  const alertText = readAlertText(options.alertsInput);
   const result = classifyRuns(rawRuns);
-  const alertRefs = extractAlertRunRefs(readAlertText(options.alertsInput));
+  const alertRefs = extractAlertRunRefs(alertText);
   const alertEvidence = buildAlertEvidence(alertRefs, result.rows, options);
+  const tmuxHistoryEvidence = buildTmuxHistoryEvidence(alertText);
   result.alerts = alertEvidence.alerts;
   result.alertSummary = alertEvidence.summary;
+  result.tmuxHistory = tmuxHistoryEvidence.rows;
+  result.tmuxHistorySummary = tmuxHistoryEvidence.summary;
   const output = options.format === "json" ? `${JSON.stringify(result, null, 2)}\n` : renderMarkdown(result);
 
   if (options.output) fs.writeFileSync(path.resolve(repoRoot, options.output), output);

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -804,3 +804,271 @@ test("CI alert triage dedupes duplicate current main success run and job URLs", 
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("CI alert triage suppresses stale tmux pane history blockers after recovery markers", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-tmux-stale-history-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 3790,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "fooks-issue-376-prune-remote-branch-noise",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-02T13:00:00Z",
+      updatedAt: "2026-05-02T13:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/3790",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "src/foo.ts(12,9): error TS7006: Parameter 'event' implicitly has an 'any' type.",
+    "npm test passed",
+    "PR #379 opened",
+    "ralplan terminal",
+    "tmux session killed",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.counts.actionable ?? 0, 0);
+    assert.equal(result.tmuxHistorySummary.verdict, "stale-history-replay");
+    assert.equal(result.tmuxHistorySummary.totalKeywordLines, 1);
+    assert.equal(result.tmuxHistorySummary.staleKeywordLines, 1);
+    assert.equal(result.tmuxHistorySummary.currentKeywordLines, 0);
+    assert.equal(result.tmuxHistorySummary.lastMarkerLine, 5);
+    assert.equal(result.tmuxHistory[0].evidence, "stale-history");
+    assert.equal(result.tmuxHistory[0].verdict, "tmux-history-replay");
+    assert.equal(result.tmuxHistory[0].disposition, "suppress-replay");
+    assert.match(result.tmuxHistory[0].reason, /before recovery\/terminal marker/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage keeps fresh tmux blockers after recovery markers inspectable", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-tmux-fresh-history-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 3880,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "fix/issue-388-stale-tmux-error-realert",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-03T08:00:00Z",
+      updatedAt: "2026-05-03T08:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/3880",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "npm test passed",
+    "PR #379 opened",
+    "new command output after recovery",
+    "src/current.ts(4,2): error TS7006: Parameter 'value' implicitly has an 'any' type.",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.tmuxHistorySummary.verdict, "fresh-blocker");
+    assert.equal(result.tmuxHistorySummary.totalKeywordLines, 1);
+    assert.equal(result.tmuxHistorySummary.staleKeywordLines, 0);
+    assert.equal(result.tmuxHistorySummary.currentKeywordLines, 1);
+    assert.equal(result.tmuxHistorySummary.lastMarkerLine, 2);
+    assert.equal(result.tmuxHistory[0].evidence, "current");
+    assert.equal(result.tmuxHistory[0].verdict, "fresh-blocker");
+    assert.equal(result.tmuxHistory[0].disposition, "inspect");
+    assert.match(result.tmuxHistory[0].reason, /after recovery\/terminal marker/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage treats tmux blocker keywords without recovery markers as current", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-tmux-no-marker-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([]));
+  fs.writeFileSync(alertsPath, "src/current.ts(4,2): error TS7006: Parameter 'value' implicitly has an 'any' type.\n");
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.tmuxHistorySummary.disposition, "inspect");
+    assert.equal(result.tmuxHistorySummary.verdict, "fresh-blocker");
+    assert.equal(result.tmuxHistorySummary.lastMarkerLine, null);
+    assert.equal(result.tmuxHistory[0].matchedKeyword, "error");
+    assert.equal(result.tmuxHistory[0].evidence, "current");
+    assert.equal(result.tmuxHistory[0].disposition, "inspect");
+    assert.match(result.tmuxHistory[0].reason, /no later recovery\/terminal marker/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage keeps URL actionable evidence inspectable when tmux history is stale", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-url-actionable-tmux-stale-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 9901,
+      workflowName: "CI",
+      name: "Validate",
+      headBranch: "main",
+      event: "push",
+      status: "completed",
+      conclusion: "failure",
+      createdAt: "2026-05-03T08:00:00Z",
+      updatedAt: "2026-05-03T08:05:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/9901",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "old pane line: error TS7006 from prior attempt",
+    "npm test passed",
+    "fresh CI URL still failing https://github.com/minislively/fooks/actions/runs/9901",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.alertSummary.actionableAlertCount, 1);
+    assert.equal(result.alerts[0].evidence, "actionable");
+    assert.equal(result.alerts[0].disposition, "inspect");
+    assert.equal(result.tmuxHistorySummary.disposition, "suppress-replay");
+    assert.equal(result.tmuxHistory[0].disposition, "suppress-replay");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage recognizes process exited code 0 as a tmux recovery marker", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-tmux-process-exited-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([]));
+  fs.writeFileSync(alertsPath, [
+    "src/x.ts: error TS7006",
+    "process exited code 0",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.tmuxHistorySummary.lastMarkerLine, 2);
+    assert.equal(result.tmuxHistorySummary.disposition, "suppress-replay");
+    assert.equal(result.tmuxHistory[0].evidence, "stale-history");
+    assert.equal(result.tmuxHistory[0].disposition, "suppress-replay");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage does not let benign error counts hide failed keywords", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-tmux-failed-zero-errors-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([]));
+  fs.writeFileSync(alertsPath, [
+    "summary: 1 failed, 0 errors",
+    "npm test passed",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.tmuxHistorySummary.totalKeywordLines, 1);
+    assert.equal(result.tmuxHistorySummary.staleKeywordLines, 1);
+    assert.equal(result.tmuxHistory[0].matchedKeyword, "failed");
+    assert.equal(result.tmuxHistory[0].evidence, "stale-history");
+    assert.equal(result.tmuxHistory[0].disposition, "suppress-replay");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add separate tmux pane-history keyword evidence to CI alert triage
- suppress only stale keyword lines before explicit recovery/terminal markers
- keep fresh blockers and actionable GitHub Actions URLs inspectable

## Tests
- node --check scripts/triage-ci-alerts.mjs && node --test test/ci-alert-triage.test.mjs
- npm test

Fixes #388