### PR TITLE
Broaden TUI evidence without payload permission

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -42,6 +42,7 @@ The current committed TUI / Ink fixtures are useful as domain evidence, not as c
 | --- | --- | --- |
 | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | Ink import, `Box`, `Text`, and `useInput` signals in a compact React CLI component. | Classify as `tui-ink`, mark the profile `evidence-only`, deny the TUI payload policy, and fall back with `unsupported-frontend-domain-profile`. |
 | `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | Ink import, `Box`, `Text`, `useInput`, keyboard navigation, selected-row rendering, and list mapping in a behavior-heavy prompt surface. | Classify as `tui-ink`, keep the profile `evidence-only`, deny the TUI payload policy, emit no payload, and fall back through the readiness/profile gate. The current pre-read reason is `raw-mode` because extraction preserves the original raw source before any TUI payload could be emitted. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx` | Ink import, `Box`, `Text`, nested status rows, command phase labels, elapsed time, and mapped log lines without `useInput`. | Classify as `tui-ink`, keep the profile `evidence-only`, deny the TUI payload policy, emit no payload, and fall back with `raw-mode`; this proves fixture breadth without treating non-interactive status UI as supported terminal behavior. |
 
 This reinforcement slice is intentionally small so it can run alongside RN, React Web, and WebView worktrees without touching shared detector, runtime, manifest, or payload-policy implementation files. A TUI fixture PR should prove the evidence boundary above before it proposes any source or runtime change.
 
@@ -69,6 +70,7 @@ This matrix is the current review contract for TUI-related fixtures. It is inten
 | --- | --- | --- | --- | --- |
 | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | `tui-ink`, `evidence-only` | `tui-ink-evidence-only-payload`, denied | fallback with `unsupported-frontend-domain-profile`, no payload | Syntax evidence only; no TUI support or terminal correctness claim. |
 | `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | `tui-ink`, `evidence-only` | `tui-ink-evidence-only-payload`, denied | fallback with `raw-mode`, no payload | Behavior-heavy Ink evidence only; no runtime, token, or compact extraction claim. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx` | `tui-ink`, `evidence-only` | `tui-ink-evidence-only-payload`, denied | fallback with `raw-mode`, no payload | Status/progress UI syntax evidence only; no terminal progress, command execution, token, or compact extraction claim. |
 | `test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx` | `unknown`, `deferred` | no TUI/Ink policy authorization | fallback with no payload; unsupported-profile policy remains denied in debug evidence | Negative/fallback evidence only; no F7 manifest promotion or package-support claim. |
 
 If a future PR changes any row from fallback/no-payload to payload emission, it is no longer a TUI evidence matrix update and must go through a serialized shared-policy plan.

--- a/test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx
+++ b/test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from "ink";
+
+type StatusPanelProps = {
+  command: string;
+  phase: "queued" | "running" | "done" | "failed";
+  elapsedMs: number;
+  messages: string[];
+};
+
+function statusGlyph(phase: StatusPanelProps["phase"]) {
+  if (phase === "done") return "✓";
+  if (phase === "failed") return "✕";
+  if (phase === "running") return "…";
+  return "•";
+}
+
+export function StatusPanel({ command, phase, elapsedMs, messages }: StatusPanelProps) {
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box gap={1}>
+        <Text>{statusGlyph(phase)}</Text>
+        <Text>{command}</Text>
+        <Text dimColor>{elapsedMs}ms</Text>
+      </Box>
+      {messages.map((message) => (
+        <Box key={message} gap={1}>
+          <Text dimColor>│</Text>
+          <Text>{message}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -52,6 +52,13 @@ const tuiEvidenceMatrix = [
     fallbackReason: () => "raw-mode",
   },
   {
+    fileName: "tui-ink-status-panel.tsx",
+    classification: "tui-ink",
+    claimStatus: "evidence-only",
+    expectedPolicy: expectedTuiEvidenceOnlyPolicy,
+    fallbackReason: () => "raw-mode",
+  },
+  {
     fileName: "tui-non-ink-cli-renderer.tsx",
     classification: "unknown",
     claimStatus: "deferred",
@@ -154,6 +161,29 @@ test("TUI/Ink interactive list fixture remains evidence-only and fallback-safe",
   assertTuiFallbackWithoutPayload(decision, "raw-mode");
 });
 
+test("TUI/Ink status panel fixture broadens evidence without payload permission", () => {
+  const relativeFixturePath = path.join(
+    "test",
+    "fixtures",
+    "frontend-domain-expectations",
+    "tui-ink-status-panel.tsx",
+  );
+  const fixturePath = path.join(repoRoot, relativeFixturePath);
+  const domainDetection = detect(readFixture(relativeFixturePath), "tui-ink-status-panel.tsx");
+
+  assert.equal(domainDetection.classification, "tui-ink");
+  assert.equal(domainDetection.profile.claimStatus, "evidence-only");
+  assert.ok(domainDetection.signals.includes("tui-ink:import:ink"));
+  assert.ok(domainDetection.signals.includes("tui-ink:primitive:Box"));
+  assert.ok(domainDetection.signals.includes("tui-ink:primitive:Text"));
+  assert.equal(domainDetection.signals.includes("tui-ink:hook:useInput"), false);
+  assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), expectedTuiEvidenceOnlyPolicy());
+
+  const decision = preRead.decidePreRead(fixturePath, repoRoot, "codex");
+
+  assertTuiFallbackWithoutPayload(decision, "raw-mode");
+});
+
 test("non-Ink CLI renderer fixture stays outside TUI/Ink payload policy", () => {
   const relativeFixturePath = path.join(
     "test",
@@ -212,6 +242,7 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /Current evidence-only reinforcement slice/);
   assert.match(survey, /tui-ink-basic\.tsx/);
   assert.match(survey, /tui-ink-interactive-list\.tsx/);
+  assert.match(survey, /tui-ink-status-panel\.tsx/);
   assert.match(survey, /unsupported-frontend-domain-profile/);
   assert.match(survey, /tui-non-ink-cli-renderer\.tsx/);
   assert.match(survey, /Negative\/fallback reinforcement/);


### PR DESCRIPTION
## Summary
- Add a TUI/Ink status-panel fixture that covers non-interactive status/progress UI syntax.
- Add policy regression coverage proving the new fixture remains `tui-ink`, `evidence-only`, denied by TUI payload policy, and fallback/no-payload.
- Update the TUI fixture survey and evidence matrix without touching source/runtime/manifest/shared seams.

## Scope boundary
- TUI fixture + TUI docs/test only.
- No source/runtime/shared policy changes.
- No fixture manifest promotion.
- No TUI compact payload or terminal behavior support claim.

## Verification
- `npm ci`
- `npm run build`
- `node --test test/payload-policy-tui-ink.test.mjs`
- `node --test test/payload-policy-tui-ink.test.mjs test/domain-detector.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- TUI support-claim grep over `docs src`
- `npm test`
- Scoped ai-slop-cleaner pass on changed files
