### PR TITLE
Add worktree status verdict

### DIFF
--- a/src/core/worktree-evidence.ts
+++ b/src/core/worktree-evidence.ts
@@ -72,6 +72,7 @@ export type WorktreeCurrentStatus = {
   snapshot?: WorktreeSnapshot;
   blockers: string[];
   branchDivergence?: BranchDivergence;
+  worktreeVerdict: WorktreeOperatorVerdict;
 };
 
 export type WorktreeEvidenceOptions = {
@@ -79,6 +80,39 @@ export type WorktreeEvidenceOptions = {
   gitRunner?: WorktreeGitRunner;
   now?: () => string;
 };
+
+export type WorktreeOperatorVerdict =
+  | {
+      kind: "dirty";
+      severity: "warning";
+      primary: "dirty";
+      summary: "dirty worktree";
+    }
+  | {
+      kind: "clean";
+      severity: "ok";
+      primary: "clean";
+      summary: "clean worktree";
+    }
+  | {
+      kind: "clean-behind" | "clean-ahead" | "clean-diverged";
+      severity: "warning";
+      primary: "upstream-divergence";
+      summary: string;
+      branch: string;
+      upstream: string;
+      ahead: number;
+      behind: number;
+      source: typeof WORKTREE_BRANCH_DIVERGENCE_SOURCE;
+    }
+  | {
+      kind: "neutral";
+      severity: "ok";
+      primary: "neutral";
+      summary: "no upstream tracking branch" | "detached HEAD" | "worktree status unavailable" | "branch divergence unavailable";
+      reason: "no-upstream" | "detached" | "missing-snapshot" | "unknown-divergence";
+      source?: typeof WORKTREE_BRANCH_DIVERGENCE_SOURCE;
+    };
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -207,6 +241,109 @@ export function captureWorktreeSnapshot(cwd = process.cwd(), options: WorktreeEv
   }
 }
 
