### PR TITLE
Harden RN boundary reuse before positive expansion

### DIFF
--- a/test/payload-policy-fallback.test.mjs
+++ b/test/payload-policy-fallback.test.mjs
@@ -62,6 +62,25 @@ test("fallback payload policy returns denied boundary decision for mixed fronten
   assert.deepEqual(assessFallbackPayloadPolicy(domainDetection), expectedMixedPolicy(domainDetection.reason));
 });
 
+test("fallback payload policy keeps RN and WebView mixed evidence fallback-only", () => {
+  const filePath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "negative-rn-webview-boundary.tsx");
+  const domainDetection = detectDomainFromSource(fs.readFileSync(filePath, "utf8"), filePath);
+  const preReadDecision = preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: true });
+
+  assert.equal(domainDetection.classification, "mixed");
+  assert.equal(domainDetection.reason, preRead.REACT_NATIVE_WEBVIEW_BOUNDARY_REASON);
+  assert.ok(domainDetection.signals.some((signal) => signal.startsWith("react-native:")));
+  assert.ok(domainDetection.signals.some((signal) => signal.startsWith("webview:")));
+  assert.deepEqual(assessFallbackPayloadPolicy(domainDetection), expectedMixedPolicy(domainDetection.reason));
+  assert.equal(preReadDecision.decision, "fallback");
+  assert.deepEqual(preReadDecision.reasons, [preRead.REACT_NATIVE_WEBVIEW_BOUNDARY_REASON]);
+  assert.equal(preReadDecision.fallback.reason, preRead.REACT_NATIVE_WEBVIEW_BOUNDARY_REASON);
+  assert.equal(preReadDecision.debug.domainDetection.classification, "mixed");
+  assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, false);
+  assert.equal("payload" in preReadDecision, false);
+  assert.equal("readiness" in preReadDecision, false);
+});
+
 test("fallback payload policy returns denied deferred decision for unknown domains", () => {
   const domainDetection = detect(unknownTsxSource(), "PlainUnknown.tsx");
 

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -146,6 +146,21 @@ test("frontend profile gate rejects adversarial RN narrow payload contract and f
       stale.domainPayload.reuseContract.requiredSignals = stale.domainPayload.reuseContract.requiredSignals.slice(1);
       return stale;
     }],
+    ["missing denied signal in reuse contract", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.reuseContract.deniedBySignals = stale.domainPayload.reuseContract.deniedBySignals.slice(1);
+      return stale;
+    }],
+    ["wrong reuse contract freshness source", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.reuseContract.freshnessSource = "mtime";
+      return stale;
+    }],
+    ["wrong reuse contract support boundary", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.reuseContract.supportBoundary = "react-native-supported";
+      return stale;
+    }],
     ["missing source fingerprint", () => {
       const stale = clonePayload(payload);
       delete stale.sourceFingerprint;

--- a/test/pre-read-phase-order-regression.test.mjs
+++ b/test/pre-read-phase-order-regression.test.mjs
@@ -218,6 +218,22 @@ test("cached RN narrow payload cannot cross live frontend domain and profile bou
       expectedPolicyAllowed: false,
       expectedReason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
     },
+    {
+      label: "live WebView boundary keeps source-reading fallback ahead of cached RN payload",
+      filePath: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "webview-boundary-basic.tsx"),
+      expectedClassification: "webview",
+      expectedPolicyName: "webview-boundary-fallback",
+      expectedPolicyAllowed: false,
+      expectedReason: "unsupported-react-native-webview-boundary",
+    },
+    {
+      label: "live RN/WebView mixed boundary keeps source-reading fallback ahead of cached RN payload",
+      filePath: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "negative-rn-webview-boundary.tsx"),
+      expectedClassification: "mixed",
+      expectedPolicyName: "webview-boundary-fallback",
+      expectedPolicyAllowed: false,
+      expectedReason: "unsupported-react-native-webview-boundary",
+    },
   ];
 
   for (const {


### PR DESCRIPTION
## Summary
- Harden RN+WebView mixed fallback-only behavior so mixed evidence never exposes payload/readiness artifacts.
- Add adversarial RN reuse-contract checks for denied signals, freshness source, and support-boundary drift.
- Extend stale RN cached payload regression coverage so live WebView/mixed fallback boundaries stay authoritative.

## Boundaries
- Test-only hardening; no production behavior changes.
- No RN positive fixture expansion.
- No detector rewrite, WebView/TUI behavior change, schema migration, or support/performance/token/cost claims.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/pre-read-phase-order-regression.test.mjs test/payload-policy-fallback.test.mjs test/payload-policy-registry.test.mjs test/runtime-bridge-contract.test.mjs` — 41 pass
- `git diff --check`
- `npm test` — 458 pass
