### PR TITLE
Gate release smoke on claimable benchmark evidence

### DIFF
--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -118,6 +118,38 @@ export async function buildReleaseBenchmarkEvidence({
   };
 }
 
+export function buildReleaseBenchmarkSmokeSummary(evidence) {
+  return {
+    npmUpdateClaimable: evidence.releaseClaims.npmUpdateClaimable,
+    headline: evidence.releaseClaims.headline,
+    actualInjectedContextReduction: evidence.context.actualInjectedContextReduction,
+    reuseCorrectnessClaimable: evidence.reuse.reuseCorrectnessClaimable,
+    nonClaims: {
+      cachePerformanceImprovement: evidence.nonClaims.cachePerformanceImprovement.claimable,
+      runtimeTokenSavings: evidence.nonClaims.runtimeTokenSavings.claimable,
+      providerBillingSavings: evidence.nonClaims.providerBillingSavings.claimable,
+    },
+    claimBoundary: evidence.claimBoundary,
+  };
+}
+
+export function assertReleaseBenchmarkSmokeGate(evidence) {
+  if (evidence.releaseClaims.npmUpdateClaimable === true) {
+    return;
+  }
+
+  const contextBlocker = evidence.context.actualInjectedContextReduction.blocker;
+  throw new Error(
+    [
+      "release benchmark gate failed: npm update wording is not claimable",
+      contextBlocker ? `actual injected context blocker: ${contextBlocker}` : null,
+      evidence.reuse.reuseCorrectnessClaimable === true ? null : "reuse correctness is not claimable",
+    ]
+      .filter(Boolean)
+      .join("; "),
+  );
+}
+
 export function renderReleaseBenchmarkEvidenceMarkdown(evidence) {
   const fixtureRows = evidence.context.fixtures
     .map(

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -5,6 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertPublicSurfaceClaimBoundaries } from "./release-claim-guards.mjs";
+import {
+  assertReleaseBenchmarkSmokeGate,
+  buildReleaseBenchmarkEvidence,
+  buildReleaseBenchmarkSmokeSummary,
+} from "./release-benchmark-evidence.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -128,6 +133,34 @@ function assertPackedFiles(packEntry) {
     assert(!forbiddenPrefixes.some((prefix) => filePath.startsWith(prefix)), `packed tarball includes non-public path ${filePath}`);
   }
 }
