### PR TITLE
Add React Web edit-target routing metadata

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -125,8 +125,14 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   let reactWebContextBudget: NonNullable<PreReadDecision["debug"]>["reactWebContextBudget"];
 
   if (includeReactWebContextMetadata) {
-    const estimatedPayloadBytes = estimatePayloadBytes(payload);
+    let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
+    if (payload.reactWebContext?.editTargetRouting && estimatedPayloadBytes > maxPayloadBytes) {
+      const trimmedReactWebContext = { ...payload.reactWebContext };
+      delete trimmedReactWebContext.editTargetRouting;
+      payload = { ...payload, reactWebContext: trimmedReactWebContext };
+      estimatedPayloadBytes = estimatePayloadBytes(payload);
+    }
     if (payload.reactWebContext && estimatedPayloadBytes > maxPayloadBytes) {
       payload = toModelFacingPayload(result, input.cwd, {
         includeEditGuidance: input.includeEditGuidance,

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -3,6 +3,7 @@ import {
   type EditGuidance,
   type ExtractionResult,
   type ReactWebContextA11yAnchor,
+  type ReactWebContextEditTargetRoute,
   type ReactWebContextIntentTarget,
   type ReactWebContextLocalDependency,
   type ReactWebContextMetadataV0,
@@ -17,14 +18,15 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   a11yAnchors: 16,
   localDependencies: 12,
   intentTargets: 16,
+  editTargetRouting: 8,
 } as const;
 
 const REACT_WEB_CONTEXT_WARNINGS = [
-  "React Web current supported lane only; this metadata does not imply React Native, WebView, TUI, Mixed, or Unknown support.",
-  "Source-derived repeated-read context hints only; not LSP-backed and not a dependency graph.",
+  "React Web current supported lane only; not React Native/WebView/TUI/Mixed/Unknown support.",
+  "Source-derived repeated-read context hints only; not LSP-backed or dependency graph.",
   "A11y anchors are source-observed hints only, not an accessibility audit.",
-  "This metadata is not proof of runtime/provider token savings.",
-  "Rerun extraction or read current source if sourceFingerprint.fileHash or sourceFingerprint.lineCount changes.",
+  "not proof of runtime/provider token savings.",
+  "Rerun extraction or read current source if sourceFingerprint changes.",
 ];
 
 function compact(value: string, maxLength = 80): string {
@@ -203,6 +205,80 @@ function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]
   }
 }
 
+function routeKindForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextEditTargetRoute["kind"] {
+  switch (kind) {
+    case "component":
+      return "primary-component";
+    case "props":
+      return "props-contract";
+    case "snippet":
+      return "conditional-region";
+    default:
+      return kind;
+  }
+}
+
+function buildEditTargetRouting(result: ExtractionResult, editGuidance: EditGuidance | undefined): ReactWebContextEditTargetRoute[] {
+  const routes: ReactWebContextEditTargetRoute[] = [];
+  let priority = 1;
+  const patchTargets = editGuidance?.patchTargets ?? [];
+  const hasSpecificPatchTarget = patchTargets.some((target) => target.kind !== "component" && target.kind !== "props");
+
+  for (const target of patchTargets) {
+    if (!hasSpecificPatchTarget && (target.kind === "component" || target.kind === "props")) {
+      continue;
+    }
+    routes.push({
+      kind: routeKindForPatchTarget(target.kind),
+      label: target.label,
+      priority,
+      loc: target.loc,
+      source: "editGuidance.patchTargets",
+      evidence: [`editGuidance.patchTargets.${target.kind}`],
+    });
+    priority += 1;
+  }
+
+  if (result.style?.hasStyleBranching || (result.style?.system && result.style.system !== "unknown")) {
+    routes.push({
+      kind: "style-region",
+      label: result.style.system ?? "style",
+      priority,
+      source: "style",
+      evidence: ["style"],
+    });
+    priority += 1;
+  }
+
+  for (const condition of result.structure?.conditionalRenders ?? []) {
+    routes.push({
+      kind: "conditional-region",
+      label: compact(condition),
+      priority,
+      source: "structure",
+      evidence: ["structure.conditionalRenders"],
+    });
+    priority += 1;
+  }
+
+  for (const repeated of result.structure?.repeatedBlocks ?? []) {
+    routes.push({
+      kind: "repeated-block",
+      label: compact(repeated),
+      priority,
+      source: "structure",
+      evidence: ["structure.repeatedBlocks"],
+    });
+    priority += 1;
+  }
+
+  return dedupeBy(
+    routes,
+    (item) =>
+      `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}:${item.loc?.endLine ?? ""}:${item.source}`,
+  );
+}
+
 function buildIntentTargets(result: ExtractionResult, editGuidance: EditGuidance | undefined): ReactWebContextIntentTarget[] {
   const targets: ReactWebContextIntentTarget[] = [];
 
@@ -249,8 +325,12 @@ export function buildReactWebContextMetadata(
   const a11yAnchors = pruneArray(buildA11yAnchors(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.a11yAnchors);
   const localDependencies = pruneArray(buildLocalDependencies(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.localDependencies);
   const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
+  const editTargetRouting = pruneArray(
+    buildEditTargetRouting(result, editGuidance),
+    REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.editTargetRouting,
+  );
 
-  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets);
+  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets || editTargetRouting);
   if (!hasContext) return undefined;
 
   return {
@@ -267,6 +347,7 @@ export function buildReactWebContextMetadata(
     ...(a11yAnchors ? { a11yAnchors } : {}),
     ...(localDependencies ? { localDependencies } : {}),
     ...(intentTargets ? { intentTargets } : {}),
+    ...(editTargetRouting ? { editTargetRouting } : {}),
     warnings: REACT_WEB_CONTEXT_WARNINGS,
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -135,6 +135,26 @@ export type ReactWebContextIntentTarget = {
   source: "editGuidance" | "behavior" | "structure" | "contract" | "style";
 };
 
+export type ReactWebContextEditTargetRoute = {
+  kind:
+    | "primary-component"
+    | "props-contract"
+    | "effect"
+    | "callback"
+    | "event-handler"
+    | "form-control"
+    | "submit-handler"
+    | "validation-anchor"
+    | "conditional-region"
+    | "repeated-block"
+    | "style-region";
+  label: string;
+  priority: number;
+  loc?: SourceRange;
+  source: "editGuidance.patchTargets" | "structure" | "style";
+  evidence: string[];
+};
+
 export type ReactWebContextMetadataV0 = {
   schemaVersion: typeof REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION;
   freshness: SourceFingerprint;
@@ -149,6 +169,7 @@ export type ReactWebContextMetadataV0 = {
   a11yAnchors?: ReactWebContextA11yAnchor[];
   localDependencies?: ReactWebContextLocalDependency[];
   intentTargets?: ReactWebContextIntentTarget[];
+  editTargetRouting?: ReactWebContextEditTargetRoute[];
   warnings: string[];
 };
 

--- a/test/layer2-applied-validation.test.mjs
+++ b/test/layer2-applied-validation.test.mjs
@@ -600,7 +600,7 @@ test("Codex wrapper artifacts include structured runtime usage without billing s
       ].join("\n"),
       { mode: 0o755 },
     );
-    const wrapper = new CodexWrapper({ model: "test-model", timeoutMs: 1000, command: codexPath });
+    const wrapper = new CodexWrapper({ model: "test-model", timeoutMs: 5000, command: codexPath });
     const result = await wrapper.run("context", "task");
 
     assert.equal(result.success, true);

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -30,6 +30,7 @@ test("pre-read payload builder preserves React Web payload success envelope", ()
   assert.equal(decision.debug.domainDetection.classification, "react-web");
   assert.equal(decision.debug.frontendPayloadPolicy.allowed, true);
   assert.ok(decision.payload.reactWebContext);
+  assert.equal("editTargetRouting" in decision.payload.reactWebContext, false);
   assert.equal(decision.debug.reactWebContextBudget.included, true);
   assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
 });

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -37,6 +37,74 @@ test("React Web opt-in emits context without emitting domainPayload", () => {
   assert.ok(payload.reactWebContext.stateHints.some((item) => item.kind === "callback" && item.deps.includes("name")));
   assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "handler" && item.source === "editGuidance"));
   assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "style" && item.source === "style"));
+  assert.deepEqual(
+    payload.reactWebContext.editTargetRouting.map((item) => ({
+      kind: item.kind,
+      label: item.label,
+      priority: item.priority,
+      loc: item.loc,
+      source: item.source,
+    })),
+    [
+      {
+        kind: "primary-component",
+        label: "HookEffectPanel",
+        priority: 1,
+        loc: { startLine: 9, endLine: 51 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "props-contract",
+        label: "HookEffectPanelProps",
+        priority: 2,
+        loc: { startLine: 3, endLine: 7 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "effect",
+        label: "useEffect deps:[loadUser, userId]",
+        priority: 3,
+        loc: { startLine: 12, endLine: 28 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "callback",
+        label: "useMemo deps:[name]",
+        priority: 4,
+        loc: { startLine: 30, endLine: 32 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "callback",
+        label: "useCallback deps:[loadUser, userId]",
+        priority: 5,
+        loc: { startLine: 34, endLine: 38 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "event-handler",
+        label: "handleRefresh",
+        priority: 6,
+        loc: { startLine: 34, endLine: 38 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "event-handler",
+        label: "handleRefresh",
+        priority: 7,
+        loc: { startLine: 44, endLine: 44 },
+        source: "editGuidance.patchTargets",
+      },
+      {
+        kind: "conditional-region",
+        label: "useEffect",
+        priority: 8,
+        loc: { startLine: 12, endLine: 28 },
+        source: "editGuidance.patchTargets",
+      },
+    ],
+  );
+  assert.deepEqual(payload.reactWebContext.editTargetRouting[0].evidence, ["editGuidance.patchTargets.component"]);
 
   const warnings = payload.reactWebContext.warnings.join("\n");
   assert.match(warnings, /React Web current supported lane only/);
@@ -63,6 +131,84 @@ test("React Web opt-in can emit context and domainPayload with stable top-level 
   assert.ok(keys.indexOf("designReviewMetadata") < keys.indexOf("reactWebContext"));
   assert.ok(keys.indexOf("reactWebContext") < keys.indexOf("domainPayload"));
   assert.ok(keys.indexOf("domainPayload") < keys.indexOf("exports"));
+});
+
+test("React Web edit-target routing is compact and keeps broad intent targets separate", () => {
+  const payload = payloadFor("fixtures/compressed/FormControls.tsx", {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.equal(payload.reactWebContext.editTargetRouting.length, 8);
+  assert.deepEqual(
+    payload.reactWebContext.editTargetRouting.map((item) => [item.kind, item.label, item.priority, item.source]),
+    [
+      ["primary-component", "FormControls", 1, "editGuidance.patchTargets"],
+      ["event-handler", "onSubmit", 2, "editGuidance.patchTargets"],
+      ["event-handler", "() => undefined", 3, "editGuidance.patchTargets"],
+      ["form-control", "form", 4, "editGuidance.patchTargets"],
+      ["form-control", "input[name=email]", 5, "editGuidance.patchTargets"],
+      ["form-control", "select[name=role]", 6, "editGuidance.patchTargets"],
+      ["form-control", "textarea[name=notes]", 7, "editGuidance.patchTargets"],
+      ["form-control", "Controller[name=email]", 8, "editGuidance.patchTargets"],
+    ],
+  );
+  assert.ok(payload.reactWebContext.editTargetRouting.every((item) => item.loc));
+  assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "form" && item.label === "useForm"));
+});
+
+test("React Web edit-target routing can use lower-priority range-less style facts", () => {
+  const payload = payloadFor("fixtures/compressed/HookEffectPanel.tsx", {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.deepEqual(payload.reactWebContext.editTargetRouting, [
+    {
+      kind: "style-region",
+      label: "tailwind",
+      priority: 1,
+      source: "style",
+      evidence: ["style"],
+    },
+  ]);
+});
+
+test("React Web edit-target routing skips broad-only patch targets but keeps lower-priority source facts", () => {
+  const payload = payloadFor("fixtures/compressed/FormSection.tsx", {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.deepEqual(
+    payload.reactWebContext.editTargetRouting.map((item) => ({
+      kind: item.kind,
+      label: item.label,
+      priority: item.priority,
+      source: item.source,
+      loc: item.loc,
+    })),
+    [
+      {
+        kind: "style-region",
+        label: "tailwind",
+        priority: 1,
+        source: "style",
+        loc: undefined,
+      },
+      {
+        kind: "repeated-block",
+        label: "array-map-render",
+        priority: 2,
+        source: "structure",
+        loc: undefined,
+      },
+    ],
+  );
+  assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "component" && item.label === "FormSection"));
+  assert.ok(payload.reactWebContext.intentTargets.some((item) => item.intent === "props" && item.label === "FormSectionProps"));
 });
 
 test("React Web form controls emit source-observed a11y anchors only", () => {


### PR DESCRIPTION
## Summary
- add optional `reactWebContext.editTargetRouting` for source-derived React Web edit routes
- keep broad `intentTargets` separate from ordered “where to edit first” routing
- trim optional routing before dropping all React Web context when pre-read payload budget is tight
- raise the Codex wrapper fixture timeout to avoid parallel-suite scheduler flake

## Scope boundaries
- React Web current lane only
- same-file/source-derived facts only
- no state/dataflow expansion, cross-file/LSP analysis, or provider-savings claim

## Verification
- `git diff --check`
- `npm run build && node --test test/layer2-applied-validation.test.mjs test/react-web-context-metadata.test.mjs test/pre-read-payload-builder.test.mjs test/pre-read-phase-order-regression.test.mjs test/runtime-bridge-contract.test.mjs` → 44/44 pass
- `npm test` → 415/415 pass
