### PR TITLE
Bound historical CI replay batch echo

### DIFF
--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -399,11 +399,40 @@ function alertSummaryFields(allEvidence, focusBranch) {
   };
 }
 
+function historicalReplayBatchGuard(allEvidence, focusBranch, summaryFields) {
+  if (allEvidence.length === 0) {
+    return {
+      batchVerdict: "no-pasted-ci-run-urls",
+      batchDisposition: "none",
+      batchReason: "no GitHub Actions run URLs were present in the pasted alert buffer",
+    };
+  }
+
+  const inspectable = allEvidence.filter((alert) => alert.disposition === "inspect" || alert.disposition === "review");
+  const nonReplayNoise = allEvidence.filter((alert) => !alert.replay && !alert.echo && !alert.supersededMainCancellationEcho);
+  if (inspectable.length === 0 && summaryFields.staleReplayCount > 0 && nonReplayNoise.length === 0) {
+    return {
+      batchVerdict: "historical-ci-replay-batch",
+      batchDisposition: "suppress-historical-replay-before-current-main-echo",
+      batchReason: `current GitHub Actions state for ${focusBranch} remains authoritative; all non-current pasted run URLs are stale replay noise before ${summaryFields.currentHeadCount} current-head echo${summaryFields.currentHeadCount === 1 ? "" : "es"}`,
+    };
+  }
+
+  return {
+    batchVerdict: "mixed-ci-alert-buffer",
+    batchDisposition: inspectable.length > 0 ? "inspect-before-suppressing" : "review-before-suppressing",
+    batchReason: inspectable.length > 0
+      ? `${inspectable.length} pasted CI alert row${inspectable.length === 1 ? "" : "s"} still need inspection before suppressing historical replay noise`
+      : "pasted CI alert rows are not a pure historical replay batch",
+  };
+}
+
 function buildAlertEvidence(alertRefs, rows, options = {}) {
   const focusBranch = options.branch || "main";
   const allEvidence = buildRawAlertEvidence(alertRefs, rows, { branch: focusBranch });
   const limit = options.alertEvidenceLimit || DEFAULT_ALERT_EVIDENCE_LIMIT;
   const summaryFields = alertSummaryFields(allEvidence, focusBranch);
+  const batchGuard = historicalReplayBatchGuard(allEvidence, focusBranch, summaryFields);
 
   if (allEvidence.length <= limit) {
     return {
@@ -415,6 +444,7 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
         omitted: 0,
         focusBranch,
         ...summaryFields,
+        ...batchGuard,
       },
     };
   }
@@ -460,6 +490,7 @@ function buildAlertEvidence(alertRefs, rows, options = {}) {
       focusBranch,
       staleSampleLimit: STALE_ALERT_SAMPLE_LIMIT,
       ...summaryFields,
+      ...batchGuard,
       ...summarizeOmittedAlerts(omitted),
     },
   };
@@ -555,6 +586,9 @@ function formatCountMap(map) {
 
 function alertEvidenceTable(alerts, summary) {
   if (!alerts || alerts.length === 0) return "";
+  const batchGuard = summary?.batchVerdict
+    ? ` Batch guard: \`${escapeMarkdown(summary.batchVerdict)}\` / \`${escapeMarkdown(summary.batchDisposition)}\` — ${escapeMarkdown(summary.batchReason)}.`
+    : "";
   const currentHeadVerdict = summary?.currentHeadRunIds?.length
     ? ` Current-head verdict${summary.currentHeadRunIds.length === 1 ? "" : "s"}: ${summary.currentHeadRunIds.map((id) => `\`${escapeMarkdown(id)}\``).join(", ")}. Current-main echo count: ${summary.currentMainEchoCount ?? 0}. Stale historical replay count: ${summary.staleReplayCount ?? 0}.`
     : "";
@@ -562,8 +596,8 @@ function alertEvidenceTable(alerts, summary) {
     ? ` Bounded omitted run evidence: ${summary.omittedRunEvidence.map((evidence) => `\`${escapeMarkdown(evidence.runId)}:${escapeMarkdown(evidence.conclusion)}:${escapeMarkdown(evidence.disposition)}\``).join(", ")}${summary.omitted > summary.omittedRunEvidence.length ? ` (+${summary.omitted - summary.omittedRunEvidence.length} more)` : ""}.`
     : "";
   const compactNote = summary?.mode === "compact"
-    ? `Compact mode: showing ${summary.shown}/${summary.total} pasted alert URLs for focus branch \`${escapeMarkdown(summary.focusBranch)}\`; omitted ${summary.omitted} low-signal historical replay rows (${escapeMarkdown(formatCountMap(summary.byConclusion))}).${currentHeadVerdict}${omittedEvidence}`
-    : `Full mode: showing all ${summary?.shown ?? alerts.length} pasted alert URLs.${currentHeadVerdict}`;
+    ? `Compact mode: showing ${summary.shown}/${summary.total} pasted alert URLs for focus branch \`${escapeMarkdown(summary.focusBranch)}\`; omitted ${summary.omitted} low-signal historical replay rows (${escapeMarkdown(formatCountMap(summary.byConclusion))}).${batchGuard}${currentHeadVerdict}${omittedEvidence}`
+    : `Full mode: showing all ${summary?.shown ?? alerts.length} pasted alert URLs.${batchGuard}${currentHeadVerdict}`;
   const lines = [
     "## Pasted alert URL evidence",
     "",

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -772,6 +772,9 @@ test("CI alert triage collapses success-heavy clawhip bursts to current head plu
     assert.equal(result.alertSummary.omitted, 20);
     assert.equal(result.alertSummary.currentHeadCount, 1);
     assert.deepEqual(result.alertSummary.currentHeadRunIds, ["700"]);
+    assert.equal(result.alertSummary.batchVerdict, "historical-ci-replay-batch");
+    assert.equal(result.alertSummary.batchDisposition, "suppress-historical-replay-before-current-main-echo");
+    assert.match(result.alertSummary.batchReason, /current GitHub Actions state for main remains authoritative/);
     assert.equal(result.alertSummary.actionableAlertCount, 0);
     assert.equal(result.alertSummary.verificationOnlyCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 20);


### PR DESCRIPTION
Closes #452

## Summary
- Add a bounded historical replay batch guard for CI alert triage.
- Suppress pure historical replay batches before current-main echo reporting.
- Keep mixed/inspectable buffers reviewable instead of over-claiming.

## Validation
- `node --test test/ci-alert-triage.test.mjs` (18/18 passing)

Constraint: current live GitHub PR/main state remains authoritative; old runs are replay/noise unless they match latest origin/main/open PR.
Confidence: medium-high.
Tested: node --test test/ci-alert-triage.test.mjs.
