### PR TITLE
Limit RN compact payload reuse to measured primitive input evidence

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -6,7 +6,7 @@ This document is the canonical architecture note for how fooks should evolve fro
 
 ## Status and boundaries
 
-Current broad frontend support remains the measured React Web same-file TSX/JSX lane described in the README and roadmap. React Native, WebView, TUI/Ink, Mixed, and Unknown domains require separate policy decisions before their signals can affect compact payload behavior.
+Current broad frontend support remains the measured React Web same-file TSX/JSX lane described in the README and roadmap. React Native, WebView, TUI/Ink, Mixed, and Unknown domains require separate policy decisions before their signals can affect compact payload behavior. The only current non-web compact exception is the measured `F1` React Native primitive/input gate, which may emit an RN-shaped `domainPayload` through `rn-primitive-input-narrow-payload`; this remains measured evidence only.
 
 Architecture shorthand:
 
@@ -18,7 +18,7 @@ This document does not add:
 
 - runtime behavior;
 - setup eligibility;
-- detector behavior, pre-read behavior, or payload schema changes;
+- detector behavior, pre-read behavior, or payload schema changes outside the measured React Web lane and the existing `F1` RN primitive/input narrow gate;
 - React Native broad support;
 - WebView support, bridge safety, or compact-payload reuse;
 - broad TUI semantic support or terminal correctness;
@@ -137,7 +137,7 @@ type PayloadDecision = {
 The planner is where domain-specific risk belongs:
 
 - React Web can be compact-safe when existing extractor/readiness rules prove it.
-- React Native is evidence/fallback by default, except the existing measured `F1` primitive/input narrow gate named in the frontend-domain contract.
+- React Native is evidence/fallback by default, except the existing measured `F1` primitive/input narrow gate named in the frontend-domain contract. That gate may build a React-Native-specific domain payload containing primitive/input evidence, but it must not reinterpret RN primitives as DOM controls or broaden to style/platform/navigation/list/media semantics.
 - WebView is boundary-aware or fallback-full-read by default.
 - TUI/Ink remains bounded by measured TSX syntax/payload behavior and does not imply terminal correctness.
 - Mixed and Unknown should choose fallback or defer when signals are weak or conflicting.

--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -45,7 +45,7 @@ Pre-read behavior must stay conservative for TUI/Ink: `F5` can remain extractabl
 
 ## RN component semantics readiness gate
 
-The RN fixture lane is a readiness gate, not a support promise. `F1` is the first narrow runtime candidate and is limited to primitive/input payload reuse through `rn-primitive-input-narrow-payload`; it is not broad React Native support. Other selected RN fixtures stay fallback/evidence-only until a later detector/profile promotion plan explicitly changes runtime behavior. The current fallback reason, `unsupported-react-native-webview-boundary`, is still the shared source-reading boundary reason for detector evidence and WebView/mixed boundaries; it must not be treated as a permanent domain model for every RN semantic.
+The RN fixture lane is a readiness gate, not a support promise. `F1` is the first narrow runtime candidate and is limited to primitive/input payload reuse through `rn-primitive-input-narrow-payload`; that payload may include an RN-shaped `domainPayload` with primitive and input/press evidence, but it is not broad React Native support. Other selected RN fixtures stay fallback/evidence-only until a later detector/profile promotion plan explicitly changes runtime behavior. The current fallback reason, `unsupported-react-native-webview-boundary`, is still the shared source-reading boundary reason for detector evidence and WebView/mixed boundaries; it must not be treated as a permanent domain model for every RN semantic.
 
 | Semantics group | Selected slots | Evidence examples | Required boundary |
 | --- | --- | --- | --- |

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -5,6 +5,7 @@ import type { FrontendPayloadPolicyDecision } from "./types";
 
 const FRONTEND_PROFILE_GATE_EXTENSIONS = new Set([".tsx", ".jsx"]);
 export const MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON = "missing-react-web-domain-payload";
+export const MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON = "missing-react-native-domain-payload";
 
 export type FrontendProfilePayloadReuseDecision = { allowed: true } | { allowed: false; reason: string };
 
@@ -25,6 +26,12 @@ export function assessFrontendProfilePayloadReuse(
   }
 
   if (frontendPayloadPolicy?.allowed === true) {
+    if (domainDetection.profile.lane === "react-native") {
+      return payload.domainPayload?.domain === "react-native" && payload.domainPayload.policy === frontendPayloadPolicy.name
+        ? { allowed: true }
+        : { allowed: false, reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON };
+    }
+
     return { allowed: true };
   }
 

--- a/src/core/payload-policy/react-native.ts
+++ b/src/core/payload-policy/react-native.ts
@@ -3,22 +3,22 @@ import type { FrontendPayloadPolicyDecision } from "./types";
 
 export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
 
-const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
+export const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
   "react-native:primitive:View",
   "react-native:primitive:Text",
   "react-native:primitive:TextInput",
   "react-native:primitive:Pressable",
   "react-native:jsx-prop:onChangeText",
   "react-native:jsx-prop:onPress",
-];
-const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = [
+] as const;
+export const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = [
   "webview:",
   "tui-ink:",
   "react-native:navigation-",
   "react-native:api-call:Dimensions.",
   "react-native:api-call:PanResponder.",
-];
-const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
+] as const;
+export const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
   "react-native:primitive:FlatList",
   "react-native:primitive:Image",
   "react-native:primitive:ScrollView",
