### PR TITLE
Clarify TUI concern evidence before payload design

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -38,6 +38,20 @@ Start with a small source-only corpus before any extractor or runtime change:
 
 The current committed TUI / Ink fixtures are useful as domain evidence, not as compact-payload permission:
 
+### TUI concern taxonomy
+
+This taxonomy names the source-level concerns currently represented by TUI fixtures. It is a review vocabulary, not a payload contract: **concern evidence is not payload permission**. A fixture may prove that a concern is visible in source while the TUI lane still denies compact payload emission and keeps normal source fallback.
+
+| Concern | Current meaning | Representative fixtures | Current permission boundary |
+| --- | --- | --- | --- |
+| Compact Ink syntax baseline | Minimal Ink import plus React CLI primitives that prove the file belongs to the Ink evidence lane. | `tui-ink-basic.tsx` | Evidence-only; no compact extraction permission. |
+| Keyboard input | `useInput`, key branching, selection movement, or cancel/submit keys observed in source. | `tui-ink-basic.tsx`, `tui-ink-interactive-list.tsx`, `tui-ink-form-prompt.tsx` | Evidence-only; no terminal key handling correctness claim. |
+| Prompt/form flow | Prompt state, validation/error text, apply/submit, or cancel branches in an Ink component. | `tui-ink-form-prompt.tsx` | Evidence-only; no form runtime or terminal UX correctness claim. |
+| Layout/style | Nested `Box`/`Text`, row/column layout, borders, spacing, color, dim text, or mapped display rows. | `tui-ink-layout-style.tsx` | Evidence-only; no terminal rendering correctness claim. |
+| Status/progress | Non-interactive status rows, command phase labels, progress-like output, elapsed time, or log summaries. | `tui-ink-status-panel.tsx` | Evidence-only; no command execution or progress behavior claim. |
+| Mixed-boundary | Ink evidence combined with React Web DOM or React Native primitive/input evidence in one file. | `tui-ink-web-dom-mixed.tsx`, `tui-ink-rn-narrow-mixed.tsx` | Fallback boundary; no TUI, React Web, or RN payload authorization. |
+| Non-Ink negative evidence | Terminal-looking React or CLI renderer source without Ink import, `Box`, `Text`, or `useInput` signals. | `tui-non-ink-cli-renderer.tsx` | Unknown/deferred fallback; no package or non-Ink terminal UI expansion. |
+
 | Fixture | Evidence it should prove | Required current outcome |
 | --- | --- | --- |
 | `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | Ink import, `Box`, `Text`, and `useInput` signals in a compact React CLI component. | Classify as `tui-ink`, mark the profile `evidence-only`, deny the TUI payload policy, and fall back with `unsupported-frontend-domain-profile`. |

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -16,16 +16,18 @@ This separation is intentional. Domain evidence can tell reviewers what kind of 
 
 ## Fixture roles
 
-| Fixture | Role | Required current result |
-| --- | --- | --- |
-| `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | Compact Ink syntax signal with `Box`, `Text`, and `useInput`. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | Behavior-heavy keyboard/list prompt evidence. | `tui-ink`, `evidence-only`, denied TUI policy, `raw-mode` fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-form-prompt.tsx` | Positive form/prompt evidence with input state, validation/error text, submit/apply, and cancel branches. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-layout-style.tsx` | Positive layout/style evidence with nested boxes, borders, spacing, color, dim text, and mapped rows. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx` | Non-interactive status/progress UI syntax evidence. | `tui-ink`, `evidence-only`, denied TUI policy, `raw-mode` fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx` | Negative terminal-looking React renderer without Ink signals. | `unknown`, `deferred`, no TUI policy authorization, fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-web-dom-mixed.tsx` | Mixed-negative Ink plus React Web DOM evidence. | `mixed`, `fallback-boundary`, no TUI or React Web payload authorization, fallback/no-payload. |
-| `test/fixtures/frontend-domain-expectations/tui-ink-rn-narrow-mixed.tsx` | Mixed-negative Ink plus RN primitive/input evidence. | `mixed`, `fallback-boundary`, no TUI or RN narrow payload authorization, fallback/no-payload. |
+These fixture roles are also the current TUI concern taxonomy. Concern labels help reviewers reason about source evidence, but concern evidence is not payload permission.
+
+| Fixture | Concern category | Role | Required current result |
+| --- | --- | --- | --- |
+| `test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx` | Compact Ink syntax baseline; keyboard input | Compact Ink syntax signal with `Box`, `Text`, and `useInput`. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-interactive-list.tsx` | Keyboard input | Behavior-heavy keyboard/list prompt evidence. | `tui-ink`, `evidence-only`, denied TUI policy, `raw-mode` fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-form-prompt.tsx` | Keyboard input; prompt/form flow | Positive form/prompt evidence with input state, validation/error text, submit/apply, and cancel branches. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-layout-style.tsx` | Layout/style | Positive layout/style evidence with nested boxes, borders, spacing, color, dim text, and mapped rows. | `tui-ink`, `evidence-only`, denied TUI policy, fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-status-panel.tsx` | Status/progress | Non-interactive status/progress UI syntax evidence. | `tui-ink`, `evidence-only`, denied TUI policy, `raw-mode` fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-non-ink-cli-renderer.tsx` | Non-Ink negative evidence | Negative terminal-looking React renderer without Ink signals. | `unknown`, `deferred`, no TUI policy authorization, fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-web-dom-mixed.tsx` | Mixed-boundary | Mixed-negative Ink plus React Web DOM evidence. | `mixed`, `fallback-boundary`, no TUI or React Web payload authorization, fallback/no-payload. |
+| `test/fixtures/frontend-domain-expectations/tui-ink-rn-narrow-mixed.tsx` | Mixed-boundary | Mixed-negative Ink plus RN primitive/input evidence. | `mixed`, `fallback-boundary`, no TUI or RN narrow payload authorization, fallback/no-payload. |
 
 ## Allowed next work
 

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -98,6 +98,27 @@ const tuiEvidenceMatrix = [
   },
 ];
 
+const tuiConcernTaxonomyTerms = [
+  "Compact Ink syntax baseline",
+  "Keyboard input",
+  "Prompt/form flow",
+  "Layout/style",
+  "Status/progress",
+  "Mixed-boundary",
+  "Non-Ink negative evidence",
+];
+
+const operationalConcernRows = [
+  ["tui-ink-basic.tsx", "Compact Ink syntax baseline; keyboard input"],
+  ["tui-ink-interactive-list.tsx", "Keyboard input"],
+  ["tui-ink-form-prompt.tsx", "Keyboard input; prompt/form flow"],
+  ["tui-ink-layout-style.tsx", "Layout/style"],
+  ["tui-ink-status-panel.tsx", "Status/progress"],
+  ["tui-non-ink-cli-renderer.tsx", "Non-Ink negative evidence"],
+  ["tui-ink-web-dom-mixed.tsx", "Mixed-boundary"],
+  ["tui-ink-rn-narrow-mixed.tsx", "Mixed-boundary"],
+];
+
 function tuiFixturePath(fileName) {
   return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
 }
@@ -395,6 +416,11 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   const survey = fs.readFileSync(path.join(repoRoot, "docs", "tui-fixture-candidates.md"), "utf8");
 
   assert.match(survey, /Current evidence-only reinforcement slice/);
+  assert.match(survey, /TUI concern taxonomy/);
+  assert.match(survey, /concern evidence is not payload permission/);
+  for (const term of tuiConcernTaxonomyTerms) {
+    assert.match(survey, new RegExp(term.replace("/", "\\/")));
+  }
   assert.match(survey, /tui-ink-basic\.tsx/);
   assert.match(survey, /tui-ink-interactive-list\.tsx/);
   assert.match(survey, /tui-ink-form-prompt\.tsx/);
@@ -416,17 +442,19 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
 
   assert.match(guide, /## Current state/);
   assert.match(guide, /## Fixture roles/);
+  assert.match(guide, /current TUI concern taxonomy/);
+  assert.match(guide, /Concern category/);
+  assert.match(guide, /concern evidence is not payload permission/);
   assert.match(guide, /## Allowed next work/);
   assert.match(guide, /## Promotion criteria before payload-design planning/);
   assert.match(guide, /## Stop rules/);
   assert.match(guide, /tui-ink-evidence-only-payload/);
   assert.match(guide, /fallback\/no-payload/);
   assert.match(guide, /serialized shared-policy plan/);
-  assert.match(guide, /tui-ink-form-prompt\.tsx/);
-  assert.match(guide, /tui-ink-layout-style\.tsx/);
-  assert.match(guide, /tui-ink-web-dom-mixed\.tsx/);
+  for (const [fixture, concern] of operationalConcernRows) {
+    assert.ok(guide.includes(`${fixture}\` | ${concern}`), fixture);
+  }
   assert.match(guide, /no TUI or React Web payload authorization/);
-  assert.match(guide, /tui-ink-rn-narrow-mixed\.tsx/);
   assert.match(guide, /no TUI or RN narrow payload authorization/);
   assert.doesNotMatch(guide, forbiddenSupportClaims);
 });


### PR DESCRIPTION
## Summary

- Add a docs/test-only TUI concern taxonomy that maps current Ink fixtures to layout/style, keyboard input, prompt/form flow, status/progress, mixed-boundary, non-Ink negative, and compact syntax evidence.
- Update TUI operational readiness docs so fixture roles explicitly carry concern categories while preserving evidence-only fallback/no-payload maturity.
- Extend TUI policy docs tests to lock the taxonomy wording and fixture-to-concern mapping without changing detector, payload, runtime, or manifest behavior.

## Validation

- `npm run build && node --test test/payload-policy-tui-ink.test.mjs`
- `npm test`
- `git diff --check`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

## Claim boundary

Docs/test-only. No detector, domain profile, payload policy, payload builder, pre-read, runtime adapter, or manifest changes. This does not add TUI support, terminal rendering correctness, token, billing, performance, or compact extraction claims.
