### PR TITLE
Give RN reuse a profile-owned signal contract

### DIFF
--- a/src/core/domain-profiles/react-native.ts
+++ b/src/core/domain-profiles/react-native.ts
@@ -1,5 +1,39 @@
 import { FRONTEND_DOMAIN_BOUNDARY_REASON, type DomainProfileDefinition } from "./types";
 
+export const REACT_NATIVE_SIGNAL_TAXONOMY = {
+  primitiveInput: {
+    policy: "rn-primitive-input-narrow-payload",
+    plannerDecision: "narrow-primitive-input-payload",
+    requiredSignals: [
+      "react-native:primitive:View",
+      "react-native:primitive:Text",
+      "react-native:primitive:TextInput",
+      "react-native:primitive:Pressable",
+      "react-native:jsx-prop:onChangeText",
+      "react-native:jsx-prop:onPress",
+    ],
+    forbiddenExactSignals: [
+      "react-native:primitive:FlatList",
+      "react-native:primitive:Image",
+      "react-native:primitive:ScrollView",
+      "react-native:primitive:TouchableOpacity",
+      "react-native:style-factory:StyleSheet.create",
+      "react-native:platform-select:Platform.select",
+      "react-native:style-prop:resizeMode",
+      "react-native:jsx-prop:activeOpacity",
+      "react-native:jsx-prop:pagingEnabled",
+    ],
+    forbiddenPrefixes: [
+      "webview:",
+      "tui-ink:",
+      "react-native:navigation-",
+      "react-native:api-call:Dimensions.",
+      "react-native:api-call:PanResponder.",
+    ],
+    supportBoundary: "measured-evidence-only; no broad RN/WebView/TUI support",
+  },
+} as const;
+
 export const REACT_NATIVE_DOMAIN_PROFILE: DomainProfileDefinition = {
   lane: "react-native",
   evidenceDomain: "react-native",

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -5,10 +5,10 @@ import {
   type ReactNativePrimitiveInputReuseContract,
 } from "../payload/domain-payload";
 import {
-  RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
-  RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES,
+  RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
   RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
+  RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
 } from "./react-native";
 import type { ModelFacingPayload, SourceFingerprint } from "../schema";
 import { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } from "./fallback";
@@ -30,13 +30,6 @@ function sourceFingerprintsEqual(left: SourceFingerprint | undefined, right: Sou
   return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
 }
 
-function expectedReactNativeDeniedSignals(): string[] {
-  return [
-    ...RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
-    ...RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.map((prefix) => `${prefix}*`),
-  ];
-}
-
 function isReactNativePrimitiveInputReuseContract(value: unknown): value is ReactNativePrimitiveInputReuseContract {
   if (!value || typeof value !== "object") return false;
   const contract = value as Partial<ReactNativePrimitiveInputReuseContract>;
@@ -52,8 +45,8 @@ function isReactNativePrimitiveInputReuseContract(value: unknown): value is Reac
       "frontendPayloadPolicy no longer allows RN narrow policy",
     ]) &&
     arraysEqual(contract.requiredSignals, RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS) &&
-    arraysEqual(contract.deniedBySignals, expectedReactNativeDeniedSignals()) &&
-    contract.supportBoundary === "measured-evidence-only; no broad RN/WebView/TUI support"
+    arraysEqual(contract.deniedBySignals, RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS) &&
+    contract.supportBoundary === RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY
   );
 }
 

--- a/src/core/payload-policy/react-native.ts
+++ b/src/core/payload-policy/react-native.ts
@@ -1,34 +1,16 @@
 import type { DomainDetectionResult } from "../domain-detector";
+import { REACT_NATIVE_SIGNAL_TAXONOMY } from "../domain-profiles/react-native";
 import type { FrontendPayloadPolicyDecision } from "./types";
 