+
+function copyReleaseBenchmarkInputs(targetRoot) {
+  for (const relativePath of ["dist", "fixtures", path.join("test", "fixtures")]) {
+    fs.cpSync(path.join(repoRoot, relativePath), path.join(targetRoot, relativePath), { recursive: true });
+  }
+  fs.copyFileSync(path.join(repoRoot, "package.json"), path.join(targetRoot, "package.json"));
+  const nodeModules = path.join(repoRoot, "node_modules");
+  if (fs.existsSync(nodeModules)) {
+    fs.symlinkSync(nodeModules, path.join(targetRoot, "node_modules"), "dir");
+  }
+}
+
+async function buildReleaseBenchmarkPreflightSummary() {
+  const isolatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-release-benchmark-preflight-"));
+  try {
+    copyReleaseBenchmarkInputs(isolatedRoot);
+    const evidence = await buildReleaseBenchmarkEvidence({
+      repoRoot: isolatedRoot,
+      runId: `release-smoke-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+    });
+    assertReleaseBenchmarkSmokeGate(evidence);
+    return buildReleaseBenchmarkSmokeSummary(evidence);
+  } finally {
+    fs.rmSync(isolatedRoot, { recursive: true, force: true });
+  }
+}
+
+const releaseBenchmarkSmokeSummary = await buildReleaseBenchmarkPreflightSummary();
 
 const dryRun = parsePackJson(run("npm", ["pack", "--dry-run", "--json"]));
 assertPackedFiles(dryRun);
@@ -455,6 +488,7 @@ console.log(JSON.stringify({
   installedBinary: fooksBin,
   setupSummary: setup.summary,
   hookSmokeEvidence: {
+    releaseBenchmark: releaseBenchmarkSmokeSummary,
     codex: {
       sessionStart: "recorded",
       firstPrompt: "record-only",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4063,6 +4063,23 @@ test("package release surface keeps internal docs out of the npm tarball", () =>
   assert.match(gitignore, /\.opencode\//);
 });
 
+test("release smoke runs release benchmark gate before package npm smoke work", () => {
+  const releaseSmoke = fs.readFileSync(path.join(repoRoot, "scripts", "release-smoke.mjs"), "utf8");
+  const gateIndex = releaseSmoke.indexOf("assertReleaseBenchmarkSmokeGate");
+  const firstNpmRunIndex = releaseSmoke.indexOf('run("npm",');
+
+  assert.ok(gateIndex >= 0, "release smoke should import/use release benchmark gate helper");
+  assert.ok(firstNpmRunIndex >= 0, "release smoke should still run npm package smoke checks");
+  assert.ok(gateIndex < firstNpmRunIndex, "release benchmark gate should run before package npm smoke work");
+  assert.match(releaseSmoke, /fooks-release-benchmark-preflight-/);
+  assert.match(releaseSmoke, /symlinkSync\(nodeModules/);
+  assert.ok(
+    releaseSmoke.indexOf("buildReleaseBenchmarkPreflightSummary") < firstNpmRunIndex,
+    "release benchmark preflight should be isolated before package npm smoke work",
+  );
+  assert.doesNotMatch(releaseSmoke, /evidence:release-benchmark|bench:|npm publish|npm version|git tag/);
+});
+
 test("red-team report marks cache corruption finding as historical after recovery fix", () => {
   const redTeam = fs.readFileSync(path.join(repoRoot, "RED_TEAM_REPORT.md"), "utf8");
 

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  assertReleaseBenchmarkSmokeGate,
   buildReleaseBenchmarkEvidence,
+  buildReleaseBenchmarkSmokeSummary,
   renderReleaseBenchmarkEvidenceMarkdown,
 } from "../scripts/release-benchmark-evidence.mjs";
 
@@ -49,6 +51,48 @@ test("release benchmark evidence gates npm wording on actual injected context an
   assert.ok(evidence.releaseClaims.forbidden.includes("Caching performance improved."));
   assert.ok(evidence.releaseClaims.forbidden.includes("Provider cost or billing is reduced."));
   assert.ok(evidence.releaseClaims.forbidden.includes("Diagnostic domainPayload reduction proves runtime-token savings."));
+});
+
+test("release benchmark smoke summary exposes only release-safe compact evidence", async () => {
+  const evidence = await buildReleaseBenchmarkEvidence({ runId: `smoke-summary-test-${Date.now()}-${Math.random()}` });
+  const summary = buildReleaseBenchmarkSmokeSummary(evidence);
+
+  assert.equal(summary.npmUpdateClaimable, true);
+  assert.match(summary.headline, /React Web same-file reuse is routed correctly/);
+  assert.match(summary.headline, /actual injected additionalContext/);
+  assert.equal(summary.actualInjectedContextReduction.claimable, true);
+  assert.ok(summary.actualInjectedContextReduction.minPct > 0);
+  assert.ok(summary.actualInjectedContextReduction.maxPct > 70);
+  assert.equal(summary.reuseCorrectnessClaimable, true);
+  assert.deepEqual(summary.nonClaims, {
+    cachePerformanceImprovement: false,
+    runtimeTokenSavings: false,
+    providerBillingSavings: false,
+  });
+  assert.match(summary.claimBoundary, /not provider tokenizer output/);
+  assert.match(summary.claimBoundary, /not runtime-token savings/);
+  assert.match(summary.claimBoundary, /not provider cost, billing, invoice, or charged-cost evidence/);
+});
+
+test("release benchmark smoke gate fails closed when npm update wording is not claimable", () => {
+  const evidence = {
+    releaseClaims: {
+      npmUpdateClaimable: false,
+    },
+    context: {
+      actualInjectedContextReduction: {
+        blocker: "fixture additionalContext is larger than source",
+      },
+    },
+    reuse: {
+      reuseCorrectnessClaimable: false,
+    },
+  };
+
+  assert.throws(
+    () => assertReleaseBenchmarkSmokeGate(evidence),
+    /release benchmark gate failed: npm update wording is not claimable; actual injected context blocker: fixture additionalContext is larger than source; reuse correctness is not claimable/,
+  );
 });
 
 test("release benchmark evidence Markdown gives safe public wording and explicit non-claims", async () => {


### PR DESCRIPTION
## Summary
- Gate `npm run release:smoke` on release-benchmark claimability before npm pack/install work starts.
- Add compact `hookSmokeEvidence.releaseBenchmark` output for release-safe wording.
- Keep non-claims explicit: cache performance, runtime-token savings, and provider billing/cost savings stay unclaimable.

## Evidence
- `node --test test/release-benchmark-evidence.test.mjs test/fooks.test.mjs` → 146/146 pass
- `npm run evidence:release-benchmark` → pass; `npmUpdateClaimable: true`, actual injected `additionalContext` reduction `2.399%` to `71.061%`
- `npm run release:smoke` → pass; smoke JSON includes `hookSmokeEvidence.releaseBenchmark`
- release smoke isolation check: `.fooks` file count unchanged before/after (`595 -> 595`)
- LSP diagnostics on changed scripts → 0 errors
- `git diff --check` → pass
- Architect verification → APPROVE

## Claim boundary
This PR supports release/npm wording for React Web same-file reuse and local byte-size `additionalContext` reduction only. It does **not** prove cache performance improvement, runtime-token savings, provider billing savings, or broad React Web/RN/WebView support.

## Not tested
- Full `npm test` had 3 transient/unrelated failures in one run; immediate rerun of those failing files passed (`test/benchmarks.test.mjs test/worktree-evidence.test.mjs` → 22/22 pass).
