### PR TITLE
Add React Web component API hints

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -139,6 +139,34 @@ function trimEditTargetRoutingToBudget(
   return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
 }
 
+function trimComponentApiHintsToBudget(
+  payload: NonNullable<PreReadDecision["payload"]>,
+  maxPayloadBytes: number,
+): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
+  const reactWebContext = payload.reactWebContext;
+  if (!reactWebContext || !reactWebContext.componentApiHints || reactWebContext.componentApiHints.length === 0) {
+    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
+  }
+  const hints = reactWebContext.componentApiHints;
+
+  for (let hintCount = hints.length - 1; hintCount > 0; hintCount -= 1) {
+    const trimmedReactWebContext = {
+      ...reactWebContext,
+      componentApiHints: hints.slice(0, hintCount),
+    };
+    const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+    const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
+    if (estimatedPayloadBytes <= maxPayloadBytes) {
+      return { payload: trimmedPayload, estimatedPayloadBytes };
+    }
+  }
+
+  const trimmedReactWebContext = { ...reactWebContext };
+  delete trimmedReactWebContext.componentApiHints;
+  const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+  return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
+}
+
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
   const { frontendPayloadPolicy } = input;
   const result = extractFile(input.resolvedPath);
@@ -155,6 +183,11 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   if (includeReactWebContextMetadata) {
     let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
+    if (payload.reactWebContext?.componentApiHints && estimatedPayloadBytes > maxPayloadBytes) {
+      const trimmed = trimComponentApiHintsToBudget(payload, maxPayloadBytes);
+      payload = trimmed.payload;
+      estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
+    }
     if (payload.reactWebContext?.editTargetRouting && estimatedPayloadBytes > maxPayloadBytes) {
       const trimmed = trimEditTargetRoutingToBudget(payload, maxPayloadBytes);
       payload = trimmed.payload;

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -4,6 +4,7 @@ import {
   type ExtractionResult,
   type FormControlSignal,
   type ReactWebContextA11yAnchor,
+  type ReactWebContextComponentApiHint,
   type ReactWebContextEditTargetRoute,
   type ReactWebContextFormStateFlowEntry,
   type ReactWebContextImportRoleHint,
@@ -23,6 +24,7 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   localDependencies: 12,
   importRoleHints: 12,
   stylingVariantHints: 12,
+  componentApiHints: 12,
   intentTargets: 16,
   editTargetRouting: 8,
   formStateFlow: 10,
@@ -324,6 +326,60 @@ function buildStylingVariantHints(result: ExtractionResult): ReactWebContextStyl
   }
 
   return dedupeBy(hints, (item) => `${item.kind}:${item.propName ?? ""}:${item.label}:${item.loc?.startLine ?? ""}`);
+}
+
+type ParsedPropSummary = {
+  name: string;
+  typeText: string;
+};
+
+function parsePropSummary(summary: string): ParsedPropSummary | undefined {
+  const match = summary.match(/^([A-Za-z_$][\w$]*)(?:\?)?:\s*(.+)$/);
+  if (!match) return undefined;
+  return {
+    name: match[1],
+    typeText: compact(match[2], 120),
+  };
+}
+
+function componentApiKindFor(prop: ParsedPropSummary): ReactWebContextComponentApiHint["kind"] {
+  if (prop.name === "children") return prop.typeText.includes("=>") ? "render-prop" : "children-prop";
+  if (/^render[A-Z]/.test(prop.name)) return "render-prop";
+  if (/^on[A-Z]/.test(prop.name) || prop.typeText.includes("=>")) return "callback-prop";
+  return "prop";
+}
+
+function isCustomJsxTag(tagName: string): boolean {
+  const rootName = tagName.split(".")[0] ?? "";
+  return /^[A-Z]/.test(rootName);
+}
+
+function buildComponentApiHints(result: ExtractionResult): ReactWebContextComponentApiHint[] {
+  const hints: ReactWebContextComponentApiHint[] = [];
+
+  for (const summary of result.contract?.propsSummary ?? []) {
+    const prop = parsePropSummary(summary);
+    if (!prop) continue;
+    hints.push({
+      kind: componentApiKindFor(prop),
+      label: compact(summary, 120),
+      propName: prop.name,
+      typeText: prop.typeText,
+      ...(result.contract?.propsLoc ? { loc: result.contract.propsLoc } : {}),
+      evidence: ["contract.propsSummary"],
+    });
+  }
+
+  for (const tagName of result.structure?.sections ?? []) {
+    if (!tagName || tagName === result.componentName || !isCustomJsxTag(tagName)) continue;
+    hints.push({
+      kind: "custom-component-usage",
+      label: tagName,
+      evidence: ["structure.sections"],
+    });
+  }
+
+  return dedupeBy(hints, (item) => `${item.kind}:${item.propName ?? item.label}:${item.loc?.startLine ?? ""}:${item.typeText ?? ""}`);
 }
 
 function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextIntentTarget["intent"] | undefined {
@@ -635,6 +691,7 @@ export function buildReactWebContextMetadata(
   const localDependencies = pruneArray(buildLocalDependencies(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.localDependencies);
   const importRoleHints = pruneArray(buildImportRoleHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.importRoleHints);
   const stylingVariantHints = pruneArray(buildStylingVariantHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.stylingVariantHints);
+  const componentApiHints = pruneArray(buildComponentApiHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.componentApiHints);
   const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
   const editTargetRouting = pruneArray(
     buildEditTargetRouting(result, editGuidance),
@@ -642,7 +699,18 @@ export function buildReactWebContextMetadata(
   );
   const formStateFlow = pruneArray(buildFormStateFlow(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.formStateFlow);
 
-  const hasContext = Boolean(stateHints || renderStates || a11yAnchors || localDependencies || importRoleHints || stylingVariantHints || intentTargets || editTargetRouting || formStateFlow);
+  const hasContext = Boolean(
+    stateHints ||
+      renderStates ||
+      a11yAnchors ||
+      localDependencies ||
+      importRoleHints ||
+      stylingVariantHints ||
+      componentApiHints ||
+      intentTargets ||
+      editTargetRouting ||
+      formStateFlow,
+  );
   if (!hasContext) return undefined;
 
   return {
@@ -660,6 +728,7 @@ export function buildReactWebContextMetadata(
     ...(localDependencies ? { localDependencies } : {}),
     ...(importRoleHints ? { importRoleHints } : {}),
     ...(stylingVariantHints ? { stylingVariantHints } : {}),
+    ...(componentApiHints ? { componentApiHints } : {}),
     ...(intentTargets ? { intentTargets } : {}),
     ...(editTargetRouting ? { editTargetRouting } : {}),
     ...(formStateFlow ? { formStateFlow } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -173,6 +173,15 @@ export type ReactWebContextStylingVariantHint = {
   evidence: string[];
 };
 
+export type ReactWebContextComponentApiHint = {
+  kind: "prop" | "callback-prop" | "children-prop" | "render-prop" | "custom-component-usage";
+  label: string;
+  propName?: string;
+  typeText?: string;
+  loc?: SourceRange;
+  evidence: string[];
+};
+
 export type ReactWebContextIntentTarget = {
   intent: "style" | "form" | "handler" | "state" | "branch" | "props" | "component";
   label: string;
@@ -244,6 +253,7 @@ export type ReactWebContextMetadataV0 = {
   localDependencies?: ReactWebContextLocalDependency[];
   importRoleHints?: ReactWebContextImportRoleHint[];
   stylingVariantHints?: ReactWebContextStylingVariantHint[];
+  componentApiHints?: ReactWebContextComponentApiHint[];
   intentTargets?: ReactWebContextIntentTarget[];
   editTargetRouting?: ReactWebContextEditTargetRoute[];
   formStateFlow?: ReactWebContextFormStateFlowEntry[];

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -771,6 +771,84 @@ test("React Web styling variant hints are omitted without source variation ancho
   assert.equal(payload.reactWebContext?.stylingVariantHints, undefined);
 });
 
+test("React Web component API hints summarize same-file source API facts", () => {
+  const source = `
+    import React from "react";
+
+    type ApiPanelProps = {
+      title: string;
+      onSave?: (value: string) => void;
+      children?: React.ReactNode;
+      renderFooter?: (state: { dirty: boolean }) => React.ReactNode;
+      count?: number;
+    };
+
+    function FieldShell({ children }: { children?: React.ReactNode }) {
+      return <div className="field-shell">{children}</div>;
+    }
+
+    export function ApiPanel({ title, onSave, children, renderFooter, count = 0 }: ApiPanelProps) {
+      return (
+        <section aria-label="API panel">
+          <FieldShell>
+            <button onClick={() => onSave?.(title)}>Save</button>
+            {children}
+            {renderFooter?.({ dirty: count > 0 })}
+          </FieldShell>
+          <p>Extra body copy keeps this fixture past the tiny raw threshold for metadata testing.</p>
+          <p>Component API hints must remain source-derived and avoid cross-file usage semantics.</p>
+          <p>The repeated-read payload should expose the props contract and custom JSX usage anchors.</p>
+          <p>Another neutral sentence keeps this fixture in the compressed React Web lane.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "ApiPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  const hints = payload.reactWebContext.componentApiHints;
+  assert.ok(hints);
+
+  assert.ok(hints.some((item) => item.kind === "prop" && item.propName === "title" && item.evidence.includes("contract.propsSummary")));
+  assert.ok(hints.some((item) => item.kind === "callback-prop" && item.propName === "onSave"));
+  assert.ok(hints.some((item) => item.kind === "children-prop" && item.propName === "children"));
+  assert.ok(hints.some((item) => item.kind === "render-prop" && item.propName === "renderFooter"));
+  assert.ok(hints.some((item) => item.kind === "custom-component-usage" && item.label === "FieldShell" && item.evidence.includes("structure.sections")));
+  assert.ok(hints.filter((item) => item.evidence.includes("contract.propsSummary")).every((item) => item.loc && item.typeText));
+  assert.equal(JSON.stringify(hints).includes("crossFile"), false);
+  assert.equal(JSON.stringify(hints).includes("typeChecker"), false);
+});
+
+test("React Web component API hints omit lowercase DOM tags without props contracts", () => {
+  const source = `
+    export function DomOnlyPanel() {
+      return (
+        <section>
+          <h2>Plain DOM panel</h2>
+          <p>This component intentionally has no props contract or custom component usage.</p>
+          <button type="button">Save</button>
+          <textarea name="notes" />
+          <select name="status"><option>Open</option></select>
+          <p>Additional neutral content keeps this fixture in compressed mode.</p>
+          <p>Lowercase DOM tags must not be promoted to component API hints.</p>
+          <p>Another neutral sentence keeps this assertion independent from tiny raw thresholds.</p>
+        </section>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "DomOnlyPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.equal(payload.reactWebContext?.componentApiHints, undefined);
+});
+
 test("non React Web and raw/useOriginal payloads omit reactWebContext", () => {
   for (const fixture of [
     "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",


### PR DESCRIPTION
## Summary
- Add source-derived `componentApiHints` to React Web context metadata for props contracts, callback/children/render-prop hints, and custom JSX tag usage anchors.
- Keep the lane source-only: no cross-file usage graph, no TS checker semantics, no runtime behavior inference, no new dependency.
- Trim component API hints under the existing React Web context payload budget before falling back to edit-target routing trimming or metadata omission.

## Tests
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs`
- `npm test` (465 pass)
- `git diff --check`

## Boundaries
- Same-file/source-observed hints only.
- `custom-component-usage` reports JSX tag anchors; it does not resolve cross-file component usage or prove library semantics.
- Required/optional-ish semantics remain source text from `contract.propsSummary`, not typechecker-backed truth.