### PR TITLE
Prioritize React Web edit context under budget

### DIFF
--- a/docs/react-web-context-budget-regression.md
+++ b/docs/react-web-context-budget-regression.md
@@ -1,7 +1,7 @@
 # React Web context budget regression note
 
-`reactWebContext.editTargetRouting` is ordered routing evidence, not required source context. When a repeated React Web edit payload crosses the metadata budget, the pre-read builder must trim that array as a stable prefix before considering full `reactWebContext` fallback.
+`reactWebContext.editTargetRouting` is ordered routing evidence, not required source context, but it is the most direct "where should the model edit?" signal in the React Web context envelope. When a repeated React Web edit payload crosses the metadata budget, the pre-read builder must trim lower-priority metadata groups before trimming edit routing.
 
-This preserves the highest-priority edit route evidence (`priority: 1`, then `2`, etc.) without re-extracting or rereading component context. If the payload still exceeds the budget after the routing prefix is exhausted, the builder may omit `editTargetRouting`, and then omit `reactWebContext` as the final budget-safe fallback.
+This preserves the highest-priority edit route evidence (`priority: 1`, then `2`, etc.) without re-extracting or rereading component context. If lower-priority groups are exhausted and the payload still exceeds budget, the builder may trim `editTargetRouting` as an ordered prefix, and then omit `reactWebContext` as the final budget-safe fallback.
 
-Focused regression: `test/pre-read-payload-builder.test.mjs` covers an oversized `HookEffectPanel.tsx` repeated-edit payload and locks that trimmed routing remains in original priority order while the rest of `reactWebContext` stays available.
+Focused regression: `test/pre-read-payload-builder.test.mjs` covers an oversized `HookEffectPanel.tsx` repeated-edit payload and locks that routing remains in original priority order while lower-priority metadata is trimmed first.

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -41,9 +41,9 @@ function payloadContextModeReason(
     : `${phase}-exact-file-narrow-payload`;
 }
 
-function buildRuntimeContextPayload(payload: ModelFacingPayload): { optimized: boolean; payload: unknown } {
+function buildRuntimeContextPayload(payload: ModelFacingPayload, includeReactWebContext = true): { optimized: boolean; payload: unknown } {
   if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
-    const reactWebContext = payload.reactWebContext
+    const reactWebContext = includeReactWebContext && payload.reactWebContext
       ? {
           schemaVersion: payload.reactWebContext.schemaVersion,
           freshness: payload.reactWebContext.freshness,
@@ -67,12 +67,35 @@ function buildRuntimeContextPayload(payload: ModelFacingPayload): { optimized: b
   return { optimized: false, payload };
 }
 
-function buildAdditionalContext(filePath: string, payload: ModelFacingPayload, contextMode: ContextMode): string {
-  const runtimeContextPayload = buildRuntimeContextPayload(payload);
+function renderAdditionalContext(
+  filePath: string,
+  payloadMode: ModelFacingPayload["mode"],
+  contextMode: ContextMode,
+  runtimeContextPayload: ReturnType<typeof buildRuntimeContextPayload>,
+): string {
   return [
-    `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · context-mode: ${contextMode}`,
+    `${buildPreReadReuseStatus(payloadMode)} · file: ${filePath} · context-mode: ${contextMode}`,
     JSON.stringify(runtimeContextPayload.payload, null, runtimeContextPayload.optimized ? undefined : 2),
   ].join("\n");
+}
+
+function buildAdditionalContext(
+  filePath: string,
+  payload: ModelFacingPayload,
+  contextMode: ContextMode,
+  maxOptimizedContextBytes?: number,
+): string {
+  const runtimeContextPayload = buildRuntimeContextPayload(payload);
+  const additionalContext = renderAdditionalContext(filePath, payload.mode, contextMode, runtimeContextPayload);
+  if (
+    runtimeContextPayload.optimized &&
+    payload.reactWebContext &&
+    maxOptimizedContextBytes !== undefined &&
+    estimateTextBytes(additionalContext) > maxOptimizedContextBytes
+  ) {
+    return renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload, false));
+  }
+  return additionalContext;
 }
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
@@ -350,7 +373,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       });
       if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
         const optInContextMode = payloadContextMode(optInDecision.payload);
