### PR TITLE
Add operator activity snapshot (#424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stron
 | `fooks doctor` | current project + runtime-home inspection | Reads local setup and hook-readiness artifacts without writing files; it is not live provider health, billing-token, cost, or `ccusage` proof. |
 | `fooks status` | current project inspection | Reads local fooks telemetry/status; it is not a package installer or billing-token report. |
 | `fooks status artifacts` | current project + local git/tmux inspection | Read-only audit of fooks-scoped tmux sessions, git worktrees, and branches that may be merged into the selected base; it does not prove inactivity and never deletes artifacts. |
+| `fooks status activity` | current project + local git/tmux inspection | Compact read-only operator snapshot for dogfood nudges; remote issue/PR counts require explicit `--include-remote-counts`. |
 
 By default, `fooks setup` prints a short readiness summary so the command does not look like a wall of debug JSON. Use `fooks setup --json` when you need the full `scope` object and support/debug paths that show what is project-local versus user-runtime/home scoped.
 
@@ -219,6 +220,7 @@ fooks status codex   # check Codex attach/hook state
 fooks status claude  # check Claude project-local context hook / handoff health
 fooks status cache   # check local fooks cache health
 fooks status artifacts # read-only fooks tmux/worktree/branch artifact audit
+fooks status activity  # compact read-only operator activity snapshot
 fooks compare src/components/Button.tsx --json  # local original-vs-fooks payload estimate
 ```
 
@@ -230,6 +232,8 @@ fooks scan
 ```
 
 `fooks status` reads local `.fooks/sessions` summaries produced by the Codex automatic hook path and the Claude project-local context-hook path. The values are approximate context-size estimates only; status includes runtime/source breakdowns, omits per-session details, and is not provider usage/billing tokens, invoices, dashboards, charged costs, or a `ccusage` replacement.
+
+`fooks status activity` is a compact read-only dogfood operator snapshot. It preserves the existing bare status, worktree, and artifacts contracts, reports current local worktree branch/divergence and dirty-path delta, and lists fooks-like tmux sessions when available. It does not call GitHub by default; pass `--include-remote-counts` to opt in to non-blocking `gh` open issue/PR counts.
 
 `fooks status artifacts` is a read-only dogfood cleanup audit for local fooks artifacts after PRs merge. It inspects local git worktrees/branches and tmux panes, scopes results to fooks-like names or `.omx-worktrees` paths, and uses conservative labels such as `activeOrUnknown`, `likelyMerged`, `missingPath`, and `candidateCleanup`. The command does not run `git fetch`, `git worktree prune`, `git worktree remove`, `git branch -d`, or `tmux kill-session`; any `manualCleanupCommands` in the JSON are copy/paste suggestions only. Missing worktree paths only suggest `git worktree prune --dry-run` so operators can inspect before deciding whether to run cleanup manually. When tmux panes are still attached to deleted worktree paths, the JSON also includes `staleRuntimeCleanups` with the manual order: verify inactivity, stop the tmux/OMX/Codex session, then run any git worktree prune/remove follow-up. Verify the PR is merged and the session/worktree is inactive before copying any command.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,6 +78,7 @@ fooks status codex
 fooks status claude
 fooks status cache
 fooks status artifacts
+fooks status activity [--include-remote-counts]
 ```
 
 Good signs:
@@ -88,10 +89,13 @@ Good signs:
 - Claude status is `context-hook-ready` when the local adapter files, Claude attachment manifest, and project-local Claude hooks are present. It may be `handoff-ready` when adapter/manifest artifacts exist but the project-local hooks have not been installed yet. This is not a Claude `Read` interception or runtime-token savings claim.
 - Cache status is `empty` for a fresh repo or `healthy` after scan/use.
 - Artifact status reports fooks-scoped tmux sessions, git worktrees, and branches as local read-only cleanup candidates; it may show zero candidates or blockers when git/tmux are unavailable.
+- Activity status reports a compact read-only operator snapshot: current worktree branch/divergence/current dirty-path delta plus active fooks-like tmux panes when tmux is available. Open issue/PR counts are omitted unless `--include-remote-counts` is passed.
 
 `fooks doctor [codex|claude] [--json]` is read-only. It checks local fooks setup artifacts, runtime manifests, hook event installation, Codex trust status, cache health, and supported source-file presence. Focused `fooks doctor claude` also includes an optional TypeScript language server host-tooling check as warning-only. It does not mutate `.fooks/`, Codex hooks, Claude project-local settings, or runtime-home manifests. It also does not prove live provider health; it is not a ccusage replacement and not provider usage/billing-token telemetry, invoices, dashboards, or charged costs.
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider usage/billing tokens, invoices, dashboards, charged costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
+
+`fooks status activity` is read-only and local-first. It does not alter bare `fooks status`, `fooks status worktree`, or `fooks status artifacts` JSON contracts. By default it reads only local git status/local tracking refs and tmux panes, reports current dirty-path counts as a current-status delta rather than a session baseline comparison, and treats missing tmux as a non-fatal blocker. Passing `--include-remote-counts` explicitly opts in to non-blocking GitHub CLI (`gh`) open issue/PR counts with failures captured in JSON; no remote counts are attempted by default.
 
 `fooks status artifacts` is also read-only. It audits local fooks-scoped tmux panes, git worktrees, and branches against `origin/main` when available, falling back to `main`. It reports conservative statuses (`activeOrUnknown`, `likelyMerged`, `missingPath`, `candidateCleanup`) and a claim boundary that local evidence does not prove inactivity. The command never deletes anything and never runs cleanup commands. If JSON includes `manualCleanupCommands`, copy them only after verifying the PR merged and the session/worktree is inactive. Missing worktree paths only suggest `git worktree prune --dry-run`; inspect that output before deciding whether to run any real cleanup manually. If stale tmux panes still point at deleted worktree paths, `staleRuntimeCleanups` documents the safe manual order: verify inactivity, stop the tmux/OMX/Codex session, then run git worktree prune/remove follow-up only after the runtime is stopped.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -647,6 +647,7 @@ Everyday commands:
   ${displayCliName} status cache
   ${displayCliName} status worktree
   ${displayCliName} status artifacts
+  ${displayCliName} status activity [--include-remote-counts]
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
   ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -1099,7 +1100,18 @@ async function run(): Promise<void> {
         print(auditArtifacts(process.cwd()));
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', or 'artifacts'");
+      if (arg1 === "activity") {
+        const allowed = new Set(["--include-remote-counts", "--json"]);
+        for (const arg of rest.slice(1)) {
+          if (!allowed.has(arg)) {
+            throw new Error(`Unexpected status activity argument: ${arg}`);
+          }
+        }
+        const { readOperatorActivitySnapshot } = await import("../core/operator-activity.js");
+        print(readOperatorActivitySnapshot(process.cwd(), { includeRemoteCounts: rest.includes("--include-remote-counts") }));
+        return;
+      }
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'artifacts', or 'activity'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/core/operator-activity.ts
+++ b/src/core/operator-activity.ts
@@ -1,0 +1,318 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  currentWorktreeEvidenceStatus,
+  type WorktreeCurrentStatus,
+  type WorktreeEvidenceOptions,
+  WORKTREE_BRANCH_DIVERGENCE_SOURCE,
+} from "./worktree-evidence";
+
+export const OPERATOR_ACTIVITY_SCHEMA_VERSION = 1;
+export const OPERATOR_ACTIVITY_COMMAND = "status activity";
+export const OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG = "--include-remote-counts";
+export const OPERATOR_ACTIVITY_CLAIM_BOUNDARY =
+  "Local read-only fooks operator activity snapshot; no provider messaging, no backlog invention, no git fetch, and remote issue/PR counts only when explicitly enabled.";
+export const OPERATOR_ACTIVITY_TMUX_COMMAND = "tmux list-panes -a -F #{session_name}\\t#{pane_current_path}\\t#{pane_current_command}";
+export const OPERATOR_ACTIVITY_REMOTE_SOURCE = "GitHub CLI gh issue/pr list; explicit opt-in only";
+export const DEFAULT_OPERATOR_ACTIVITY_TIMEOUT_MS = 1000;
+export const DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS = 1500;
+
+export type OperatorActivityCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
+export type OperatorActivityPathExists = (targetPath: string) => boolean;
+
+export type OperatorActivityOptions = WorktreeEvidenceOptions & {
+  includeRemoteCounts?: boolean;
+  commandRunner?: OperatorActivityCommandRunner;
+  pathExists?: OperatorActivityPathExists;
+  now?: () => string;
+};
+
+export type OperatorActivityWorktree = {
+  clean: boolean | null;
+  verdict: WorktreeCurrentStatus["worktreeVerdict"];
+  branch?: string;
+  upstream?: string;
+  ahead?: number;
+  behind?: number;
+  divergenceSource?: typeof WORKTREE_BRANCH_DIVERGENCE_SOURCE;
+  delta: {
+    source: "current git status only; no session baseline comparison";
+    changedPathCount: number;
+    trackedPathCount: number;
+    untrackedPathCount: number;
+    conflictedPathCount: number;
+    changedPaths: string[];
+    conflictedPaths: string[];
+  };
+  blockers: string[];
+};
+
+export type OperatorActivityTmuxPane = {
+  path: string;
+  exists: boolean;
+  current: boolean;
+  command?: string;
+};
+
+export type OperatorActivityTmuxSession = {
+  session: string;
+  paneCount: number;
+  current: boolean;
+  panes: OperatorActivityTmuxPane[];
+};
+
+export type OperatorActivityTmux = {
+  available: boolean;
+  command: typeof OPERATOR_ACTIVITY_TMUX_COMMAND;
+  sessions: OperatorActivityTmuxSession[];
+  blockers: string[];
+};
+
+export type OperatorActivityRemoteCounts =
+  | {
+      enabled: false;
+      source: "disabled; pass --include-remote-counts to opt in";
+    }
+  | {
+      enabled: true;
+      source: typeof OPERATOR_ACTIVITY_REMOTE_SOURCE;
+      openIssues?: number;
+      openPullRequests?: number;
+      blockers: string[];
+    };
+
+export type OperatorActivitySnapshot = {
+  schemaVersion: typeof OPERATOR_ACTIVITY_SCHEMA_VERSION;
+  command: typeof OPERATOR_ACTIVITY_COMMAND;
+  generatedAt: string;
+  cwd: string;
+  claimBoundary: typeof OPERATOR_ACTIVITY_CLAIM_BOUNDARY;
+  readOnly: true;
+  worktree: OperatorActivityWorktree;
+  tmux: OperatorActivityTmux;
+  optionalCounts: OperatorActivityRemoteCounts;
+  blockers: string[];
+};
+
+type ParsedTmuxPane = {
+  session: string;
+  path: string;
+  command?: string;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function errorDetail(error: unknown): string {
+  const maybeError = error && typeof error === "object" ? (error as { message?: unknown; stderr?: unknown; signal?: unknown; code?: unknown }) : {};
+  const stderr = maybeError.stderr;
+  const stderrText = Buffer.isBuffer(stderr) ? stderr.toString("utf8").trim() : typeof stderr === "string" ? stderr.trim() : "";
+  const message = typeof maybeError.message === "string" ? maybeError.message.trim() : String(error);
+  const status = maybeError.signal ? `signal ${String(maybeError.signal)}` : maybeError.code !== undefined ? `code ${String(maybeError.code)}` : "";
+  const detail = stderrText || message || "unknown error";
+  return status ? `${detail} (${status})` : detail;
+}
+
+function safeResolve(targetPath: string): string {
+  return path.resolve(targetPath.replace(/ \(deleted\)$/u, ""));
+}
+
+function pathContainsCwd(parent: string, cwd: string): boolean {
+  const relative = path.relative(safeResolve(parent), safeResolve(cwd));
+  return relative === "" || (Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function includesFooksSignal(value: string, cwd: string): boolean {
+  const lower = value.replace(/\\/g, "/").toLowerCase();
+  const cwdBase = path.basename(cwd).toLowerCase();
+  return lower.includes("fooks") || (cwdBase.includes("fooks") && lower.includes(cwdBase));
+}
+
+function panePathDeleted(panePath: string): boolean {
+  return panePath.includes("(deleted)");
+}
+
+function panePathWithoutDeletedMarker(panePath: string): string {
+  return panePath.replace(/ \(deleted\)$/u, "").trim();
+}
+
+export function defaultOperatorActivityCommandRunner(command: string, args: string[], cwd: string, timeoutMs: number): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+export function parseOperatorActivityTmuxPanes(output: string): ParsedTmuxPane[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const [session, panePath, ...commandParts] = line.split("\t");
+      if (!session || !panePath) return undefined;
+      const command = commandParts.join("\t").trim();
+      const entry: ParsedTmuxPane = { session, path: panePath };
+      if (command) {
+        entry.command = command;
+      }
+      return entry;
+    })
+    .filter((entry): entry is ParsedTmuxPane => Boolean(entry));
+}
+
+function buildWorktreeSnapshot(status: WorktreeCurrentStatus): OperatorActivityWorktree {
+  const snapshot = status.snapshot;
+  const divergence = status.branchDivergence;
+  const branchFields = divergence?.kind === "available"
+    ? {
+        branch: divergence.branch,
+        upstream: divergence.upstream,
+        ahead: divergence.ahead,
+        behind: divergence.behind,
+        divergenceSource: divergence.source,
+      }
+    : divergence?.kind === "no-upstream"
+      ? { branch: divergence.branch, divergenceSource: divergence.source }
+      : divergence?.kind === "unknown" || divergence?.kind === "detached"
+        ? { divergenceSource: divergence.source }
+        : {};
+
+  return {
+    clean: snapshot?.clean ?? null,
+    verdict: status.worktreeVerdict,
+    ...branchFields,
+    delta: {
+      source: "current git status only; no session baseline comparison",
+      changedPathCount: snapshot?.changedPaths.length ?? 0,
+      trackedPathCount: snapshot?.trackedPaths.length ?? 0,
+      untrackedPathCount: snapshot?.untrackedPaths.length ?? 0,
+      conflictedPathCount: snapshot?.conflictedPaths.length ?? 0,
+      changedPaths: snapshot?.changedPaths ?? [],
+      conflictedPaths: snapshot?.conflictedPaths ?? [],
+    },
+    blockers: status.blockers,
+  };
+}
+
+function readTmuxActivity(cwd: string, options: OperatorActivityOptions): OperatorActivityTmux {
+  const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
+  const pathExists = options.pathExists ?? fs.existsSync;
+  const blockers: string[] = [];
+  let output = "";
+
+  try {
+    output = runner("tmux", ["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}\t#{pane_current_command}"], cwd, DEFAULT_OPERATOR_ACTIVITY_TIMEOUT_MS);
+  } catch (error) {
+    blockers.push(`tmux activity unavailable: ${errorDetail(error)}`);
+    return {
+      available: false,
+      command: OPERATOR_ACTIVITY_TMUX_COMMAND,
+      sessions: [],
+      blockers: uniqueSorted(blockers),
+    };
+  }
+
+  const currentCwd = safeResolve(cwd);
+  const panesBySession = new Map<string, OperatorActivityTmuxPane[]>();
+  for (const pane of parseOperatorActivityTmuxPanes(output)) {
+    const cleanPanePath = panePathWithoutDeletedMarker(pane.path);
+    const deleted = panePathDeleted(pane.path);
+    const exists = !deleted && pathExists(cleanPanePath);
+    const current = exists && (pathContainsCwd(cleanPanePath, currentCwd) || pathContainsCwd(currentCwd, cleanPanePath));
+    if (!includesFooksSignal(pane.session, cwd) && !includesFooksSignal(cleanPanePath, cwd) && !current) continue;
+    const panes = panesBySession.get(pane.session) ?? [];
+    panes.push({ path: pane.path, exists, current, command: pane.command });
+    panesBySession.set(pane.session, panes);
+  }
+
+  return {
+    available: true,
+    command: OPERATOR_ACTIVITY_TMUX_COMMAND,
+    sessions: [...panesBySession.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([session, panes]) => ({
+        session,
+        paneCount: panes.length,
+        current: panes.some((pane) => pane.current),
+        panes,
+      })),
+    blockers: uniqueSorted(blockers),
+  };
+}
+
+function parseGhJsonCount(output: string): number | undefined {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    return Array.isArray(parsed) ? parsed.length : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRemoteCounts(cwd: string, options: OperatorActivityOptions): OperatorActivityRemoteCounts {
+  if (!options.includeRemoteCounts) {
+    return { enabled: false, source: "disabled; pass --include-remote-counts to opt in" };
+  }
+
+  const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
+  const blockers: string[] = [];
+  let openIssues: number | undefined;
+  let openPullRequests: number | undefined;
+
+  try {
+    const output = runner("gh", ["issue", "list", "--state", "open", "--json", "number", "--limit", "1000"], cwd, DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS);
+    openIssues = parseGhJsonCount(output);
+    if (openIssues === undefined) blockers.push("GitHub open issue count unavailable: unable to parse gh issue list JSON");
+  } catch (error) {
+    blockers.push(`GitHub open issue count unavailable: ${errorDetail(error)}`);
+  }
+
+  try {
+    const output = runner("gh", ["pr", "list", "--state", "open", "--json", "number", "--limit", "1000"], cwd, DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS);
+    openPullRequests = parseGhJsonCount(output);
+    if (openPullRequests === undefined) blockers.push("GitHub open PR count unavailable: unable to parse gh pr list JSON");
+  } catch (error) {
+    blockers.push(`GitHub open PR count unavailable: ${errorDetail(error)}`);
+  }
+
+  return {
+    enabled: true,
+    source: OPERATOR_ACTIVITY_REMOTE_SOURCE,
+    openIssues,
+    openPullRequests,
+    blockers: uniqueSorted(blockers),
+  };
+}
+
+export function readOperatorActivitySnapshot(cwd = process.cwd(), options: OperatorActivityOptions = {}): OperatorActivitySnapshot {
+  const generatedAt = options.now?.() ?? nowIso();
+  const worktreeStatus = currentWorktreeEvidenceStatus(cwd, { ...options, now: () => generatedAt });
+  const worktree = buildWorktreeSnapshot(worktreeStatus);
+  const tmux = readTmuxActivity(cwd, options);
+  const optionalCounts = readRemoteCounts(cwd, options);
+  const optionalCountBlockers = optionalCounts.enabled ? optionalCounts.blockers : [];
+
+  return {
+    schemaVersion: OPERATOR_ACTIVITY_SCHEMA_VERSION,
+    command: OPERATOR_ACTIVITY_COMMAND,
+    generatedAt,
+    cwd,
+    claimBoundary: OPERATOR_ACTIVITY_CLAIM_BOUNDARY,
+    readOnly: true,
+    worktree,
+    tmux,
+    optionalCounts,
+    blockers: uniqueSorted([...worktree.blockers, ...tmux.blockers, ...optionalCountBlockers]),
+  };
+}

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1,0 +1,150 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+
+const {
+  OPERATOR_ACTIVITY_CLAIM_BOUNDARY,
+  OPERATOR_ACTIVITY_COMMAND,
+  OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG,
+  OPERATOR_ACTIVITY_REMOTE_SOURCE,
+  OPERATOR_ACTIVITY_TMUX_COMMAND,
+  parseOperatorActivityTmuxPanes,
+  readOperatorActivitySnapshot,
+} = require(path.join(repoRoot, "dist", "core", "operator-activity.js"));
+
+function run(args, cwd, envOverrides = {}) {
+  return JSON.parse(execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } }));
+}
+
+function runText(args, cwd) {
+  return execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8" });
+}
+
+function makeTempProject() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-activity-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, "src", "index.ts"), "export const value = 1;\n");
+  return tempDir;
+}
+
+test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {
+  assert.deepEqual(parseOperatorActivityTmuxPanes("fooks-a\t/tmp/fooks\tzsh\nother\t/tmp/other\tnode\n"), [
+    { session: "fooks-a", path: "/tmp/fooks", command: "zsh" },
+    { session: "other", path: "/tmp/other", command: "node" },
+  ]);
+});
+
+test("operator activity snapshot is local-first and does not call remote counts unless explicitly enabled", () => {
+  const tempDir = makeTempProject();
+  const calls = [];
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    now: () => "2026-05-03T22:10:00.000Z",
+    runner: () => " M src/index.ts\0?? notes.md\0",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "dogfood/issue-424\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "2\t1\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      calls.push([command, ...args].join(" "));
+      if (command === "gh") throw new Error("gh must not be called by default");
+      return `fooks-dogfood\t${tempDir}\tzsh\nnot-related\t/tmp/elsewhere\tzsh\n`;
+    },
+  });
+
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.command, OPERATOR_ACTIVITY_COMMAND);
+  assert.equal(snapshot.claimBoundary, OPERATOR_ACTIVITY_CLAIM_BOUNDARY);
+  assert.equal(snapshot.readOnly, true);
+  assert.equal(snapshot.generatedAt, "2026-05-03T22:10:00.000Z");
+  assert.equal(snapshot.worktree.branch, "dogfood/issue-424");
+  assert.equal(snapshot.worktree.upstream, "origin/main");
+  assert.equal(snapshot.worktree.ahead, 2);
+  assert.equal(snapshot.worktree.behind, 1);
+  assert.equal(snapshot.worktree.clean, false);
+  assert.equal(snapshot.worktree.delta.source, "current git status only; no session baseline comparison");
+  assert.deepEqual(snapshot.worktree.delta.changedPaths, ["notes.md", "src/index.ts"]);
+  assert.equal(snapshot.tmux.available, true);
+  assert.equal(snapshot.tmux.command, OPERATOR_ACTIVITY_TMUX_COMMAND);
+  assert.equal(snapshot.tmux.sessions.length, 1);
+  assert.equal(snapshot.tmux.sessions[0].session, "fooks-dogfood");
+  assert.equal(snapshot.optionalCounts.enabled, false);
+  assert.match(snapshot.optionalCounts.source, /--include-remote-counts/);
+  assert.equal(calls.some((call) => call.startsWith("gh ")), false);
+});
+
+test("operator activity treats tmux and opt-in GitHub count failures as non-fatal blockers", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    runner: () => "",
+    gitRunner: () => { throw new Error("no branch"); },
+    commandRunner: (command, args) => {
+      if (command === "tmux") throw new Error("tmux missing");
+      if (command === "gh" && args[0] === "issue") return "[{\"number\":1},{\"number\":2}]";
+      throw new Error("gh unavailable");
+    },
+  });
+
+  assert.equal(snapshot.tmux.available, false);
+  assert.match(snapshot.tmux.blockers.join("\n"), /tmux missing/);
+  assert.equal(snapshot.optionalCounts.enabled, true);
+  assert.equal(snapshot.optionalCounts.source, OPERATOR_ACTIVITY_REMOTE_SOURCE);
+  assert.equal(snapshot.optionalCounts.openIssues, 2);
+  assert.equal(snapshot.optionalCounts.openPullRequests, undefined);
+  assert.match(snapshot.optionalCounts.blockers.join("\n"), /gh unavailable/);
+  assert.match(snapshot.blockers.join("\n"), /tmux missing/);
+  assert.match(snapshot.blockers.join("\n"), /gh unavailable/);
+});
+
+test("status activity CLI route preserves existing status contracts", () => {
+  const tempDir = makeTempProject();
+  const before = fs.readdirSync(tempDir).sort();
+
+  const activity = run(["status", "activity"], tempDir);
+  assert.equal(activity.command, OPERATOR_ACTIVITY_COMMAND);
+  assert.equal(activity.optionalCounts.enabled, false);
+  assert.equal(activity.readOnly, true);
+  assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
+
+  const bare = run(["status"], tempDir);
+  assert.equal(bare.schemaVersion, 1);
+  assert.equal(bare.metricTier, "estimated");
+  assert.equal("worktree" in bare, false);
+  assert.equal("tmux" in bare, false);
+  assert.equal("optionalCounts" in bare, false);
+
+  const worktree = run(["status", "worktree"], tempDir);
+  assert.equal(worktree.schemaVersion, 1);
+  assert.equal("tmux" in worktree, false);
+  assert.equal("optionalCounts" in worktree, false);
+
+  const artifacts = run(["status", "artifacts"], tempDir);
+  assert.equal(artifacts.command, "status artifacts");
+  assert.ok(Array.isArray(artifacts.manualCleanupCommands));
+  assert.equal("optionalCounts" in artifacts, false);
+
+  const help = runText(["--help"], tempDir);
+  assert.match(help, /fooks status activity \[--include-remote-counts\]/);
+
+  let output = "";
+  try {
+    runText(["status", "activity", "--unexpected"], tempDir);
+  } catch (error) {
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.match(output, /Unexpected status activity argument/);
+  assert.match(OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG, /--include-remote-counts/);
+});


### PR DESCRIPTION
## Summary
- add explicit `fooks status activity` JSON surface for compact operator dogfood status
- report local worktree branch/divergence/current dirty-path delta and fooks-like tmux panes without changing existing status contracts
- keep open issue/PR counts behind explicit non-blocking `--include-remote-counts`

Closes #424.

## Tests
- `npm run build`
- `node --test test/operator-activity.test.mjs test/worktree-evidence.test.mjs test/artifact-audit.test.mjs test/fooks.test.mjs`

## Notes
- `.clawhip/project.json` was left untracked/local-only.