### PR TITLE
Keep React Web smoke bounded from RN support

### DIFF
--- a/test/react-web-release-smoke.test.mjs
+++ b/test/react-web-release-smoke.test.mjs
@@ -98,3 +98,22 @@ test("release smoke: WebView boundary falls back instead of becoming React Web s
   assert.equal(domainDetection.profile.claimStatus, "fallback-boundary");
   assert.ok(domainDetection.signals.includes("webview:component:WebView"));
 });
+
+test("release smoke: React Native boundary falls back instead of becoming React Web support", () => {
+  const { first, second } = repeatedPrompt(
+    "test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx",
+    "react-native-boundary",
+  );
+
+  assert.equal(first.action, "record");
+  assert.equal(second.action, "fallback");
+  assert.equal(second.debug.decision.decision, "fallback");
+  assert.deepEqual(second.debug.decision.reasons, ["unsupported-frontend-domain-profile"]);
+  assert.equal(second.debug.decision.fallback.reason, "unsupported-frontend-domain-profile");
+  assert.equal("payload" in second.debug.decision, false);
+
+  const domainDetection = second.debug.decision.debug.domainDetection;
+  assert.equal(domainDetection.classification, "react-native");
+  assert.equal(domainDetection.profile.claimStatus, "fallback-boundary");
+  assert.notEqual(domainDetection.classification, "react-web");
+});


### PR DESCRIPTION
## Summary
- Add a React Native boundary case to the React Web release smoke.
- Verify RN primitive/platform/navigation fixture falls back instead of becoming a React Web-supported compact payload.
- Keep the smoke claim bounded: this proves runtime domain-boundary behavior, not caching performance, billing reduction, or npm release readiness.

## What this proves
- React Web same-file repeated work still injects a compact current-lane payload.
- WebView remains a fallback boundary.
- React Native remains outside the React Web support claim and does not emit a React Web payload in this smoke path.

## What this does not prove
- No provider-cost or billing reduction claim.
- No broad cache-performance benchmark claim.
- No npm publish/release validation.

## Verification
- `npm run build`
- `node --test test/react-web-release-smoke.test.mjs`
- `node --test test/react-web-release-smoke.test.mjs test/react-web-domain-payload-expansion.test.mjs test/pre-read-fallback-builder.test.mjs test/react-web-context-metadata.test.mjs`
