### PR TITLE
Add React Web form state flow metadata

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -10,7 +10,7 @@ const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
 const CALLBACK_HOOK_NAMES = new Set(["useMemo", "useCallback"]);
 const FORM_CONTROL_TAGS = new Set(["form", "input", "select", "textarea"]);
-const CONTROL_PROP_NAMES = new Set(["name", "type", "value", "defaultValue", "required", "disabled", "readOnly", "checked", "defaultChecked"]);
+const CONTROL_PROP_NAMES = new Set(["id", "name", "type", "value", "defaultValue", "required", "disabled", "readOnly", "checked", "defaultChecked"]);
 const MAX_EFFECT_SIGNALS = 8;
 const MAX_CALLBACK_SIGNALS = 8;
 const MAX_EVENT_HANDLER_SIGNALS = 12;
@@ -389,6 +389,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const formControls: NonNullable<FormSurface["controls"]> = [];
   const submitHandlers: NonNullable<FormSurface["submitHandlers"]> = [];
   const validationAnchors: NonNullable<FormSurface["validationAnchors"]> = [];
+  const stateConditions: NonNullable<FormSurface["stateConditions"]> = [];
   const a11yAnchors: A11yAnchorSignal[] = [];
   const conditionalRenders = new Set<string>();
   const repeatedBlocks = new Set<string>();
@@ -440,7 +441,9 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     }
 
     const propNames: string[] = [];
+    const propValues: Record<string, string> = {};
     const handlers: string[] = [];
+    const handlerValues: Record<string, string> = {};
     let controlName: string | undefined;
     let controlType: string | undefined;
     for (const property of node.attributes.properties) {
@@ -459,6 +462,8 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       const attrName = property.name.getText(sourceFile);
       if (CONTROL_PROP_NAMES.has(attrName)) {
         propNames.push(attrName);
+        const value = jsxAttributeValue(property);
+        if (value) propValues[attrName] = value;
       }
       if (tag === "label") {
         addA11yAnchor("label", jsxAttributeValue(property) ?? tag, property);
@@ -477,12 +482,18 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       }
       if (attrName === "disabled") {
         addA11yAnchor("disabled", controlName ? `${tag}[name=${controlName}]` : tag, property);
+        const value = jsxAttributeValue(property);
+        if (value && value !== "true") {
+          addLocatedAnchor(stateConditions, value, property);
+        }
       }
       if (attrName === "readOnly") {
         addA11yAnchor("readonly", controlName ? `${tag}[name=${controlName}]` : tag, property);
       }
       if (/^on[A-Z]/.test(attrName)) {
         handlers.push(attrName);
+        const value = jsxAttributeValue(property);
+        if (value) handlerValues[attrName] = value;
       }
       if (attrName === "name") {
         controlName = jsxAttributeValue(property);
@@ -502,7 +513,9 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       ...(controlName ? { name: controlName } : {}),
       ...(controlType ? { type: controlType } : {}),
       ...(propNames.length ? { props: [...new Set(propNames)].slice(0, MAX_CONTROL_PROPS) } : {}),
+      ...(Object.keys(propValues).length ? { propValues } : {}),
       ...(handlers.length ? { handlers: [...new Set(handlers)].slice(0, MAX_CONTROL_PROPS) } : {}),
+      ...(Object.keys(handlerValues).length ? { handlerValues } : {}),
       loc: sourceRangeOf(sourceFile, node),
     });
   };
@@ -591,8 +604,9 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     controls: dedupeBy(formControls, (item) => `${item.tag}:${item.name ?? ""}:${item.type ?? ""}:${item.loc?.startLine ?? ""}`).slice(0, MAX_FORM_CONTROLS),
     submitHandlers: dedupeBy(submitHandlers, (item) => `${item.value}:${item.loc?.startLine ?? ""}`).slice(0, MAX_FORM_ANCHORS),
     validationAnchors: dedupeBy(validationAnchors, (item) => `${item.value}:${item.loc?.startLine ?? ""}`).slice(0, MAX_FORM_ANCHORS),
+    stateConditions: dedupeBy(stateConditions, (item) => `${item.value}:${item.loc?.startLine ?? ""}`).slice(0, MAX_FORM_ANCHORS),
   };
