### PR TITLE
Add React Web release smoke coverage

### DIFF
--- a/test/react-web-release-smoke.test.mjs
+++ b/test/react-web-release-smoke.test.mjs
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+
+function cleanupRuntimeSessions(prefix) {
+  const root = path.join(repoRoot, ".fooks", "state", "codex-runtime");
+  if (!fs.existsSync(root)) return;
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith(prefix)) {
+      fs.rmSync(path.join(root, entry.name), { force: true });
+    }
+  }
+
+  if (fs.existsSync(root) && fs.readdirSync(root).length === 0) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function repeatedPrompt(relativeFile, suffix) {
+  const sessionId = `react-web-release-smoke-${suffix}-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${relativeFile}`,
+    },
+    repoRoot,
+  );
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${relativeFile} again and keep the same-file context compact if safe`,
+    },
+    repoRoot,
+  );
+
+  return { first, second };
+}
+
+test.after(() => {
+  cleanupRuntimeSessions("react-web-release-smoke-");
+});
+
+test("release smoke: repeated React Web TSX work injects compact current-lane payload", () => {
+  const { first, second } = repeatedPrompt("fixtures/compressed/HookEffectPanel.tsx", "react-web");
+
+  assert.equal(first.action, "record");
+  assert.equal(second.action, "inject");
+  assert.equal(second.debug.decision.decision, "payload");
+  assert.deepEqual(second.debug.decision.reasons, []);
+
+  const payload = second.debug.decision.payload;
+  assert.notEqual(payload.useOriginal, true, "release smoke must exercise the compact path, not raw source reuse");
+
+  const domainPayload = payload.domainPayload;
+  assert.equal(domainPayload.schemaVersion, "domain-payload.v1");
+  assert.equal(domainPayload.domain, "react-web");
+  assert.equal(domainPayload.policy, "react-web-current-supported-lane");
+  assert.equal(domainPayload.plannerDecision, "compact-safe");
+  assert.equal(domainPayload.claimStatus, "current-supported-lane");
+  assert.equal(domainPayload.claimBoundary, "react-web-measured-extraction");
+  assert.ok(domainPayload.warnings.some((warning) => warning.includes("React Web current supported lane only")));
+
+  assert.equal(domainPayload.facts.componentName, "HookEffectPanel");
+  assert.deepEqual(domainPayload.facts.hooks, ["useCallback", "useEffect", "useMemo", "useState"]);
+  assert.ok(domainPayload.facts.domTags.includes("button"));
+  assert.ok(domainPayload.facts.jsxAttributes.includes("className"));
+  assert.ok(domainPayload.facts.eventHandlers.includes("handleRefresh"));
+  assert.equal(domainPayload.facts.styleSystem, "tailwind");
+});
+
+test("release smoke: WebView boundary falls back instead of becoming React Web support", () => {
+  const { first, second } = repeatedPrompt(
+    "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx",
+    "webview-boundary",
+  );
+
+  assert.equal(first.action, "record");
+  assert.equal(second.action, "fallback");
+  assert.equal(second.debug.decision.decision, "fallback");
+  assert.deepEqual(second.debug.decision.reasons, ["unsupported-react-native-webview-boundary"]);
+  assert.equal(second.debug.decision.fallback.reason, "unsupported-react-native-webview-boundary");
+  assert.equal("payload" in second.debug.decision, false);
+
+  const domainDetection = second.debug.decision.debug.domainDetection;
+  assert.equal(domainDetection.classification, "webview");
+  assert.equal(domainDetection.profile.claimStatus, "fallback-boundary");
+  assert.ok(domainDetection.signals.includes("webview:component:WebView"));
+});


### PR DESCRIPTION
## Summary

Adds a focused release-smoke test for the strongest current fooks path: Codex repeated same-file React Web TSX work.

The smoke intentionally checks both sides of the release boundary:

- React Web repeated same-file work records first, then injects a compact current-lane `react-web` domain payload.
- WebView boundary input falls back instead of being treated as React Web support.

## Why this is bounded

This is release-readiness coverage, not a new support or benchmark claim. It does not publish to npm, generate new public benchmark numbers, or validate React Native/WebView support.

## Results

Targeted smoke:

```text
node --test test/react-web-release-smoke.test.mjs
✔ release smoke: repeated React Web TSX work injects compact current-lane payload
✔ release smoke: WebView boundary falls back instead of becoming React Web support
2/2 passed
```

Related React Web/boundary group:

```text
node --test test/react-web-release-smoke.test.mjs test/react-web-domain-payload-expansion.test.mjs test/pre-read-fallback-builder.test.mjs test/react-web-context-metadata.test.mjs
18/18 passed
```

## Verification

```text
npm run build
node --test test/react-web-release-smoke.test.mjs
node --test test/react-web-release-smoke.test.mjs test/react-web-domain-payload-expansion.test.mjs test/pre-read-fallback-builder.test.mjs test/react-web-context-metadata.test.mjs
```

Also ran full `npm test` with the new smoke included. The React Web smoke passed in the full run, but the full suite had two unrelated/environmental failures:

- `process-model probe compares current cli against helper-backed warm paths` failed once with helper readiness timeout, then passed when rerun individually.
- `doctor warns for clean local tracking divergence but suppresses dirty divergence` failed once in the full run, then passed when rerun individually.

Individual reruns:

```text
node --test test/benchmarks.test.mjs --test-name-pattern "process-model probe"
10/10 passed

node --test test/worktree-evidence.test.mjs --test-name-pattern "doctor warns for clean local tracking divergence"
11/11 passed
```