-        const optInAdditionalContext = buildAdditionalContext(target, optInDecision.payload, optInContextMode);
+        const optInAdditionalContext = buildAdditionalContext(target, optInDecision.payload, optInContextMode, originalEstimatedBytes);
         const estimatedContextBytes = estimateTextBytes(optInAdditionalContext);
         if (estimatedContextBytes <= editGuidanceBudgetLimit(originalEstimatedBytes)) {
           decision = optInDecision;
@@ -363,7 +386,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    const additionalContext = buildAdditionalContext(target, decision.payload, contextMode);
+    const additionalContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
     const runtimeDecision: CodexRuntimeHookDecision = {

--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -111,20 +111,40 @@ function reactWebContextPayloadBudget(rawSizeBytes: number): number {
   );
 }
 
-function trimEditTargetRoutingToBudget(
+type ReactWebContext = NonNullable<NonNullable<PreReadDecision["payload"]>["reactWebContext"]>;
+type ReactWebContextArrayKey = Exclude<{
+  [Key in keyof ReactWebContext]: ReactWebContext[Key] extends unknown[] | undefined ? Key : never;
+}[keyof ReactWebContext], undefined>;
+
+const REACT_WEB_CONTEXT_TRIM_POLICY: ReactWebContextArrayKey[] = [
+  "importRoleHints",
+  "stylingVariantHints",
+  "localDependencies",
+  "renderStates",
+  "stateHints",
+  "componentApiHints",
+  "layoutRegionHints",
+  "intentTargets",
+  "a11yAnchors",
+  "formStateFlow",
+  "editTargetRouting",
+];
+
+function trimReactWebContextArrayFieldToBudget(
   payload: NonNullable<PreReadDecision["payload"]>,
   maxPayloadBytes: number,
+  field: ReactWebContextArrayKey,
 ): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
   const reactWebContext = payload.reactWebContext;
-  if (!reactWebContext || !reactWebContext.editTargetRouting || reactWebContext.editTargetRouting.length === 0) {
+  const values = reactWebContext?.[field];
+  if (!reactWebContext || !Array.isArray(values) || values.length === 0) {
     return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
   }
-  const routes = reactWebContext.editTargetRouting;
 
-  for (let routeCount = routes.length - 1; routeCount > 0; routeCount -= 1) {
+  for (let itemCount = values.length - 1; itemCount > 0; itemCount -= 1) {
     const trimmedReactWebContext = {
       ...reactWebContext,
-      editTargetRouting: routes.slice(0, routeCount),
+      [field]: values.slice(0, itemCount),
     };
     const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
     const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
@@ -134,65 +154,26 @@ function trimEditTargetRoutingToBudget(
   }
 
   const trimmedReactWebContext = { ...reactWebContext };
-  delete trimmedReactWebContext.editTargetRouting;
+  delete trimmedReactWebContext[field];
   const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
   return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
 }
 
-function trimComponentApiHintsToBudget(
+function trimReactWebContextToBudget(
   payload: NonNullable<PreReadDecision["payload"]>,
   maxPayloadBytes: number,
 ): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
-  const reactWebContext = payload.reactWebContext;
-  if (!reactWebContext || !reactWebContext.componentApiHints || reactWebContext.componentApiHints.length === 0) {
-    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
-  }
-  const hints = reactWebContext.componentApiHints;
+  let trimmedPayload = payload;
+  let estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
 
-  for (let hintCount = hints.length - 1; hintCount > 0; hintCount -= 1) {
-    const trimmedReactWebContext = {
-      ...reactWebContext,
-      componentApiHints: hints.slice(0, hintCount),
-    };
-    const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
-    const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
-    if (estimatedPayloadBytes <= maxPayloadBytes) {
-      return { payload: trimmedPayload, estimatedPayloadBytes };
-    }
+  for (const field of REACT_WEB_CONTEXT_TRIM_POLICY) {
+    if (estimatedPayloadBytes <= maxPayloadBytes) break;
+    const trimmed = trimReactWebContextArrayFieldToBudget(trimmedPayload, maxPayloadBytes, field);
+    trimmedPayload = trimmed.payload;
+    estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
   }
 
-  const trimmedReactWebContext = { ...reactWebContext };
-  delete trimmedReactWebContext.componentApiHints;
-  const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
-  return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
-}
-
-function trimLayoutRegionHintsToBudget(
-  payload: NonNullable<PreReadDecision["payload"]>,
-  maxPayloadBytes: number,
-): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
-  const reactWebContext = payload.reactWebContext;
-  if (!reactWebContext || !reactWebContext.layoutRegionHints || reactWebContext.layoutRegionHints.length === 0) {
-    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
-  }
-  const hints = reactWebContext.layoutRegionHints;
-
-  for (let hintCount = hints.length - 1; hintCount > 0; hintCount -= 1) {
-    const trimmedReactWebContext = {
-      ...reactWebContext,
-      layoutRegionHints: hints.slice(0, hintCount),
-    };
-    const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
-    const estimatedPayloadBytes = estimatePayloadBytes(trimmedPayload);
-    if (estimatedPayloadBytes <= maxPayloadBytes) {
-      return { payload: trimmedPayload, estimatedPayloadBytes };
-    }
-  }
-
-  const trimmedReactWebContext = { ...reactWebContext };
-  delete trimmedReactWebContext.layoutRegionHints;
-  const trimmedPayload = { ...payload, reactWebContext: trimmedReactWebContext };
-  return { payload: trimmedPayload, estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload) };
+  return { payload: trimmedPayload, estimatedPayloadBytes };
 }
 
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
@@ -211,18 +192,8 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   if (includeReactWebContextMetadata) {
     let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
-    if (payload.reactWebContext?.layoutRegionHints && estimatedPayloadBytes > maxPayloadBytes) {
-      const trimmed = trimLayoutRegionHintsToBudget(payload, maxPayloadBytes);
-      payload = trimmed.payload;
-      estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
-    }
-    if (payload.reactWebContext?.componentApiHints && estimatedPayloadBytes > maxPayloadBytes) {
-      const trimmed = trimComponentApiHintsToBudget(payload, maxPayloadBytes);
-      payload = trimmed.payload;
-      estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
-    }
-    if (payload.reactWebContext?.editTargetRouting && estimatedPayloadBytes > maxPayloadBytes) {
-      const trimmed = trimEditTargetRoutingToBudget(payload, maxPayloadBytes);
+    if (payload.reactWebContext && estimatedPayloadBytes > maxPayloadBytes) {
+      const trimmed = trimReactWebContextToBudget(payload, maxPayloadBytes);
       payload = trimmed.payload;
       estimatedPayloadBytes = trimmed.estimatedPayloadBytes;
     }

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -32,7 +32,7 @@ test("pre-read payload builder preserves React Web payload success envelope", ()
   assert.equal(decision.debug.domainDetection.classification, "react-web");
   assert.equal(decision.debug.frontendPayloadPolicy.allowed, true);
   assert.ok(decision.payload.reactWebContext);
-  assert.equal("editTargetRouting" in decision.payload.reactWebContext, false);
+  assert.equal(decision.payload.reactWebContext.editTargetRouting.length, 2);
   assert.equal(decision.debug.reactWebContextBudget.included, true);
   assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
 });
@@ -68,7 +68,7 @@ test("pre-read payload builder omits React Web context metadata when payload bud
   }
 });
 
-test("pre-read payload builder trims React Web edit-target routing as an ordered prefix before metadata fallback", () => {
+test("pre-read payload builder preserves React Web edit-target routing before lower-priority metadata", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-routing-budget-"));
   try {
     const target = path.join(tempDir, "HookEffectPanel.tsx");
@@ -84,7 +84,14 @@ test("pre-read payload builder trims React Web edit-target routing as an ordered
     assert.equal(decision.debug.reactWebContextBudget.included, true);
     assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
     assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
-    assert.equal(decision.payload.reactWebContext.editTargetRouting.length < 8, true);
+    assert.equal("importRoleHints" in decision.payload.reactWebContext, false);
+    assert.equal("stylingVariantHints" in decision.payload.reactWebContext, false);
+    assert.equal("localDependencies" in decision.payload.reactWebContext, false);
+    assert.equal("renderStates" in decision.payload.reactWebContext, false);
+    assert.equal("stateHints" in decision.payload.reactWebContext, false);
+    assert.equal("componentApiHints" in decision.payload.reactWebContext, false);
+    assert.equal("layoutRegionHints" in decision.payload.reactWebContext, false);
+    assert.equal(decision.payload.reactWebContext.editTargetRouting.length, 8);
     assert.deepEqual(
       decision.payload.reactWebContext.editTargetRouting.map((item) => ({
         kind: item.kind,
@@ -115,9 +122,43 @@ test("pre-read payload builder trims React Web edit-target routing as an ordered
           source: "editGuidance.patchTargets",
           evidence: ["editGuidance.patchTargets.effect"],
         },
+        {
+          kind: "callback",
+          label: "useMemo deps:[name]",
+          priority: 4,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.callback"],
+        },
+        {
+          kind: "callback",
+          label: "useCallback deps:[loadUser, userId]",
+          priority: 5,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.callback"],
+        },
+        {
+          kind: "event-handler",
+          label: "handleRefresh",
+          priority: 6,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.event-handler"],
+        },
+        {
+          kind: "event-handler",
+          label: "handleRefresh",
+          priority: 7,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.event-handler"],
+        },
+        {
+          kind: "conditional-region",
+          label: "useEffect",
+          priority: 8,
+          source: "editGuidance.patchTargets",
+          evidence: ["editGuidance.patchTargets.snippet"],
+        },
       ],
     );
-    assert.ok(decision.payload.reactWebContext.stateHints.length > 0);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Replaces one-off React Web context trimming with an explicit edit-target-first trim policy.
- Preserves edit routing under budget pressure while trimming lower-directness metadata first.
- Keeps Codex host-facing React Web runtime context compact by omitting the minimal `reactWebContext` wrapper when it would make optimized additionalContext larger than source.
- Updates the existing budget regression note to match the new priority behavior.

## Tests
- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs test/react-web-context-evidence.test.mjs test/release-benchmark-evidence.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test` (470 pass)

## Boundaries
- No new React Web context fields.
- No new dependencies.
- No public savings/support claims added.
- No cross-file, typechecker, runtime DOM, visual, or design-system semantics.
