### PR TITLE
Keep TUI evidence reinforcement fallback-safe

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -34,6 +34,27 @@ Start with a small source-only corpus before any extractor or runtime change:
 4. **Command status/progress fixture** — one component that renders command status or progress UI without requiring command execution to interpret it.
 5. **Negative/fallback fixture** — one file that looks like CLI code but should remain full-source because it is non-React, mixed-domain, generated, or too behavior-heavy.
 
+## Current evidence-only reinforcement slice
+
+The current committed TUI / Ink fixtures are useful as domain evidence, not as compact-payload permission:
+
+| Fixture | Evidence it should prove | Required current outcome |
+| --- | --- | --- |
+| `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | Ink import, `Box`, `Text`, and `useInput` signals in a compact React CLI component. | Classify as `tui-ink`, mark the profile `evidence-only`, deny the TUI payload policy, and fall back with `unsupported-frontend-domain-profile`. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | Ink import, `Box`, `Text`, `useInput`, keyboard navigation, selected-row rendering, and list mapping in a behavior-heavy prompt surface. | Classify as `tui-ink`, keep the profile `evidence-only`, deny the TUI payload policy, emit no payload, and fall back through the readiness/profile gate. The current pre-read reason is `raw-mode` because extraction preserves the original raw source before any TUI payload could be emitted. |
+
+This reinforcement slice is intentionally small so it can run alongside RN, React Web, and WebView worktrees without touching shared detector, runtime, manifest, or payload-policy implementation files. A TUI fixture PR should prove the evidence boundary above before it proposes any source or runtime change.
+
+Reviewers should check that TUI evidence remains separate from payload permission:
+
+1. Classification may say `tui-ink`.
+2. Profile claim status must stay `evidence-only`.
+3. Payload policy must stay denied with the TUI evidence-only reason.
+4. Pre-read must keep normal source fallback through `unsupported-frontend-domain-profile`, `raw-mode`, or another explicit denied-readiness reason that emits no payload.
+5. No model-facing payload should be emitted for these fixtures.
+
+Any future step that changes one of those outcomes is no longer a fixture reinforcement PR; it needs a serialized shared-policy plan with its own fixtures, measured acceptance bar, and claim-boundary review.
+
 ## Candidate source notes
 
 If a future PR names public repositories, keep the list conservative and verify license, activity, file paths, and commit SHAs at that time. Good seed sources are likely to be established Ink examples, React-based CLI apps, or prompt/status UI components with inspectable TSX/JSX. Do not use curated lists, stale forks, or runtime-only demos as evidence fixtures unless a pinned source file clearly exercises one category above.

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -23,6 +23,10 @@ function detect(source, filePath = "Cli.tsx") {
   return detectDomainFromSource(source, filePath);
 }
 
+function readFixture(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
 function tuiInkSource() {
   return `import React from "react";
     import { Box, Text, useInput } from "ink";
@@ -38,6 +42,16 @@ function expectedTuiEvidenceOnlyPolicy() {
     allowed: false,
     reason: TUI_INK_EVIDENCE_ONLY_REASON,
   };
+}
+
+function assertTuiFallbackWithoutPayload(decision, reason) {
+  assert.equal(decision.eligible, true);
+  assert.equal(decision.decision, "fallback");
+  assert.deepEqual(decision.reasons, [reason]);
+  assert.equal(decision.fallback.reason, reason);
+  assert.equal(decision.debug.domainDetection.classification, "tui-ink");
+  assert.deepEqual(decision.debug.frontendPayloadPolicy, expectedTuiEvidenceOnlyPolicy());
+  assert.equal("payload" in decision, false);
 }
 
 test("TUI/Ink payload policy returns evidence-only denied decision for Ink evidence", () => {
@@ -78,17 +92,44 @@ test("TUI/Ink pre-read stays fallback-only even with an explicit denied policy",
   const fixturePath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "tui-ink-basic.tsx");
   const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
 
-  assert.equal(decision.eligible, true);
-  assert.equal(decision.decision, "fallback");
-  assert.deepEqual(decision.reasons, [preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON]);
-  assert.equal(decision.fallback.reason, preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
-  assert.equal(decision.debug.domainDetection.classification, "tui-ink");
-  assert.deepEqual(decision.debug.frontendPayloadPolicy, expectedTuiEvidenceOnlyPolicy());
-  assert.equal("payload" in decision, false);
+  assertTuiFallbackWithoutPayload(decision, preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+});
+
+test("TUI/Ink interactive list fixture remains evidence-only and fallback-safe", () => {
+  const relativeFixturePath = path.join(
+    "test",
+    "fixtures",
+    "frontend-domain-expectations",
+    "tui-ink-interactive-list.tsx",
+  );
+  const fixturePath = path.join(repoRoot, relativeFixturePath);
+  const domainDetection = detect(readFixture(relativeFixturePath), "tui-ink-interactive-list.tsx");
+
+  assert.equal(domainDetection.classification, "tui-ink");
+  assert.equal(domainDetection.profile.claimStatus, "evidence-only");
+  assert.ok(domainDetection.signals.includes("tui-ink:import:ink"));
+  assert.ok(domainDetection.signals.includes("tui-ink:primitive:Box"));
+  assert.ok(domainDetection.signals.includes("tui-ink:primitive:Text"));
+  assert.ok(domainDetection.signals.includes("tui-ink:hook:useInput"));
+  assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), expectedTuiEvidenceOnlyPolicy());
+
+  const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
+
+  assertTuiFallbackWithoutPayload(decision, "raw-mode");
 });
 
 test("TUI/Ink policy seam source avoids broad terminal support claims", () => {
   for (const relativePath of [path.join("src", "core", "payload-policy", "tui-ink.ts")]) {
     assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
   }
+});
+
+test("TUI/Ink fixture survey documents evidence-only reinforcement without support claims", () => {
+  const survey = fs.readFileSync(path.join(repoRoot, "docs", "tui-fixture-candidates.md"), "utf8");
+
+  assert.match(survey, /Current evidence-only reinforcement slice/);
+  assert.match(survey, /tui-ink-basic\.tsx/);
+  assert.match(survey, /tui-ink-interactive-list\.tsx/);
+  assert.match(survey, /unsupported-frontend-domain-profile/);
+  assert.doesNotMatch(survey, forbiddenSupportClaims);
 });


### PR DESCRIPTION
## Summary
- Document the current TUI/Ink evidence-only reinforcement slice.
- Add a focused regression for the existing interactive-list TUI fixture.
- Keep TUI/Ink fallback-safe with no payload, support, or terminal-correctness promotion.

## Scope boundary
- TUI-only docs/test change.
- No source/runtime shared seam changes.
- No fixture manifest changes.
- No TUI compact payload support claim.

## Verification
- `npm ci`
- `npm run build`
- `node --test test/payload-policy-tui-ink.test.mjs test/payload-policy-registry.test.mjs test/payload-policy-profile-gate.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- TUI support-claim grep over `docs src`
- `npm test` (412 pass)
- Scoped ai-slop-cleaner pass on changed files, then full re-verification
