### PR TITLE
Add opt-in React Web context metadata

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -4,13 +4,13 @@ import ts from "typescript";
 import { hashText } from "./hash";
 import { decideMode } from "./decide";
 import { detectDomainFromSource } from "./domain-detector";
-import type { ExtractionResult, FormSurface, Language, SourceRange, StyleSystem } from "./schema";
+import type { A11yAnchorSignal, ExtractionResult, FormSurface, Language, SourceRange, StyleSystem } from "./schema";
 
 const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer", "useLayoutEffect", "useContext", "useId", "useTransition"]);
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
 const CALLBACK_HOOK_NAMES = new Set(["useMemo", "useCallback"]);
 const FORM_CONTROL_TAGS = new Set(["form", "input", "select", "textarea"]);
-const CONTROL_PROP_NAMES = new Set(["name", "type", "value", "defaultValue", "required", "disabled", "checked", "defaultChecked"]);
+const CONTROL_PROP_NAMES = new Set(["name", "type", "value", "defaultValue", "required", "disabled", "readOnly", "checked", "defaultChecked"]);
 const MAX_EFFECT_SIGNALS = 8;
 const MAX_CALLBACK_SIGNALS = 8;
 const MAX_EVENT_HANDLER_SIGNALS = 12;
@@ -389,6 +389,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const formControls: NonNullable<FormSurface["controls"]> = [];
   const submitHandlers: NonNullable<FormSurface["submitHandlers"]> = [];
   const validationAnchors: NonNullable<FormSurface["validationAnchors"]> = [];
+  const a11yAnchors: A11yAnchorSignal[] = [];
   const conditionalRenders = new Set<string>();
   const repeatedBlocks = new Set<string>();
   const snippetCandidates: NonNullable<ExtractionResult["snippets"]> = [];
@@ -415,6 +416,12 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     const compacted = compactText(value);
     if (!compacted) return;
     items.push({ value: compacted, loc: sourceRangeOf(sourceFile, node) });
