### PR TITLE
Add React Web styling variant hints

### DIFF
--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -4,7 +4,7 @@ import ts from "typescript";
 import { hashText } from "./hash";
 import { decideMode } from "./decide";
 import { detectDomainFromSource } from "./domain-detector";
-import type { A11yAnchorSignal, ExtractionResult, FormSurface, ImportSignal, Language, SourceRange, StyleSystem } from "./schema";
+import type { A11yAnchorSignal, ExtractionResult, FormSurface, ImportSignal, Language, SourceRange, StyleSystem, StyleVariantSignal } from "./schema";
 
 const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer", "useLayoutEffect", "useContext", "useId", "useTransition"]);
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
@@ -19,6 +19,8 @@ const MAX_FORM_ANCHORS = 8;
 const MAX_DEPENDENCIES = 8;
 const MAX_CONTROL_PROPS = 8;
 const MAX_TEXT_LENGTH = 48;
+const STYLE_VARIANT_PROP_NAMES = new Set(["variant", "size", "tone", "intent", "disabled", "selected", "loading", "compact"]);
+const MAX_STYLE_VARIANT_SIGNALS = 16;
 
 function getLanguage(filePath: string): Language {
   const ext = path.extname(filePath);
@@ -366,6 +368,7 @@ function detectStyleSystem(sourceFile: ts.SourceFile): ExtractionResult["style"]
   let system: StyleSystem = "unknown";
   const summary: string[] = [];
   const sourceText = sourceFile.text;
+  const variantSignals: StyleVariantSignal[] = [];
 
   if (imports.some((spec) => spec.includes(".module.css") || spec.includes(".module.scss"))) {
     system = "css-modules";
@@ -387,7 +390,77 @@ function detectStyleSystem(sourceFile: ts.SourceFile): ExtractionResult["style"]
     summary.push("inline-style-prop");
   }
   const hasStyleBranching = /className\s*=\s*\{/.test(sourceText) || /style\s*=\s*\{/.test(sourceText);
-  return { system, summary, hasStyleBranching };
+
+  const jsxAttributeValue = (attribute: ts.JsxAttribute): string | undefined => {
+    if (!attribute.initializer) return "true";
+    if (ts.isStringLiteral(attribute.initializer)) return attribute.initializer.text;
+    if (ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression) {
+      return compactText(attribute.initializer.expression.getText(sourceFile), 80);
+    }
+    return compactText(attribute.initializer.getText(sourceFile), 80);
+  };
+
+  const addStyleSignal = (signal: StyleVariantSignal): void => {
+    if (!signal.label) return;
+    variantSignals.push(signal);
+  };
+
+  function visit(node: ts.Node): void {
+    if (ts.isJsxAttribute(node)) {
+      const propName = node.name.getText(sourceFile);
+      const value = jsxAttributeValue(node);
+      if (propName === "className" && node.initializer && ts.isJsxExpression(node.initializer) && node.initializer.expression) {
+        addStyleSignal({
+          kind: "className-branch",
+          label: compactText(node.initializer.expression.getText(sourceFile), 80),
+          propName,
+          ...(value ? { value } : {}),
+          loc: sourceRangeOf(sourceFile, node),
+        });
+      }
+      if (propName === "style") {
+        addStyleSignal({
+          kind: "inline-style",
+          label: value ? compactText(value, 80) : "style",
+          propName,
+          ...(value ? { value } : {}),
+          loc: sourceRangeOf(sourceFile, node),
+        });
+      }
+      if (propName === "data-state") {
+        addStyleSignal({
+          kind: "data-state",
+          label: value ? `data-state=${compactText(value, 60)}` : "data-state",
+          propName,
+          ...(value ? { value } : {}),
+          loc: sourceRangeOf(sourceFile, node),
+        });
+      }
+      if (STYLE_VARIANT_PROP_NAMES.has(propName)) {
+        addStyleSignal({
+          kind: "variant-prop",
+          label: value ? `${propName}=${compactText(value, 60)}` : propName,
+          propName,
+          ...(value ? { value } : {}),
+          loc: sourceRangeOf(sourceFile, node),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  const dedupedSignals = dedupeBy(
+    variantSignals,
+    (item) => `${item.kind}:${item.propName ?? ""}:${item.label}:${item.loc?.startLine ?? ""}`,
+  ).slice(0, MAX_STYLE_VARIANT_SIGNALS);
+
+  return {
+    system,
+    summary,
+    hasStyleBranching,
+    ...(dedupedSignals.length ? { variantSignals: dedupedSignals } : {}),
+  };
 }
 
 function collectSectionsFromJsx(sourceFile: ts.SourceFile): { sections: string[]; jsxDepth: number } {

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -12,6 +12,7 @@ import {
   type ReactWebContextMetadataV0,
   type ReactWebContextRenderState,
   type ReactWebContextStateHint,
+  type ReactWebContextStylingVariantHint,
   type SourceFingerprint,
 } from "./schema";
 
@@ -21,6 +22,7 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   a11yAnchors: 16,
   localDependencies: 12,
   importRoleHints: 12,
+  stylingVariantHints: 12,
   intentTargets: 16,
   editTargetRouting: 8,
   formStateFlow: 10,
@@ -286,6 +288,42 @@ function buildImportRoleHints(result: ExtractionResult): ReactWebContextImportRo
   }
 
   return dedupeBy(hints, (item) => `${item.role}:${item.moduleSpecifier}:${item.importedSymbols?.join(",") ?? ""}`);
+}
+
+const STYLE_VARIANT_CONTRACT_NAMES = new Set(["variant", "size", "tone", "intent", "disabled", "selected", "loading", "compact"]);
+
+function propName(summary: string): string | undefined {
+  const match = summary.match(/^([A-Za-z_$][\w$]*)\??:/);
+  return match?.[1];
+}
+
+function buildStylingVariantHints(result: ExtractionResult): ReactWebContextStylingVariantHint[] {
+  const hints: ReactWebContextStylingVariantHint[] = [];
+
+  for (const signal of result.style?.variantSignals ?? []) {
+    hints.push({
+      kind: signal.kind,
+      label: compact(signal.label),
+      ...(signal.propName ? { propName: signal.propName } : {}),
+      ...(signal.value ? { value: compact(signal.value, 80) } : {}),
+      ...(signal.loc ? { loc: signal.loc } : {}),
+      evidence: [`style.variantSignals.${signal.kind}`],
+    });
+  }
+
+  for (const summary of result.contract?.propsSummary ?? []) {
+    const name = propName(summary);
+    if (!name || !STYLE_VARIANT_CONTRACT_NAMES.has(name)) continue;
+    hints.push({
+      kind: "props-contract",
+      label: compact(summary, 80),
+      propName: name,
+      ...(result.contract?.propsLoc ? { loc: result.contract.propsLoc } : {}),
+      evidence: ["contract.propsSummary"],
+    });
+  }
+
+  return dedupeBy(hints, (item) => `${item.kind}:${item.propName ?? ""}:${item.label}:${item.loc?.startLine ?? ""}`);
 }
 
 function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextIntentTarget["intent"] | undefined {
@@ -596,6 +634,7 @@ export function buildReactWebContextMetadata(
   const a11yAnchors = pruneArray(buildA11yAnchors(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.a11yAnchors);
   const localDependencies = pruneArray(buildLocalDependencies(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.localDependencies);
   const importRoleHints = pruneArray(buildImportRoleHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.importRoleHints);
+  const stylingVariantHints = pruneArray(buildStylingVariantHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.stylingVariantHints);
   const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
   const editTargetRouting = pruneArray(
     buildEditTargetRouting(result, editGuidance),
@@ -603,7 +642,7 @@ export function buildReactWebContextMetadata(
   );
   const formStateFlow = pruneArray(buildFormStateFlow(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.formStateFlow);
 
-  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || importRoleHints || intentTargets || editTargetRouting || formStateFlow);
+  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || importRoleHints || stylingVariantHints || intentTargets || editTargetRouting || formStateFlow);
   if (!hasContext) return undefined;
 
   return {
@@ -620,6 +659,7 @@ export function buildReactWebContextMetadata(
     ...(a11yAnchors ? { a11yAnchors } : {}),
     ...(localDependencies ? { localDependencies } : {}),
     ...(importRoleHints ? { importRoleHints } : {}),
+    ...(stylingVariantHints ? { stylingVariantHints } : {}),
     ...(intentTargets ? { intentTargets } : {}),
     ...(editTargetRouting ? { editTargetRouting } : {}),
     ...(formStateFlow ? { formStateFlow } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -84,6 +84,14 @@ export type ImportSignal = {
   loc?: SourceRange;
 };
 
+export type StyleVariantSignal = {
+  kind: "className-branch" | "inline-style" | "variant-prop" | "data-state";
+  label: string;
+  propName?: string;
+  value?: string;
+  loc?: SourceRange;
+};
+
 export type PatchTargetKind =
   | "component"
   | "props"
@@ -152,6 +160,15 @@ export type ReactWebContextImportRoleHint = {
   role: "form-library" | "validation-library" | "routing" | "ui-kit" | "icon-library" | "local-component";
   moduleSpecifier: string;
   importedSymbols?: string[];
+  loc?: SourceRange;
+  evidence: string[];
+};
+
+export type ReactWebContextStylingVariantHint = {
+  kind: "className-branch" | "inline-style" | "variant-prop" | "data-state" | "props-contract";
+  label: string;
+  propName?: string;
+  value?: string;
   loc?: SourceRange;
   evidence: string[];
 };
@@ -226,6 +243,7 @@ export type ReactWebContextMetadataV0 = {
   a11yAnchors?: ReactWebContextA11yAnchor[];
   localDependencies?: ReactWebContextLocalDependency[];
   importRoleHints?: ReactWebContextImportRoleHint[];
+  stylingVariantHints?: ReactWebContextStylingVariantHint[];
   intentTargets?: ReactWebContextIntentTarget[];
   editTargetRouting?: ReactWebContextEditTargetRoute[];
   formStateFlow?: ReactWebContextFormStateFlowEntry[];
@@ -276,6 +294,7 @@ export type ExtractionResult = {
     system?: StyleSystem;
     summary?: string[];
     hasStyleBranching?: boolean;
+    variantSignals?: StyleVariantSignal[];
   };
   snippets?: Array<{
     label: string;
@@ -329,6 +348,7 @@ export type ModelFacingPayload = {
     system?: StyleSystem;
     summary?: string[];
     hasStyleBranching?: boolean;
+    variantSignals?: StyleVariantSignal[];
   };
   snippets?: ExtractionResult["snippets"];
   editGuidance?: EditGuidance;

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -694,6 +694,83 @@ test("React Web wrapper fixture can expose source-observed htmlFor anchor from d
   assert.ok(payload.reactWebContext.a11yAnchors.some((item) => item.kind === "htmlFor"));
 });
 
+test("React Web styling variant hints summarize source-only style variation anchors", () => {
+  const source = `
+    type VariantPanelProps = {
+      variant?: "primary" | "secondary";
+      size?: "sm" | "lg";
+      disabled?: boolean;
+      selected?: boolean;
+    };
+
+    export function VariantPanel({ variant = "primary", size = "sm", disabled, selected }: VariantPanelProps) {
+      const toneClass = variant === "primary" ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-900";
+      const sizeClass = size === "lg" ? "px-4 py-3" : "px-2 py-1";
+      return (
+        <section
+          data-state={selected ? "selected" : "idle"}
+          className={disabled ? "opacity-50 pointer-events-none" : toneClass + " " + sizeClass}
+          style={{ opacity: disabled ? 0.5 : 1 }}
+        >
+          <button
+            variant={variant}
+            size={size}
+            disabled={disabled}
+            className="rounded-md border"
+          >
+            Save
+          </button>
+          <p>Extra body copy keeps this fixture past the tiny raw threshold for metadata testing.</p>
+          <p>Styling hints must stay source-derived and avoid design-system semantics.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "VariantPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  const hints = payload.reactWebContext.stylingVariantHints;
+  assert.ok(hints);
+
+  assert.ok(hints.some((item) => item.kind === "props-contract" && item.propName === "variant" && item.evidence.includes("contract.propsSummary")));
+  assert.ok(hints.some((item) => item.kind === "props-contract" && item.propName === "size"));
+  assert.ok(hints.some((item) => item.kind === "data-state" && item.propName === "data-state" && item.evidence.includes("style.variantSignals.data-state")));
+  assert.ok(hints.some((item) => item.kind === "className-branch" && item.propName === "className" && item.loc));
+  assert.ok(hints.some((item) => item.kind === "inline-style" && item.propName === "style" && item.loc));
+  assert.ok(hints.some((item) => item.kind === "variant-prop" && item.propName === "disabled"));
+});
+
+test("React Web styling variant hints are omitted without source variation anchors", () => {
+  const source = `
+    export function PlainPanel() {
+      return (
+        <section>
+          <h2>Plain panel</h2>
+          <p>This fixture has no className, style, variant-ish props, or data-state anchors.</p>
+          <p>It is intentionally long enough to avoid tiny raw fallback.</p>
+          <p>The React Web context may still include component structure, but not styling variant hints.</p>
+          <p>Additional neutral text keeps this source in the compressed path for the regression.</p>
+          <p>No source-observed style variation anchors should be invented from this plain content.</p>
+          <p>Another neutral line avoids coupling the assertion to tiny raw thresholds.</p>
+          <p>Final neutral line preserves the absence of styling variant evidence.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "PlainPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.equal(result.style.variantSignals, undefined);
+  assert.equal(payload.reactWebContext?.stylingVariantHints, undefined);
+});
+
 test("non React Web and raw/useOriginal payloads omit reactWebContext", () => {
   for (const fixture of [
     "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",


### PR DESCRIPTION
## Summary
- add source-derived style variant extraction for className branches, inline style props, `data-state`, and variant-ish JSX props
- expose opt-in `reactWebContext.stylingVariantHints` with source ranges and evidence labels
- include props-contract styling axes such as `variant`, `size`, `disabled`, `selected` without interpreting their design-system meaning

## Boundaries
- Source-only same-file React Web hints; no design-system semantics or visual understanding claims.
- No cross-file usage resolution and no new dependencies.
- No provider/token savings claim beyond existing local payload-shape verification.

## Tests
- `npm run build`
- `node --test test/react-web-context-metadata.test.mjs` (20 pass)
- `node --test test/pre-read-payload-builder.test.mjs` (3 pass)
- `npm test` (461 pass)
- `git diff --check`
