### PR TITLE
Guard TUI against non-Ink CLI payload reuse

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -55,6 +55,12 @@ Reviewers should check that TUI evidence remains separate from payload permissio
 
 Any future step that changes one of those outcomes is no longer a fixture reinforcement PR; it needs a serialized shared-policy plan with its own fixtures, measured acceptance bar, and claim-boundary review.
 
+### Negative/fallback reinforcement
+
+The next safe TUI fixture shape is a non-Ink CLI renderer that looks terminal-oriented to humans but has no `ink` import, `Box`, `Text`, or `useInput` evidence. `test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx` exists to keep that boundary explicit: it should remain outside the `tui-ink` lane, receive no TUI payload policy authorization, and fall back without a model-facing payload.
+
+This fixture does not activate the deferred F7 manifest slot or broaden TUI package support. It is a local negative/fallback regression only; any manifest promotion still needs a serialized shared-policy plan.
+
 ## Candidate source notes
 
 If a future PR names public repositories, keep the list conservative and verify license, activity, file paths, and commit SHAs at that time. Good seed sources are likely to be established Ink examples, React-based CLI apps, or prompt/status UI components with inspectable TSX/JSX. Do not use curated lists, stale forks, or runtime-only demos as evidence fixtures unless a pinned source file clearly exercises one category above.

--- a/test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx
+++ b/test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+type TerminalSummaryProps = {
+  busy: boolean;
+  lines: string[];
+};
+
+function Screen({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function Line({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+export function TerminalSummary({ busy, lines }: TerminalSummaryProps) {
+  return (
+    <Screen>
+      <Line>{busy ? "Running" : "Idle"}</Line>
+      {lines.map((line) => (
+        <Line key={line}>{line}</Line>
+      ))}
+    </Screen>
+  );
+}

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -44,6 +44,14 @@ function expectedTuiEvidenceOnlyPolicy() {
   };
 }
 
+function assertFallbackWithoutPayload(decision) {
+  assert.equal(decision.eligible, true);
+  assert.equal(decision.decision, "fallback");
+  assert.ok(decision.reasons.length > 0);
+  assert.equal(decision.fallback.action, "full-read");
+  assert.equal("payload" in decision, false);
+}
+
 function assertTuiFallbackWithoutPayload(decision, reason) {
   assert.equal(decision.eligible, true);
   assert.equal(decision.decision, "fallback");
@@ -118,6 +126,30 @@ test("TUI/Ink interactive list fixture remains evidence-only and fallback-safe",
   assertTuiFallbackWithoutPayload(decision, "raw-mode");
 });
 
+test("non-Ink CLI renderer fixture stays outside TUI/Ink payload policy", () => {
+  const relativeFixturePath = path.join(
+    "test",
+    "fixtures",
+    "frontend-domain-expectations",
+    "tui-non-ink-cli-renderer.tsx",
+  );
+  const fixturePath = path.join(repoRoot, relativeFixturePath);
+  const domainDetection = detect(readFixture(relativeFixturePath), "tui-non-ink-cli-renderer.tsx");
+
+  assert.notEqual(domainDetection.classification, "tui-ink");
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(domainDetection.profile.claimStatus, "deferred");
+  assert.equal(domainDetection.signals.some((signal) => signal.startsWith("tui-ink:")), false);
+  assert.equal(assessTuiInkPayloadPolicy(domainDetection), undefined);
+
+  const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
+
+  assertFallbackWithoutPayload(decision);
+  assert.equal(decision.debug.domainDetection.classification, "unknown");
+  assert.equal(decision.debug.frontendPayloadPolicy.allowed, false);
+  assert.equal(decision.debug.frontendPayloadPolicy.reason, preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
+});
+
 test("TUI/Ink policy seam source avoids broad terminal support claims", () => {
   for (const relativePath of [path.join("src", "core", "payload-policy", "tui-ink.ts")]) {
     assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
@@ -131,5 +163,7 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /tui-ink-basic\.tsx/);
   assert.match(survey, /tui-ink-interactive-list\.tsx/);
   assert.match(survey, /unsupported-frontend-domain-profile/);
+  assert.match(survey, /tui-non-ink-cli-renderer\.tsx/);
+  assert.match(survey, /Negative\/fallback reinforcement/);
   assert.doesNotMatch(survey, forbiddenSupportClaims);
 });


### PR DESCRIPTION
## Summary
- Add a synthetic non-Ink CLI renderer fixture that looks terminal-oriented but has no Ink evidence.
- Add a focused TUI policy/pre-read regression proving the fixture stays outside `tui-ink`, receives no TUI policy authorization, and falls back without payload.
- Document the negative/fallback reinforcement boundary without activating deferred F7 or broadening TUI support claims.

## Scope boundary
- TUI-only docs/test/fixture change.
- No TUI payload support.
- No shared source/runtime seam changes.
- No fixture manifest changes.

## Verification
- `npm ci`
- `npm run build`
- `node --test test/payload-policy-tui-ink.test.mjs test/payload-policy-registry.test.mjs test/payload-policy-profile-gate.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- TUI support-claim grep over `docs src`
- `npm test` (421 pass)
- Scoped ai-slop-cleaner pass on changed files
