### PR TITLE
Gate React Web context metadata in runtime pre-read

### DIFF
--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -433,7 +433,10 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
     canAttemptRuntimeEditGuidance(prompt, target, cwd, policy, freshness);
   if (editGuidanceAllowed) {
     try {
-      const optInDecision = decidePreRead(resolvedTarget, cwd, "claude", { includeEditGuidance: true });
+      const optInDecision = decidePreRead(resolvedTarget, cwd, "claude", {
+        includeEditGuidance: true,
+        includeReactWebContextMetadata: false,
+      });
       if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
         const optInContextMode = payloadContextMode(optInDecision.payload);
         const optInPayloadContext = buildPayloadContext(target, optInDecision.payload, optInContextMode);

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -318,7 +318,10 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     canAttemptRuntimeEditGuidance(prompt, target, cwd, policy, freshness);
   if (editGuidanceAllowed) {
     try {
-      const optInDecision = decidePreRead(path.join(cwd, target), cwd, "codex", { includeEditGuidance: true });
+      const optInDecision = decidePreRead(path.join(cwd, target), cwd, "codex", {
+        includeEditGuidance: true,
+        includeReactWebContextMetadata: false,
+      });
       if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
         const optInContextMode = payloadContextMode(optInDecision.payload);
         const optInAdditionalContext = buildAdditionalContext(target, optInDecision.payload, optInContextMode);

--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -8,6 +8,8 @@ import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types
 import type { PreReadDecision } from "../core/schema";
 
 export const REACT_NATIVE_WEBVIEW_BOUNDARY_REASON = "unsupported-react-native-webview-boundary";
+const REACT_WEB_CONTEXT_METADATA_MIN_BUDGET_BYTES = 4_096;
+const REACT_WEB_CONTEXT_METADATA_MAX_BUDGET_BYTES = 16_384;
 
 export type PreReadFallbackDecisionInput = {
   runtime: PreReadDecision["runtime"];
@@ -87,6 +89,7 @@ export type PreReadPayloadPlanInput = {
   resolvedPath: string;
   cwd: string;
   includeEditGuidance: boolean;
+  includeReactWebContextMetadata?: boolean;
   domainDetection: DomainDetectionResult;
   frontendPayloadPolicy?: FrontendPayloadPolicyDecision;
 };
@@ -97,20 +100,64 @@ export type PreReadPayloadPlan = {
   debug: NonNullable<PreReadDecision["debug"]>;
 };
 
+function estimatePayloadBytes(payload: NonNullable<PreReadDecision["payload"]>): number {
+  return Buffer.byteLength(JSON.stringify(payload), "utf8");
+}
+
+function reactWebContextPayloadBudget(rawSizeBytes: number): number {
+  return Math.min(
+    REACT_WEB_CONTEXT_METADATA_MAX_BUDGET_BYTES,
+    Math.max(rawSizeBytes, REACT_WEB_CONTEXT_METADATA_MIN_BUDGET_BYTES),
+  );
+}
+
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
   const { frontendPayloadPolicy } = input;
   const result = extractFile(input.resolvedPath);
   const payloadBuildOptions = toFrontendPayloadBuildOptions(frontendPayloadPolicy);
-  const payload = toModelFacingPayload(result, input.cwd, {
+  const includeReactWebContextMetadata =
+    input.includeReactWebContextMetadata ?? payloadBuildOptions.includeReactWebContextMetadata;
+  let payload = toModelFacingPayload(result, input.cwd, {
     includeEditGuidance: input.includeEditGuidance,
     ...payloadBuildOptions,
+    includeReactWebContextMetadata,
   });
+  let reactWebContextBudget: NonNullable<PreReadDecision["debug"]>["reactWebContextBudget"];
+
+  if (includeReactWebContextMetadata) {
+    const estimatedPayloadBytes = estimatePayloadBytes(payload);
+    const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
+    if (payload.reactWebContext && estimatedPayloadBytes > maxPayloadBytes) {
+      payload = toModelFacingPayload(result, input.cwd, {
+        includeEditGuidance: input.includeEditGuidance,
+        ...payloadBuildOptions,
+        includeReactWebContextMetadata: false,
+      });
+      reactWebContextBudget = {
+        included: false,
+        estimatedPayloadBytes,
+        maxPayloadBytes,
+        reason: "budget-exceeded",
+      };
+    } else {
+      reactWebContextBudget = {
+        included: Boolean(payload.reactWebContext),
+        estimatedPayloadBytes,
+        maxPayloadBytes,
+        reason: payload.reactWebContext ? "within-budget" : "not-emitted",
+      };
+    }
+  }
+
   const readiness = assessPayloadReadiness(result, payload);
   const debug = buildPreReadPayloadDebug({
     result,
     domainDetection: input.domainDetection,
     frontendPayloadPolicy,
   });
+  if (reactWebContextBudget) {
+    debug.reactWebContextBudget = reactWebContextBudget;
+  }
 
   return { payload, readiness, debug };
 }

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -41,7 +41,7 @@ export {
 };
 export { hasReactNativeWebViewBoundaryMarker, REACT_NATIVE_WEBVIEW_BOUNDARY_REASON } from "./pre-read-stack";
 
-export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance">;
+export type PreReadOptions = Pick<ModelFacingPayloadOptions, "includeEditGuidance" | "includeReactWebContextMetadata">;
 export type { FrontendPayloadPolicyDecision };
 
 function eligibleExtensions(runtime: PreReadDecision["runtime"]): ReadonlySet<string> {
@@ -99,6 +99,7 @@ export function decidePreRead(
     resolvedPath,
     cwd,
     includeEditGuidance: options.includeEditGuidance === true,
+    includeReactWebContextMetadata: options.includeReactWebContextMetadata,
     domainDetection,
     frontendPayloadPolicy,
   });

--- a/src/core/payload-policy/registry.ts
+++ b/src/core/payload-policy/registry.ts
@@ -12,6 +12,7 @@ export type FrontendPayloadPolicyAssessor = (
 
 export type FrontendPayloadBuildOptions = {
   includeDomainPayload: boolean;
+  includeReactWebContextMetadata?: boolean;
   domainPayloadPolicy?: string;
 };
 
@@ -43,9 +44,10 @@ export function assessFrontendPayloadPolicy(
 export function toFrontendPayloadBuildOptions(
   policy: FrontendPayloadPolicyDecision | undefined,
 ): FrontendPayloadBuildOptions {
+  const isReactWebCurrentSupported = policy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY;
   return {
-    includeDomainPayload:
-      policy?.name === REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY || policy?.name === RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    includeDomainPayload: isReactWebCurrentSupported || policy?.name === RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+    ...(isReactWebCurrentSupported ? { includeReactWebContextMetadata: true } : {}),
     ...(policy?.name ? { domainPayloadPolicy: policy.name } : {}),
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -289,6 +289,12 @@ export type PreReadDecision = {
       reason?: string;
       evidenceGates?: string[];
     };
+    reactWebContextBudget?: {
+      included: boolean;
+      estimatedPayloadBytes: number;
+      maxPayloadBytes: number;
+      reason?: "within-budget" | "budget-exceeded" | "not-requested" | "not-emitted";
+    };
   };
   fallback?: {
     action: "full-read";

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -97,6 +97,7 @@ test("frontend payload build options include domain payload for React Web and me
 
   assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactWebPolicy), {
     includeDomainPayload: true,
+    includeReactWebContextMetadata: true,
     domainPayloadPolicy: reactWebPolicy.name,
   });
   assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactNativePolicy), {

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -29,4 +29,38 @@ test("pre-read payload builder preserves React Web payload success envelope", ()
   assert.equal(decision.debug.language, "tsx");
   assert.equal(decision.debug.domainDetection.classification, "react-web");
   assert.equal(decision.debug.frontendPayloadPolicy.allowed, true);
+  assert.ok(decision.payload.reactWebContext);
+  assert.equal(decision.debug.reactWebContextBudget.included, true);
+  assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+});
+
+test("pre-read payload builder omits React Web context metadata when payload budget is exceeded", () => {
+  const decision = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
+    includeEditGuidance: true,
+  });
+  assert.equal(decision.decision, "payload");
+  assert.ok(decision.payload.reactWebContext);
+
+  const originalStringify = JSON.stringify;
+  try {
+    JSON.stringify = (value, replacer, space) => {
+      const json = originalStringify(value, replacer, space);
+      if (value && typeof value === "object" && "reactWebContext" in value) {
+        return `${json}${"x".repeat(20_000)}`;
+      }
+      return json;
+    };
+
+    const budgeted = preRead.decidePreRead(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), repoRoot, "codex", {
+      includeEditGuidance: true,
+    });
+
+    assert.equal(budgeted.decision, "payload");
+    assert.equal("reactWebContext" in budgeted.payload, false);
+    assert.equal(budgeted.payload.domainPayload.domain, "react-web");
+    assert.equal(budgeted.debug.reactWebContextBudget.included, false);
+    assert.equal(budgeted.debug.reactWebContextBudget.reason, "budget-exceeded");
+  } finally {
+    JSON.stringify = originalStringify;
+  }
 });

--- a/test/pre-read-phase-order-regression.test.mjs
+++ b/test/pre-read-phase-order-regression.test.mjs
@@ -21,6 +21,7 @@ const PAYLOAD_DEBUG_KEYS = [
   "frontendPayloadPolicy",
   "language",
   "mode",
+  "reactWebContextBudget",
 ];
 
 function assertNoPayloadPlanningArtifacts(decision) {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -80,6 +80,32 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.ok(secondInject.reasons.includes("edit-guidance-opt-in"));
   assert.deepEqual(secondInject.debug.decision.payload.editGuidance.freshness, secondInject.debug.decision.payload.sourceFingerprint);
 
+  const contextSession = `bridge-contract-react-web-context-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: contextSession }, repoRoot);
+  const firstContext = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: contextSession,
+      prompt: "Inspect fixtures/compressed/FormSection.tsx",
+    },
+    repoRoot,
+  );
+  const secondContext = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: contextSession,
+      prompt: "Inspect fixtures/compressed/FormSection.tsx again",
+    },
+    repoRoot,
+  );
+
+  assert.equal(firstContext.action, "record");
+  assert.equal(secondContext.action, "inject");
+  assert.equal(secondContext.contextModeReason, "repeated-exact-file-react-web-payload");
+  assert.equal(secondContext.additionalContext.includes("\"reactWebContext\""), true);
+  assert.equal(secondContext.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
+  assert.equal(secondContext.debug.decision.debug.reactWebContextBudget.included, true);
+
   const wrapperSession = `bridge-contract-wrapper-debug-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: wrapperSession }, repoRoot);
   const firstWrapper = handleCodexRuntimeHook(


### PR DESCRIPTION
## Summary
- enable React Web `reactWebContext` in the runtime/pre-read payload path via the existing frontend policy build seam
- add a payload-size budget gate: over-budget payloads drop `reactWebContext` but preserve the existing React Web `domainPayload`
- keep edit-guidance priority stable by disabling `reactWebContext` on the edit-guidance opt-in retry path

## Why this is needed
This is the product-path follow-up to the parser metadata PR: parser metadata alone is useful for manual/opt-in calls, but repeated-read context reduction needs the runtime/pre-read path to carry the compact source-derived context when safe.

Provider/runtime savings evidence remains intentionally separate: this PR enables the guarded runtime path, but does not claim live provider-token, billing-token, or stable runtime-token savings.

## Verification
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/payload-policy-registry.test.mjs test/react-web-context-metadata.test.mjs test/pre-read-phase-order-regression.test.mjs test/runtime-bridge-contract.test.mjs test/react-web-domain-payload-expansion.test.mjs test/fooks.test.mjs`
- `npm run lint`
- `npm test` (408/408 pass)
- `git diff --check`

Stacked on: #402
