### PR TITLE
Guard pre-read fallback reasons against stale domain payloads

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -144,13 +144,15 @@ export function buildPreReadDecisionFromPayloadPlan(input: PreReadDecisionFromPa
       });
     }
 
+    const reason = input.domainDetection.reason ?? profileGate.reason;
     return buildPreReadFallbackDecision({
       runtime: input.runtime,
       filePath: input.filePath,
       eligible: true,
-      reasons: [profileGate.reason],
+      reasons: [reason],
       readiness: input.readiness,
-      debug: input.debug,
+      debug: frontendDebug(input.domainDetection, input.frontendPayloadPolicy),
+      fallbackReason: reason,
     });
   }
 

--- a/test/pre-read-phase-order-regression.test.mjs
+++ b/test/pre-read-phase-order-regression.test.mjs
@@ -3,12 +3,15 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+const { buildPreReadDecisionFromPayloadPlan } = require(path.join(repoRoot, "dist", "adapters", "pre-read-stack.js"));
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
 
 const PAYLOAD_DEBUG_KEYS = [
   "complexityScore",
@@ -71,4 +74,50 @@ test("pre-read adapter phase ordering preserves boundary short-circuit and paylo
   assert.equal(payloadDecision.debug.language, "tsx");
   assert.equal(payloadDecision.debug.domainDetection.classification, "react-web");
   assert.equal(payloadDecision.debug.frontendPayloadPolicy.allowed, true);
+});
+
+test("pre-read payload-plan seam keeps live fallback reasons ahead of stale cached domain payloads", () => {
+  const stalePayloadDecision = preRead.decidePreRead(
+    path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"),
+    repoRoot,
+    "codex",
+    { includeEditGuidance: true },
+  );
+
+  assert.equal(stalePayloadDecision.decision, "payload");
+  assert.equal(stalePayloadDecision.readiness.ready, true);
+  assert.ok(stalePayloadDecision.payload);
+  assert.equal(stalePayloadDecision.payload.domainPayload?.domain, "react-web");
+  assert.equal(stalePayloadDecision.payload.domainPayload?.plannerDecision, "compact-safe");
+  assert.equal(stalePayloadDecision.debug.domainDetection.classification, "react-web");
+
+  const webviewPath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "webview-boundary-basic.tsx");
+  const liveDomainDetection = detectDomainFromSource(fs.readFileSync(webviewPath, "utf8"), webviewPath);
+  const livePayloadPolicy = preRead.assessFrontendPayloadPolicy(liveDomainDetection);
+
+  assert.equal(liveDomainDetection.classification, "webview");
+  assert.equal(liveDomainDetection.reason, "unsupported-react-native-webview-boundary");
+  assert.equal(livePayloadPolicy.allowed, false);
+  assert.equal(livePayloadPolicy.reason, "unsupported-react-native-webview-boundary");
+
+  // This intentionally adversarial pairing models cached/pre-read drift: a stale
+  // React Web payload is ready, but the live source evidence is WebView fallback.
+  const decision = buildPreReadDecisionFromPayloadPlan({
+    runtime: "codex",
+    filePath: path.join("test", "fixtures", "frontend-domain-expectations", "webview-boundary-basic.tsx"),
+    extension: ".tsx",
+    domainDetection: liveDomainDetection,
+    frontendPayloadPolicy: livePayloadPolicy,
+    payload: stalePayloadDecision.payload,
+    readiness: stalePayloadDecision.readiness,
+    debug: stalePayloadDecision.debug,
+  });
+
+  assert.equal(decision.decision, "fallback");
+  assert.equal("payload" in decision, false, "stale React Web payload must not widen a live WebView fallback");
+  assert.deepEqual(decision.reasons, ["unsupported-react-native-webview-boundary"]);
+  assert.equal(decision.fallback.reason, "unsupported-react-native-webview-boundary");
+  assert.equal(decision.debug.domainDetection.classification, "webview");
+  assert.equal(decision.debug.domainDetection.reason, "unsupported-react-native-webview-boundary");
+  assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
 });


### PR DESCRIPTION
## Summary
- add an adversarial pre-read regression that pairs stale React Web payload/readiness with live WebView fallback evidence
- preserve live fallback reasons and live frontend debug at the payload-plan profile gate fallback seam
- keep the guard narrow; no broad cache invalidation or remote branch cleanup

## Verification
- `npm run build && node --test test/pre-read-phase-order-regression.test.mjs test/payload-policy-fallback.test.mjs`
- `npm run build && node --test test/pre-read-phase-order-regression.test.mjs test/payload-policy-fallback.test.mjs test/payload-policy-tui-ink.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test`

Closes #391
