### PR TITLE
Add React Web import role hints

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -4,7 +4,7 @@ import ts from "typescript";
 import { hashText } from "./hash";
 import { decideMode } from "./decide";
 import { detectDomainFromSource } from "./domain-detector";
-import type { A11yAnchorSignal, ExtractionResult, FormSurface, Language, SourceRange, StyleSystem } from "./schema";
+import type { A11yAnchorSignal, ExtractionResult, FormSurface, ImportSignal, Language, SourceRange, StyleSystem } from "./schema";
 
 const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer", "useLayoutEffect", "useContext", "useId", "useTransition"]);
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
@@ -176,6 +176,38 @@ function getComponentName(exports: ExtractionResult["exports"]): string | undefi
   const defaultExport = exports.find((item) => item.kind === "default" && isPascal(item.name));
   if (defaultExport) return defaultExport.name;
   return exports.find((item) => isPascal(item.name))?.name;
+}
+
+function collectImports(sourceFile: ts.SourceFile): ImportSignal[] {
+  const imports: ImportSignal[] = [];
+
+  const addImport = (moduleSpecifier: string, importedSymbols: string[], node: ts.Node): void => {
+    const compacted = compactText(moduleSpecifier, 80);
+    if (!compacted) return;
+    imports.push({
+      moduleSpecifier: compacted,
+      ...(importedSymbols.length ? { importedSymbols: [...new Set(importedSymbols)].slice(0, 12) } : {}),
+      loc: sourceRangeOf(sourceFile, node),
+    });
+  };
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const symbols: string[] = [];
+    const clause = statement.importClause;
+    if (clause?.name) symbols.push(clause.name.text);
+    if (clause?.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        symbols.push(element.name.text);
+      }
+    }
+    if (clause?.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+      symbols.push(clause.namedBindings.name.text);
+    }
+    addImport(statement.moduleSpecifier.text, symbols, statement);
+  }
+
+  return dedupeBy(imports, (item) => `${item.moduleSpecifier}:${item.importedSymbols?.join(",") ?? ""}:${item.loc?.startLine ?? ""}`).slice(0, 24);
 }
 
 function collectModuleDeclarations(sourceFile: ts.SourceFile): NonNullable<NonNullable<ExtractionResult["structure"]>["moduleDeclarations"]> {
@@ -704,6 +736,7 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
   const contract = getPropsInfo(sourceFile, componentName);
   const style = detectStyleSystem(sourceFile);
   const behaviorStructure = collectBehaviorAndStructure(sourceFile);
+  const imports = collectImports(sourceFile);
   const importCount = sourceFile.statements.filter(ts.isImportDeclaration).length;
   const moduleDeclarations = language === "ts" || language === "js"
     ? collectModuleDeclarations(sourceFile)
@@ -727,10 +760,11 @@ export function extractSource(filePath: string, sourceText: string): ExtractionR
       generatedAt: new Date().toISOString(),
     },
   };
