### PR TITLE
Preserve React Web routing order under budget

### DIFF
--- a/docs/react-web-context-budget-regression.md
+++ b/docs/react-web-context-budget-regression.md
@@ -1,0 +1,7 @@
+# React Web context budget regression note
+
+`reactWebContext.editTargetRouting` is ordered routing evidence, not required source context. When a repeated React Web edit payload crosses the metadata budget, the pre-read builder must trim that array as a stable prefix before considering full `reactWebContext` fallback.
+
+This preserves the highest-priority edit route evidence (`priority: 1`, then `2`, etc.) without re-extracting or rereading component context. If the payload still exceeds the budget after the routing prefix is exhausted, the builder may omit `editTargetRouting`, and then omit `reactWebContext` as the final budget-safe fallback.
+
+Focused regression: `test/pre-read-payload-builder.test.mjs` covers an oversized `HookEffectPanel.tsx` repeated-edit payload and locks that trimmed routing remains in original priority order while the rest of `reactWebContext` stays available.

--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -111,6 +111,34 @@ function reactWebContextPayloadBudget(rawSizeBytes: number): number {
   );
 }
 
+function trimEditTargetRoutingToBudget(
+  payload: NonNullable<PreReadDecision["payload"]>,
+  maxPayloadBytes: number,
+): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
+  const reactWebContext = payload.reactWebContext;
+  if (!reactWebContext || !reactWebContext.editTargetRouting || reactWebContext.editTargetRouting.length === 0) {
+    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
+  }
+  const routes = reactWebContext.editTargetRouting;
+
+  for (let routeCount = routes.length - 1; routeCount > 0; routeCount -= 1) {
+    const trimmedReactWebContext = {
+      ...reactWebContext,
+      editTargetRouting: routes.slice(0, routeCount),
+    };
+    const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+    const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
+    if (estimatedPayloadBytes <= maxPayloadBytes) {
+      return { payload: trimmedPayload, estimatedPayloadBytes };
+    }
+  }
+
+  const trimmedReactWebContext = { ...reactWebContext };
+  delete trimmedReactWebContext.editTargetRouting;
+  const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+  return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
+}
+
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
   const { frontendPayloadPolicy } = input;
   const result = extractFile(input.resolvedPath);
@@ -128,10 +156,9 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
     let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
     if (payload.reactWebContext?.editTargetRouting && estimatedPayloadBytes > maxPayloadBytes) {
-      const trimmedReactWebContext = { ...payload.reactWebContext };
-      delete trimmedReactWebContext.editTargetRouting;
-      payload = { ...payload, reactWebContext: trimmedReactWebContext };
-      estimatedPayloadBytes = estimatePayloadBytes(payload);
+      const trimmed = trimEditTargetRoutingToBudget(payload, maxPayloadBytes);
+      payload = trimmed.payload;
+      estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
     }
     if (payload.reactWebContext && estimatedPayloadBytes > maxPayloadBytes) {
       payload = toModelFacingPayload(result, input.cwd, {

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -3,6 +3,8 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 
@@ -63,5 +65,60 @@ test("pre-read payload builder omits React Web context metadata when payload bud
     assert.equal(budgeted.debug.reactWebContextBudget.reason, "budget-exceeded");
   } finally {
     JSON.stringify = originalStringify;
+  }
+});
+
+test("pre-read payload builder trims React Web edit-target routing as an ordered prefix before metadata fallback", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-routing-budget-"));
+  try {
+    const target = path.join(tempDir, "HookEffectPanel.tsx");
+    const source = fs.readFileSync(path.join(repoRoot, "fixtures", "compressed", "HookEffectPanel.tsx"), "utf8");
+    fs.writeFileSync(target, `${source}\n/* ${"budget-pad ".repeat(600)} */\n`);
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: true,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
+    assert.equal(decision.payload.reactWebContext.editTargetRouting.length < 8, true);
+    assert.deepEqual(
+      decision.payload.reactWebContext.editTargetRouting.map((item) => ({
+        kind: item.kind,
+        label: item.label,
+        priority: item.priority,
+        source: item.source,
+        evidence: item.evidence,
+      })),
+      [
+        {
+          kind: "primary-component",
+          label: "HookEffectPanel",
+          priority: 1,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.component"],
+        },
+        {
+          kind: "props-contract",
+          label: "HookEffectPanelProps",
+          priority: 2,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.props"],
+        },
+        {
+          kind: "effect",
+          label: "useEffect deps:[loadUser, userId]",
+          priority: 3,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.effect"],
+        },
+      ],
+    );
+    assert.ok(decision.payload.reactWebContext.stateHints.length > 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- trim reactWebContext.editTargetRouting as a stable ordered prefix before dropping all routing metadata
- preserve the existing full reactWebContext fallback when the payload remains over budget
- document the React Web routing-budget regression contract

## Verification
- npm run build && node --test test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs
- npm run typecheck