### PR TITLE
Add React Web a11y semantic anchor relations

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -391,6 +391,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const validationAnchors: NonNullable<FormSurface["validationAnchors"]> = [];
   const stateConditions: NonNullable<FormSurface["stateConditions"]> = [];
   const a11yAnchors: A11yAnchorSignal[] = [];
+  const a11ySourceIds: NonNullable<NonNullable<ExtractionResult["behavior"]>["a11ySourceIds"]> = [];
   const conditionalRenders = new Set<string>();
   const repeatedBlocks = new Set<string>();
   const snippetCandidates: NonNullable<ExtractionResult["snippets"]> = [];
@@ -419,10 +420,30 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     items.push({ value: compacted, loc: sourceRangeOf(sourceFile, node) });
   };
 
-  const addA11yAnchor = (kind: A11yAnchorSignal["kind"], label: string, node: ts.Node): void => {
+  const addA11yAnchor = (
+    kind: A11yAnchorSignal["kind"],
+    label: string,
+    node: ts.Node,
+    metadata: Pick<A11yAnchorSignal, "sourceId" | "references"> = {},
+  ): void => {
     const compacted = compactText(label);
     if (!compacted) return;
-    a11yAnchors.push({ kind, label: compacted, loc: sourceRangeOf(sourceFile, node) });
+    a11yAnchors.push({
+      kind,
+      label: compacted,
+      loc: sourceRangeOf(sourceFile, node),
+      ...(metadata.sourceId ? { sourceId: metadata.sourceId } : {}),
+      ...(metadata.references && metadata.references.length > 0 ? { references: metadata.references } : {}),
+    });
+  };
+
+  const idRefTokens = (value: string | undefined): string[] => {
+    if (!value || value === "true") return [];
+    return value
+      .split(/\s+/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .slice(0, 8);
   };
 
   const jsxAttributeValue = (attribute: ts.JsxAttribute): string | undefined => {
@@ -436,6 +457,16 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
 
   const collectJsxOpening = (node: ts.JsxOpeningElement | ts.JsxSelfClosingElement): void => {
     const tag = node.tagName.getText(sourceFile);
+    const attributeValues = new Map<string, string>();
+    for (const property of node.attributes.properties) {
+      if (!ts.isJsxAttribute(property)) continue;
+      const value = jsxAttributeValue(property);
+      if (value) attributeValues.set(property.name.getText(sourceFile), value);
+    }
+    const elementId = attributeValues.get("id");
+    if (elementId) {
+      a11ySourceIds.push({ value: elementId, loc: sourceRangeOf(sourceFile, node) });
+    }
     if (tag === "Controller") {
       addLocatedAnchor(validationAnchors, "Controller", node);
     }
@@ -466,16 +497,28 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
         if (value) propValues[attrName] = value;
       }
       if (tag === "label") {
-        addA11yAnchor("label", jsxAttributeValue(property) ?? tag, property);
+        addA11yAnchor("label", jsxAttributeValue(property) ?? tag, property, {
+          ...(elementId ? { sourceId: elementId } : {}),
+        });
       }
       if (attrName === "htmlFor") {
-        addA11yAnchor("htmlFor", jsxAttributeValue(property) ?? attrName, property);
+        const value = jsxAttributeValue(property) ?? attrName;
+        addA11yAnchor("htmlFor", value, property, {
+          references: idRefTokens(value),
+          ...(elementId ? { sourceId: elementId } : {}),
+        });
       }
       if (attrName === "role") {
-        addA11yAnchor("role", jsxAttributeValue(property) ?? attrName, property);
+        addA11yAnchor("role", jsxAttributeValue(property) ?? attrName, property, {
+          ...(elementId ? { sourceId: elementId } : {}),
+        });
       }
       if (attrName.startsWith("aria-")) {
-        addA11yAnchor("aria", `${attrName}=${jsxAttributeValue(property) ?? "true"}`, property);
+        const value = jsxAttributeValue(property) ?? "true";
+        addA11yAnchor("aria", `${attrName}=${value}`, property, {
+          ...(attrName === "aria-describedby" || attrName === "aria-labelledby" ? { references: idRefTokens(value) } : {}),
+          ...(elementId ? { sourceId: elementId } : {}),
+        });
       }
       if (attrName === "required") {
         addA11yAnchor("required", controlName ? `${tag}[name=${controlName}]` : tag, property);
@@ -612,6 +655,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const eventHandlerList = [...eventHandlers];
   const eventHandlerSignalList = dedupeBy(eventHandlerSignals, (item) => `${item.name}:${item.trigger ?? ""}:${item.loc?.startLine ?? ""}`).slice(0, MAX_EVENT_HANDLER_SIGNALS);
   const a11yAnchorList = dedupeBy(a11yAnchors, (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`).slice(0, 16);
+  const a11ySourceIdList = dedupeBy(a11ySourceIds, (item) => `${item.value}:${item.loc?.startLine ?? ""}`).slice(0, 16);
   return {
     behavior: {
       hooks: [...hooks],
@@ -632,6 +676,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
           }
         : {}),
       ...(a11yAnchorList.length ? { a11yAnchors: a11yAnchorList } : {}),
+      ...(a11ySourceIdList.length ? { a11ySourceIds: a11ySourceIdList } : {}),
       hasSideEffects,
     },
     structure: {

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -110,14 +110,60 @@ function buildRenderStates(result: ExtractionResult): ReactWebContextRenderState
   return dedupeBy(states, (item) => `${item.kind}:${item.label}:${item.condition ?? ""}`);
 }
 
+function ariaReferenceIds(label: string): string[] {
+  const [, value = ""] = label.split("=");
+  return value
+    .split(/\s+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
 function buildA11yAnchors(result: ExtractionResult): ReactWebContextA11yAnchor[] {
   const anchors: ReactWebContextA11yAnchor[] = [];
+  const controlIds = new Set<string>();
+  const sourceIds = new Set<string>();
+
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    const id = control.propValues?.id;
+    if (id) {
+      controlIds.add(id);
+      sourceIds.add(id);
+    }
+  }
+
+  for (const sourceId of result.behavior?.a11ySourceIds ?? []) {
+    sourceIds.add(sourceId.value);
+  }
 
   for (const anchor of result.behavior?.a11yAnchors ?? []) {
+    if (anchor.sourceId) sourceIds.add(anchor.sourceId);
+  }
+
+  for (const anchor of result.behavior?.a11yAnchors ?? []) {
+    const references = anchor.references ?? (anchor.kind === "aria" ? ariaReferenceIds(anchor.label) : []);
+    const resolvedIds = references.filter((id) => sourceIds.has(id));
+    const relation = (() => {
+      if (anchor.kind === "htmlFor" && references[0] && controlIds.has(references[0])) {
+        return { kind: "label-control" as const, targetId: references[0] };
+      }
+      if (anchor.kind === "aria" && /^aria-(describedby|labelledby)=/.test(anchor.label) && resolvedIds.length > 0) {
+        return { kind: "aria-idrefs" as const, targetIds: references, resolvedIds };
+      }
+      if (anchor.kind === "aria" && /^aria-invalid=/.test(anchor.label)) {
+        return { kind: "invalid-state" as const, ...(anchor.sourceId ? { sourceId: anchor.sourceId } : {}) };
+      }
+      if (anchor.kind === "role" && /^alert$/i.test(anchor.label)) {
+        return { kind: "alert-region" as const, ...(anchor.sourceId ? { sourceId: anchor.sourceId } : {}) };
+      }
+      return undefined;
+    })();
+
     anchors.push({
       kind: anchor.kind,
       label: anchor.label,
       ...(anchor.loc ? { loc: anchor.loc } : {}),
+      ...(relation ? { relation } : {}),
       evidence: ["behavior.a11yAnchors"],
     });
   }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -69,6 +69,8 @@ export type A11yAnchorSignal = {
   kind: "label" | "htmlFor" | "aria" | "role" | "required" | "disabled" | "readonly" | "error-text";
   label: string;
   loc?: SourceRange;
+  sourceId?: string;
+  references?: string[];
 };
 
 export type ModuleDeclarationSignal = LocatedString & {
@@ -117,10 +119,19 @@ export type ReactWebContextRenderState = {
   evidence: string[];
 };
 
+export type ReactWebContextA11yAnchorRelation = {
+  kind: "label-control" | "aria-idrefs" | "invalid-state" | "alert-region";
+  sourceId?: string;
+  targetId?: string;
+  targetIds?: string[];
+  resolvedIds?: string[];
+};
+
 export type ReactWebContextA11yAnchor = {
   kind: "label" | "htmlFor" | "aria" | "role" | "required" | "disabled" | "readonly" | "error-text";
   label: string;
   loc?: SourceRange;
+  relation?: ReactWebContextA11yAnchorRelation;
   evidence: string[];
 };
 
@@ -235,6 +246,7 @@ export type ExtractionResult = {
     eventHandlerSignals?: EventHandlerSignal[];
     formSurface?: FormSurface;
     a11yAnchors?: A11yAnchorSignal[];
+    a11ySourceIds?: LocatedString[];
     hasSideEffects?: boolean;
   };
   structure?: {

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -458,6 +458,118 @@ test("React Web opt-in emits source-observed role aria and readOnly anchors", ()
   assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "readonly" && item.label === "input[name=displayName]"));
 });
 
+
+
+test("React Web a11y anchors expose source-derived semantic relationships", () => {
+  const source = `
+    import React from "react";
+
+    type ContactFormProps = { email: string; invalid: boolean; onEmailChange(value: string): void };
+
+    export function ContactForm({ email, invalid, onEmailChange }: ContactFormProps) {
+      return (
+        <form className="grid gap-3 rounded-lg border p-4">
+          <label htmlFor="email" className="text-sm font-medium">Email</label>
+          <input
+            id="email"
+            name="email"
+            value={email}
+            onChange={(event) => onEmailChange(event.currentTarget.value)}
+            aria-invalid={invalid}
+            aria-describedby="email-error email-help missing-id"
+            aria-labelledby="email-label"
+          />
+          <span id="email-label" className="sr-only">Primary email address</span>
+          <p id="email-error" role="alert" className="text-sm text-red-600">Email is required</p>
+          <p id="email-help" className="text-xs text-slate-500">Use your work email for account recovery.</p>
+          <p className="text-xs text-slate-500">This source is intentionally long enough to stay in compressed mode.</p>
+          <p className="text-xs text-slate-500">A11y relations remain source-derived facts, not runtime DOM validation.</p>
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "ContactForm.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+
+  const anchors = payload.reactWebContext.a11yAnchors;
+  assert.ok(
+    anchors.some(
+      (item) => item.kind === "htmlFor" && item.label === "email" && item.relation?.kind === "label-control" && item.relation.targetId === "email",
+    ),
+  );
+  assert.ok(
+    anchors.some(
+      (item) =>
+        item.kind === "aria" &&
+        item.label.startsWith("aria-describedby=email-error email-help") &&
+        item.relation?.kind === "aria-idrefs" &&
+        item.relation.resolvedIds.includes("email-error") &&
+        !item.relation.resolvedIds.includes("missing-id"),
+    ),
+  );
+  assert.ok(
+    anchors.some(
+      (item) =>
+        item.kind === "aria" &&
+        item.label === "aria-labelledby=email-label" &&
+        item.relation?.kind === "aria-idrefs" &&
+        item.relation.resolvedIds.includes("email-label"),
+    ),
+  );
+  assert.ok(
+    anchors.some((item) => item.kind === "aria" && item.label === "aria-invalid=invalid" && item.relation?.kind === "invalid-state"),
+  );
+  assert.ok(
+    anchors.some((item) => item.kind === "role" && item.label === "alert" && item.relation?.kind === "alert-region" && item.relation.sourceId === "email-error"),
+  );
+});
+
+test("React Web a11y id-ref relations require matching source ids", () => {
+  const source = `
+    import React from "react";
+
+    export function MissingA11yRelation() {
+      return (
+        <form className="grid gap-3 rounded-lg border p-4">
+          <label htmlFor="missing-email" className="text-sm font-medium">Email</label>
+          <input
+            id="email"
+            name="email"
+            aria-describedby="missing-help"
+            className="rounded border px-3 py-2"
+          />
+          <p className="text-xs text-slate-500">This fixture is intentionally long enough for compressed metadata.</p>
+          <p className="text-xs text-slate-500">Missing source ids must not become resolved semantic relations.</p>
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "MissingA11yRelation.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+
+  const anchors = payload.reactWebContext.a11yAnchors;
+  assert.ok(anchors.some((item) => item.kind === "htmlFor" && item.label === "missing-email"));
+  assert.equal(
+    anchors.some((item) => item.kind === "htmlFor" && item.label === "missing-email" && item.relation?.kind === "label-control"),
+    false,
+  );
+  assert.ok(anchors.some((item) => item.kind === "aria" && item.label === "aria-describedby=missing-help"));
+  assert.equal(
+    anchors.some((item) => item.kind === "aria" && item.label === "aria-describedby=missing-help" && item.relation?.kind === "aria-idrefs"),
+    false,
+  );
+});
+
 test("React Web wrapper fixture can expose source-observed htmlFor anchor from domain evidence", () => {
   const payload = payloadFor("test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx", {
     includeReactWebContextMetadata: true,


### PR DESCRIPTION
## Summary\n- extend existing React Web `a11yAnchors` with optional source-derived relation facts\n- resolve label/htmlFor -> control id, aria idrefs, aria-invalid, and role=alert anchors without adding an audit surface\n- add regression coverage for resolved and missing source-id relationships\n\n## Boundaries\n- no WCAG/a11y audit or runtime DOM validation claims\n- no cross-file id resolution\n- no formStateFlow/edit-target routing expansion\n- no new dependencies\n\n## Tests\n- `npm run build`\n- `node --test test/react-web-context-metadata.test.mjs`\n- `node --test test/pre-read-payload-builder.test.mjs`\n- `npm test` (453/453)