### PR TITLE
Derive payload policy drift guards from registry

### DIFF
--- a/test/payload-policy-registry-drift.test.mjs
+++ b/test/payload-policy-registry-drift.test.mjs
@@ -16,17 +16,6 @@ const FALLBACK_POLICY_LANE_COVERAGE = {
   fallback: ["mixed", "unknown"],
 };
 
-const LANE_OWNED_PAYLOAD_POLICY_MODULES = new Set([
-  path.join("src", "core", "payload-policy", "react-web.ts"),
-  path.join("src", "core", "payload-policy", "react-native.ts"),
-  path.join("src", "core", "payload-policy", "webview.ts"),
-  path.join("src", "core", "payload-policy", "tui-ink.ts"),
-  path.join("src", "core", "payload-policy", "fallback.ts"),
-  path.join("src", "core", "payload-policy", "registry.ts"),
-]);
-
-const LANE_SPECIFIC_ASSESSOR_IMPORT = /import\s*\{[^}]*\bassess(?:ReactWeb|ReactNative|WebView|TuiInk|Fallback)PayloadPolicy\b[^}]*\}\s*from\s*["'][^"']*\/payload-policy\/(?:react-web|react-native|webview|tui-ink|fallback)["']/;
-
 function listSourceFiles(directory) {
   const entries = fs.readdirSync(directory, { withFileTypes: true });
   return entries.flatMap((entry) => {
@@ -35,6 +24,23 @@ function listSourceFiles(directory) {
     if (!entry.isFile() || !absolutePath.endsWith(".ts")) return [];
     return [absolutePath];
   });
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function laneOwnedAssessorNames() {
+  return FRONTEND_PAYLOAD_POLICY_REGISTRY.map((entry) => entry.assess.name).filter(Boolean).sort();
+}
+
+function importsLaneOwnedAssessor(sourceText, assessorNames) {
+  const assessorPattern = assessorNames.map(escapeRegExp).join("|");
+  const laneAssessorImport = new RegExp(
+    `import\\s*\\{[^}]*\\b(?:${assessorPattern})\\b[^}]*\\}\\s*from\\s*["'][^"']*\\/payload-policy\\/[^"']+["']`,
+  );
+
+  return laneAssessorImport.test(sourceText);
 }
 
 test("payload policy registry accounts for every registered frontend profile lane", () => {
@@ -52,10 +58,13 @@ test("payload policy registry accounts for every registered frontend profile lan
 });
 
 test("runtime source cannot bypass the payload policy registry with lane-owned assessors", () => {
+  const assessorNames = laneOwnedAssessorNames();
+  assert.ok(assessorNames.length > 0, "payload-policy registry must expose lane-owned assessor functions");
+
   const bypasses = listSourceFiles(path.join(repoRoot, "src"))
     .map((absolutePath) => path.relative(repoRoot, absolutePath))
-    .filter((relativePath) => !LANE_OWNED_PAYLOAD_POLICY_MODULES.has(relativePath))
-    .filter((relativePath) => LANE_SPECIFIC_ASSESSOR_IMPORT.test(fs.readFileSync(path.join(repoRoot, relativePath), "utf8")));
+    .filter((relativePath) => !relativePath.startsWith(path.join("src", "core", "payload-policy") + path.sep))
+    .filter((relativePath) => importsLaneOwnedAssessor(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), assessorNames));
 
   assert.deepEqual(
     bypasses,


### PR DESCRIPTION
## Summary
- Replace hardcoded lane-owned payload-policy module and assessor lists in the drift guard.
- Derive lane-owned assessor names from `FRONTEND_PAYLOAD_POLICY_REGISTRY`.
- Preserve the no-bypass guard for runtime source outside `src/core/payload-policy/**`.

## Scope boundary
- Test-only change.
- Fresh worktree implementation: `fooks-payload-policy-drift-registry-driven`.
- No runtime or policy behavior changes.
- No RN/WebView/TUI support claim expansion.

## Verification
- `npm run build`
- focused payload-policy drift/registry/domain-coverage/profile-gate/pre-read/runtime/fooks tests
- `npm run typecheck -- --pretty false`
- `git diff --check`
- support-claim grep over `docs` and `src`
- `npm test`