-export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = "rn-primitive-input-narrow-payload";
-
-export const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = [
-  "react-native:primitive:View",
-  "react-native:primitive:Text",
-  "react-native:primitive:TextInput",
-  "react-native:primitive:Pressable",
-  "react-native:jsx-prop:onChangeText",
-  "react-native:jsx-prop:onPress",
+export const RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.policy;
+export const RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.requiredSignals;
+export const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenPrefixes;
+export const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenExactSignals;
+export const RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS = [
+  ...RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
+  ...RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.map((prefix) => `${prefix}*`),
 ] as const;
-export const RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES = [
-  "webview:",
-  "tui-ink:",
-  "react-native:navigation-",
-  "react-native:api-call:Dimensions.",
-  "react-native:api-call:PanResponder.",
-] as const;
-export const RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS = [
-  "react-native:primitive:FlatList",
-  "react-native:primitive:Image",
-  "react-native:primitive:ScrollView",
-  "react-native:primitive:TouchableOpacity",
-  "react-native:style-factory:StyleSheet.create",
-  "react-native:platform-select:Platform.select",
-  "react-native:style-prop:resizeMode",
-  "react-native:jsx-prop:activeOpacity",
-  "react-native:jsx-prop:pagingEnabled",
-] as const;
+export const RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.supportBoundary;
 
 type ReactNativePrimitiveInputSignalGate =
   | { allowed: true }

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -1,10 +1,10 @@
 import type { DomainDetectionResult } from "../domain-detector";
 import {
   assessReactNativePrimitiveInputSignalGate,
-  RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
-  RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES,
+  RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
   RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
+  RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
 } from "../payload-policy/react-native";
 import type { ExtractionResult, FormControlSignal, StyleSystem } from "../schema";
 
@@ -221,11 +221,8 @@ function buildReactNativePrimitiveInputReuseContract(): ReactNativePrimitiveInpu
       "frontendPayloadPolicy no longer allows RN narrow policy",
     ],
     requiredSignals: [...RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS],
-    deniedBySignals: [
-      ...RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
-      ...RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES.map((prefix) => `${prefix}*`),
-    ],
-    supportBoundary: "measured-evidence-only; no broad RN/WebView/TUI support",
+    deniedBySignals: [...RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS],
+    supportBoundary: RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
   };
 }
 
