### PR TITLE
Prove React Web runtime context with host-facing bytes

### DIFF
--- a/scripts/react-web-context-evidence.mjs
+++ b/scripts/react-web-context-evidence.mjs
@@ -71,6 +71,8 @@ export async function measureReactWebFixture({ repoRoot = defaultRepoRoot, relat
   const domainPayload = payload?.domainPayload ?? null;
   const sourceBytes = byteLength(source);
   const runtimePayloadBytes = payload ? byteLength(JSON.stringify(payload)) : 0;
+  const additionalContext = typeof second.additionalContext === "string" ? second.additionalContext : "";
+  const additionalContextBytes = byteLength(additionalContext);
   const domainPayloadBytes = domainPayload ? byteLength(JSON.stringify(domainPayload)) : 0;
 
   return {
@@ -81,10 +83,13 @@ export async function measureReactWebFixture({ repoRoot = defaultRepoRoot, relat
     classification: second.debug?.decision?.debug?.domainDetection?.classification ?? null,
     sourceBytes,
     runtimePayloadBytes,
+    additionalContextBytes,
     domainPayloadBytes,
     runtimePayloadReductionPct: percentReduction(sourceBytes, runtimePayloadBytes),
+    additionalContextReductionPct: percentReduction(sourceBytes, additionalContextBytes),
     domainPayloadReductionPct: percentReduction(sourceBytes, domainPayloadBytes),
     runtimePayloadLargerThanSource: runtimePayloadBytes > sourceBytes,
+    additionalContextLargerThanSource: additionalContextBytes > sourceBytes,
     domainPayloadLargerThanSource: domainPayloadBytes > sourceBytes,
     claimBoundary: domainPayload?.claimBoundary ?? null,
     claimStatus: domainPayload?.claimStatus ?? null,
@@ -96,6 +101,7 @@ export async function buildReactWebContextEvidence({
   fixtures = DEFAULT_REACT_WEB_EVIDENCE_FIXTURES,
   runId = new Date().toISOString().replace(/[:.]/g, "-"),
 } = {}) {
+  cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-${runId}-`);
   const rows = [];
   for (const relativeFile of fixtures) {
     rows.push(await measureReactWebFixture({ repoRoot, relativeFile, runId }));
@@ -105,29 +111,41 @@ export async function buildReactWebContextEvidence({
   const domainReductionValues = rows.map((row) => row.domainPayloadReductionPct);
   const runtimeReductionValues = rows.map((row) => row.runtimePayloadReductionPct);
   const allDomainPayloadsSmaller = rows.every((row) => row.secondAction === "inject" && row.classification === "react-web" && !row.domainPayloadLargerThanSource);
+  const additionalContextReductionValues = rows.map((row) => row.additionalContextReductionPct);
   const allRuntimePayloadsSmaller = rows.every((row) => row.secondAction === "inject" && !row.runtimePayloadLargerThanSource);
+  const allAdditionalContextsSmaller = rows.every((row) => row.secondAction === "inject" && !row.additionalContextLargerThanSource);
 
   return {
-    schemaVersion: "react-web-context-evidence.v1",
+    schemaVersion: "react-web-context-evidence.v2",
     generatedAt: new Date().toISOString(),
     runId,
-    measurement: "local-source-bytes-vs-runtime-json-bytes",
+    measurement: "local-source-bytes-vs-host-facing-additional-context-bytes",
     claimBoundary:
-      "Local fixture byte-size evidence only: source-derived React Web domainPayload compactness, not provider tokenizer output, not runtime-token savings, not cache performance, not latency, and not provider billing or invoice savings.",
+      "Local fixture byte-size evidence only: actual host-facing additionalContext compactness for React Web current-lane reuse; domainPayload is diagnostic-only. This is not provider tokenizer output, not runtime-token savings, not cache performance, not latency, and not provider billing or invoice savings.",
     fixtures: rows,
     summary: {
       fixtureCount: rows.length,
       allReactWebInjects: rows.every((row) => row.firstAction === "record" && row.secondAction === "inject" && row.classification === "react-web"),
+      actualInjectedContextReduction: {
+        claimable: allAdditionalContextsSmaller,
+        minPct: Math.min(...additionalContextReductionValues),
+        maxPct: Math.max(...additionalContextReductionValues),
+        blocker: allAdditionalContextsSmaller
+          ? null
+          : "actual host-facing additionalContext is not smaller than source for every fixture",
+      },
       domainPayloadReduction: {
         claimable: allDomainPayloadsSmaller,
+        diagnosticOnly: true,
         minPct: Math.min(...domainReductionValues),
         maxPct: Math.max(...domainReductionValues),
       },
       fullRuntimePayloadReduction: {
         claimable: allRuntimePayloadsSmaller,
+        diagnosticOnly: true,
         minPct: Math.min(...runtimeReductionValues),
         maxPct: Math.max(...runtimeReductionValues),
-        blocker: allRuntimePayloadsSmaller ? null : "full runtime payload includes envelope/extraction fields and is not smaller than source for every fixture",
+        blocker: allRuntimePayloadsSmaller ? null : "internal runtime payload JSON includes envelope/extraction fields and is not smaller than source for every fixture",
       },
       cachePerformanceImprovement: {
         claimable: false,
@@ -145,7 +163,7 @@ export function renderReactWebContextEvidenceMarkdown(evidence) {
   const rows = evidence.fixtures
     .map(
       (row) =>
-        `| \`${row.file}\` | ${row.sourceBytes} | ${row.domainPayloadBytes} | ${row.domainPayloadReductionPct}% | ${row.runtimePayloadBytes} | ${row.runtimePayloadReductionPct}% |`,
+        `| \`${row.file}\` | ${row.sourceBytes} | ${row.additionalContextBytes} | ${row.additionalContextReductionPct}% | ${row.domainPayloadBytes} | ${row.domainPayloadReductionPct}% | ${row.runtimePayloadBytes} | ${row.runtimePayloadReductionPct}% |`,
     )
     .join("\n");
 
@@ -156,20 +174,21 @@ ${evidence.claimBoundary}
 ## Summary
 
 - React Web repeated same-file injects observed: ${evidence.summary.allReactWebInjects ? "yes" : "no"}
-- Domain payload reduction claimable: ${evidence.summary.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.summary.domainPayloadReduction.minPct}% to ${evidence.summary.domainPayloadReduction.maxPct}% local byte reduction)
-- Full runtime payload reduction claimable: ${evidence.summary.fullRuntimePayloadReduction.claimable ? "yes" : "no"}
+- Actual injected context reduction claimable: ${evidence.summary.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.summary.actualInjectedContextReduction.minPct}% to ${evidence.summary.actualInjectedContextReduction.maxPct}% local byte reduction)
+- Domain payload reduction diagnostic-only: ${evidence.summary.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.summary.domainPayloadReduction.minPct}% to ${evidence.summary.domainPayloadReduction.maxPct}% local byte reduction)
+- Internal runtime payload reduction diagnostic-only: ${evidence.summary.fullRuntimePayloadReduction.claimable ? "yes" : "no"}
 - Cache performance improvement claimable: no
 - Provider billing savings claimable: no
 
 ## Fixture measurements
 
-| Fixture | Source bytes | domainPayload bytes | domainPayload reduction | full runtime payload bytes | full runtime payload reduction |
-| --- | ---: | ---: | ---: | ---: | ---: |
+| Fixture | Source bytes | actual additionalContext bytes | actual additionalContext reduction | diagnostic domainPayload bytes | diagnostic domainPayload reduction | diagnostic runtime payload bytes | diagnostic runtime payload reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${rows}
 
 ## Claim boundary
 
-This artifact supports a bounded statement that React Web same-file reuse can carry a smaller source-derived domainPayload. It does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims.
+This artifact supports bounded statements only when actual host-facing additionalContext is smaller than source for the measured React Web current-lane fixtures. The source-derived domainPayload metric is diagnostic-only. It does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims.
 `;
 }
 

--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -13,12 +13,12 @@ function finite(value) {
 }
 
 function claimLine(contextEvidence, reuseEvidence) {
-  const min = contextEvidence.summary.domainPayloadReduction.minPct;
-  const max = contextEvidence.summary.domainPayloadReduction.maxPct;
-  if (!contextEvidence.summary.domainPayloadReduction.claimable || !reuseEvidence.summary.reuseCorrectnessClaimable) {
-    return "React Web evidence is present, but release wording must stay diagnostic until all claimability gates pass.";
+  const min = contextEvidence.summary.actualInjectedContextReduction.minPct;
+  const max = contextEvidence.summary.actualInjectedContextReduction.maxPct;
+  if (!contextEvidence.summary.actualInjectedContextReduction.claimable || !reuseEvidence.summary.reuseCorrectnessClaimable) {
+    return "React Web evidence is present, but npm wording must stay diagnostic until actual injected context and reuse-correctness gates pass.";
   }
-  return `React Web same-file reuse is routed correctly, and current-lane fixtures show ${min}% to ${max}% smaller source-derived domainPayloads in local byte-size evidence.`;
+  return `React Web same-file reuse is routed correctly, and current-lane fixtures show ${min}% to ${max}% smaller actual injected additionalContext by local byte-size evidence.`;
 }
 
 export async function buildReleaseBenchmarkEvidence({
@@ -29,19 +29,26 @@ export async function buildReleaseBenchmarkEvidence({
   const reuseEvidence = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
 
   const releaseClaims = {
-    npmUpdateClaimable: contextEvidence.summary.domainPayloadReduction.claimable && reuseEvidence.summary.reuseCorrectnessClaimable,
+    npmUpdateClaimable: contextEvidence.summary.actualInjectedContextReduction.claimable && reuseEvidence.summary.reuseCorrectnessClaimable,
     headline: claimLine(contextEvidence, reuseEvidence),
     allowed: [
       "React Web same-file reuse routes record -> inject for current-lane fixtures.",
       "React Web source changes refresh before attach and do not reuse stale fingerprints.",
-      `React Web current-lane fixtures show ${contextEvidence.summary.domainPayloadReduction.minPct}% to ${contextEvidence.summary.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads by local byte-size measurement.`,
+      ...(contextEvidence.summary.actualInjectedContextReduction.claimable
+        ? [
+            `React Web current-lane fixtures show ${contextEvidence.summary.actualInjectedContextReduction.minPct}% to ${contextEvidence.summary.actualInjectedContextReduction.maxPct}% smaller actual injected additionalContext by local byte-size measurement.`,
+          ]
+        : [
+            "React Web current-lane actual injected additionalContext evidence is diagnostic-only until all fixtures are smaller than source.",
+          ]),
       "RN and WebView boundaries fall back instead of becoming React Web payload support.",
     ],
     forbidden: [
       "Caching performance improved.",
       "Runtime-token savings are proven.",
       "Provider cost or billing is reduced.",
-      "Full runtime payloads are always smaller than source.",
+      "Actual injected runtime context is always smaller than source without fixture evidence.",
+      "Diagnostic domainPayload reduction proves runtime-token savings.",
       "Broad React Web, React Native, or WebView support is available.",
     ],
   };
@@ -58,8 +65,15 @@ export async function buildReleaseBenchmarkEvidence({
       schemaVersion: contextEvidence.schemaVersion,
       fixtureCount: contextEvidence.summary.fixtureCount,
       allReactWebInjects: contextEvidence.summary.allReactWebInjects,
+      actualInjectedContextReduction: {
+        claimable: contextEvidence.summary.actualInjectedContextReduction.claimable,
+        minPct: finite(contextEvidence.summary.actualInjectedContextReduction.minPct),
+        maxPct: finite(contextEvidence.summary.actualInjectedContextReduction.maxPct),
+        blocker: contextEvidence.summary.actualInjectedContextReduction.blocker,
+      },
       domainPayloadReduction: {
         claimable: contextEvidence.summary.domainPayloadReduction.claimable,
+        diagnosticOnly: true,
         minPct: finite(contextEvidence.summary.domainPayloadReduction.minPct),
         maxPct: finite(contextEvidence.summary.domainPayloadReduction.maxPct),
       },
@@ -72,6 +86,8 @@ export async function buildReleaseBenchmarkEvidence({
       fixtures: contextEvidence.fixtures.map((row) => ({
         file: row.file,
         sourceBytes: row.sourceBytes,
+        additionalContextBytes: row.additionalContextBytes,
+        additionalContextReductionPct: row.additionalContextReductionPct,
         domainPayloadBytes: row.domainPayloadBytes,
         domainPayloadReductionPct: row.domainPayloadReductionPct,
         runtimePayloadBytes: row.runtimePayloadBytes,
@@ -106,7 +122,7 @@ export function renderReleaseBenchmarkEvidenceMarkdown(evidence) {
   const fixtureRows = evidence.context.fixtures
     .map(
       (row) =>
-        `| \`${row.file}\` | ${row.sourceBytes} | ${row.domainPayloadBytes} | ${row.domainPayloadReductionPct}% | ${row.runtimePayloadBytes} | ${row.runtimePayloadReductionPct}% |`,
+        `| \`${row.file}\` | ${row.sourceBytes} | ${row.additionalContextBytes} | ${row.additionalContextReductionPct}% | ${row.domainPayloadBytes} | ${row.domainPayloadReductionPct}% | ${row.runtimePayloadBytes} | ${row.runtimePayloadReductionPct}% |`,
     )
     .join("\n");
 
@@ -121,13 +137,14 @@ ${evidence.releaseClaims.headline}
 ## Claimable for this npm update
 
 - npm update wording claimable: ${evidence.releaseClaims.npmUpdateClaimable ? "yes" : "no"}
-- React Web context reduction: ${evidence.context.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.context.domainPayloadReduction.minPct}% to ${evidence.context.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads)
+- React Web actual injected context reduction: ${evidence.context.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.context.actualInjectedContextReduction.minPct}% to ${evidence.context.actualInjectedContextReduction.maxPct}% smaller actual additionalContext)
+- React Web domainPayload reduction diagnostic-only: ${evidence.context.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.context.domainPayloadReduction.minPct}% to ${evidence.context.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads)
 - React Web reuse correctness: ${evidence.reuse.reuseCorrectnessClaimable ? "yes" : "no"}
 
 ## Fixture context-size measurements
 
-| Fixture | Source bytes | domainPayload bytes | domainPayload reduction | full runtime payload bytes | full runtime payload reduction |
-| --- | ---: | ---: | ---: | ---: | ---: |
+| Fixture | Source bytes | actual additionalContext bytes | actual additionalContext reduction | diagnostic domainPayload bytes | diagnostic domainPayload reduction | diagnostic runtime payload bytes | diagnostic runtime payload reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${fixtureRows}
 
 ## Reuse-correctness checks
@@ -142,7 +159,8 @@ ${fixtureRows}
 - Cache performance improvement: no
 - Runtime-token savings: no
 - Provider billing/cost savings: no
-- Full runtime payloads always smaller than source: no
+- Actual injected runtime context always smaller than source without fixture evidence: no
+- Diagnostic domainPayload reduction proves runtime-token savings: no
 - Broad React Web/RN/WebView support: no
 `;
 }

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -41,11 +41,37 @@ function payloadContextModeReason(
     : `${phase}-exact-file-narrow-payload`;
 }
 
+function buildRuntimeContextPayload(payload: ModelFacingPayload): { optimized: boolean; payload: unknown } {
+  if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
+    const reactWebContext = payload.reactWebContext
+      ? {
+          schemaVersion: payload.reactWebContext.schemaVersion,
+          freshness: payload.reactWebContext.freshness,
+          scope: {
+            kind: payload.reactWebContext.scope.kind,
+            filePath: payload.reactWebContext.scope.filePath,
+            componentName: payload.reactWebContext.scope.componentName,
+          },
+        }
+      : undefined;
+    return {
+      optimized: true,
+      payload: {
+        filePath: payload.filePath,
+        sourceFingerprint: payload.sourceFingerprint,
+        domainPayload: payload.domainPayload,
+        ...(reactWebContext ? { reactWebContext } : {}),
+      },
+    };
+  }
+  return { optimized: false, payload };
+}
+
 function buildAdditionalContext(filePath: string, payload: ModelFacingPayload, contextMode: ContextMode): string {
+  const runtimeContextPayload = buildRuntimeContextPayload(payload);
   return [
     `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · context-mode: ${contextMode}`,
-    "",
-    JSON.stringify(payload, null, 2),
+    JSON.stringify(runtimeContextPayload.payload, null, runtimeContextPayload.optimized ? undefined : 2),
   ].join("\n");
 }
 

--- a/test/react-web-context-evidence.test.mjs
+++ b/test/react-web-context-evidence.test.mjs
@@ -5,11 +5,11 @@ import {
   renderReactWebContextEvidenceMarkdown,
 } from "../scripts/react-web-context-evidence.mjs";
 
-test("React Web context evidence proves bounded domainPayload reduction without broad savings claims", async () => {
-  const evidence = await buildReactWebContextEvidence({ runId: "test" });
+test("React Web context evidence measures actual injected additionalContext without broad savings claims", async () => {
+  const evidence = await buildReactWebContextEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-web-context-evidence.v1");
-  assert.equal(evidence.measurement, "local-source-bytes-vs-runtime-json-bytes");
+  assert.equal(evidence.schemaVersion, "react-web-context-evidence.v2");
+  assert.equal(evidence.measurement, "local-source-bytes-vs-host-facing-additional-context-bytes");
   assert.match(evidence.claimBoundary, /not provider tokenizer output/);
   assert.match(evidence.claimBoundary, /not runtime-token savings/);
   assert.match(evidence.claimBoundary, /not cache performance/);
@@ -17,7 +17,21 @@ test("React Web context evidence proves bounded domainPayload reduction without 
 
   assert.equal(evidence.summary.fixtureCount, 5);
   assert.equal(evidence.summary.allReactWebInjects, true);
+  assert.equal(evidence.summary.actualInjectedContextReduction.claimable, true);
+  assert.equal(evidence.summary.actualInjectedContextReduction.blocker, null);
+  assert.ok(evidence.summary.actualInjectedContextReduction.minPct > 0);
+  assert.ok(evidence.summary.actualInjectedContextReduction.maxPct > 70);
+  assert.ok(
+    evidence.fixtures.every((row) => !row.additionalContextLargerThanSource),
+    "optimized host-facing additionalContext should be smaller than source for every measured fixture",
+  );
+  assert.ok(
+    evidence.fixtures.some((row) => row.additionalContextBytes < row.runtimePayloadBytes),
+    "actual injected context should use the optimized runtime envelope rather than full internal payload JSON",
+  );
+
   assert.equal(evidence.summary.domainPayloadReduction.claimable, true);
+  assert.equal(evidence.summary.domainPayloadReduction.diagnosticOnly, true);
   assert.ok(evidence.summary.domainPayloadReduction.minPct > 25);
 
   assert.equal(evidence.summary.fullRuntimePayloadReduction.claimable, false);
@@ -41,6 +55,8 @@ test("React Web context evidence proves bounded domainPayload reduction without 
     assert.equal(row.secondAction, "inject");
     assert.equal(row.decision, "payload");
     assert.equal(row.classification, "react-web");
+    assert.ok(row.additionalContextBytes > 0);
+    assert.equal(typeof row.additionalContextReductionPct, "number");
     assert.equal(row.domainPayloadLargerThanSource, false);
     assert.equal(row.claimBoundary, "react-web-measured-extraction");
     assert.equal(row.claimStatus, "current-supported-lane");
@@ -48,13 +64,15 @@ test("React Web context evidence proves bounded domainPayload reduction without 
 });
 
 test("React Web context evidence Markdown keeps the public claim boundary explicit", async () => {
-  const evidence = await buildReactWebContextEvidence({ runId: "markdown-test" });
+  const evidence = await buildReactWebContextEvidence({ runId: `markdown-test-${Date.now()}-${Math.random()}` });
   const markdown = renderReactWebContextEvidenceMarkdown(evidence);
 
-  assert.match(markdown, /Domain payload reduction claimable: yes/);
-  assert.match(markdown, /Full runtime payload reduction claimable: no/);
+  assert.match(markdown, /Actual injected context reduction claimable: yes/);
+  assert.match(markdown, /Domain payload reduction diagnostic-only: yes/);
+  assert.match(markdown, /Internal runtime payload reduction diagnostic-only: no/);
   assert.match(markdown, /Cache performance improvement claimable: no/);
   assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /domainPayload metric is diagnostic-only/);
   assert.match(markdown, /does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims/);
   assert.doesNotMatch(markdown, /provider billing savings claimable: yes/i);
   assert.doesNotMatch(markdown, /cache performance improvement claimable: yes/i);

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -5,8 +5,8 @@ import {
   renderReleaseBenchmarkEvidenceMarkdown,
 } from "../scripts/release-benchmark-evidence.mjs";
 
-test("release benchmark evidence combines context reduction and reuse correctness for npm wording", async () => {
-  const evidence = await buildReleaseBenchmarkEvidence({ runId: "test" });
+test("release benchmark evidence gates npm wording on actual injected context and reuse correctness", async () => {
+  const evidence = await buildReleaseBenchmarkEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
   assert.equal(evidence.schemaVersion, "release-benchmark-evidence.v1");
   assert.equal(evidence.measurement, "release-facing-local-evidence-summary");
@@ -18,10 +18,18 @@ test("release benchmark evidence combines context reduction and reuse correctnes
 
   assert.equal(evidence.releaseClaims.npmUpdateClaimable, true);
   assert.match(evidence.releaseClaims.headline, /React Web same-file reuse is routed correctly/);
-  assert.match(evidence.releaseClaims.headline, /30\.\d+% to 77\.\d+% smaller source-derived domainPayloads/);
+  assert.match(evidence.releaseClaims.headline, /smaller actual injected additionalContext/);
+  assert.ok(
+    evidence.releaseClaims.allowed.some((claim) => /smaller actual injected additionalContext/.test(claim)),
+  );
 
   assert.equal(evidence.context.allReactWebInjects, true);
+  assert.equal(evidence.context.actualInjectedContextReduction.claimable, true);
+  assert.equal(evidence.context.actualInjectedContextReduction.blocker, null);
+  assert.ok(evidence.context.actualInjectedContextReduction.minPct > 0);
+  assert.ok(evidence.context.actualInjectedContextReduction.maxPct > 70);
   assert.equal(evidence.context.domainPayloadReduction.claimable, true);
+  assert.equal(evidence.context.domainPayloadReduction.diagnosticOnly, true);
   assert.ok(evidence.context.domainPayloadReduction.minPct > 30);
   assert.ok(evidence.context.domainPayloadReduction.maxPct > 70);
   assert.equal(evidence.context.fullRuntimePayloadReduction.claimable, false);
@@ -40,20 +48,23 @@ test("release benchmark evidence combines context reduction and reuse correctnes
   assert.equal(evidence.nonClaims.providerBillingSavings.claimable, false);
   assert.ok(evidence.releaseClaims.forbidden.includes("Caching performance improved."));
   assert.ok(evidence.releaseClaims.forbidden.includes("Provider cost or billing is reduced."));
+  assert.ok(evidence.releaseClaims.forbidden.includes("Diagnostic domainPayload reduction proves runtime-token savings."));
 });
 
 test("release benchmark evidence Markdown gives safe public wording and explicit non-claims", async () => {
-  const evidence = await buildReleaseBenchmarkEvidence({ runId: "markdown-test" });
+  const evidence = await buildReleaseBenchmarkEvidence({ runId: `markdown-test-${Date.now()}-${Math.random()}` });
   const markdown = renderReleaseBenchmarkEvidenceMarkdown(evidence);
 
   assert.match(markdown, /Release-safe headline/);
   assert.match(markdown, /npm update wording claimable: yes/);
-  assert.match(markdown, /React Web context reduction: yes/);
+  assert.match(markdown, /React Web actual injected context reduction: yes/);
+  assert.match(markdown, /React Web domainPayload reduction diagnostic-only: yes/);
   assert.match(markdown, /React Web reuse correctness: yes/);
   assert.match(markdown, /Cache performance improvement: no/);
   assert.match(markdown, /Runtime-token savings: no/);
   assert.match(markdown, /Provider billing\/cost savings: no/);
-  assert.match(markdown, /Full runtime payloads always smaller than source: no/);
+  assert.match(markdown, /Actual injected runtime context always smaller than source without fixture evidence: no/);
+  assert.match(markdown, /Diagnostic domainPayload reduction proves runtime-token savings: no/);
   assert.doesNotMatch(markdown, /Cache performance improvement: yes/i);
   assert.doesNotMatch(markdown, /Runtime-token savings: yes/i);
   assert.doesNotMatch(markdown, /Provider billing\/cost savings: yes/i);


### PR DESCRIPTION
## Summary
- measure React Web evidence against the actual host-facing `additionalContext` string, not just internal payload JSON/domainPayload
- shrink the non-edit React Web runtime envelope while preserving raw originals, edit guidance, freshness, and RN/WebView fallback boundaries
- gate npm-facing release claims on actual injected context reduction + reuse correctness; keep domainPayload diagnostic-only

## Evidence
- Baseline before envelope optimization: actual injected context was not claimable (`-225.814%` to `-31.011%`, all measured fixtures larger than source)
- After optimization: actual injected `additionalContext` is claimable across current-lane fixtures (`2.399%` to `71.061%` smaller than source)
- `domainPayload` remains diagnostic-only (`30.585%` to `77.459%` smaller)

## Tests
- [x] `npm test` — 457/457 passing
- [x] `npm run evidence:react-web-context -- --run-id=ralph-final-context --output=/tmp/react-web-context-ralph-final.json --markdown-output=/tmp/react-web-context-ralph-final.md`
- [x] `npm run evidence:react-web-reuse -- --run-id=ralph-final-reuse --output=/tmp/react-web-reuse-ralph-final.json --markdown-output=/tmp/react-web-reuse-ralph-final.md`
- [x] `npm run evidence:release-benchmark -- --run-id=ralph-final-release --output=/tmp/release-benchmark-ralph-final.json --markdown-output=/tmp/release-benchmark-ralph-final.md`
- [x] `npm run release:smoke`
- [x] targeted post-deslop: `node --test test/react-web-context-evidence.test.mjs test/release-benchmark-evidence.test.mjs test/runtime-bridge-contract.test.mjs`
- [x] `lsp_diagnostics` on `src/adapters/codex-runtime-hook.ts` — 0 errors

## Non-claims
- no npm publish/version bump in this PR
- no provider-token, provider-cost, billing, invoice, latency, or cache-performance claim
- no broad React Native/WebView support claim
