### PR TITLE
Summarize release benchmark evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bench:cache": "npm run build && node scripts/benchmark-cache.mjs",
     "evidence:react-web-context": "npm run build && node scripts/react-web-context-evidence.mjs",
     "evidence:react-web-reuse": "npm run build && node scripts/react-web-reuse-evidence.mjs",
+    "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",
     "bench": "npm run build && node benchmarks/scripts/run-all.mjs",
     "bench:scan": "npm run build && node benchmarks/scripts/scan-cache.mjs",

--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebContextEvidence } from "./react-web-context-evidence.mjs";
+import { buildReactWebReuseEvidence } from "./react-web-reuse-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+function finite(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function claimLine(contextEvidence, reuseEvidence) {
+  const min = contextEvidence.summary.domainPayloadReduction.minPct;
+  const max = contextEvidence.summary.domainPayloadReduction.maxPct;
+  if (!contextEvidence.summary.domainPayloadReduction.claimable || !reuseEvidence.summary.reuseCorrectnessClaimable) {
+    return "React Web evidence is present, but release wording must stay diagnostic until all claimability gates pass.";
+  }
+  return `React Web same-file reuse is routed correctly, and current-lane fixtures show ${min}% to ${max}% smaller source-derived domainPayloads in local byte-size evidence.`;
+}
+
+export async function buildReleaseBenchmarkEvidence({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const contextEvidence = await buildReactWebContextEvidence({ repoRoot, runId: `${runId}-context` });
+  const reuseEvidence = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
+
+  const releaseClaims = {
+    npmUpdateClaimable: contextEvidence.summary.domainPayloadReduction.claimable && reuseEvidence.summary.reuseCorrectnessClaimable,
+    headline: claimLine(contextEvidence, reuseEvidence),
+    allowed: [
+      "React Web same-file reuse routes record -> inject for current-lane fixtures.",
+      "React Web source changes refresh before attach and do not reuse stale fingerprints.",
+      `React Web current-lane fixtures show ${contextEvidence.summary.domainPayloadReduction.minPct}% to ${contextEvidence.summary.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads by local byte-size measurement.`,
+      "RN and WebView boundaries fall back instead of becoming React Web payload support.",
+    ],
+    forbidden: [
+      "Caching performance improved.",
+      "Runtime-token savings are proven.",
+      "Provider cost or billing is reduced.",
+      "Full runtime payloads are always smaller than source.",
+      "Broad React Web, React Native, or WebView support is available.",
+    ],
+  };
+
+  return {
+    schemaVersion: "release-benchmark-evidence.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "release-facing-local-evidence-summary",
+    claimBoundary:
+      "Release-facing local evidence summary only: combines React Web context byte-size and reuse-correctness artifacts; not provider tokenizer output, not runtime-token savings, not wall-clock cache performance, not latency, not provider cost, billing, invoice, or charged-cost evidence.",
+    releaseClaims,
+    context: {
+      schemaVersion: contextEvidence.schemaVersion,
+      fixtureCount: contextEvidence.summary.fixtureCount,
+      allReactWebInjects: contextEvidence.summary.allReactWebInjects,
+      domainPayloadReduction: {
+        claimable: contextEvidence.summary.domainPayloadReduction.claimable,
+        minPct: finite(contextEvidence.summary.domainPayloadReduction.minPct),
+        maxPct: finite(contextEvidence.summary.domainPayloadReduction.maxPct),
+      },
+      fullRuntimePayloadReduction: {
+        claimable: contextEvidence.summary.fullRuntimePayloadReduction.claimable,
+        minPct: finite(contextEvidence.summary.fullRuntimePayloadReduction.minPct),
+        maxPct: finite(contextEvidence.summary.fullRuntimePayloadReduction.maxPct),
+        blocker: contextEvidence.summary.fullRuntimePayloadReduction.blocker,
+      },
+      fixtures: contextEvidence.fixtures.map((row) => ({
+        file: row.file,
+        sourceBytes: row.sourceBytes,
+        domainPayloadBytes: row.domainPayloadBytes,
+        domainPayloadReductionPct: row.domainPayloadReductionPct,
+        runtimePayloadBytes: row.runtimePayloadBytes,
+        runtimePayloadReductionPct: row.runtimePayloadReductionPct,
+      })),
+    },
+    reuse: {
+      schemaVersion: reuseEvidence.schemaVersion,
+      reuseCorrectnessClaimable: reuseEvidence.summary.reuseCorrectnessClaimable,
+      sameFileReactWebReuse: reuseEvidence.checks.sameFileReactWebReuse,
+      sourceChangeRefresh: reuseEvidence.checks.sourceChangeRefresh,
+      unsupportedDomainFallbacks: reuseEvidence.checks.unsupportedDomainFallbacks,
+    },
+    nonClaims: {
+      cachePerformanceImprovement: {
+        claimable: false,
+        blocker: "no wall-clock latency, cache-hit-rate, or end-to-end runtime benchmark is measured by this release-facing artifact",
+      },
+      runtimeTokenSavings: {
+        claimable: false,
+        blocker: "no comparable runtime-token telemetry is measured by this release-facing artifact",
+      },
+      providerBillingSavings: {
+        claimable: false,
+        blocker: "no provider usage, tokenizer, billing dashboard, invoice, or charged-cost data is measured by this release-facing artifact",
+      },
+    },
+  };
+}
+
+export function renderReleaseBenchmarkEvidenceMarkdown(evidence) {
+  const fixtureRows = evidence.context.fixtures
+    .map(
+      (row) =>
+        `| \`${row.file}\` | ${row.sourceBytes} | ${row.domainPayloadBytes} | ${row.domainPayloadReductionPct}% | ${row.runtimePayloadBytes} | ${row.runtimePayloadReductionPct}% |`,
+    )
+    .join("\n");
+
+  return `# Release benchmark evidence
+
+${evidence.claimBoundary}
+
+## Release-safe headline
+
+${evidence.releaseClaims.headline}
+
+## Claimable for this npm update
+
+- npm update wording claimable: ${evidence.releaseClaims.npmUpdateClaimable ? "yes" : "no"}
+- React Web context reduction: ${evidence.context.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.context.domainPayloadReduction.minPct}% to ${evidence.context.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads)
+- React Web reuse correctness: ${evidence.reuse.reuseCorrectnessClaimable ? "yes" : "no"}
+
+## Fixture context-size measurements
+
+| Fixture | Source bytes | domainPayload bytes | domainPayload reduction | full runtime payload bytes | full runtime payload reduction |
+| --- | ---: | ---: | ---: | ---: | ---: |
+${fixtureRows}
+
+## Reuse-correctness checks
+
+- Same-file React Web: ${evidence.reuse.sameFileReactWebReuse.firstAction} -> ${evidence.reuse.sameFileReactWebReuse.secondAction}
+- Source-change refresh: ${evidence.reuse.sourceChangeRefresh.action}; reasons=${evidence.reuse.sourceChangeRefresh.reasons.join(", ")}; stalePayloadReused=${evidence.reuse.sourceChangeRefresh.stalePayloadReused}
+- WebView boundary: ${evidence.reuse.unsupportedDomainFallbacks.webview.secondAction}; reason=${evidence.reuse.unsupportedDomainFallbacks.webview.fallbackReason}
+- React Native boundary: ${evidence.reuse.unsupportedDomainFallbacks.reactNative.secondAction}; reason=${evidence.reuse.unsupportedDomainFallbacks.reactNative.fallbackReason}
+
+## Non-claims
+
+- Cache performance improvement: no
+- Runtime-token savings: no
+- Provider billing/cost savings: no
+- Full runtime payloads always smaller than source: no
+- Broad React Web/RN/WebView support: no
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReleaseBenchmarkEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReleaseBenchmarkEvidenceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReleaseBenchmarkEvidence,
+  renderReleaseBenchmarkEvidenceMarkdown,
+} from "../scripts/release-benchmark-evidence.mjs";
+
+test("release benchmark evidence combines context reduction and reuse correctness for npm wording", async () => {
+  const evidence = await buildReleaseBenchmarkEvidence({ runId: "test" });
+
+  assert.equal(evidence.schemaVersion, "release-benchmark-evidence.v1");
+  assert.equal(evidence.measurement, "release-facing-local-evidence-summary");
+  assert.match(evidence.claimBoundary, /Release-facing local evidence summary only/);
+  assert.match(evidence.claimBoundary, /not provider tokenizer output/);
+  assert.match(evidence.claimBoundary, /not runtime-token savings/);
+  assert.match(evidence.claimBoundary, /not wall-clock cache performance/);
+  assert.match(evidence.claimBoundary, /not provider cost, billing, invoice, or charged-cost evidence/);
+
+  assert.equal(evidence.releaseClaims.npmUpdateClaimable, true);
+  assert.match(evidence.releaseClaims.headline, /React Web same-file reuse is routed correctly/);
+  assert.match(evidence.releaseClaims.headline, /30\.\d+% to 77\.\d+% smaller source-derived domainPayloads/);
+
+  assert.equal(evidence.context.allReactWebInjects, true);
+  assert.equal(evidence.context.domainPayloadReduction.claimable, true);
+  assert.ok(evidence.context.domainPayloadReduction.minPct > 30);
+  assert.ok(evidence.context.domainPayloadReduction.maxPct > 70);
+  assert.equal(evidence.context.fullRuntimePayloadReduction.claimable, false);
+  assert.match(evidence.context.fullRuntimePayloadReduction.blocker, /not smaller than source for every fixture/);
+
+  assert.equal(evidence.reuse.reuseCorrectnessClaimable, true);
+  assert.equal(evidence.reuse.sameFileReactWebReuse.firstAction, "record");
+  assert.equal(evidence.reuse.sameFileReactWebReuse.secondAction, "inject");
+  assert.equal(evidence.reuse.sourceChangeRefresh.stalePayloadReused, false);
+  assert.ok(evidence.reuse.sourceChangeRefresh.reasons.includes("refreshed-before-attach"));
+  assert.equal(evidence.reuse.unsupportedDomainFallbacks.webview.secondAction, "fallback");
+  assert.equal(evidence.reuse.unsupportedDomainFallbacks.reactNative.secondAction, "fallback");
+
+  assert.equal(evidence.nonClaims.cachePerformanceImprovement.claimable, false);
+  assert.equal(evidence.nonClaims.runtimeTokenSavings.claimable, false);
+  assert.equal(evidence.nonClaims.providerBillingSavings.claimable, false);
+  assert.ok(evidence.releaseClaims.forbidden.includes("Caching performance improved."));
+  assert.ok(evidence.releaseClaims.forbidden.includes("Provider cost or billing is reduced."));
+});
+
+test("release benchmark evidence Markdown gives safe public wording and explicit non-claims", async () => {
+  const evidence = await buildReleaseBenchmarkEvidence({ runId: "markdown-test" });
+  const markdown = renderReleaseBenchmarkEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /Release-safe headline/);
+  assert.match(markdown, /npm update wording claimable: yes/);
+  assert.match(markdown, /React Web context reduction: yes/);
+  assert.match(markdown, /React Web reuse correctness: yes/);
+  assert.match(markdown, /Cache performance improvement: no/);
+  assert.match(markdown, /Runtime-token savings: no/);
+  assert.match(markdown, /Provider billing\/cost savings: no/);
+  assert.match(markdown, /Full runtime payloads always smaller than source: no/);
+  assert.doesNotMatch(markdown, /Cache performance improvement: yes/i);
+  assert.doesNotMatch(markdown, /Runtime-token savings: yes/i);
+  assert.doesNotMatch(markdown, /Provider billing\/cost savings: yes/i);
+});


### PR DESCRIPTION
## Summary
- Add `npm run evidence:release-benchmark` as the release-facing benchmark summary for the next npm update.
- Combine React Web context-size evidence with reuse-correctness evidence.
- Emit safe release wording plus explicit forbidden claims.

## Local evidence result
`npm run evidence:release-benchmark -- --run-id=local-smoke --output=/tmp/release-benchmark-evidence.json --markdown-output=/tmp/release-benchmark-evidence.md`

Claimable for npm wording:
- React Web same-file reuse is routed correctly.
- Current-lane fixtures show **30.585% to 77.459% smaller source-derived domainPayloads** by local byte-size measurement.
- React Web source changes refresh before attach and do not reuse stale fingerprints.
- RN and WebView boundaries fall back instead of becoming React Web payload support.

Still not claimable:
- “Caching performance improved”
- Runtime-token savings
- Provider cost or billing reduction
- Full runtime payloads are always smaller than source
- Broad React Web/RN/WebView support

## Verification
- `npm run build`
- `node --test test/release-benchmark-evidence.test.mjs test/react-web-context-evidence.test.mjs test/react-web-reuse-evidence.test.mjs test/react-web-runtime-evidence-claim-boundary.test.mjs`
- `npm run evidence:release-benchmark -- --run-id=local-smoke --output=/tmp/release-benchmark-evidence.json --markdown-output=/tmp/release-benchmark-evidence.md`
