### PR TITLE
Lock TUI evidence rows as fallback-only

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -61,6 +61,18 @@ The next safe TUI fixture shape is a non-Ink CLI renderer that looks terminal-or
 
 This fixture does not activate the deferred F7 manifest slot or broaden TUI package support. It is a local negative/fallback regression only; any manifest promotion still needs a serialized shared-policy plan.
 
+## Current TUI evidence matrix
+
+This matrix is the current review contract for TUI-related fixtures. It is intentionally docs/test scoped: it records evidence and fallback expectations, but it does not grant compact payload permission.
+
+| Fixture | Expected domain classification | Payload policy expectation | Pre-read expectation | Claim boundary |
+| --- | --- | --- | --- | --- |
+| `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `tui-ink`, `evidence-only` | `tui-ink-evidence-only-payload`, denied | fallback with `unsupported-frontend-domain-profile`, no payload | Syntax evidence only; no TUI support or terminal correctness claim. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | `tui-ink`, `evidence-only` | `tui-ink-evidence-only-payload`, denied | fallback with `raw-mode`, no payload | Behavior-heavy Ink evidence only; no runtime, token, or compact extraction claim. |
+| `test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx` | `unknown`, `deferred` | no TUI/Ink policy authorization | fallback with no payload; unsupported-profile policy remains denied in debug evidence | Negative/fallback evidence only; no F7 manifest promotion or package-support claim. |
+
+If a future PR changes any row from fallback/no-payload to payload emission, it is no longer a TUI evidence matrix update and must go through a serialized shared-policy plan.
+
 ## Candidate source notes
 
 If a future PR names public repositories, keep the list conservative and verify license, activity, file paths, and commit SHAs at that time. Good seed sources are likely to be established Ink examples, React-based CLI apps, or prompt/status UI components with inspectable TSX/JSX. Do not use curated lists, stale forks, or runtime-only demos as evidence fixtures unless a pinned source file clearly exercises one category above.

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -36,6 +36,34 @@ function tuiInkSource() {
     }`;
 }
 
+const tuiEvidenceMatrix = [
+  {
+    fileName: "tui-ink-basic.tsx",
+    classification: "tui-ink",
+    claimStatus: "evidence-only",
+    expectedPolicy: expectedTuiEvidenceOnlyPolicy,
+    fallbackReason: () => preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  },
+  {
+    fileName: "tui-ink-interactive-list.tsx",
+    classification: "tui-ink",
+    claimStatus: "evidence-only",
+    expectedPolicy: expectedTuiEvidenceOnlyPolicy,
+    fallbackReason: () => "raw-mode",
+  },
+  {
+    fileName: "tui-non-ink-cli-renderer.tsx",
+    classification: "unknown",
+    claimStatus: "deferred",
+    expectedPolicy: () => undefined,
+    fallbackReason: () => undefined,
+  },
+];
+
+function tuiFixturePath(fileName) {
+  return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
+}
+
 function expectedTuiEvidenceOnlyPolicy() {
   return {
     name: TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY,
@@ -150,6 +178,28 @@ test("non-Ink CLI renderer fixture stays outside TUI/Ink payload policy", () => 
   assert.equal(decision.debug.frontendPayloadPolicy.reason, preRead.UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON);
 });
 
+test("TUI evidence matrix rows stay aligned with policy and pre-read boundaries", () => {
+  for (const row of tuiEvidenceMatrix) {
+    const relativeFixturePath = tuiFixturePath(row.fileName);
+    const fixturePath = path.join(repoRoot, relativeFixturePath);
+    const domainDetection = detect(readFixture(relativeFixturePath), row.fileName);
+    const expectedPolicy = row.expectedPolicy();
+    const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
+
+    assert.equal(domainDetection.classification, row.classification, row.fileName);
+    assert.equal(domainDetection.profile.claimStatus, row.claimStatus, row.fileName);
+    assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), expectedPolicy, row.fileName);
+    assert.equal(decision.decision, "fallback", row.fileName);
+    assert.equal("payload" in decision, false, row.fileName);
+
+    const fallbackReason = row.fallbackReason();
+    if (fallbackReason) {
+      assert.deepEqual(decision.reasons, [fallbackReason], row.fileName);
+      assert.equal(decision.fallback.reason, fallbackReason, row.fileName);
+    }
+  }
+});
+
 test("TUI/Ink policy seam source avoids broad terminal support claims", () => {
   for (const relativePath of [path.join("src", "core", "payload-policy", "tui-ink.ts")]) {
     assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
@@ -165,5 +215,7 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /unsupported-frontend-domain-profile/);
   assert.match(survey, /tui-non-ink-cli-renderer\.tsx/);
   assert.match(survey, /Negative\/fallback reinforcement/);
+  assert.match(survey, /Current TUI evidence matrix/);
+  assert.match(survey, /tui-ink-evidence-only-payload/);
   assert.doesNotMatch(survey, forbiddenSupportClaims);
 });


### PR DESCRIPTION
## Summary
- Add a current TUI evidence matrix for the three committed TUI-related fixtures.
- Add a matrix-driven regression that checks classification, policy, fallback, and no-payload boundaries.
- Keep TUI payload support, shared seams, and manifest changes out of scope.

## Scope boundary
- TUI-only docs/test change.
- No source/runtime shared seam changes.
- No fixture manifest changes.
- No TUI compact payload support claim.

## Verification
- `npm ci`
- `npm run build`
- `node --test test/payload-policy-tui-ink.test.mjs test/payload-policy-registry.test.mjs test/payload-policy-profile-gate.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- TUI support-claim grep over `docs src`
- `npm test`
- Scoped ai-slop-cleaner pass on changed files