@@ -28,7 +28,11 @@ const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
   "react-native:style-prop:resizeMode",
   "react-native:jsx-prop:activeOpacity",
   "react-native:jsx-prop:pagingEnabled",
-];
+] as const;
+
+type ReactNativePrimitiveInputSignalGate =
+  | { allowed: true }
+  | { allowed: false; reason: `forbidden-signal:${string}` | `missing-signal:${string}` };
 
 function hasSignal(domainDetection: DomainDetectionResult, signal: string): boolean {
   return domainDetection.signals.includes(signal);
@@ -38,28 +42,35 @@ function hasAnySignalWithPrefix(domainDetection: DomainDetectionResult, prefix: 
   return domainDetection.signals.some((signal) => signal.startsWith(prefix));
 }
 
+export function assessReactNativePrimitiveInputSignalGate(
+  domainDetection: DomainDetectionResult,
+): ReactNativePrimitiveInputSignalGate {
+  const forbiddenSignal =
+    RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS.find((signal) => hasSignal(domainDetection, signal)) ??
+    RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.find((prefix) => hasAnySignalWithPrefix(domainDetection, prefix));
+  if (forbiddenSignal) {
+    return { allowed: false, reason: `forbidden-signal:${forbiddenSignal}` };
+  }
+
+  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
+  if (missingSignal) {
+    return { allowed: false, reason: `missing-signal:${missingSignal}` };
+  }
+
+  return { allowed: true };
+}
+
 export function assessReactNativePayloadPolicy(
   domainDetection: DomainDetectionResult,
 ): FrontendPayloadPolicyDecision | undefined {
   if (domainDetection.classification !== "react-native") return undefined;
 
-  const forbiddenSignal =
-    RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS.find((signal) => hasSignal(domainDetection, signal)) ??
-    RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.find((prefix) => hasAnySignalWithPrefix(domainDetection, prefix));
-  if (forbiddenSignal) {
+  const signalGate = assessReactNativePrimitiveInputSignalGate(domainDetection);
+  if (!signalGate.allowed) {
     return {
       name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
       allowed: false,
-      reason: `forbidden-signal:${forbiddenSignal}`,
-    };
-  }
-
-  const missingSignal = RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS.find((signal) => !hasSignal(domainDetection, signal));
-  if (missingSignal) {
-    return {
-      name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
-      allowed: false,
-      reason: `missing-signal:${missingSignal}`,
+      reason: signalGate.reason,
     };
   }
 

--- a/src/core/payload-policy/registry.ts
+++ b/src/core/payload-policy/registry.ts
@@ -1,6 +1,6 @@
 import type { DomainDetectionResult } from "../domain-detector";
 import { assessFallbackPayloadPolicy } from "./fallback";
-import { assessReactNativePayloadPolicy } from "./react-native";
+import { assessReactNativePayloadPolicy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY } from "./react-native";
 import { assessReactWebPayloadPolicy, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY } from "./react-web";
 import { assessTuiInkPayloadPolicy } from "./tui-ink";
 import type { FrontendPayloadPolicyDecision } from "./types";
@@ -44,7 +44,8 @@ export function toFrontendPayloadBuildOptions(
   policy: FrontendPayloadPolicyDecision | undefined,
 ): FrontendPayloadBuildOptions {
   return {
-    includeDomainPayload: policy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY,
+    includeDomainPayload:
+      policy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY || policy?.name === RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
     ...(policy?.name ? { domainPayloadPolicy: policy.name } : {}),
   };
 }

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -1,4 +1,8 @@
 import type { DomainDetectionResult } from "../domain-detector";
+import {
+  assessReactNativePrimitiveInputSignalGate,
+  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+} from "../payload-policy/react-native";
 import type { ExtractionResult, FormControlSignal, StyleSystem } from "../schema";
 
 export const DOMAIN_PAYLOAD_SCHEMA_VERSION = "domain-payload.v1";
@@ -30,7 +34,27 @@ export type ReactWebDomainPayload = {
   warnings: string[];
 };
 
-export type DomainPayload = ReactWebDomainPayload;
+export type ReactNativePrimitiveInputDomainPayload = {
+  schemaVersion: typeof DOMAIN_PAYLOAD_SCHEMA_VERSION;
+  domain: "react-native";
+  policy: typeof RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY;
+  plannerDecision: "narrow-primitive-input-payload";
+  claimStatus: "measured-evidence-only";
+  claimBoundary: "rn-primitive-input-narrow-payload-only";
+  evidence: string[];
+  facts: {
+    primitives: string[];
+    jsxProps: string[];
+    componentName?: string;
+    exports?: Pick<ExtractionResult["exports"][number], "name" | "kind" | "type">[];
+    hooks?: string[];
+    eventHandlers?: string[];
+    jsxDepth?: number;
+  };
+  warnings: string[];
+};
+
+export type DomainPayload = ReactWebDomainPayload | ReactNativePrimitiveInputDomainPayload;
 
 type ReactWebPayloadEvidenceFacts = {
   evidence: string[];
@@ -41,6 +65,17 @@ type ReactWebPayloadEvidenceFacts = {
 type ReactWebPayloadPlan = {
   result: ExtractionResult;
   evidenceFacts: ReactWebPayloadEvidenceFacts;
+};
+
+type ReactNativePayloadEvidenceFacts = {
+  evidence: string[];
+  primitives: string[];
+  jsxProps: string[];
+};
+
+type ReactNativePayloadPlan = {
+  result: ExtractionResult;
+  evidenceFacts: ReactNativePayloadEvidenceFacts;
 };
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -83,6 +118,17 @@ function collectReactWebPayloadEvidence(domainDetection: DomainDetectionResult):
   };
 }
 
+function collectReactNativePayloadEvidence(domainDetection: DomainDetectionResult): ReactNativePayloadEvidenceFacts | undefined {
+  const reactNativeEvidence = domainDetection.evidence.filter((item) => item.domain === "react-native");
+  if (reactNativeEvidence.length === 0) return undefined;
+
+  return {
+    evidence: uniqueSorted(reactNativeEvidence.map((item) => `${item.domain}:${item.signal}:${item.detail}`)),
+    primitives: uniqueSorted(reactNativeEvidence.filter((item) => item.signal === "primitive").map((item) => item.detail)),
+    jsxProps: uniqueSorted(reactNativeEvidence.filter((item) => item.signal === "jsx-prop").map((item) => item.detail)),
+  };
+}
+
 function planReactWebPayload(
   result: ExtractionResult,
   domainDetection: DomainDetectionResult | undefined,
@@ -95,6 +141,22 @@ function planReactWebPayload(
   if (domainDetection.profile.claimBoundary !== "react-web-measured-extraction") return undefined;
 
   const evidenceFacts = collectReactWebPayloadEvidence(domainDetection);
+  if (!evidenceFacts) return undefined;
+
+  return { result, evidenceFacts };
+}
+
+function planReactNativePrimitiveInputPayload(
+  result: ExtractionResult,
+  domainDetection: DomainDetectionResult | undefined,
+  policy: string,
+): ReactNativePayloadPlan | undefined {
+  if (policy !== RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY) return undefined;
+  if (!domainDetection) return undefined;
+  if (domainDetection.classification !== "react-native") return undefined;
+  if (!assessReactNativePrimitiveInputSignalGate(domainDetection).allowed) return undefined;
+
+  const evidenceFacts = collectReactNativePayloadEvidence(domainDetection);
   if (!evidenceFacts) return undefined;
 
   return { result, evidenceFacts };
@@ -128,6 +190,25 @@ function buildReactWebPayloadFacts(
   };
 }
 
+function buildReactNativePayloadFacts(
+  result: ExtractionResult,
+  evidenceFacts: ReactNativePayloadEvidenceFacts,
+): ReactNativePrimitiveInputDomainPayload["facts"] {
+  const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
+  const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+  const exportFacts = compactExports(result.exports);
+
+  return {
+    primitives: evidenceFacts.primitives,
+    jsxProps: evidenceFacts.jsxProps,
+    ...(result.componentName ? { componentName: result.componentName } : {}),
+    ...(exportFacts && exportFacts.length > 0 ? { exports: exportFacts } : {}),
+    ...(hooks.length > 0 ? { hooks } : {}),
+    ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
+    ...(typeof result.structure?.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
+  };
+}
+
 export function buildReactWebDomainPayload(
   result: ExtractionResult,
   domainDetection: DomainDetectionResult | undefined = result.domainDetection,
@@ -150,4 +231,40 @@ export function buildReactWebDomainPayload(
       "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",
     ],
   };
+}
+
+export function buildReactNativePrimitiveInputDomainPayload(
+  result: ExtractionResult,
+  domainDetection: DomainDetectionResult | undefined = result.domainDetection,
+  policy = RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+): ReactNativePrimitiveInputDomainPayload | undefined {
+  const plan = planReactNativePrimitiveInputPayload(result, domainDetection, policy);
+  if (!plan) return undefined;
+
+  return {
+    schemaVersion: DOMAIN_PAYLOAD_SCHEMA_VERSION,
+    domain: "react-native",
+    policy: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    plannerDecision: "narrow-primitive-input-payload",
+    claimStatus: "measured-evidence-only",
+    claimBoundary: "rn-primitive-input-narrow-payload-only",
+    evidence: plan.evidenceFacts.evidence,
+    facts: buildReactNativePayloadFacts(plan.result, plan.evidenceFacts),
+    warnings: [
+      "React Native primitive/input payload reuse is limited to the measured F1-style gate.",
+      "Do not reinterpret React Native primitives as DOM controls, web form semantics, navigation behavior, native platform behavior, or WebView bridge behavior.",
+      "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",
+    ],
+  };
+}
+
+export function buildFrontendDomainPayload(
+  result: ExtractionResult,
+  domainDetection: DomainDetectionResult | undefined = result.domainDetection,
+  policy = REACT_WEB_DOMAIN_PAYLOAD_POLICY,
+): DomainPayload | undefined {
+  return (
+    buildReactWebDomainPayload(result, domainDetection, policy) ??
+    buildReactNativePrimitiveInputDomainPayload(result, domainDetection, policy)
+  );
 }

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { deriveDesignReviewMetadata } from "../design-review-metadata";
-import { buildReactWebDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
+import { buildFrontendDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
 import type { EditGuidance, ExtractionResult, ModelFacingPayload, PatchTarget, PatchTargetKind, SourceFingerprint, SourceRange } from "../schema";
 
 const PATCH_TARGET_LIMIT = 12;
@@ -129,7 +129,7 @@ function buildEditGuidance(result: ExtractionResult, freshness: SourceFingerprin
 
 export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd(), options: ModelFacingPayloadOptions = {}): ModelFacingPayload {
   const domainPayload = options.includeDomainPayload
-    ? buildReactWebDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
+    ? buildFrontendDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
     : undefined;
 
   if (result.useOriginal && result.mode === "raw" && result.rawText) {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1256,7 +1256,10 @@ export function CustomOnlyForm() {
   assert.equal(rnPrimitive.readiness.ready, true);
   assert.equal(rnPrimitive.readiness.signals.hasContract, true);
   assert.ok(rnPrimitive.payload.contract.propsName);
-  assert.equal("domainPayload" in rnPrimitive.payload, false);
+  assert.equal(rnPrimitive.payload.domainPayload.domain, "react-native");
+  assert.equal(rnPrimitive.payload.domainPayload.policy, preReadModule.RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+  assert.deepEqual(rnPrimitive.payload.domainPayload.facts.primitives, ["Pressable", "Text", "TextInput", "View"]);
+  assert.deepEqual(rnPrimitive.payload.domainPayload.facts.jsxProps, ["onChangeText", "onPress"]);
 
   for (const rnFixture of [
     "rn-style-platform-navigation.tsx",

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -15,6 +15,7 @@ const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "pa
 const {
   assessFrontendProfilePayloadReuse,
   MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON,
+  MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON,
 } = require(path.join(repoRoot, "dist", "core", "payload-policy", "profile-gate.js"));
 const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
 const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
@@ -65,7 +66,25 @@ test("frontend profile gate allows narrow allowed non-web frontend policies", ()
 
   assert.equal(domainDetection.classification, "react-native");
   assert.equal(policy.allowed, true);
+  assert.equal(payload.domainPayload.domain, "react-native");
+  assert.equal(payload.domainPayload.policy, policy.name);
+  assert.deepEqual(payload.domainPayload.facts.primitives, ["Pressable", "Text", "TextInput", "View"]);
+  assert.deepEqual(payload.domainPayload.facts.jsxProps, ["onChangeText", "onPress"]);
   assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+});
+
+test("frontend profile gate requires RN domain payload for the measured narrow RN policy", () => {
+  const source = `import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Native.tsx");
+  const withoutDomainPayload = { ...payload };
+  delete withoutDomainPayload.domainPayload;
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.equal(policy.allowed, true);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutDomainPayload, policy), {
+    allowed: false,
+    reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON,
+  });
 });
 
 test("frontend profile gate denies unsupported frontend profile reuse", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -11,9 +11,16 @@ const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
 const {
+  assessReactNativePrimitiveInputSignalGate,
   assessReactNativePayloadPolicy,
+  RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
+  RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+  RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
 } = require(path.join(repoRoot, "dist", "core", "payload-policy", "react-native.js"));
+const { buildReactNativePrimitiveInputDomainPayload } = require(
+  path.join(repoRoot, "dist", "core", "payload", "domain-payload.js"),
+);
 const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
 
 const forbiddenSupportClaims = /React Native support is available|React Native is supported today|React Native support will ship|broad React Native support|default React Native compact extraction is enabled/i;
@@ -27,6 +34,15 @@ function rnPrimitiveInputSource(extraJsx = "") {
     export function NativeInput() {
       return <View><Text>Email</Text><TextInput value="" onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable>${extraJsx}</View>;
     }`;
+}
+
+function signalToEvidence(signal) {
+  const [, signalKind, ...detailParts] = signal.split(":");
+  return {
+    domain: "react-native",
+    signal: signalKind,
+    detail: detailParts.join(":"),
+  };
 }
 
 test("React Native payload policy allows the measured primitive/input signal set only", () => {
@@ -96,6 +112,88 @@ test("pre-read compatibility entrypoint delegates RN primitive/input decisions t
 
   assert.deepEqual(preRead.assessFrontendPayloadPolicy(domainDetection), assessReactNativePayloadPolicy(domainDetection));
   assert.equal(preRead.RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+});
+
+test("React Native F1 signal gate is the shared source of truth for policy and payload builder", () => {
+  const requiredSignals = [
+    "react-native:primitive:View",
+    "react-native:primitive:Text",
+    "react-native:primitive:TextInput",
+    "react-native:primitive:Pressable",
+    "react-native:jsx-prop:onChangeText",
+    "react-native:jsx-prop:onPress",
+  ];
+  const forbiddenExactSignals = [
+    "react-native:primitive:FlatList",
+    "react-native:primitive:Image",
+    "react-native:primitive:ScrollView",
+    "react-native:primitive:TouchableOpacity",
+    "react-native:style-factory:StyleSheet.create",
+    "react-native:platform-select:Platform.select",
+    "react-native:style-prop:resizeMode",
+    "react-native:jsx-prop:activeOpacity",
+    "react-native:jsx-prop:pagingEnabled",
+  ];
+
+  assert.deepEqual(RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS, requiredSignals);
+  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS, forbiddenExactSignals);
+  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES, [
+    "webview:",
+    "tui-ink:",
+    "react-native:navigation-",
+    "react-native:api-call:Dimensions.",
+    "react-native:api-call:PanResponder.",
+  ]);
+
+  const extractionResult = {
+    componentName: "NativeInput",
+    exports: [],
+    behavior: {},
+    structure: {},
+    domainDetection: undefined,
+  };
+  const allowedDetection = {
+    classification: "react-native",
+    signals: requiredSignals,
+    evidence: requiredSignals.map(signalToEvidence),
+    profile: { lane: "react-native", claimStatus: "evidence-only", claimBoundary: "unsupported-react-native-webview-boundary" },
+  };
+
+  assert.deepEqual(assessReactNativePrimitiveInputSignalGate(allowedDetection), { allowed: true });
+  assert.deepEqual(assessReactNativePayloadPolicy(allowedDetection), {
+    name: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    allowed: true,
+  });
+  assert.equal(
+    buildReactNativePrimitiveInputDomainPayload(extractionResult, allowedDetection)?.policy,
+    RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+  );
+
+  for (const missingSignal of requiredSignals) {
+    const domainDetection = {
+      ...allowedDetection,
+      signals: requiredSignals.filter((signal) => signal !== missingSignal),
+    };
+
+    assert.deepEqual(assessReactNativePrimitiveInputSignalGate(domainDetection), {
+      allowed: false,
+      reason: `missing-signal:${missingSignal}`,
+    });
+    assert.equal(buildReactNativePrimitiveInputDomainPayload(extractionResult, domainDetection), undefined);
+  }
+
+  for (const forbiddenSignal of forbiddenExactSignals) {
+    const domainDetection = {
+      ...allowedDetection,
+      signals: [...requiredSignals, forbiddenSignal],
+    };
+
+    assert.deepEqual(assessReactNativePrimitiveInputSignalGate(domainDetection), {
+      allowed: false,
+      reason: `forbidden-signal:${forbiddenSignal}`,
+    });
+    assert.equal(buildReactNativePrimitiveInputDomainPayload(extractionResult, domainDetection), undefined);
+  }
 });
 
 test("React Native policy seam source avoids broad React Native support claims", () => {

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -91,15 +91,20 @@ test("pre-read compatibility entrypoint exports the core policy registry APIs", 
   }
 });
 
-test("frontend payload build options include domain payload only for React Web policy", () => {
+test("frontend payload build options include domain payload for React Web and measured RN narrow policies", () => {
   const reactWebPolicy = registry.assessFrontendPayloadPolicy(samples["react-web"]);
+  const reactNativePolicy = registry.assessFrontendPayloadPolicy(samples["react-native"]);
 
   assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactWebPolicy), {
     includeDomainPayload: true,
     domainPayloadPolicy: reactWebPolicy.name,
   });
+  assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactNativePolicy), {
+    includeDomainPayload: true,
+    domainPayloadPolicy: reactNativePolicy.name,
+  });
 
-  for (const lane of ["webview", "tui-ink", "react-native", "mixed", "unknown"]) {
+  for (const lane of ["webview", "tui-ink", "mixed", "unknown"]) {
     const policy = registry.assessFrontendPayloadPolicy(samples[lane]);
     assert.deepEqual(
       registry.toFrontendPayloadBuildOptions(policy),

--- a/test/pre-read-phase-order-regression.test.mjs
+++ b/test/pre-read-phase-order-regression.test.mjs
@@ -134,7 +134,8 @@ test("live RN policy downgrade does not reuse stale RN narrow payload", () => {
   assert.equal(stalePayloadDecision.decision, "payload");
   assert.equal(stalePayloadDecision.readiness.ready, true);
   assert.ok(stalePayloadDecision.payload);
-  assert.equal(stalePayloadDecision.payload.domainPayload, undefined);
+  assert.equal(stalePayloadDecision.payload.domainPayload.domain, "react-native");
+  assert.equal(stalePayloadDecision.payload.domainPayload.policy, "rn-primitive-input-narrow-payload");
   assert.equal(stalePayloadDecision.debug.domainDetection.classification, "react-native");
   assert.equal(stalePayloadDecision.debug.frontendPayloadPolicy.name, "rn-primitive-input-narrow-payload");
   assert.equal(stalePayloadDecision.debug.frontendPayloadPolicy.allowed, true);

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -319,8 +319,10 @@ test("codex runtime activates React Web payload semantics only for the React Web
   assert.equal(rnPrimitive.second.debug.decision.debug.domainDetection.classification, "react-native");
   assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.name, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
   assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.allowed, true);
-  assert.equal("domainPayload" in rnPrimitive.second.debug.decision.payload, false);
-  assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), false);
+  assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.domain, "react-native");
+  assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+  assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), true);
+  assert.match(rnPrimitive.second.additionalContext, /"domain":\s*"react-native"/);
 
   for (const [label, fixture, forbiddenSignal] of [
     ["rn-style-platform", "rn-style-platform-navigation.tsx", "react-native:primitive:ScrollView"],
@@ -550,8 +552,10 @@ test("claude runtime keeps RN F1 narrow payload separate from broader RN domains
   assert.equal(rnPrimitive.second.debug.decision.debug.domainDetection.classification, "react-native");
   assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.name, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
   assert.equal(rnPrimitive.second.debug.decision.debug.frontendPayloadPolicy.allowed, true);
-  assert.equal("domainPayload" in rnPrimitive.second.debug.decision.payload, false);
-  assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), false);
+  assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.domain, "react-native");
+  assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+  assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), true);
+  assert.match(rnPrimitive.second.additionalContext, /"domain":\s*"react-native"/);
 
   for (const [label, fixture] of [
     ["rn-style-platform", "rn-style-platform-navigation.tsx"],


### PR DESCRIPTION
## Summary

- Add a narrow React Native F1 compact payload exception for measured primitive/input component evidence.
- Keep broader React Native, WebView, TUI, and mixed frontend domains on fallback/source-reading boundaries.
- Route RN F1 policy decisions through the shared frontend payload policy registry and keep runtime bridge behavior claim-bounded.

## Scope

This branch only enables compact payload reuse for React Native files that satisfy the measured primitive/input signal gate. It does not implement React Web/RN cache metadata parity, WebView compact extraction, TUI compact extraction, or broad React Native support.

## Validation

- `git diff --check`
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/payload-policy-registry.test.mjs test/pre-read-phase-order-regression.test.mjs test/runtime-bridge-contract.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm test`
- Forbidden broad-support claim grep over `docs src`

## Follow-up

Recommended next branch: a separate React Web/RN parity/cache metadata plan that compares domain-specific cache metadata needs instead of cloning React Web cache behavior into every frontend domain.

## Notes

No push or GitHub PR was created from this local closeout.