-  const hasFormSurface = formSurface.controls.length > 0 || formSurface.submitHandlers.length > 0 || formSurface.validationAnchors.length > 0;
+  const hasFormSurface = formSurface.controls.length > 0 || formSurface.submitHandlers.length > 0 || formSurface.validationAnchors.length > 0 || formSurface.stateConditions.length > 0;
   const effectSignalList = dedupeBy(effectSignals, (item) => `${item.hook}:${item.loc?.startLine ?? ""}:${item.deps?.join(",") ?? ""}`).slice(0, MAX_EFFECT_SIGNALS);
   const callbackSignalList = dedupeBy(callbackSignals, (item) => `${item.hook}:${item.loc?.startLine ?? ""}:${item.deps?.join(",") ?? ""}`).slice(0, MAX_CALLBACK_SIGNALS);
   const eventHandlerList = [...eventHandlers];
@@ -613,6 +627,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
               ...(formSurface.controls.length ? { controls: formSurface.controls } : {}),
               ...(formSurface.submitHandlers.length ? { submitHandlers: formSurface.submitHandlers } : {}),
               ...(formSurface.validationAnchors.length ? { validationAnchors: formSurface.validationAnchors } : {}),
+              ...(formSurface.stateConditions.length ? { stateConditions: formSurface.stateConditions } : {}),
             },
           }
         : {}),

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -2,8 +2,10 @@ import {
   REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION,
   type EditGuidance,
   type ExtractionResult,
+  type FormControlSignal,
   type ReactWebContextA11yAnchor,
   type ReactWebContextEditTargetRoute,
+  type ReactWebContextFormStateFlowEntry,
   type ReactWebContextIntentTarget,
   type ReactWebContextLocalDependency,
   type ReactWebContextMetadataV0,
@@ -19,6 +21,7 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   localDependencies: 12,
   intentTargets: 16,
   editTargetRouting: 8,
+  formStateFlow: 10,
 } as const;
 
 const REACT_WEB_CONTEXT_WARNINGS = [
@@ -279,6 +282,172 @@ function buildEditTargetRouting(result: ExtractionResult, editGuidance: EditGuid
   );
 }
 
