### PR TITLE
Add React Web layout region hints

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -167,6 +167,34 @@ function trimComponentApiHintsToBudget(
   return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
 }
 
+function trimLayoutRegionHintsToBudget(
+  payload: NonNullable<PreReadDecision["payload"]>,
+  maxPayloadBytes: number,
+): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
+  const reactWebContext = payload.reactWebContext;
+  if (!reactWebContext || !reactWebContext.layoutRegionHints || reactWebContext.layoutRegionHints.length === 0) {
+    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
+  }
+  const hints = reactWebContext.layoutRegionHints;
+
+  for (let hintCount = hints.length - 1; hintCount > 0; hintCount -= 1) {
+    const trimmedReactWebContext = {
+      ...reactWebContext,
+      layoutRegionHints: hints.slice(0, hintCount),
+    };
+    const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+    const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
+    if (estimatedPayloadBytes <= maxPayloadBytes) {
+      return { payload: trimmedPayload, estimatedPayloadBytes };
+    }
+  }
+
+  const trimmedReactWebContext = { ...reactWebContext };
+  delete trimmedReactWebContext.layoutRegionHints;
+  const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
+  return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
+}
+
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
   const { frontendPayloadPolicy } = input;
   const result = extractFile(input.resolvedPath);
@@ -183,6 +211,11 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   if (includeReactWebContextMetadata) {
     let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
+    if (payload.reactWebContext?.layoutRegionHints && estimatedPayloadBytes > maxPayloadBytes) {
+      const trimmed = trimLayoutRegionHintsToBudget(payload, maxPayloadBytes);
+      payload = trimmed.payload;
+      estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
+    }
     if (payload.reactWebContext?.componentApiHints && estimatedPayloadBytes > maxPayloadBytes) {
       const trimmed = trimComponentApiHintsToBudget(payload, maxPayloadBytes);
       payload = trimmed.payload;

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -9,6 +9,7 @@ import {
   type ReactWebContextFormStateFlowEntry,
   type ReactWebContextImportRoleHint,
   type ReactWebContextIntentTarget,
+  type ReactWebContextLayoutRegionHint,
   type ReactWebContextLocalDependency,
   type ReactWebContextMetadataV0,
   type ReactWebContextRenderState,
@@ -25,6 +26,7 @@ export const REACT_WEB_CONTEXT_METADATA_ITEM_CAPS = {
   importRoleHints: 12,
   stylingVariantHints: 12,
   componentApiHints: 12,
+  layoutRegionHints: 16,
   intentTargets: 16,
   editTargetRouting: 8,
   formStateFlow: 10,
@@ -382,6 +384,99 @@ function buildComponentApiHints(result: ExtractionResult): ReactWebContextCompon
   return dedupeBy(hints, (item) => `${item.kind}:${item.propName ?? item.label}:${item.loc?.startLine ?? ""}:${item.typeText ?? ""}`);
 }
 
+const LAYOUT_REGION_TAGS = new Map<string, ReactWebContextLayoutRegionHint["kind"]>([
+  ["header", "semantic-region"],
+  ["main", "semantic-region"],
+  ["section", "semantic-region"],
+  ["article", "semantic-region"],
+  ["footer", "semantic-region"],
+  ["nav", "semantic-region"],
+  ["aside", "semantic-region"],
+  ["ul", "list-region"],
+  ["ol", "list-region"],
+  ["li", "list-region"],
+  ["table", "table-region"],
+  ["thead", "table-region"],
+  ["tbody", "table-region"],
+  ["tr", "table-region"],
+  ["form", "form-region"],
+  ["fieldset", "form-region"],
+]);
+
+function stateForRegionCondition(condition: string): ReactWebContextLayoutRegionHint["state"] | undefined {
+  const normalized = condition.toLowerCase();
+  if (/\b(?:loading|pending|isloading|isfetching)\b/.test(normalized)) return "loading";
+  if (/\b(?:error|err|failed|invalid)\b/.test(normalized)) return "error";
+  if (/\b(?:empty|isempty|length\s*===\s*0|length\s*<\s*1|no[A-Z_\s-])/.test(condition)) return "empty";
+  if (/\b(?:disabled|isdisabled)\b/.test(normalized)) return "disabled";
+  return undefined;
+}
+
+function hasLayoutClassToken(label: string): boolean {
+  return /\b(?:grid|flex|container|list|table|card|header|footer|sidebar|layout|stack|row|col|columns|gap-)\b/.test(
+    label.toLowerCase(),
+  );
+}
+
+function buildLayoutRegionHints(result: ExtractionResult): ReactWebContextLayoutRegionHint[] {
+  const hints: ReactWebContextLayoutRegionHint[] = [];
+
+  for (const tagName of result.structure?.sections ?? []) {
+    const normalizedTag = tagName.toLowerCase();
+    const kind = LAYOUT_REGION_TAGS.get(normalizedTag);
+    if (!kind) continue;
+    hints.push({
+      kind,
+      label: tagName,
+      tagName,
+      evidence: ["structure.sections"],
+    });
+  }
+
+  for (const repeated of result.structure?.repeatedBlocks ?? []) {
+    hints.push({
+      kind: "repeated-region",
+      label: compact(repeated, 100),
+      evidence: ["structure.repeatedBlocks"],
+    });
+  }
+
+  for (const condition of result.structure?.conditionalRenders ?? []) {
+    const state = stateForRegionCondition(condition);
+    hints.push({
+      kind: state ? "state-region" : "conditional-region",
+      label: compact(condition, 100),
+      ...(state ? { state } : {}),
+      evidence: ["structure.conditionalRenders"],
+    });
+  }
+
+  for (const control of result.behavior?.formSurface?.controls ?? []) {
+    hints.push({
+      kind: "form-row",
+      label: control.name ? `${control.tag}[name=${control.name}]` : control.tag,
+      tagName: control.tag,
+      ...(control.loc ? { loc: control.loc } : {}),
+      evidence: ["behavior.formSurface.controls"],
+    });
+  }
+
+  for (const signal of result.style?.variantSignals ?? []) {
+    if (signal.kind !== "className-branch" || !hasLayoutClassToken(signal.label)) continue;
+    hints.push({
+      kind: "container-region",
+      label: compact(signal.label, 100),
+      ...(signal.loc ? { loc: signal.loc } : {}),
+      evidence: ["style.variantSignals.className-branch"],
+    });
+  }
+
+  return dedupeBy(
+    hints,
+    (item) => `${item.kind}:${item.tagName ?? ""}:${item.label}:${item.state ?? ""}:${item.loc?.startLine ?? ""}`,
+  );
+}
+
 function intentForPatchTarget(kind: EditGuidance["patchTargets"][number]["kind"]): ReactWebContextIntentTarget["intent"] | undefined {
   switch (kind) {
     case "component":
@@ -692,6 +787,7 @@ export function buildReactWebContextMetadata(
   const importRoleHints = pruneArray(buildImportRoleHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.importRoleHints);
   const stylingVariantHints = pruneArray(buildStylingVariantHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.stylingVariantHints);
   const componentApiHints = pruneArray(buildComponentApiHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.componentApiHints);
+  const layoutRegionHints = pruneArray(buildLayoutRegionHints(result), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.layoutRegionHints);
   const intentTargets = pruneArray(buildIntentTargets(result, editGuidance), REACT_WEB_CONTEXT_METADATA_ITEM_CAPS.intentTargets);
   const editTargetRouting = pruneArray(
     buildEditTargetRouting(result, editGuidance),
@@ -707,6 +803,7 @@ export function buildReactWebContextMetadata(
       importRoleHints ||
       stylingVariantHints ||
       componentApiHints ||
+      layoutRegionHints ||
       intentTargets ||
       editTargetRouting ||
       formStateFlow,
@@ -729,6 +826,7 @@ export function buildReactWebContextMetadata(
     ...(importRoleHints ? { importRoleHints } : {}),
     ...(stylingVariantHints ? { stylingVariantHints } : {}),
     ...(componentApiHints ? { componentApiHints } : {}),
+    ...(layoutRegionHints ? { layoutRegionHints } : {}),
     ...(intentTargets ? { intentTargets } : {}),
     ...(editTargetRouting ? { editTargetRouting } : {}),
     ...(formStateFlow ? { formStateFlow } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -182,6 +182,24 @@ export type ReactWebContextComponentApiHint = {
   evidence: string[];
 };
 
+export type ReactWebContextLayoutRegionHint = {
+  kind:
+    | "semantic-region"
+    | "list-region"
+    | "table-region"
+    | "form-region"
+    | "form-row"
+    | "repeated-region"
+    | "conditional-region"
+    | "state-region"
+    | "container-region";
+  label: string;
+  tagName?: string;
+  state?: "loading" | "error" | "empty" | "disabled" | "unknown";
+  loc?: SourceRange;
+  evidence: string[];
+};
+
 export type ReactWebContextIntentTarget = {
   intent: "style" | "form" | "handler" | "state" | "branch" | "props" | "component";
   label: string;
@@ -254,6 +272,7 @@ export type ReactWebContextMetadataV0 = {
   importRoleHints?: ReactWebContextImportRoleHint[];
   stylingVariantHints?: ReactWebContextStylingVariantHint[];
   componentApiHints?: ReactWebContextComponentApiHint[];
+  layoutRegionHints?: ReactWebContextLayoutRegionHint[];
   intentTargets?: ReactWebContextIntentTarget[];
   editTargetRouting?: ReactWebContextEditTargetRoute[];
   formStateFlow?: ReactWebContextFormStateFlowEntry[];

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -849,6 +849,94 @@ test("React Web component API hints omit lowercase DOM tags without props contra
   assert.equal(payload.reactWebContext?.componentApiHints, undefined);
 });
 
+test("React Web layout region hints summarize source-only region anchors", () => {
+  const source = `
+    type LayoutPanelProps = {
+      items: Array<{ id: string; label: string }>;
+      isLoading?: boolean;
+      error?: string;
+    };
+
+    export function LayoutPanel({ items, isLoading, error }: LayoutPanelProps) {
+      return (
+        <main className={isLoading ? "grid gap-4" : "flex flex-col gap-4"}>
+          <header>
+            <h1>Account overview</h1>
+          </header>
+          <section>
+            {isLoading && <p>Loading accounts</p>}
+            {error ? <p role="alert">{error}</p> : null}
+            {items.length === 0 && <p>No accounts yet</p>}
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>{item.label}</li>
+              ))}
+            </ul>
+          </section>
+          <form>
+            <label htmlFor="filter">Filter</label>
+            <input id="filter" name="filter" />
+          </form>
+          <footer>
+            <button type="button">Refresh</button>
+          </footer>
+          <p>Additional neutral copy keeps this fixture above the tiny raw threshold.</p>
+          <p>Layout region hints must stay source-derived and avoid visual understanding claims.</p>
+        </main>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "LayoutPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.ok(payload.reactWebContext);
+  const hints = payload.reactWebContext.layoutRegionHints;
+  assert.ok(hints);
+
+  assert.ok(hints.some((item) => item.kind === "semantic-region" && item.tagName === "main" && item.evidence.includes("structure.sections")));
+  assert.ok(hints.some((item) => item.kind === "semantic-region" && item.tagName === "header"));
+  assert.ok(hints.some((item) => item.kind === "list-region" && item.tagName === "ul"));
+  assert.ok(hints.some((item) => item.kind === "form-region" && item.tagName === "form"));
+  assert.ok(hints.some((item) => item.kind === "form-row" && item.label === "input[name=filter]" && item.loc));
+  assert.ok(hints.some((item) => item.kind === "repeated-region" && item.evidence.includes("structure.repeatedBlocks")));
+  assert.ok(hints.some((item) => item.kind === "state-region" && item.state === "loading"));
+  assert.ok(hints.some((item) => item.kind === "state-region" && item.state === "error"));
+  assert.ok(hints.some((item) => item.kind === "container-region" && item.evidence.includes("style.variantSignals.className-branch")));
+
+  const serialized = JSON.stringify(hints);
+  assert.equal(serialized.includes("visualUnderstanding"), false);
+  assert.equal(serialized.includes("designSystem"), false);
+  assert.equal(serialized.includes("crossFile"), false);
+  assert.equal(serialized.includes("runtimeDom"), false);
+});
+
+test("React Web layout region hints omit plain DOM without region evidence", () => {
+  const source = `
+    export function PlainCopyPanel() {
+      return (
+        <div>
+          <p>Plain copy panel without semantic containers or repeated source anchors.</p>
+          <p>This fixture intentionally avoids form, list, table, header, footer, and className branches.</p>
+          <button type="button">Close</button>
+          <span>Additional neutral inline content keeps this fixture in compressed mode.</span>
+          <p>Another neutral sentence keeps this assertion independent from tiny raw thresholds.</p>
+          <p>No source-observed layout region evidence should be invented here.</p>
+        </div>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "PlainCopyPanel.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(payload.useOriginal, undefined);
+  assert.equal(payload.reactWebContext?.layoutRegionHints, undefined);
+});
+
 test("non React Web and raw/useOriginal payloads omit reactWebContext", () => {
   for (const fixture of [
     "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",


### PR DESCRIPTION
## Summary
- Adds source-only `layoutRegionHints` to React Web context metadata for semantic/list/table/form/repeated/conditional/state/container anchors.
- Keeps hints evidence-backed from existing extractor facts (`structure`, `formSurface`, `style.variantSignals`) without visual, runtime DOM, design-system, cross-file, dependency, or typechecker semantics.
- Trims layout-region hints under the React Web context payload budget before broader metadata fallback.

## Tests
- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs`
- `npm test` (467 pass)

## Boundaries
- Not claiming browser layout, screenshot/visual understanding, cross-file usage, design-system semantics, or runtime DOM behavior.