@@ -275,7 +272,7 @@ export function buildReactWebDomainPayload(
 export function buildReactNativePrimitiveInputDomainPayload(
   result: ExtractionResult,
   domainDetection: DomainDetectionResult | undefined = result.domainDetection,
-  policy = RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
+  policy: string = RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
 ): ReactNativePrimitiveInputDomainPayload | undefined {
   const plan = planReactNativePrimitiveInputPayload(result, domainDetection, policy);
   if (!plan) return undefined;

--- a/test/domain-profiles.test.mjs
+++ b/test/domain-profiles.test.mjs
@@ -16,12 +16,53 @@ const {
   profileForClassification,
   resolveDomainClassification,
 } = require(path.join(repoRoot, "dist", "core", "domain-profiles", "registry.js"));
+const { REACT_NATIVE_SIGNAL_TAXONOMY } = require(path.join(
+  repoRoot,
+  "dist",
+  "core",
+  "domain-profiles",
+  "react-native.js",
+));
 
 const forbiddenSupportClaims = /React Native support is available|React Native is supported today|WebView support is available|WebView is supported today|TUI support is available|TUI is supported today|TUI\/Ink is supported today|default WebView compact extraction is enabled/i;
 
 function evidence(domain, signal = "import", detail = domain) {
   return [{ domain, signal, detail }];
 }
+
+test("React Native profile owns the primitive/input signal taxonomy contract", () => {
+  assert.deepEqual(REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput, {
+    policy: "rn-primitive-input-narrow-payload",
+    plannerDecision: "narrow-primitive-input-payload",
+    requiredSignals: [
+      "react-native:primitive:View",
+      "react-native:primitive:Text",
+      "react-native:primitive:TextInput",
+      "react-native:primitive:Pressable",
+      "react-native:jsx-prop:onChangeText",
+      "react-native:jsx-prop:onPress",
+    ],
+    forbiddenExactSignals: [
+      "react-native:primitive:FlatList",
+      "react-native:primitive:Image",
+      "react-native:primitive:ScrollView",
+      "react-native:primitive:TouchableOpacity",
+      "react-native:style-factory:StyleSheet.create",
+      "react-native:platform-select:Platform.select",
+      "react-native:style-prop:resizeMode",
+      "react-native:jsx-prop:activeOpacity",
+      "react-native:jsx-prop:pagingEnabled",
+    ],
+    forbiddenPrefixes: [
+      "webview:",
+      "tui-ink:",
+      "react-native:navigation-",
+      "react-native:api-call:Dimensions.",
+      "react-native:api-call:PanResponder.",
+    ],
+    supportBoundary: "measured-evidence-only; no broad RN/WebView/TUI support",
+  });
+});
 
 test("domain profile registry exposes behavior-neutral lane ownership metadata", () => {
   assert.deepEqual(

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -13,11 +13,20 @@ const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "
 const {
   assessReactNativePrimitiveInputSignalGate,
   assessReactNativePayloadPolicy,
+  RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS,
   RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS,
   RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES,
   RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,
   RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
+  RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
 } = require(path.join(repoRoot, "dist", "core", "payload-policy", "react-native.js"));
+const { REACT_NATIVE_SIGNAL_TAXONOMY } = require(path.join(
+  repoRoot,
+  "dist",
+  "core",
+  "domain-profiles",
+  "react-native.js",
+));
 const { buildReactNativePrimitiveInputDomainPayload } = require(
   path.join(repoRoot, "dist", "core", "payload", "domain-payload.js"),
 );
@@ -223,15 +232,25 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
     "react-native:jsx-prop:pagingEnabled",
   ];
 
-  assert.deepEqual(RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS, requiredSignals);
-  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS, forbiddenExactSignals);
-  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES, [
+  assert.deepEqual(REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.requiredSignals, requiredSignals);
+  assert.deepEqual(REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenExactSignals, forbiddenExactSignals);
+  assert.deepEqual(REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenPrefixes, [
     "webview:",
     "tui-ink:",
     "react-native:navigation-",
     "react-native:api-call:Dimensions.",
     "react-native:api-call:PanResponder.",
   ]);
+  assert.equal(REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.supportBoundary, "measured-evidence-only; no broad RN/WebView/TUI support");
+
+  assert.deepEqual(RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS, REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.requiredSignals);
+  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_EXACT_SIGNALS, REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenExactSignals);
+  assert.deepEqual(RN_PRIMITIVE_INPUT_FORBIDDEN_PREFIXES, REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenPrefixes);
+  assert.deepEqual(RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS, [
+    ...REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenExactSignals,
+    ...REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.forbiddenPrefixes.map((prefix) => `${prefix}*`),
+  ]);
+  assert.equal(RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY, REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput.supportBoundary);
 
   const extractionResult = {
     componentName: "NativeInput",


### PR DESCRIPTION
## Summary
- Add a profile-owned React Native primitive/input signal taxonomy contract.
- Derive RN payload policy, reuse gating, and profile-gate required/forbidden boundaries from that taxonomy.
- Add regressions proving the taxonomy stays behavior-neutral and does not broaden RN support claims.

## Boundaries
- No detector, pre-read phase ordering, payload-readiness, or schema migration behavior change.
- No React Native positive expansion beyond the existing measured primitive/input lane.
- No WebView/TUI behavior changes and no broad support/performance/token/cost claims.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/domain-profiles.test.mjs test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/pre-read-phase-order-regression.test.mjs test/domain-payload-policy-coverage.test.mjs test/runtime-bridge-contract.test.mjs` — 33 pass
- `git diff --check`
- `npm test` — 455 pass