+function controlLabel(control: FormControlSignal): string {
+  if (control.name) return `${control.tag}[name=${control.name}]`;
+  const id = control.propValues?.id;
+  if (id) return `${control.tag}#${id}`;
+  return control.tag;
+}
+
+function conditionRole(expr: string): NonNullable<ReactWebContextFormStateFlowEntry["condition"]>["role"] {
+  if (/disabled/i.test(expr)) return "disabled";
+  if (/loading|pending|saving|submitting|isLoading|isPending|isSaving|isSubmitting/.test(expr)) return "loading";
+  if (/error|invalid|aria-invalid/.test(expr)) return "error";
+  return "unknown";
+}
+
+function identifierTokens(value: string | undefined): string[] {
+  if (!value || value === "true") return [];
+  return value.match(/[A-Za-z_$][\w$]*/g) ?? [];
+}
+
+function relationTokens(result: ExtractionResult): string[] {
+  const tokens = new Set<string>();
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    for (const value of [
+      control.propValues?.value,
+      control.propValues?.checked,
+      control.propValues?.disabled,
+      control.handlerValues?.onChange,
+      control.handlerValues?.onInput,
+    ]) {
+      for (const token of identifierTokens(value)) {
+        tokens.add(token);
+      }
+    }
+  }
+  for (const submit of result.behavior?.formSurface?.submitHandlers ?? []) {
+    for (const token of identifierTokens(submit.value)) {
+      tokens.add(token);
+    }
+  }
+  for (const condition of result.behavior?.formSurface?.stateConditions ?? []) {
+    for (const token of identifierTokens(condition.value)) {
+      tokens.add(token);
+    }
+  }
+  return [...tokens];
+}
+
+function buildFormStateFlow(result: ExtractionResult): ReactWebContextFormStateFlowEntry[] {
+  const entries: ReactWebContextFormStateFlowEntry[] = [];
+  const controls = result.behavior?.formSurface?.controls ?? [];
+  const controlDisabledExprs = new Set<string>();
+
+  for (const control of controls) {
+    const valueExpr = control.propValues?.value;
+    const checkedExpr = control.propValues?.checked;
+    const onChangeExpr = control.handlerValues?.onChange;
+    if (valueExpr || checkedExpr) {
+      const label = controlLabel(control);
+      entries.push({
+        kind: "controlled-control",
+        label: compact(label),
+        ...(control.loc ? { loc: control.loc } : {}),
+        control: {
+          tag: control.tag,
+          ...(control.name ? { name: control.name } : {}),
+          ...(control.propValues?.id ? { id: control.propValues.id } : {}),
+          ...(valueExpr ? { valueExpr: compact(valueExpr) } : {}),
+          ...(checkedExpr ? { checkedExpr: compact(checkedExpr) } : {}),
+          ...(onChangeExpr ? { onChangeExpr: compact(onChangeExpr) } : {}),
+        },
+        evidence: ["behavior.formSurface.controls"],
+      });
+    }
+
+    const disabledExpr = control.propValues?.disabled;
+    if (disabledExpr && disabledExpr !== "true") {
+      controlDisabledExprs.add(disabledExpr);
+      entries.push({
+        kind: "state-condition",
+        label: compact(`${controlLabel(control)} disabled`),
+        ...(control.loc ? { loc: control.loc } : {}),
+        condition: {
+          role: conditionRole(disabledExpr),
+          expr: compact(disabledExpr),
+        },
+        evidence: ["behavior.formSurface.controls.propValues.disabled"],
+      });
+    }
+  }
+
+  for (const condition of result.behavior?.formSurface?.stateConditions ?? []) {
+    if (controlDisabledExprs.has(condition.value)) continue;
+    entries.push({
+      kind: "state-condition",
+      label: compact(`disabled:${condition.value}`),
+      ...(condition.loc ? { loc: condition.loc } : {}),
+      condition: {
+        role: conditionRole(condition.value),
+        expr: compact(condition.value),
+      },
+      evidence: ["behavior.formSurface.stateConditions"],
+    });
+  }
+
+  for (const submit of result.behavior?.formSurface?.submitHandlers ?? []) {
+    const submitControl = controls.find((control) => control.tag === "form" && control.handlerValues?.onSubmit === submit.value);
+    entries.push({
+      kind: "submit-flow",
+      label: compact(`form onSubmit=${submit.value}`),
+      ...(submit.loc ? { loc: submit.loc } : {}),
+      submit: {
+        onSubmitExpr: compact(submit.value),
+        handler: compact(submit.value),
+      },
+      evidence: [
+        "behavior.formSurface.submitHandlers",
+        ...(submitControl ? ["behavior.formSurface.controls.handlerValues.onSubmit"] : []),
+      ],
+    });
+  }
+
+  for (const anchor of result.behavior?.a11yAnchors ?? []) {
+    if (anchor.kind !== "role" && anchor.kind !== "aria" && anchor.kind !== "error-text") continue;
+    if (!/alert|invalid|error/i.test(anchor.label)) continue;
+    entries.push({
+      kind: "state-condition",
+      label: compact(anchor.label),
+      ...(anchor.loc ? { loc: anchor.loc } : {}),
+      condition: {
+        role: "error",
+        expr: compact(anchor.label),
+      },
+      evidence: ["behavior.a11yAnchors"],
+    });
+  }
+
+  const tokens = relationTokens(result);
+  const hookSignals = [...(result.behavior?.effectSignals ?? []), ...(result.behavior?.callbackSignals ?? [])];
+  for (const signal of hookSignals) {
+    if (!signal.deps || signal.deps.length === 0) continue;
+    const relatesTo = signal.deps.filter((dep) => tokens.includes(dep));
+    if (relatesTo.length === 0) continue;
+    entries.push({
+      kind: signal.hook === "useMemo" ? "derived-state" : "hook-dependency-link",
+      label: compact(`${signal.hook} deps:[${signal.deps.join(", ")}]`),
+      ...(signal.loc ? { loc: signal.loc } : {}),
+      hook: {
+        hook: signal.hook as NonNullable<ReactWebContextFormStateFlowEntry["hook"]>["hook"],
+        deps: signal.deps,
+        ...(relatesTo.length ? { relatesTo } : {}),
+      },
+      evidence: [signal.hook === "useMemo" ? "behavior.callbackSignals.useMemo" : "behavior.effectOrCallbackSignals"],
+    });
+  }
+
+  return dedupeBy(
+    entries,
+    (item) => {
+      if (item.kind === "state-condition") {
+        return `${item.kind}:${item.loc?.startLine ?? ""}:${item.loc?.endLine ?? ""}:${item.condition?.expr ?? ""}`;
+      }
+      return `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}:${item.control?.valueExpr ?? ""}:${item.control?.checkedExpr ?? ""}:${item.control?.onChangeExpr ?? ""}:${item.submit?.onSubmitExpr ?? ""}`;
+    },
+  );
+}
+
 function buildIntentTargets(result: ExtractionResult, editGuidance: EditGuidance | undefined): ReactWebContextIntentTarget[] {
   const targets: ReactWebContextIntentTarget[] = [];
 
@@ -329,8 +498,9 @@ export function buildReactWebContextMetadata(
     buildEditTargetRouting(result, editGuidance),
     REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.editTargetRouting,
   );
+  const formStateFlow = pruneArray(buildFormStateFlow(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.formStateFlow);
 
-  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets || editTargetRouting);
+  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets || editTargetRouting || formStateFlow);
   if (!hasContext) return undefined;
 
   return {
@@ -348,6 +518,7 @@ export function buildReactWebContextMetadata(
     ...(localDependencies ? { localDependencies } : {}),
     ...(intentTargets ? { intentTargets } : {}),
     ...(editTargetRouting ? { editTargetRouting } : {}),
+    ...(formStateFlow ? { formStateFlow } : {}),
     warnings: REACT_WEB_CONTEXT_WARNINGS,
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -52,7 +52,9 @@ export type FormControlSignal = {
   name?: string;
   type?: string;
   props?: string[];
+  propValues?: Record<string, string>;
   handlers?: string[];
+  handlerValues?: Record<string, string>;
   loc?: SourceRange;
 };
 
@@ -60,6 +62,7 @@ export type FormSurface = {
   controls?: FormControlSignal[];
   submitHandlers?: LocatedString[];
   validationAnchors?: LocatedString[];
+  stateConditions?: LocatedString[];
 };
 
 export type A11yAnchorSignal = {
@@ -155,6 +158,35 @@ export type ReactWebContextEditTargetRoute = {
   evidence: string[];
 };
 
+export type ReactWebContextFormStateFlowEntry = {
+  kind: "controlled-control" | "submit-flow" | "state-condition" | "derived-state" | "hook-dependency-link";
+  label: string;
+  loc?: SourceRange;
+  control?: {
+    tag?: string;
+    name?: string;
+    id?: string;
+    valueExpr?: string;
+    checkedExpr?: string;
+    onChangeExpr?: string;
+  };
+  submit?: {
+    onSubmitExpr?: string;
+    handler?: string;
+    disabledExpr?: string;
+  };
+  condition?: {
+    role: "loading" | "error" | "disabled" | "unknown";
+    expr: string;
+  };
+  hook?: {
+    hook: "useEffect" | "useLayoutEffect" | "useCallback" | "useMemo";
+    deps: string[];
+    relatesTo?: string[];
+  };
+  evidence: string[];
+};
+
 export type ReactWebContextMetadataV0 = {
   schemaVersion: typeof REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION;
   freshness: SourceFingerprint;
@@ -170,6 +202,7 @@ export type ReactWebContextMetadataV0 = {
   localDependencies?: ReactWebContextLocalDependency[];
   intentTargets?: ReactWebContextIntentTarget[];
   editTargetRouting?: ReactWebContextEditTargetRoute[];
+  formStateFlow?: ReactWebContextFormStateFlowEntry[];
   warnings: string[];
 };
 

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -222,6 +222,205 @@ test("React Web form controls emit source-observed a11y anchors only", () => {
   assert.equal(payload.reactWebContext.warnings.some((item) => item.includes("not an accessibility audit")), true);
 });
 
+test("React Web formStateFlow links controlled controls submit and state conditions", () => {
+  const source = `
+    import React, { useCallback, useMemo, useState } from "react";
+
+    export function SignupForm() {
+      const [email, setEmail] = useState("");
+      const [accepted, setAccepted] = useState(false);
+      const [saving, setSaving] = useState(false);
+      const [error, setError] = useState("");
+      const canSubmit = useMemo(() => email.includes("@") && accepted, [email, accepted]);
+      const handleEmailChange = useCallback((event) => setEmail(event.target.value), []);
+      const handleSubmit = useCallback((event) => {
+        event.preventDefault();
+        setSaving(true);
+        setError("");
+      }, [email, canSubmit]);
+
+      return (
+        <form onSubmit={handleSubmit}>
+          <input id="email" name="email" value={email} onChange={handleEmailChange} />
+          <input
+            name="accepted"
+            type="checkbox"
+            checked={accepted}
+            onChange={() => setAccepted(!accepted)}
+          />
+          <button type="submit" disabled={saving || !canSubmit}>Save</button>
+          {error ? <p role="alert">{error}</p> : null}
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "SignupForm.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  const flow = payload.reactWebContext.formStateFlow;
+  assert.ok(flow);
+  assert.ok(flow.length <= 10);
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "controlled-control" &&
+        item.control?.tag === "input" &&
+        item.control?.name === "email" &&
+        item.control?.id === "email" &&
+        item.control?.valueExpr === "email" &&
+        item.control?.onChangeExpr === "handleEmailChange" &&
+        item.loc,
+    ),
+  );
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "controlled-control" &&
+        item.control?.name === "accepted" &&
+        item.control?.checkedExpr === "accepted" &&
+        item.control?.onChangeExpr.includes("setAccepted"),
+    ),
+  );
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "submit-flow" &&
+        item.submit?.onSubmitExpr === "handleSubmit" &&
+        !item.submit?.disabledExpr,
+    ),
+  );
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "state-condition" &&
+        item.condition?.role === "loading" &&
+        item.condition?.expr === "saving || !canSubmit",
+    ),
+  );
+  assert.ok(flow.some((item) => item.kind === "state-condition" && item.condition?.role === "error"));
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "derived-state" &&
+        item.hook?.hook === "useMemo" &&
+        item.hook?.deps.includes("email") &&
+        item.hook?.relatesTo?.includes("accepted"),
+    ),
+  );
+  assert.ok(
+    flow.some(
+      (item) =>
+        item.kind === "hook-dependency-link" &&
+        item.hook?.hook === "useCallback" &&
+        item.hook?.deps.includes("canSubmit") &&
+        item.hook?.relatesTo?.includes("email") &&
+        item.hook?.relatesTo?.includes("canSubmit"),
+    ),
+  );
+  assert.equal(
+    flow.filter((item) => item.kind === "state-condition" && item.condition?.expr === "saving || !canSubmit").length,
+    1,
+  );
+  assert.equal(
+    flow.filter((item) => item.kind === "hook-dependency-link" || item.kind === "derived-state").length <
+      payload.reactWebContext.stateHints.length,
+    true,
+  );
+  assert.notDeepEqual(
+    flow.map((item) => [item.kind, item.label]),
+    payload.reactWebContext.editTargetRouting.map((item) => [item.kind, item.label]),
+  );
+});
+
+test("React Web formStateFlow is omitted without form or relational state-flow facts", () => {
+  const payload = payloadFor("fixtures/compressed/FormSection.tsx", {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.equal("formStateFlow" in payload.reactWebContext, false);
+});
+
+test("React Web formStateFlow dedupes multiline disabled control conditions", () => {
+  const source = `
+    import React, { useState } from "react";
+
+    export function DisabledPanel() {
+      const [saving, setSaving] = useState(false);
+      const [email, setEmail] = useState("");
+
+      return (
+        <form>
+          <p className="text-sm text-slate-500">
+            This fixture is intentionally long enough for compressed extraction while keeping the disabled condition local.
+          </p>
+          <input
+            name="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            disabled={saving}
+          />
+          <p className="text-sm text-slate-500">
+            The second paragraph keeps this fixture in compressed mode for React Web context metadata.
+          </p>
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "DisabledPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext?.formStateFlow);
+  assert.equal(
+    payload.reactWebContext.formStateFlow.filter(
+      (item) => item.kind === "state-condition" && item.condition?.expr === "saving",
+    ).length,
+    1,
+  );
+});
+
+test("React Web formStateFlow does not link hooks from uncontrolled name or id tokens", () => {
+  const source = `
+    import React, { useEffect } from "react";
+
+    export function UncontrolledEmail({ email }) {
+      useEffect(() => {
+        console.log(email);
+      }, [email]);
+
+      return (
+        <form>
+          <input id="email" name="email" onChange={() => undefined} />
+          <p className="text-sm text-slate-500">
+            This fixture is long enough for compressed React Web metadata while staying uncontrolled.
+          </p>
+          <p className="text-sm text-slate-500">
+            The hook dep matches only the field name/id, not a value or checked expression.
+          </p>
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "UncontrolledEmail.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.ok(payload.reactWebContext);
+  assert.equal(
+    payload.reactWebContext.formStateFlow?.some(
+      (item) => item.kind === "hook-dependency-link" && item.hook?.deps.includes("email"),
+    ) ?? false,
+    false,
+  );
+});
+
 test("React Web opt-in emits source-observed role aria and readOnly anchors", () => {
   const source = `
     import React from "react";


### PR DESCRIPTION
## Summary
- Add `reactWebContext.formStateFlow` as a capped, opt-in React Web metadata surface for source-observed form/state relationships.
- Capture JSX expression values for control props/handlers so controlled inputs, submit anchors, disabled/error conditions, and hook links can be summarized without broad dataflow claims.
- Add regression tests for controlled controls, submit flow, multiline disabled dedupe, and name/id-only hook false positives.

## Boundaries
- Same-file/source-derived facts only.
- Does not add cross-file usage, LSP/type-flow, a11y audit, visual/layout inference, or provider/runtime savings claims.
- Keeps `stateHints` and `editTargetRouting` ownership separate; `formStateFlow` is relationship-oriented only.

## Verification
- `npm run build`
- `node --test test/react-web-context-metadata.test.mjs`
- `node --test test/pre-read-payload-builder.test.mjs`
- `npm test` — 440/440 passing
- Architect verification: APPROVE after false-association fixes and post-deslop regression.