+export function summarizeWorktreeOperatorVerdict(snapshot: WorktreeSnapshot | undefined, branchDivergence: BranchDivergence | undefined): WorktreeOperatorVerdict {
+  if (!snapshot) {
+    return {
+      kind: "neutral",
+      severity: "ok",
+      primary: "neutral",
+      summary: "worktree status unavailable",
+      reason: "missing-snapshot",
+      source: branchDivergence?.source,
+    };
+  }
+
+  if (!snapshot.clean) {
+    return {
+      kind: "dirty",
+      severity: "warning",
+      primary: "dirty",
+      summary: "dirty worktree",
+    };
+  }
+
+  if (!branchDivergence || branchDivergence.kind === "unknown") {
+    return {
+      kind: "neutral",
+      severity: "ok",
+      primary: "neutral",
+      summary: "branch divergence unavailable",
+      reason: "unknown-divergence",
+      source: branchDivergence?.source,
+    };
+  }
+
+  if (branchDivergence.kind === "no-upstream") {
+    return {
+      kind: "neutral",
+      severity: "ok",
+      primary: "neutral",
+      summary: "no upstream tracking branch",
+      reason: "no-upstream",
+      source: branchDivergence.source,
+    };
+  }
+
+  if (branchDivergence.kind === "detached") {
+    return {
+      kind: "neutral",
+      severity: "ok",
+      primary: "neutral",
+      summary: "detached HEAD",
+      reason: "detached",
+      source: branchDivergence.source,
+    };
+  }
+
+  const { ahead, behind, branch, upstream, source } = branchDivergence;
+  if (ahead > 0 && behind > 0) {
+    return {
+      kind: "clean-diverged",
+      severity: "warning",
+      primary: "upstream-divergence",
+      summary: `clean worktree diverged from ${upstream}: ${ahead} ahead, ${behind} behind`,
+      branch,
+      upstream,
+      ahead,
+      behind,
+      source,
+    };
+  }
+  if (behind > 0) {
+    return {
+      kind: "clean-behind",
+      severity: "warning",
+      primary: "upstream-divergence",
+      summary: `clean worktree behind ${upstream} by ${behind}`,
+      branch,
+      upstream,
+      ahead,
+      behind,
+      source,
+    };
+  }
+  if (ahead > 0) {
+    return {
+      kind: "clean-ahead",
+      severity: "warning",
+      primary: "upstream-divergence",
+      summary: `clean worktree ahead of ${upstream} by ${ahead}`,
+      branch,
+      upstream,
+      ahead,
+      behind,
+      source,
+    };
+  }
+
+  return {
+    kind: "clean",
+    severity: "ok",
+    primary: "clean",
+    summary: "clean worktree",
+  };
+}
+
 export function computeWorktreeDelta(baseline: WorktreeSnapshot, latest: WorktreeSnapshot): WorktreeDelta {
   const baselineDirty = new Set(baseline.changedPaths);
   const latestDirty = new Set(latest.changedPaths);
@@ -294,6 +431,7 @@ export function finalizeWorktreeEvidenceSafe(
 export function currentWorktreeEvidenceStatus(cwd = process.cwd(), options: WorktreeEvidenceOptions = {}): WorktreeCurrentStatus {
   const capturedAt = options.now?.() ?? nowIso();
   const capture = captureWorktreeSnapshot(cwd, { ...options, now: () => capturedAt });
+  const branchDivergence = capture.snapshot?.branchDivergence ?? captureBranchDivergence(cwd, options);
   return {
     schemaVersion: WORKTREE_EVIDENCE_SCHEMA_VERSION,
     claimBoundary: WORKTREE_EVIDENCE_CLAIM_BOUNDARY,
@@ -302,6 +440,7 @@ export function currentWorktreeEvidenceStatus(cwd = process.cwd(), options: Work
     capturedAt,
     snapshot: capture.snapshot,
     blockers: capture.blockers,
-    branchDivergence: capture.snapshot?.branchDivergence ?? captureBranchDivergence(cwd, options),
+    branchDivergence,
+    worktreeVerdict: summarizeWorktreeOperatorVerdict(capture.snapshot, branchDivergence),
   };
 }

--- a/test/worktree-evidence.test.mjs
+++ b/test/worktree-evidence.test.mjs
@@ -288,6 +288,12 @@ test("status worktree reports clean branches behind, ahead, and diverged using l
   assert.equal(behind.branchDivergence.behind, 1);
   assert.equal(behind.branchDivergence.ahead, 0);
   assert.equal(behind.branchDivergence.source, WORKTREE_BRANCH_DIVERGENCE_SOURCE);
+  assert.equal(behind.worktreeVerdict.kind, "clean-behind");
+  assert.equal(behind.worktreeVerdict.severity, "warning");
+  assert.equal(behind.worktreeVerdict.primary, "upstream-divergence");
+  assert.equal(behind.worktreeVerdict.behind, 1);
+  assert.equal(behind.worktreeVerdict.ahead, 0);
+  assert.match(behind.worktreeVerdict.summary, /behind origin\/main by 1/);
 
   const aheadRepo = makeTrackedRepo();
   commitFile(aheadRepo.clone, "ahead.txt", "ahead\n", "ahead");
@@ -296,6 +302,12 @@ test("status worktree reports clean branches behind, ahead, and diverged using l
   assert.equal(ahead.branchDivergence.kind, "available");
   assert.equal(ahead.branchDivergence.ahead, 1);
   assert.equal(ahead.branchDivergence.behind, 0);
+  assert.equal(ahead.worktreeVerdict.kind, "clean-ahead");
+  assert.equal(ahead.worktreeVerdict.severity, "warning");
+  assert.equal(ahead.worktreeVerdict.primary, "upstream-divergence");
+  assert.equal(ahead.worktreeVerdict.ahead, 1);
+  assert.equal(ahead.worktreeVerdict.behind, 0);
+  assert.match(ahead.worktreeVerdict.summary, /ahead of origin\/main by 1/);
 
   const divergedRepo = makeTrackedRepo();
   commitFile(divergedRepo.clone, "local.txt", "local\n", "local");
@@ -305,6 +317,12 @@ test("status worktree reports clean branches behind, ahead, and diverged using l
   assert.equal(diverged.branchDivergence.kind, "available");
   assert.equal(diverged.branchDivergence.ahead, 1);
   assert.equal(diverged.branchDivergence.behind, 1);
+  assert.equal(diverged.worktreeVerdict.kind, "clean-diverged");
+  assert.equal(diverged.worktreeVerdict.severity, "warning");
+  assert.equal(diverged.worktreeVerdict.primary, "upstream-divergence");
+  assert.equal(diverged.worktreeVerdict.ahead, 1);
+  assert.equal(diverged.worktreeVerdict.behind, 1);
+  assert.match(diverged.worktreeVerdict.summary, /diverged from origin\/main: 1 ahead, 1 behind/);
 });
 
 test("branch divergence keeps no-upstream and detached states quiet", () => {
@@ -313,10 +331,33 @@ test("branch divergence keeps no-upstream and detached states quiet", () => {
   const noUpstream = run(["status", "worktree"], repo.clone);
   assert.equal(noUpstream.branchDivergence.kind, "no-upstream");
   assert.equal(noUpstream.branchDivergence.branch, "local-only");
+  assert.equal(noUpstream.worktreeVerdict.kind, "neutral");
+  assert.equal(noUpstream.worktreeVerdict.severity, "ok");
+  assert.equal(noUpstream.worktreeVerdict.primary, "neutral");
+  assert.equal(noUpstream.worktreeVerdict.reason, "no-upstream");
 
   git(repo.clone, ["checkout", "--detach"]);
   const detached = run(["status", "worktree"], repo.clone);
   assert.equal(detached.branchDivergence.kind, "detached");
+  assert.equal(detached.worktreeVerdict.kind, "neutral");
+  assert.equal(detached.worktreeVerdict.severity, "ok");
+  assert.equal(detached.worktreeVerdict.primary, "neutral");
+  assert.equal(detached.worktreeVerdict.reason, "detached");
+});
+
+test("dirty worktrees keep dirty verdict primary even with local tracking divergence", () => {
+  const repo = makeTrackedRepo();
+  pushRemoteCommit(repo, "remote-dirty-status.txt", "remote\n", "remote dirty status");
+  fs.writeFileSync(path.join(repo.clone, "dirty.txt"), "dirty\n");
+  const dirty = run(["status", "worktree"], repo.clone);
+  assert.equal(dirty.snapshot.clean, false);
+  assert.equal(dirty.branchDivergence.kind, "available");
+  assert.equal(dirty.branchDivergence.behind, 1);
+  assert.equal(dirty.branchDivergence.ahead, 0);
+  assert.equal(dirty.worktreeVerdict.kind, "dirty");
+  assert.equal(dirty.worktreeVerdict.severity, "warning");
+  assert.equal(dirty.worktreeVerdict.primary, "dirty");
+  assert.equal(dirty.worktreeVerdict.summary, "dirty worktree");
 });
 
 test("doctor warns for clean local tracking divergence but suppresses dirty divergence", () => {


### PR DESCRIPTION
## Summary
- Add derived `worktreeVerdict` to `status worktree` output for operator-facing local divergence signals
- Preserve dirty verdict primacy while keeping raw `branchDivergence` evidence available
- Keep no-upstream/detached quiet and preserve bare `fooks status` metric shape

Fixes #415

## Verification
- npm run build
- node --test test/worktree-evidence.test.mjs
- git diff --check