+  };
+
+  const addA11yAnchor = (kind: A11yAnchorSignal["kind"], label: string, node: ts.Node): void => {
+    const compacted = compactText(label);
+    if (!compacted) return;
+    a11yAnchors.push({ kind, label: compacted, loc: sourceRangeOf(sourceFile, node) });
   };
 
   const jsxAttributeValue = (attribute: ts.JsxAttribute): string | undefined => {
@@ -452,6 +459,27 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       const attrName = property.name.getText(sourceFile);
       if (CONTROL_PROP_NAMES.has(attrName)) {
         propNames.push(attrName);
+      }
+      if (tag === "label") {
+        addA11yAnchor("label", jsxAttributeValue(property) ?? tag, property);
+      }
+      if (attrName === "htmlFor") {
+        addA11yAnchor("htmlFor", jsxAttributeValue(property) ?? attrName, property);
+      }
+      if (attrName === "role") {
+        addA11yAnchor("role", jsxAttributeValue(property) ?? attrName, property);
+      }
+      if (attrName.startsWith("aria-")) {
+        addA11yAnchor("aria", `${attrName}=${jsxAttributeValue(property) ?? "true"}`, property);
+      }
+      if (attrName === "required") {
+        addA11yAnchor("required", controlName ? `${tag}[name=${controlName}]` : tag, property);
+      }
+      if (attrName === "disabled") {
+        addA11yAnchor("disabled", controlName ? `${tag}[name=${controlName}]` : tag, property);
+      }
+      if (attrName === "readOnly") {
+        addA11yAnchor("readonly", controlName ? `${tag}[name=${controlName}]` : tag, property);
       }
       if (/^on[A-Z]/.test(attrName)) {
         handlers.push(attrName);
@@ -569,6 +597,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const callbackSignalList = dedupeBy(callbackSignals, (item) => `${item.hook}:${item.loc?.startLine ?? ""}:${item.deps?.join(",") ?? ""}`).slice(0, MAX_CALLBACK_SIGNALS);
   const eventHandlerList = [...eventHandlers];
   const eventHandlerSignalList = dedupeBy(eventHandlerSignals, (item) => `${item.name}:${item.trigger ?? ""}:${item.loc?.startLine ?? ""}`).slice(0, MAX_EVENT_HANDLER_SIGNALS);
+  const a11yAnchorList = dedupeBy(a11yAnchors, (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`).slice(0, 16);
   return {
     behavior: {
       hooks: [...hooks],
@@ -587,6 +616,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
             },
           }
         : {}),
+      ...(a11yAnchorList.length ? { a11yAnchors: a11yAnchorList } : {}),
       hasSideEffects,
     },
     structure: {

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { deriveDesignReviewMetadata } from "../design-review-metadata";
-import { buildFrontendDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
+import { buildReactWebContextMetadata } from "../react-web-context-metadata";
+import { buildFrontendDomainPayload, buildReactWebDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
 import type { EditGuidance, ExtractionResult, ModelFacingPayload, PatchTarget, PatchTargetKind, SourceFingerprint, SourceRange } from "../schema";
 
 const PATCH_TARGET_LIMIT = 12;
@@ -14,6 +15,7 @@ const EDIT_GUIDANCE_INSTRUCTIONS = [
 export type ModelFacingPayloadOptions = {
   includeEditGuidance?: boolean;
   includeDesignReviewMetadata?: boolean;
+  includeReactWebContextMetadata?: boolean;
   includeDomainPayload?: boolean;
   domainPayloadPolicy?: string;
 };
@@ -128,14 +130,19 @@ function buildEditGuidance(result: ExtractionResult, freshness: SourceFingerprin
 }
 
 export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd(), options: ModelFacingPayloadOptions = {}): ModelFacingPayload {
+  const relativeFilePath = toRelativePath(result.filePath, cwd);
+  const reactWebDomainPayload = options.includeReactWebContextMetadata
+    ? buildReactWebDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
+    : undefined;
   const domainPayload = options.includeDomainPayload
     ? buildFrontendDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
     : undefined;
+  const domainPayloadGate = domainPayload ?? reactWebDomainPayload;
 
   if (result.useOriginal && result.mode === "raw" && result.rawText) {
     return {
       mode: result.mode,
-      filePath: toRelativePath(result.filePath, cwd),
+      filePath: relativeFilePath,
       useOriginal: true,
       rawText: result.rawText,
       ...(domainPayload ? { domainPayload } : {}),
@@ -197,16 +204,20 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
   const designReviewMetadata = options.includeDesignReviewMetadata
     ? deriveDesignReviewMetadata(result)
     : undefined;
+  const reactWebContext = options.includeReactWebContextMetadata && domainPayloadGate
+    ? buildReactWebContextMetadata(result, fingerprint, relativeFilePath, editGuidance)
+    : undefined;
 
   return {
     mode: result.mode,
-    filePath: toRelativePath(result.filePath, cwd),
+    filePath: relativeFilePath,
     ...(result.mode === "raw" && result.rawText ? { rawText: result.rawText } : {}),
     ...(result.componentName ? { componentName: result.componentName } : {}),
     ...(result.componentLoc ? { componentLoc: result.componentLoc } : {}),
     ...(fingerprint ? { sourceFingerprint: fingerprint } : {}),
     ...(editGuidance ? { editGuidance } : {}),
     ...(designReviewMetadata ? { designReviewMetadata } : {}),
+    ...(reactWebContext ? { reactWebContext } : {}),
     ...(domainPayload ? { domainPayload } : {}),
     ...(result.exports.length > 0 ? { exports: result.exports } : {}),
     ...(contract ? { contract } : {}),

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -1,0 +1,272 @@
+import {
+  REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION,
+  type EditGuidance,
+  type ExtractionResult,
+  type ReactWebContextA11yAnchor,
+  type ReactWebContextIntentTarget,
+  type ReactWebContextLocalDependency,
+  type ReactWebContextMetadataV0,
+  type ReactWebContextRenderState,
+  type ReactWebContextStateHint,
+  type SourceFingerprint,
+} from "./schema";
+
+export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
+  stateHints: 12,
+  renderStates: 12,
+  a11yAnchors: 16,
+  localDependencies: 12,
+  intentTargets: 16,
+} as const;
+
+const REACT_WEB_CONTEXT_WARNINGS = [
+  "React Web current supported lane only; this metadata does not imply React Native, WebView, TUI, Mixed, or Unknown support.",
+  "Source-derived repeated-read context hints only; not LSP-backed and not a dependency graph.",
+  "A11y anchors are source-observed hints only, not an accessibility audit.",
+  "This metadata is not proof of runtime/provider token savings.",
+  "Rerun extraction or read current source if sourceFingerprint.fileHash or sourceFingerprint.lineCount changes.",
+];
+
+function compact(value: string, maxLength = 80): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}
+
+function pruneArray<T>(items: T[], limit: number): T[] | undefined {
+  return items.length > 0 ? items.slice(0, limit) : undefined;
+}
+
+function dedupeBy<T>(items: T[], keyOf: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    const key = keyOf(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function buildStateHints(result: ExtractionResult): ReactWebContextStateHint[] {
+  const hints: ReactWebContextStateHint[] = [];
+
+  for (const label of result.behavior?.stateSummary ?? []) {
+    hints.push({
+      label: compact(label),
+      kind: "state",
+      evidence: ["behavior.stateSummary"],
+    });
+  }
+
+  for (const signal of result.behavior?.effectSignals ?? []) {
+    hints.push({
+      label: signal.hook,
+      kind: "effect",
+      ...(signal.loc ? { loc: signal.loc } : {}),
+      ...(signal.deps && signal.deps.length > 0 ? { deps: signal.deps } : {}),
+      evidence: ["behavior.effectSignals"],
+    });
+  }
+
+  for (const signal of result.behavior?.callbackSignals ?? []) {
+    hints.push({
+      label: signal.hook,
+      kind: "callback",
+      ...(signal.loc ? { loc: signal.loc } : {}),
+      ...(signal.deps && signal.deps.length > 0 ? { deps: signal.deps } : {}),
+      evidence: ["behavior.callbackSignals"],
+    });
+  }
+
+  return dedupeBy(hints, (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}:${item.deps?.join(",") ?? ""}`);
+}
+
+function buildRenderStates(result: ExtractionResult): ReactWebContextRenderState[] {
+  const states: ReactWebContextRenderState[] = [];
+
+  for (const condition of result.structure?.conditionalRenders ?? []) {
+    states.push({
+      label: "conditional-render",
+      kind: "conditional",
+      condition: compact(condition),
+      evidence: ["structure.conditionalRenders"],
+    });
+  }
+
+  for (const repeated of result.structure?.repeatedBlocks ?? []) {
+    states.push({
+      label: compact(repeated),
+      kind: "repeated",
+      evidence: ["structure.repeatedBlocks"],
+    });
+  }
+
+  return dedupeBy(states, (item) => `${item.kind}:${item.label}:${item.condition ?? ""}`);
+}
+
+function buildA11yAnchors(result: ExtractionResult): ReactWebContextA11yAnchor[] {
+  const anchors: ReactWebContextA11yAnchor[] = [];
+
+  for (const anchor of result.behavior?.a11yAnchors ?? []) {
+    anchors.push({
+      kind: anchor.kind,
+      label: anchor.label,
+      ...(anchor.loc ? { loc: anchor.loc } : {}),
+      evidence: ["behavior.a11yAnchors"],
+    });
+  }
+
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    for (const prop of control.props ?? []) {
+      if (prop === "required" || prop === "disabled" || prop === "readOnly") {
+        anchors.push({
+          kind: prop === "readOnly" ? "readonly" : prop,
+          label: control.name ? `${control.tag}[name=${control.name}]` : control.tag,
+          ...(control.loc ? { loc: control.loc } : {}),
+          evidence: ["behavior.formSurface.controls.props"],
+        });
+      }
+    }
+  }
+
+  for (const attr of result.domainDetection?.evidence ?? []) {
+    if (attr.domain !== "react-web" || attr.signal !== "jsx-attribute") continue;
+    if (attr.detail === "htmlFor") {
+      anchors.push({ kind: "htmlFor", label: "htmlFor", evidence: ["domainDetection.evidence.jsx-attribute"] });
+    }
+    if (attr.detail === "role") {
+      anchors.push({ kind: "role", label: "role", evidence: ["domainDetection.evidence.jsx-attribute"] });
+    }
+    if (attr.detail.startsWith("aria-")) {
+      anchors.push({ kind: "aria", label: attr.detail, evidence: ["domainDetection.evidence.jsx-attribute"] });
+    }
+  }
+
+  for (const anchor of result.behavior?.formSurface?.validationAnchors ?? []) {
+    if (/error/i.test(anchor.value)) {
+      anchors.push({
+        kind: "error-text",
+        label: compact(anchor.value),
+        ...(anchor.loc ? { loc: anchor.loc } : {}),
+        evidence: ["behavior.formSurface.validationAnchors"],
+      });
+    }
+  }
+
+  return dedupeBy(anchors, (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`);
+}
+
+function buildLocalDependencies(result: ExtractionResult): ReactWebContextLocalDependency[] {
+  const dependencies: ReactWebContextLocalDependency[] = [];
+
+  for (const declaration of result.structure?.moduleDeclarations ?? []) {
+    dependencies.push({
+      symbol: declaration.value,
+      kind: "local-declaration",
+      ...(declaration.loc ? { loc: declaration.loc } : {}),
+      ...(result.componentName ? { usedBy: [result.componentName] } : {}),
+    });
+  }
+
+  for (const item of result.exports) {
+    dependencies.push({
+      symbol: item.name,
+      kind: "local-declaration",
+      ...(result.componentLoc ? { loc: result.componentLoc } : {}),
+      ...(result.componentName ? { usedBy: [result.componentName] } : {}),
+    });
+  }
+
+  return dedupeBy(dependencies, (item) => `${item.kind}:${item.symbol}:${item.loc?.startLine ?? ""}`);
+}
+
+function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextIntentTarget["intent"] | undefined {
+  switch (kind) {
+    case "component":
+      return "component";
+    case "props":
+      return "props";
+    case "effect":
+    case "callback":
+      return "state";
+    case "event-handler":
+      return "handler";
+    case "form-control":
+    case "submit-handler":
+    case "validation-anchor":
+      return "form";
+    case "snippet":
+      return "branch";
+    default:
+      return undefined;
+  }
+}
+
+function buildIntentTargets(result: ExtractionResult, editGuidance: EditGuidance | undefined): ReactWebContextIntentTarget[] {
+  const targets: ReactWebContextIntentTarget[] = [];
+
+  for (const target of editGuidance?.patchTargets ?? []) {
+    const intent = intentForPatchTarget(target.kind);
+    if (!intent) continue;
+    targets.push({
+      intent,
+      label: target.label,
+      loc: target.loc,
+      source: "editGuidance",
+    });
+  }
+
+  if (result.style?.hasStyleBranching || (result.style?.system && result.style.system !== "unknown")) {
+    targets.push({
+      intent: "style",
+      label: result.style.system ?? "style",
+      source: "style",
+    });
+  }
+
+  for (const condition of result.structure?.conditionalRenders ?? []) {
+    targets.push({
+      intent: "branch",
+      label: compact(condition),
+      source: "structure",
+    });
+  }
+
+  return dedupeBy(targets, (item) => `${item.intent}:${item.label}:${item.loc?.startLine ?? ""}:${item.source}`);
+}
+
+export function buildReactWebContextMetadata(
+  result: ExtractionResult,
+  freshness: SourceFingerprint | undefined,
+  filePath: string,
+  editGuidance?: EditGuidance,
+): ReactWebContextMetadataV0 | undefined {
+  if (!freshness) return undefined;
+
+  const stateHints = pruneArray(buildStateHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.stateHints);
+  const renderStates = pruneArray(buildRenderStates(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.renderStates);
+  const a11yAnchors = pruneArray(buildA11yAnchors(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.a11yAnchors);
+  const localDependencies = pruneArray(buildLocalDependencies(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.localDependencies);
+  const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
+
+  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets);
+  if (!hasContext) return undefined;
+
+  return {
+    schemaVersion: REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION,
+    freshness,
+    scope: {
+      kind: result.componentName && result.componentLoc ? "same-component" : "same-file",
+      filePath,
+      ...(result.componentName ? { componentName: result.componentName } : {}),
+      ...(result.componentLoc ? { componentLoc: result.componentLoc } : {}),
+    },
+    ...(stateHints ? { stateHints } : {}),
+    ...(renderStates ? { renderStates } : {}),
+    ...(a11yAnchors ? { a11yAnchors } : {}),
+    ...(localDependencies ? { localDependencies } : {}),
+    ...(intentTargets ? { intentTargets } : {}),
+    warnings: REACT_WEB_CONTEXT_WARNINGS,
+  };
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -62,6 +62,12 @@ export type FormSurface = {
   validationAnchors?: LocatedString[];
 };
 
+export type A11yAnchorSignal = {
+  kind: "label" | "htmlFor" | "aria" | "role" | "required" | "disabled" | "readonly" | "error-text";
+  label: string;
+  loc?: SourceRange;
+};
+
 export type ModuleDeclarationSignal = LocatedString & {
   kind: "function" | "class" | "variable" | "type" | "interface" | "enum";
   exported?: boolean;
@@ -89,6 +95,61 @@ export type EditGuidance = {
   freshness: SourceFingerprint;
   instructions: string[];
   patchTargets: PatchTarget[];
+};
+
+export const REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION = "react-web-context.v0" as const;
+
+export type ReactWebContextStateHint = {
+  label: string;
+  kind: "state" | "effect" | "callback";
+  loc?: SourceRange;
+  deps?: string[];
+  evidence: string[];
+};
+
+export type ReactWebContextRenderState = {
+  label: string;
+  kind: "conditional" | "repeated";
+  condition?: string;
+  evidence: string[];
+};
+
+export type ReactWebContextA11yAnchor = {
+  kind: "label" | "htmlFor" | "aria" | "role" | "required" | "disabled" | "readonly" | "error-text";
+  label: string;
+  loc?: SourceRange;
+  evidence: string[];
+};
+
+export type ReactWebContextLocalDependency = {
+  symbol: string;
+  kind: "local-declaration";
+  loc?: SourceRange;
+  usedBy?: string[];
+};
+
+export type ReactWebContextIntentTarget = {
+  intent: "style" | "form" | "handler" | "state" | "branch" | "props" | "component";
+  label: string;
+  loc?: SourceRange;
+  source: "editGuidance" | "behavior" | "structure" | "contract" | "style";
+};
+
+export type ReactWebContextMetadataV0 = {
+  schemaVersion: typeof REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION;
+  freshness: SourceFingerprint;
+  scope: {
+    kind: "same-file" | "same-component";
+    filePath: string;
+    componentName?: string;
+    componentLoc?: SourceRange;
+  };
+  stateHints?: ReactWebContextStateHint[];
+  renderStates?: ReactWebContextRenderState[];
+  a11yAnchors?: ReactWebContextA11yAnchor[];
+  localDependencies?: ReactWebContextLocalDependency[];
+  intentTargets?: ReactWebContextIntentTarget[];
+  warnings: string[];
 };
 
 export type ExtractionResult = {
@@ -119,6 +180,7 @@ export type ExtractionResult = {
     eventHandlers?: string[];
     eventHandlerSignals?: EventHandlerSignal[];
     formSurface?: FormSurface;
+    a11yAnchors?: A11yAnchorSignal[];
     hasSideEffects?: boolean;
   };
   structure?: {
@@ -188,6 +250,7 @@ export type ModelFacingPayload = {
   snippets?: ExtractionResult["snippets"];
   editGuidance?: EditGuidance;
   designReviewMetadata?: DesignReviewMetadataV0;
+  reactWebContext?: ReactWebContextMetadataV0;
   domainPayload?: DomainPayload;
 };
 

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { extractFile, extractSource } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
+
+function payloadFor(relativeFile, options = {}) {
+  const result = extractFile(path.join(repoRoot, relativeFile));
+  return toModelFacingPayload(result, repoRoot, options);
+}
+
+test("reactWebContext is opt-in and does not change default model-facing payloads", () => {
+  const payload = payloadFor("fixtures/compressed/HookEffectPanel.tsx");
+
+  assert.equal("reactWebContext" in payload, false);
+  assert.ok(payload.sourceFingerprint);
+});
+
+test("React Web opt-in emits context without emitting domainPayload", () => {
+  const payload = payloadFor("fixtures/compressed/HookEffectPanel.tsx", {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal("domainPayload" in payload, false);
+  assert.ok(payload.reactWebContext);
+  assert.equal(payload.reactWebContext.schemaVersion, "react-web-context.v0");
+  assert.deepEqual(payload.reactWebContext.freshness, payload.sourceFingerprint);
+  assert.equal(payload.reactWebContext.scope.kind, "same-component");
+  assert.equal(payload.reactWebContext.scope.filePath, path.join("fixtures", "compressed", "HookEffectPanel.tsx"));
+
+  assert.ok(payload.reactWebContext.stateHints.some((item) => item.kind === "effect" && item.deps.includes("loadUser")));
+  assert.ok(payload.reactWebContext.stateHints.some((item) => item.kind === "callback" && item.deps.includes("name")));
+  assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "handler" && item.source === "editGuidance"));
+  assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "style" && item.source === "style"));
+
+  const warnings = payload.reactWebContext.warnings.join("\n");
+  assert.match(warnings, /React Web current supported lane only/);
+  assert.match(warnings, /Source-derived repeated-read context hints only/);
+  assert.match(warnings, /not LSP-backed/);
+  assert.match(warnings, /not an accessibility audit/);
+  assert.match(warnings, /not proof of runtime\/provider token savings/);
+  assert.match(warnings, /Rerun extraction or read current source/);
+});
+
+test("React Web opt-in can emit context and domainPayload with stable top-level order", () => {
+  const payload = payloadFor("fixtures/compressed/HookEffectPanel.tsx", {
+    includeEditGuidance: true,
+    includeDesignReviewMetadata: true,
+    includeReactWebContextMetadata: true,
+    includeDomainPayload: true,
+  });
+
+  assert.ok(payload.designReviewMetadata);
+  assert.ok(payload.reactWebContext);
+  assert.equal(payload.domainPayload.domain, "react-web");
+
+  const keys = Object.keys(payload);
+  assert.ok(keys.indexOf("designReviewMetadata") < keys.indexOf("reactWebContext"));
+  assert.ok(keys.indexOf("reactWebContext") < keys.indexOf("domainPayload"));
+  assert.ok(keys.indexOf("domainPayload") < keys.indexOf("exports"));
+});
+
+test("React Web form controls emit source-observed a11y anchors only", () => {
+  const payload = payloadFor("fixtures/compressed/FormControls.tsx", {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "required" && item.label === "input[name=email]"));
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "disabled" && item.label === "textarea[name=notes]"));
+  assert.equal(payload.reactWebContext.warnings.some((item) => item.includes("not an accessibility audit")), true);
+});
+
+test("React Web opt-in emits source-observed role aria and readOnly anchors", () => {
+  const source = `
+    import React from "react";
+
+    type A11yPanelProps = { value: string; readonly?: boolean };
+
+    export function A11yPanel({ value, readonly = true }: A11yPanelProps) {
+      return (
+        <section className="grid gap-4 rounded-lg border p-4" role="region" aria-label="Account settings">
+          <label htmlFor="displayName" className="text-sm font-medium">Display name</label>
+          <input
+            id="displayName"
+            name="displayName"
+            className="rounded border px-3 py-2"
+            value={value}
+            readOnly={readonly}
+            aria-invalid="false"
+          />
+          <p className="text-xs text-slate-500">This compact fixture is intentionally long enough for extraction.</p>
+          <p className="text-xs text-slate-500">It keeps role, aria and readOnly as local source-derived anchors.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "A11yPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "role" && item.label === "region"));
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "aria" && item.label === "aria-label=Account settings"));
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "aria" && item.label === "aria-invalid=false"));
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "readonly" && item.label === "input[name=displayName]"));
+});
+
+test("React Web wrapper fixture can expose source-observed htmlFor anchor from domain evidence", () => {
+  const payload = payloadFor("test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx", {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "htmlFor"));
+});
+
+test("non React Web and raw/useOriginal payloads omit reactWebContext", () => {
+  for (const fixture of [
+    "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",
+    "test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx",
+    "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx",
+  ]) {
+    const payload = payloadFor(fixture, { includeReactWebContextMetadata: true });
+    assert.equal("reactWebContext" in payload, false, `${fixture} must not emit reactWebContext`);
+  }
+
+  const rawPayload = payloadFor("fixtures/raw/SimpleButton.tsx", { includeReactWebContextMetadata: true });
+  assert.equal(rawPayload.useOriginal, true);
+  assert.equal("reactWebContext" in rawPayload, false);
+});


### PR DESCRIPTION
## Summary
- add opt-in `reactWebContext` metadata for the current React Web lane
- capture source-derived repeated-read context: state/effect/callback hints, render states, a11y anchors, local declarations, and intent targets
- keep `domainPayload`, runtime repeated-read injection, raw/useOriginal payloads, and non-React-Web lanes unchanged

## Risk controls
- React-Web-gated via the existing domain payload gate
- source-freshness fingerprint included; warnings keep claim boundaries explicit
- no live provider/runtime token-savings claim in this PR

## Verification
- `npm run build`
- `node --test test/react-web-context-metadata.test.mjs`
- `node --test test/fooks.test.mjs`
- `node --test test/react-web-domain-payload-expansion.test.mjs test/runtime-bridge-contract.test.mjs test/pre-read-phase-order-regression.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run lint`
- `npm test` (407/407 pass)
- `git diff --check`
