### PR TITLE
Harden RN narrow reuse gate against stale payloads

### DIFF
--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -1,5 +1,16 @@
 import type { DomainDetectionResult } from "../domain-detector";
-import type { ModelFacingPayload } from "../schema";
+import {
+  DOMAIN_PAYLOAD_SCHEMA_VERSION,
+  type ReactNativePrimitiveInputDomainPayload,
+  type ReactNativePrimitiveInputReuseContract,
+} from "../payload/domain-payload";
+import {
+  RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
+  RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES,
+  RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+  RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
+} from "./react-native";
+import type { ModelFacingPayload, SourceFingerprint } from "../schema";
 import { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } from "./fallback";
 import type { FrontendPayloadPolicyDecision } from "./types";
 
@@ -8,6 +19,63 @@ export const MISSING_REACT_WEB_DOMAIN_PAYLOAD_REASON = "missing-react-web-domain
 export const MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON = "missing-react-native-domain-payload";
 
 export type FrontendProfilePayloadReuseDecision = { allowed: true } | { allowed: false; reason: string };
+
+function arraysEqual(left: string[] | undefined, right: readonly string[]): boolean {
+  if (!left || left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function sourceFingerprintsEqual(left: SourceFingerprint | undefined, right: SourceFingerprint | undefined): boolean {
+  if (!left || !right) return false;
+  return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
+}
+
+function expectedReactNativeDeniedSignals(): string[] {
+  return [
+    ...RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
+    ...RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.map((prefix) => `${prefix}*`),
+  ];
+}
+
+function isReactNativePrimitiveInputReuseContract(value: unknown): value is ReactNativePrimitiveInputReuseContract {
+  if (!value || typeof value !== "object") return false;
+  const contract = value as Partial<ReactNativePrimitiveInputReuseContract>;
+
+  return (
+    contract.sourceDerivedOnly === true &&
+    contract.policy === RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY &&
+    contract.plannerDecision === "narrow-primitive-input-payload" &&
+    contract.freshnessSource === "sourceFingerprint" &&
+    arraysEqual(contract.staleWhen, [
+      "sourceFingerprint.fileHash changes",
+      "sourceFingerprint.lineCount changes",
+      "frontendPayloadPolicy no longer allows RN narrow policy",
+    ]) &&
+    arraysEqual(contract.requiredSignals, RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS) &&
+    arraysEqual(contract.deniedBySignals, expectedReactNativeDeniedSignals()) &&
+    contract.supportBoundary === "measured-evidence-only; no broad RN/WebView/TUI support"
+  );
+}
+
+function isReactNativePrimitiveInputDomainPayload(
+  payload: ModelFacingPayload,
+  expectedPolicy: string,
+): payload is ModelFacingPayload & { domainPayload: ReactNativePrimitiveInputDomainPayload } {
+  const domainPayload = payload.domainPayload;
+  if (!domainPayload || domainPayload.domain !== "react-native") return false;
+
+  if (expectedPolicy !== RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY) return false;
+  if (domainPayload.schemaVersion !== DOMAIN_PAYLOAD_SCHEMA_VERSION) return false;
+  if (domainPayload.policy !== RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY) return false;
+  if (domainPayload.plannerDecision !== "narrow-primitive-input-payload") return false;
+  if (domainPayload.claimStatus !== "measured-evidence-only") return false;
+  if (domainPayload.claimBoundary !== "rn-primitive-input-narrow-payload-only") return false;
+  if (!isReactNativePrimitiveInputReuseContract(domainPayload.reuseContract)) return false;
+  if (!payload.sourceFingerprint) return false;
+  if (payload.editGuidance?.freshness && !sourceFingerprintsEqual(payload.sourceFingerprint, payload.editGuidance.freshness)) return false;
+
+  return true;
+}
 
 export function assessFrontendProfilePayloadReuse(
   extension: string,
@@ -27,7 +95,7 @@ export function assessFrontendProfilePayloadReuse(
 
   if (frontendPayloadPolicy?.allowed === true) {
     if (domainDetection.profile.lane === "react-native") {
-      return payload.domainPayload?.domain === "react-native" && payload.domainPayload.policy === frontendPayloadPolicy.name
+      return isReactNativePrimitiveInputDomainPayload(payload, frontendPayloadPolicy.name)
         ? { allowed: true }
         : { allowed: false, reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON };
     }

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -21,6 +21,10 @@ const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(p
 const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
 const { buildPreReadDecisionFromPayloadPlan } = require(path.join(repoRoot, "dist", "adapters", "pre-read-stack.js"));
 
+function clonePayload(payload) {
+  return JSON.parse(JSON.stringify(payload));
+}
+
 function payloadForSource(source, fileName, options = {}) {
   const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-profile-gate-"));
   try {
@@ -88,6 +92,110 @@ test("frontend profile gate requires RN domain payload for the measured narrow R
     allowed: false,
     reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON,
   });
+});
+
+test("frontend profile gate rejects adversarial RN narrow payload contract and freshness mismatches", () => {
+  const source = `import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Native.tsx", { includeEditGuidance: true });
+
+  assert.equal(domainDetection.classification, "react-native");
+  assert.equal(policy.allowed, true);
+  assert.equal(payload.domainPayload.domain, "react-native");
+  assert.ok(payload.sourceFingerprint, "RN reusable payload must carry a source fingerprint");
+  assert.ok(payload.editGuidance?.freshness, "edit guidance freshness gives the gate an internal source-fingerprint cross-check");
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+
+  const rejectedPayloads = [
+    ["missing domain payload", () => {
+      const stale = clonePayload(payload);
+      delete stale.domainPayload;
+      return stale;
+    }],
+    ["wrong schema", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.schemaVersion = "domain-payload.v0";
+      return stale;
+    }],
+    ["wrong planner decision", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.plannerDecision = "compact-safe";
+      return stale;
+    }],
+    ["wrong claim boundary", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.claimBoundary = "react-web-measured-extraction";
+      return stale;
+    }],
+    ["wrong policy", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.policy = "react-web-current-supported-lane";
+      return stale;
+    }],
+    ["missing reuse contract", () => {
+      const stale = clonePayload(payload);
+      delete stale.domainPayload.reuseContract;
+      return stale;
+    }],
+    ["wrong reuse contract planner decision", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.reuseContract.plannerDecision = "compact-safe";
+      return stale;
+    }],
+    ["missing required signal in reuse contract", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.reuseContract.requiredSignals = stale.domainPayload.reuseContract.requiredSignals.slice(1);
+      return stale;
+    }],
+    ["missing source fingerprint", () => {
+      const stale = clonePayload(payload);
+      delete stale.sourceFingerprint;
+      return stale;
+    }],
+    ["source fingerprint disagrees with edit guidance freshness", () => {
+      const stale = clonePayload(payload);
+      stale.sourceFingerprint.fileHash = "stale-hash";
+      return stale;
+    }],
+  ];
+
+  for (const [label, buildPayload] of rejectedPayloads) {
+    assert.deepEqual(
+      assessFrontendProfilePayloadReuse(".tsx", domainDetection, buildPayload(), policy),
+      { allowed: false, reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON },
+      label,
+    );
+  }
+});
+
+test("pre-read payload-plan seam rejects RN stale source-fingerprint payloads", () => {
+  const source = `import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`;
+  const { domainDetection, policy, payload } = payloadForSource(source, "Native.tsx", { includeEditGuidance: true });
+  const stalePayload = clonePayload(payload);
+  stalePayload.sourceFingerprint.lineCount += 1;
+
+  const directGateDecision = assessFrontendProfilePayloadReuse(".tsx", domainDetection, stalePayload, policy);
+  const preReadDecision = buildPreReadDecisionFromPayloadPlan({
+    runtime: "codex",
+    filePath: "Native.tsx",
+    extension: ".tsx",
+    domainDetection,
+    frontendPayloadPolicy: policy,
+    payload: stalePayload,
+    readiness: { ready: true, reasons: [], signals: {} },
+    debug: { domainDetection, frontendPayloadPolicy: policy },
+  });
+
+  assert.deepEqual(directGateDecision, {
+    allowed: false,
+    reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON,
+  });
+  assert.equal(preReadDecision.decision, "fallback");
+  assert.deepEqual(preReadDecision.reasons, [MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON]);
+  assert.equal(preReadDecision.fallback.reason, MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON);
+  assert.equal("payload" in preReadDecision, false);
+  assert.equal("readiness" in preReadDecision, false);
+  assert.equal(preReadDecision.debug.domainDetection.classification, "react-native");
+  assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
 });
 
 test("frontend profile gate denies unsupported frontend profile reuse", () => {


### PR DESCRIPTION
## Summary
- Harden the RN primitive/input narrow payload reuse gate against stale or adversarial cached payloads.
- Require RN reusable payloads to match schema, policy/planner decision, claim boundary, reuse contract, source fingerprint, and edit-guidance freshness.
- Add regression coverage for adversarial RN payload contract drift and stale source-fingerprint fallback through the pre-read seam.

## Boundaries
- This does **not** broaden React Native support.
- This does **not** enable WebView or TUI compact extraction.
- This does **not** implement full persisted-cache invalidation or a cache schema migration.
- React Web behavior remains unchanged.

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/payload-policy-registry.test.mjs test/pre-read-phase-order-regression.test.mjs test/runtime-bridge-contract.test.mjs test/claim-boundary-doc-audit.test.mjs` — 38/38 pass
- `node --test test/fooks.test.mjs` — 140/140 pass
- `npm test` — 414/414 pass
- Forbidden broad support claim grep over `docs src` — no matches

## Review evidence
- Ralph architect verification: APPROVE, no required fixes.
- ai-slop-cleaner scoped pass: no fallback slop/debug/TODO findings; no cleanup edits required.
