### PR TITLE
Define TUI payload readiness before design

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -97,6 +97,17 @@ This matrix is the current review contract for TUI-related fixtures. It is inten
 
 If a future PR changes any row from fallback/no-payload to payload emission, it is no longer a TUI evidence matrix update and must go through a serialized shared-policy plan.
 
+## Payload design readiness handoff
+
+The evidence matrix above is sufficient to discuss a future payload-design PRD, but it is not itself a payload contract. A payload-design handoff must first prove that the current evidence-only lane stays denied:
+
+- positive Ink concern evidence is mapped to fixtures before design assumptions are made;
+- negative, weak, and mixed fixtures keep fallback/no-payload behavior;
+- the TUI payload policy remains `allowed: false` for current fixtures;
+- pre-read emits no model-facing TUI payload;
+- terminal runtime facts, command execution, key handling correctness, token reduction, billing reduction, provider-cost reduction, and performance outcomes are treated as non-claims until measured in a separate plan;
+- any detector, registry, manifest, payload builder, pre-read, runtime, or cross-lane frontend edit is out of scope for a readiness handoff and requires a separate serialized plan.
+
 ## Candidate source notes
 
 If a future PR names public repositories, keep the list conservative and verify license, activity, file paths, and commit SHAs at that time. Good seed sources are likely to be established Ink examples, React-based CLI apps, or prompt/status UI components with inspectable TSX/JSX. Do not use curated lists, stale forks, or runtime-only demos as evidence fixtures unless a pinned source file clearly exercises one category above.

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -53,6 +53,22 @@ Before a TUI payload-design plan is useful, the repo should already have:
 
 Meeting these criteria does not enable a payload. It only means the next plan can discuss whether a narrow payload gate is worth designing.
 
+## Payload design readiness gate
+
+This readiness gate is the review contract for a future TUI payload-design PRD. Passing the gate means the repo has enough bounded evidence to plan a design; it does not mean TUI is supported, compact extraction is allowed, or runtime injection may begin.
+
+A future payload-design PRD may start only when all of these checks are true:
+
+1. positive Ink evidence categories are named and mapped to representative fixtures;
+2. non-Ink, weak, and mixed-domain cases still deny TUI payload authorization;
+3. every current TUI fixture keeps `allowed: false` under the TUI payload policy;
+4. pre-read decisions emit no model-facing TUI payload;
+5. claim-boundary checks reject support, terminal correctness, token, billing, provider-cost, and performance wording;
+6. any future shared-seam edit names the exact files, owners, merge order, and fallback regressions before implementation;
+7. terminal semantics that cannot be proven from AST facts are listed as full-source requirements rather than compact-context facts.
+
+The disqualifier list is intentionally strict. Stop the current lane and write a separate serialized plan if a change needs `allowed: true`, a TUI payload builder, runtime/pre-read injection, detector or registry edits, manifest changes, fixture classification changes, cross-lane RN/React Web/WebView edits, or any measured-value claim.
+
 ## Stop rules
 
 Stop the current PR and switch to serialized shared-policy planning if the change would:

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -119,6 +119,16 @@ const operationalConcernRows = [
   ["tui-ink-rn-narrow-mixed.tsx", "Mixed-boundary"],
 ];
 
+const payloadReadinessGateTerms = [
+  "Payload design readiness gate",
+  "does not mean TUI is supported",
+  "compact extraction is allowed",
+  "runtime injection may begin",
+  "allowed: false",
+  "model-facing TUI payload",
+  "separate serialized plan",
+];
+
 function tuiFixturePath(fileName) {
   return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
 }
@@ -397,6 +407,7 @@ test("TUI evidence matrix rows stay aligned with policy and pre-read boundaries"
     assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), expectedPolicy, row.fileName);
     assert.equal(decision.decision, "fallback", row.fileName);
     assert.equal("payload" in decision, false, row.fileName);
+    assert.notEqual(expectedPolicy?.allowed, true, row.fileName);
 
     const fallbackReason = row.fallbackReason();
     if (fallbackReason) {
@@ -419,7 +430,7 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /TUI concern taxonomy/);
   assert.match(survey, /concern evidence is not payload permission/);
   for (const term of tuiConcernTaxonomyTerms) {
-    assert.match(survey, new RegExp(term.replace("/", "\\/")));
+    assert.ok(survey.includes(term), term);
   }
   assert.match(survey, /tui-ink-basic\.tsx/);
   assert.match(survey, /tui-ink-interactive-list\.tsx/);
@@ -432,6 +443,10 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /tui-ink-rn-narrow-mixed\.tsx/);
   assert.match(survey, /Negative\/fallback reinforcement/);
   assert.match(survey, /Current TUI evidence matrix/);
+  assert.match(survey, /Payload design readiness handoff/);
+  assert.match(survey, /not itself a payload contract/);
+  assert.match(survey, /pre-read emits no model-facing TUI payload/);
+  assert.match(survey, /separate serialized plan/);
   assert.match(survey, /tui-ink-evidence-only-payload/);
   assert.match(survey, /mixed frontend boundary/);
   assert.doesNotMatch(survey, forbiddenSupportClaims);
@@ -447,10 +462,14 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /concern evidence is not payload permission/);
   assert.match(guide, /## Allowed next work/);
   assert.match(guide, /## Promotion criteria before payload-design planning/);
+  assert.match(guide, /## Payload design readiness gate/);
   assert.match(guide, /## Stop rules/);
   assert.match(guide, /tui-ink-evidence-only-payload/);
   assert.match(guide, /fallback\/no-payload/);
   assert.match(guide, /serialized shared-policy plan/);
+  for (const term of payloadReadinessGateTerms) {
+    assert.ok(guide.includes(term), term);
+  }
   for (const [fixture, concern] of operationalConcernRows) {
     assert.ok(guide.includes(`${fixture}\` | ${concern}`), fixture);
   }


### PR DESCRIPTION
## Summary

- Add a TUI payload-design readiness gate to the operational readiness guide.
- Document the fixture-survey handoff boundary for any future TUI payload-design PRD.
- Strengthen TUI policy tests so current fixtures remain denied, fallback-only, and no-payload while docs avoid support/value claims.

## Validation

- `node --test test/payload-policy-tui-ink.test.mjs`
- `npm test`
- `git diff --check`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

## Claim boundary

Docs/test-only. No detector, registry, payload policy source, payload builder, pre-read, runtime, manifest, fixture, RN, React Web, or WebView lane changes. This does not add TUI support, TUI payload permission, terminal rendering correctness, token, billing, provider-cost, performance, or runtime-injection claims.