-  if (moduleDeclarations.length > 0) {
+  if (moduleDeclarations.length > 0 || imports.length > 0) {
     base.structure = {
       ...base.structure,
-      moduleDeclarations,
+      ...(moduleDeclarations.length > 0 ? { moduleDeclarations } : {}),
+      ...(imports.length > 0 ? { imports } : {}),
     };
   }
 

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -6,6 +6,7 @@ import {
   type ReactWebContextA11yAnchor,
   type ReactWebContextEditTargetRoute,
   type ReactWebContextFormStateFlowEntry,
+  type ReactWebContextImportRoleHint,
   type ReactWebContextIntentTarget,
   type ReactWebContextLocalDependency,
   type ReactWebContextMetadataV0,
@@ -19,6 +20,7 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   renderStates: 12,
   a11yAnchors: 16,
   localDependencies: 12,
+  importRoleHints: 12,
   intentTargets: 16,
   editTargetRouting: 8,
   formStateFlow: 10,
@@ -230,6 +232,60 @@ function buildLocalDependencies(result: ExtractionResult): ReactWebContextLocalD
   }
 
   return dedupeBy(dependencies, (item) => `${item.kind}:${item.symbol}:${item.loc?.startLine ?? ""}`);
+}
+
+function importRoleFor(moduleSpecifier: string, importedSymbols: string[] = []): ReactWebContextImportRoleHint["role"] | undefined {
+  if (moduleSpecifier === "react-hook-form" || moduleSpecifier.startsWith("@hookform/")) return "form-library";
+  if (["zod", "yup", "valibot", "joi", "superstruct", "arktype"].includes(moduleSpecifier)) return "validation-library";
+  if (
+    moduleSpecifier === "next/link" ||
+    moduleSpecifier === "next/navigation" ||
+    moduleSpecifier === "react-router" ||
+    moduleSpecifier === "react-router-dom" ||
+    moduleSpecifier === "@remix-run/react"
+  ) {
+    return "routing";
+  }
+  if (
+    moduleSpecifier.startsWith("@/components/ui") ||
+    moduleSpecifier.includes("/components/ui/") ||
+    moduleSpecifier.startsWith("@radix-ui/") ||
+    moduleSpecifier.startsWith("@mui/") ||
+    moduleSpecifier.startsWith("@chakra-ui/") ||
+    moduleSpecifier === "antd"
+  ) {
+    return "ui-kit";
+  }
+  if (
+    moduleSpecifier === "lucide-react" ||
+    moduleSpecifier.startsWith("react-icons/") ||
+    moduleSpecifier.startsWith("@heroicons/react")
+  ) {
+    return "icon-library";
+  }
+  if (moduleSpecifier.startsWith(".")) {
+    const hasComponentSymbol = importedSymbols.some((symbol) => /^[A-Z]/.test(symbol) && !/(?:Props|Type|Types|Config|Options)$/.test(symbol));
+    if (hasComponentSymbol) return "local-component";
+  }
+  return undefined;
+}
+
+function buildImportRoleHints(result: ExtractionResult): ReactWebContextImportRoleHint[] {
+  const hints: ReactWebContextImportRoleHint[] = [];
+
+  for (const importSignal of result.structure?.imports ?? []) {
+    const role = importRoleFor(importSignal.moduleSpecifier, importSignal.importedSymbols ?? []);
+    if (!role) continue;
+    hints.push({
+      role,
+      moduleSpecifier: importSignal.moduleSpecifier,
+      ...(importSignal.importedSymbols && importSignal.importedSymbols.length > 0 ? { importedSymbols: importSignal.importedSymbols } : {}),
+      ...(importSignal.loc ? { loc: importSignal.loc } : {}),
+      evidence: ["structure.imports"],
+    });
+  }
+
+  return dedupeBy(hints, (item) => `${item.role}:${item.moduleSpecifier}:${item.importedSymbols?.join(",") ?? ""}`);
 }
 
 function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextIntentTarget["intent"] | undefined {
@@ -539,6 +595,7 @@ export function buildReactWebContextMetadata(
   const renderStates = pruneArray(buildRenderStates(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.renderStates);
   const a11yAnchors = pruneArray(buildA11yAnchors(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.a11yAnchors);
   const localDependencies = pruneArray(buildLocalDependencies(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.localDependencies);
+  const importRoleHints = pruneArray(buildImportRoleHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.importRoleHints);
   const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
   const editTargetRouting = pruneArray(
     buildEditTargetRouting(result, editGuidance),
@@ -546,7 +603,7 @@ export function buildReactWebContextMetadata(
   );
   const formStateFlow = pruneArray(buildFormStateFlow(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.formStateFlow);
 
-  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || intentTargets || editTargetRouting || formStateFlow);
+  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || importRoleHints || intentTargets || editTargetRouting || formStateFlow);
   if (!hasContext) return undefined;
 
   return {
@@ -562,6 +619,7 @@ export function buildReactWebContextMetadata(
     ...(renderStates ? { renderStates } : {}),
     ...(a11yAnchors ? { a11yAnchors } : {}),
     ...(localDependencies ? { localDependencies } : {}),
+    ...(importRoleHints ? { importRoleHints } : {}),
     ...(intentTargets ? { intentTargets } : {}),
     ...(editTargetRouting ? { editTargetRouting } : {}),
     ...(formStateFlow ? { formStateFlow } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -78,6 +78,12 @@ export type ModuleDeclarationSignal = LocatedString & {
   exported?: boolean;
 };
 
+export type ImportSignal = {
+  moduleSpecifier: string;
+  importedSymbols?: string[];
+  loc?: SourceRange;
+};
+
 export type PatchTargetKind =
   | "component"
   | "props"
@@ -140,6 +146,14 @@ export type ReactWebContextLocalDependency = {
   kind: "local-declaration";
   loc?: SourceRange;
   usedBy?: string[];
+};
+
+export type ReactWebContextImportRoleHint = {
+  role: "form-library" | "validation-library" | "routing" | "ui-kit" | "icon-library" | "local-component";
+  moduleSpecifier: string;
+  importedSymbols?: string[];
+  loc?: SourceRange;
+  evidence: string[];
 };
 
 export type ReactWebContextIntentTarget = {
@@ -211,6 +225,7 @@ export type ReactWebContextMetadataV0 = {
   renderStates?: ReactWebContextRenderState[];
   a11yAnchors?: ReactWebContextA11yAnchor[];
   localDependencies?: ReactWebContextLocalDependency[];
+  importRoleHints?: ReactWebContextImportRoleHint[];
   intentTargets?: ReactWebContextIntentTarget[];
   editTargetRouting?: ReactWebContextEditTargetRoute[];
   formStateFlow?: ReactWebContextFormStateFlowEntry[];
@@ -255,6 +270,7 @@ export type ExtractionResult = {
     repeatedBlocks?: string[];
     jsxDepth?: number;
     moduleDeclarations?: ModuleDeclarationSignal[];
+    imports?: ImportSignal[];
   };
   style?: {
     system?: StyleSystem;
@@ -307,6 +323,7 @@ export type ModelFacingPayload = {
     repeatedBlocks?: string[];
     jsxDepth?: number;
     moduleDeclarations?: ModuleDeclarationSignal[];
+    imports?: ImportSignal[];
   };
   style?: {
     system?: StyleSystem;

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -421,6 +421,121 @@ test("React Web formStateFlow does not link hooks from uncontrolled name or id t
   );
 });
 
+
+test("React Web import role hints summarize source-only dependency roles", () => {
+  const source = `
+    import React from "react";
+    import { useForm } from "react-hook-form";
+    import { z } from "zod";
+    import Link from "next/link";
+    import { Button } from "@/components/ui/button";
+    import { Mail } from "lucide-react";
+    import FieldShell from "./FieldShell";
+    import { format } from "date-fns";
+
+    type ImportRolePanelProps = { email: string };
+
+    export function ImportRolePanel({ email }: ImportRolePanelProps) {
+      const form = useForm();
+      const schema = z.object({ email: z.string() });
+      return (
+        <FieldShell className="grid gap-3 rounded-lg border p-4">
+          <Button type="button" className="inline-flex items-center gap-2">
+            <Mail aria-hidden="true" />
+            {email}
+          </Button>
+          <Link href="/settings" className="text-sm underline">Settings</Link>
+          <p className="text-xs text-slate-500">{format(new Date(), "yyyy-MM-dd")}</p>
+          <p className="text-xs text-slate-500">Import role hints are source facts only, not runtime library behavior.</p>
+          <p className="text-xs text-slate-500">This fixture is intentionally long enough for compressed metadata.</p>
+        </FieldShell>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "ImportRolePanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  assert.deepEqual(
+    payload.reactWebContext.importRoleHints.map((item) => ({
+      role: item.role,
+      moduleSpecifier: item.moduleSpecifier,
+      importedSymbols: item.importedSymbols,
+      evidence: item.evidence,
+    })),
+    [
+      {
+        role: "form-library",
+        moduleSpecifier: "react-hook-form",
+        importedSymbols: ["useForm"],
+        evidence: ["structure.imports"],
+      },
+      {
+        role: "validation-library",
+        moduleSpecifier: "zod",
+        importedSymbols: ["z"],
+        evidence: ["structure.imports"],
+      },
+      {
+        role: "routing",
+        moduleSpecifier: "next/link",
+        importedSymbols: ["Link"],
+        evidence: ["structure.imports"],
+      },
+      {
+        role: "ui-kit",
+        moduleSpecifier: "@/components/ui/button",
+        importedSymbols: ["Button"],
+        evidence: ["structure.imports"],
+      },
+      {
+        role: "icon-library",
+        moduleSpecifier: "lucide-react",
+        importedSymbols: ["Mail"],
+        evidence: ["structure.imports"],
+      },
+      {
+        role: "local-component",
+        moduleSpecifier: "./FieldShell",
+        importedSymbols: ["FieldShell"],
+        evidence: ["structure.imports"],
+      },
+    ],
+  );
+  assert.equal(
+    payload.reactWebContext.importRoleHints.some((item) => item.moduleSpecifier === "date-fns"),
+    false,
+  );
+});
+
+test("React Web import role hints are omitted without recognized source evidence", () => {
+  const source = `
+    import React from "react";
+    import { format } from "date-fns";
+
+    export function UnknownImportPanel() {
+      return (
+        <section className="grid gap-3 rounded-lg border p-4">
+          <p className="text-xs text-slate-500">{format(new Date(), "yyyy-MM-dd")}</p>
+          <p className="text-xs text-slate-500">Unknown imports should not become guessed dependency role hints.</p>
+          <p className="text-xs text-slate-500">This fixture is intentionally long enough for compressed metadata.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "UnknownImportPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  assert.equal("importRoleHints" in payload.reactWebContext, false);
+});
+
 test("React Web opt-in emits source-observed role aria and readOnly anchors", () => {
   const source = `
     import React from "react";


### PR DESCRIPTION
## Summary
- add source-derived `structure.imports` signals from TS/TSX import declarations
- expose opt-in `reactWebContext.importRoleHints` for source-only import roles: form, validation, routing, UI kit, icon, and local component imports
- keep unknown imports omitted and avoid dependency graph/runtime semantics claims

## Boundaries
- Source-only: module specifier + imported symbols + import source range evidence.
- No package install/version/license/security checks.
- No cross-file usage resolution or runtime/library behavior inference.
- Local component role is intentionally conservative: relative imports need component-like imported symbols and type/helper suffixes are excluded.

## Tests
- `npm run build`
- `node --test test/react-web-context-metadata.test.mjs` (18 pass)
- `node --test test/pre-read-payload-builder.test.mjs` (3 pass)
- `npm test` (456 pass)
- `git diff --check`
