### PR TITLE
Correct package identity before public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fooks
 
+Stop paying the frontend context tax twice.
+
 Smaller model-facing context for repeated same-file work in Codex.
 
 `fooks` reduces model-facing input for supported repeated frontend same-file work. In the strongest path, a Codex user mentions the same React `.tsx` / `.jsx` file more than once in one repo: the first eligible mention records compact context, and later same-file prompts may reuse a compact model-facing payload when safe. Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
@@ -7,7 +9,7 @@ Smaller model-facing context for repeated same-file work in Codex.
 First-minute path:
 
 ```bash
-npm install -g fxxk-frontned-hooks
+npm install -g fxxk-frontend-hooks
 cd your-supported-project
 fooks setup
 fooks doctor
@@ -18,7 +20,7 @@ Then open Codex in that repo and work normally on the same supported file. `fook
 
 Best fit: repeated same-file React `.tsx` / `.jsx` work in Codex. There is also an experimental Codex-first `.ts` / `.js` same-file beta when module signals are strong enough. The first-minute proof is local model-facing payload evidence, not provider billing or stable runtime-token proof. React Native/WebView, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap asks, not current support.
 
-- Public npm package: `fxxk-frontned-hooks`
+- Public npm package: `fxxk-frontend-hooks`
 - CLI command: `fooks`
 
 ## 30-second version
@@ -39,9 +41,11 @@ The first-minute path above is the shortest setup/proof loop: install the CLI, a
 
 `fooks doctor` is the read-only health check for setup/hook readiness; its default output starts with status, why, first blocker, and next action so a new user can recover without reading JSON. `fooks compare` now defaults to a concise verdict/next-action summary for one supported file; add `--json` for exact local source-vs-payload evidence.
 
+If you run `fooks doctor` from a source checkout, new git worktree, or freshly cloned project before `fooks setup`, an `unhealthy` result usually means the project-local adapter/runtime manifests have not been activated yet. That is expected for an unprepared checkout; run `fooks setup`, then rerun `fooks doctor` to verify the dogfood state you will actually use.
+
 ### First-run checklist
 
-1. Install the package: `npm install -g fxxk-frontned-hooks`.
+1. Install the package: `npm install -g fxxk-frontend-hooks`.
 2. Confirm the command resolves to the package you expect: `which fooks` and `fooks --help`.
 3. Activate only the repo you are inside: `fooks setup`. The default output should be a short `ready`, `partial`, or `blocked` summary, not a debug JSON wall.
 4. Diagnose locally: `fooks doctor` for readiness, `fooks status` for local estimated session telemetry, `fooks status artifacts` for a read-only fooks tmux/worktree/branch audit, and `fooks compare <file> --json` for one-file payload proof.
@@ -54,6 +58,15 @@ The first-minute path above is the shortest setup/proof loop: install the CLI, a
 | Repeated same-file React `.tsx` / `.jsx` work in Codex. This includes normal React apps, Next.js components, and Ink-style React CLI components when the target file is real TSX/JSX. | Experimental Codex-first same-file `.ts` / `.js` module work when module signals are strong enough. | Universal file-read interception for every language, framework, runtime, or file type. |
 | Project setup that prepares Codex hooks plus narrower Claude/opencode helper paths when available. | Codex-only TS/JS setup can qualify when a strong beta module exists, but Claude/opencode helper setup is still React-only. | A claim that Claude or opencode has Codex-equivalent automatic runtime-token behavior or read-interception parity. |
 | Local model-facing payload estimates with `fooks compare` and local session estimates with `fooks status`. | TS/JS beta stays same-file only and does not imply semantic/framework understanding. | Provider usage/billing-token telemetry, provider tokenizer behavior, provider invoice/dashboard/charged-cost proof, or a `ccusage` replacement. |
+
+## Common scope questions
+
+| Question | Current strongest path | Current limit | Next credible path |
+| --- | --- | --- | --- |
+| “Does this help my general TypeScript project?” | Codex-only same-file `.ts` / `.js` beta when a strong module qualifies. | No broad semantic framework or multi-file refactor claim. | Add measured fixtures and claim gates before widening TS/JS support. |
+| “Can it refactor my whole Next.js app?” | Yes for repeated work on real TSX/JSX component files, including Next.js components. | No whole-app or route-wide refactor compression claim. | Prove larger Next profiles with fixtures, benchmarks, and edit-safety checks. |
+| “Does Claude get the same automation?” | Project-local `SessionStart` / `UserPromptSubmit` context hooks and manual/shared handoff artifacts. | No Claude `Read` interception or runtime-token savings proof. | Promote only with measured Claude runtime evidence and explicit hook boundaries. |
+| “What about opencode?” | Project-local `fooks_extract` custom tool and `/fooks-extract` slash command. | No automatic opencode read interception or automatic runtime-token savings. | A future read-shadow bridge would need separate safety and evidence gates. |
 
 ## Project/file support matrix
 
@@ -94,7 +107,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stron
 
 | Step | Scope | What can change |
 | --- | --- | --- |
-| `npm install -g fxxk-frontned-hooks` | global CLI install | Makes the `fooks` command available in the npm global prefix / PATH. It does not activate a project. |
+| `npm install -g fxxk-frontend-hooks` | global CLI install | Makes the `fooks` command available in the npm global prefix / PATH. It does not activate a project. |
 | `fooks setup` | current project + runtime homes | Creates project-local `.fooks/` state, may add project-local `.opencode/` helper files, and may update runtime-home files such as Codex hooks/manifests or Claude handoff manifests. |
 | `fooks doctor` | current project + runtime-home inspection | Reads local setup and hook-readiness artifacts without writing files; it is not live provider health, billing-token, cost, or `ccusage` proof. |
 | `fooks status` | current project inspection | Reads local fooks telemetry/status; it is not a package installer or billing-token report. |

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -2,7 +2,7 @@
 
 Date: 2026-04-25 UTC
 Branch: `chore/release-readiness-20260425-0000`
-Package: `fxxk-frontned-hooks`
+Package: `fxxk-frontend-hooks`
 Installed CLI: `fooks`
 
 This snapshot records the current pre-public release posture after the #172 LSP boundary cleanup and the separate #174 rejection/cleanup pass. It is intentionally evidence-scoped: it records local checks and remaining authority gates, not a publication decision.
@@ -18,9 +18,9 @@ This snapshot records the current pre-public release posture after the #172 LSP 
 
 ## Current package and CLI boundary
 
-- The npm package is `fxxk-frontned-hooks`.
+- The npm package is `fxxk-frontend-hooks`.
 - The installed command is `fooks`, via `package.json` `bin.fooks = "dist/cli/index.js"`.
-- Public install examples should continue to use `npm install -g fxxk-frontned-hooks`, not `npm install -g fooks`.
+- Public install examples should continue to use `npm install -g fxxk-frontend-hooks`, not `npm install -g fooks`.
 - `fooks setup` remains explicit; installing the package alone must not be described as automatically activating project hooks.
 
 ## Local verification on 2026-04-25 UTC
@@ -30,11 +30,11 @@ Dependencies were not present in this worktree at first, so `npm install` was ru
 | Check | Result | Evidence boundary |
 | --- | --- | --- |
 | `npm run release:smoke` | Passed | Local build, pack/install, isolated setup, hook smoke, doctor, status, and compare smoke evidence only. |
-| `npm pack --dry-run` | Passed | Dry-run package contents for `fxxk-frontned-hooks@0.1.3`; no publish performed. |
+| `npm pack --dry-run` | Passed | Dry-run package contents for `fxxk-frontend-hooks@0.1.3`; no publish performed. |
 
 Observed `release:smoke` summary:
 
-- Package under test: `fxxk-frontned-hooks@0.1.3`.
+- Package under test: `fxxk-frontend-hooks@0.1.3`.
 - Temporary installed binary: `fooks`.
 - Setup summary: `codex:automatic-ready:ready`, `claude:context-hook-ready:ready`, `opencode:tool-ready:ready`.
 - Doctor summary: 11 pass, 0 warn, 0 fail.
@@ -42,7 +42,7 @@ Observed `release:smoke` summary:
 
 Observed `npm pack --dry-run` summary:
 
-- Tarball name: `fxxk-frontned-hooks-0.1.3.tgz`.
+- Tarball name: `fxxk-frontend-hooks-0.1.3.tgz`.
 - Total files: 147.
 - Package size: 147.1 kB.
 - Unpacked size: 714.1 kB.
@@ -53,7 +53,7 @@ Observed `npm pack --dry-run` summary:
 The following remain unresolved until a human-approved publish step:
 
 - `npm publish` was not run.
-- `npm view fxxk-frontned-hooks` was not run as a release authority check in this docs-only PR.
+- `npm view fxxk-frontend-hooks` was not run as a release authority check in this docs-only PR.
 - `npm whoami` was not run; publisher identity was not asserted.
 - Package version and Git tag strategy still need an explicit release decision.
 - Any real publication remains blocked until the release checklist in `docs/release.md` is reviewed and approved.

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,9 +4,9 @@ This checklist prepares `fooks` for public npm distribution without publishing i
 
 ## Package and CLI boundary
 
-- npm package name: `fxxk-frontned-hooks`
+- npm package name: `fxxk-frontend-hooks`
 - installed CLI command: `fooks`
-- install command: `npm install -g fxxk-frontned-hooks`
+- install command: `npm install -g fxxk-frontend-hooks`
 - first setup command: `fooks setup`
 
 The npm package name intentionally differs from the CLI command because the unscoped npm package `fooks` is already occupied by another owner. Public docs must not tell users to globally install the occupied `fooks` npm package unless that ownership situation changes and a new release plan is approved.
@@ -110,7 +110,7 @@ A user who already has another global `fooks` binary may see command conflicts. 
 ```bash
 which fooks
 npm prefix -g
-npm ls -g --depth=0 | grep -E 'fooks|fxxk-frontned-hooks'
+npm ls -g --depth=0 | grep -E 'fooks|fxxk-frontend-hooks'
 ```
 
 ## Residual risk disposition
@@ -129,7 +129,7 @@ Do not run `npm publish` without explicit approval after this checklist is revie
 
 Automated local checks now covered by `npm run release:smoke`:
 
-- [x] package/CLI boundary is documented: `fxxk-frontned-hooks` installs `fooks`.
+- [x] package/CLI boundary is documented: `fxxk-frontend-hooks` installs `fooks`.
 - [x] possible pre-existing global `fooks` binary conflict is documented.
 - [x] no install, pack, publish, or version lifecycle script mutates user machines or publishes implicitly.
 - [x] `prepack` runs the TypeScript build before packing so a clean npm pack cannot silently ship stale or missing `dist/` artifacts.
@@ -144,7 +144,7 @@ Automated local checks now covered by `npm run release:smoke`:
 
 Authority-gated checks before any real publish:
 
-- [ ] `npm view fxxk-frontned-hooks` still confirms the name/state expected for release.
+- [ ] `npm view fxxk-frontend-hooks` still confirms the name/state expected for release.
 - [ ] `npm whoami` shows the intended publishing account.
 - [ ] package version and Git tag strategy are decided.
 - [ ] license decision is explicit and reflected in package metadata if required.
@@ -186,7 +186,7 @@ rm -rf /tmp/fooks-pack
 mkdir -p /tmp/fooks-pack
 npm pack --pack-destination /tmp/fooks-pack
 TMP_PREFIX=$(mktemp -d)
-TARBALL=$(ls /tmp/fooks-pack/fxxk-frontned-hooks-*.tgz | tail -n 1)
+TARBALL=$(ls /tmp/fooks-pack/fxxk-frontend-hooks-*.tgz | tail -n 1)
 npm install -g --prefix "$TMP_PREFIX" "$TARBALL"
 "$TMP_PREFIX/bin/fooks" status cache
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,10 +5,10 @@ Use this when you want one explicit command to prepare fooks for a supported fro
 ## 1. Install
 
 ```bash
-npm install -g fxxk-frontned-hooks
+npm install -g fxxk-frontend-hooks
 ```
 
-The package is named `fxxk-frontned-hooks`; it installs the `fooks` command. This is a **global CLI install** step: it changes which command is available from your npm global prefix/PATH, but it does not activate any repository by itself.
+The package is named `fxxk-frontend-hooks`; it installs the `fooks` command. This is a **global CLI install** step: it changes which command is available from your npm global prefix/PATH, but it does not activate any repository by itself.
 
 If setup seems to run the wrong binary, check:
 
@@ -52,7 +52,7 @@ Package install alone does not edit Codex hooks, Claude files, or opencode proje
 
 | Scope | Examples | Notes |
 | --- | --- | --- |
-| Global CLI install | `npm install -g fxxk-frontned-hooks`, `fooks` on PATH | This happens before setup. `fooks setup` does not install or update the npm package. |
+| Global CLI install | `npm install -g fxxk-frontend-hooks`, `fooks` on PATH | This happens before setup. `fooks setup` does not install or update the npm package. |
 | Project-local | `.fooks/config.json`, `.fooks/cache/`, `.opencode/tools/fooks_extract.ts`, `.opencode/commands/fooks-extract.md` | These apply to the current project root where you run `fooks setup`. |
 | User runtime/home | `~/.codex/hooks.json`, Codex attachment manifests, Claude handoff manifests | These are runtime integration files. Tests and smoke checks can isolate them with `FOOKS_CODEX_HOME` and `FOOKS_CLAUDE_HOME`. |
 
@@ -92,6 +92,8 @@ Good signs:
 - Activity status reports a compact read-only operator snapshot: current worktree branch/divergence/current dirty-path delta plus active fooks-like tmux panes when tmux is available. Open issue/PR counts are omitted unless `--include-remote-counts` is passed.
 
 `fooks doctor [codex|claude] [--json]` is read-only. Human output starts with status, why, first blocker, and next action, while `--json` exposes the same readiness summary for tools. It checks local fooks setup artifacts, runtime manifests, hook event installation, Codex trust status, cache health, and supported source-file presence. Focused `fooks doctor claude` also includes an optional TypeScript language server host-tooling check as warning-only. It does not mutate `.fooks/`, Codex hooks, Claude project-local settings, or runtime-home manifests. It also does not prove live provider health; it is not a ccusage replacement and not provider usage/billing-token telemetry, invoices, dashboards, or charged costs.
+
+For source checkouts, fresh clones, and temporary git worktrees, `fooks doctor` may be `unhealthy` before activation because project-local adapters and runtime manifests are intentionally not committed as universal defaults. Treat that as a setup reminder, not package corruption: run `fooks setup` in the checkout you plan to use, then rerun `fooks doctor` for the real dogfood readiness verdict.
 
 Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summaries written by the Codex automatic hook path and the Claude project-local context-hook path, includes runtime/source breakdowns, omits per-session details from CLI status output, and estimates context size with a simple bytes-to-token approximation. It must not be described as provider usage/billing tokens, invoices, dashboards, charged costs, or a `ccusage` replacement. To remove local fooks state for a repo, delete that repo's `.fooks/` directory.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fxxk-frontned-hooks",
+  "name": "fxxk-frontend-hooks",
   "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fxxk-frontned-hooks",
+      "name": "fxxk-frontend-hooks",
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fxxk-frontned-hooks",
+  "name": "fxxk-frontend-hooks",
   "version": "0.1.3",
   "type": "commonjs",
   "bin": {
@@ -25,7 +25,7 @@
     "lint": "npm run typecheck -- --pretty false",
     "smoke:claude": "npm run build && node scripts/smoke-claude-hook.mjs",
     "smoke:domain-detector": "npm run build && node dist/cli/index.js inspect-domain test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx --json",
-    "prepack": "npm run build",
+    "prepack": "npm run build && node scripts/release-smoke.mjs --prepack",
     "release:smoke": "npm run build && node scripts/release-smoke.mjs",
     "bench:layer2:r4:repeated": "npm run build && node benchmarks/layer2-frontend-task/run-r4-repeated.js",
     "bench:layer2:provider-cost": "node benchmarks/layer2-frontend-task/run-provider-cost-evidence.js",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/node": "^24.5.2"
   },
-  "description": "Frontend context compression CLI for React/TSX projects; npm package fxxk-frontned-hooks installs the fooks command.",
+  "description": "Frontend context compression CLI for React/TSX projects; npm package fxxk-frontend-hooks installs the fooks command.",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -12,6 +12,7 @@ import {
 } from "./release-benchmark-evidence.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const prepackOnly = process.argv.includes("--prepack");
 
 function run(command, args, options = {}) {
   return execFileSync(command, args, {
@@ -30,12 +31,85 @@ function assert(condition, message) {
 }
 
 function parsePackJson(stdout) {
-  const parsed = JSON.parse(stdout);
+  const trimmed = stdout.trim();
+  const arrayStart = trimmed.lastIndexOf("\n[");
+  const jsonText = arrayStart >= 0 ? trimmed.slice(arrayStart + 1) : trimmed;
+  const parsed = JSON.parse(jsonText);
   assert(Array.isArray(parsed) && parsed.length === 1, "npm pack --json should return one package entry");
   return parsed[0];
 }
 
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"));
+}
 
+function assertPackageIdentity() {
+  const pkg = readJson("package.json");
+  const lock = readJson("package-lock.json");
+  assert(pkg.name === "fxxk-frontend-hooks", `package.json name should be fxxk-frontend-hooks, got ${pkg.name}`);
+  assert(lock.name === "fxxk-frontend-hooks", `package-lock.json name should be fxxk-frontend-hooks, got ${lock.name}`);
+  assert(
+    lock.packages?.[""]?.name === "fxxk-frontend-hooks",
+    `package-lock root name should be fxxk-frontend-hooks, got ${lock.packages?.[""]?.name}`,
+  );
+  assert(pkg.bin?.fooks === "dist/cli/index.js", "package bin.fooks should remain dist/cli/index.js");
+  assert(
+    pkg.scripts?.prepack && !/npm\s+pack|npm\s+install|release:smoke/i.test(pkg.scripts.prepack),
+    "prepack must not invoke npm pack, npm install, or release:smoke",
+  );
+  return pkg;
+}
+
+function assertScopedInstallStrings() {
+  const oldTypoPackageName = `fxxk-${"front"}${"ned"}-hooks`;
+  const surfaces = [
+    "README.md",
+    "docs/setup.md",
+    "docs/release.md",
+    "docs/release-readiness.md",
+    "dist/cli/index.js",
+  ];
+  for (const relativePath of surfaces) {
+    const fullPath = path.join(repoRoot, relativePath);
+    assert(fs.existsSync(fullPath), `${relativePath} should exist for release preflight`);
+    const content = fs.readFileSync(fullPath, "utf8");
+    assert(!content.includes(oldTypoPackageName), `${relativePath} still references the old typo package name`);
+  }
+  const publicDocs = ["README.md", "docs/setup.md", "docs/release.md", "docs/release-readiness.md"]
+    .map((relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8"))
+    .join("\n");
+  assert(publicDocs.includes("npm install -g fxxk-frontend-hooks"), "public docs should show package install command");
+}
+
+function assertNoExecutableRegistryMutationAutomation() {
+  const pkg = readJson("package.json");
+  const executableSurfaces = Object.entries(pkg.scripts ?? {}).map(([name, value]) => `package.json scripts.${name}: ${value}`);
+  for (const entry of fs.readdirSync(path.join(repoRoot, "scripts"), { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".mjs")) {
+      const content = fs.readFileSync(path.join(repoRoot, "scripts", entry.name), "utf8");
+      executableSurfaces.push(`scripts/${entry.name}:\n${content}`);
+    }
+  }
+  const executableRegistryMutation = /(?:execFileSync|spawn|spawnSync|run)\s*\([^\n]*(?:publish|deprecate|unpublish)|npm\s+(?:publish|deprecate|unpublish)|package\s+delete/i;
+  const hits = executableSurfaces.filter((surface) => executableRegistryMutation.test(surface));
+  assert(hits.length === 0, `executable registry mutation automation found: ${hits.join("\n---\n")}`);
+}
+
+function assertPrepackSafeReleaseSurface() {
+  const pkg = assertPackageIdentity();
+  assert(fs.existsSync(path.join(repoRoot, "dist", "cli", "index.js")), "prepack preflight requires built dist/cli/index.js");
+  assert(fs.existsSync(path.join(repoRoot, "dist", "index.js")), "prepack preflight requires built dist/index.js");
+  assertScopedInstallStrings();
+  assertNoExecutableRegistryMutationAutomation();
+  assertPublicSurfaceClaimBoundaries({
+    "README.md": fs.readFileSync(path.join(repoRoot, "README.md"), "utf8"),
+    "docs/setup.md": fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8"),
+    "docs/release.md": fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8"),
+    "docs/release-readiness.md": fs.readFileSync(path.join(repoRoot, "docs", "release-readiness.md"), "utf8"),
+    "dist/cli/index.js": fs.readFileSync(path.join(repoRoot, "dist", "cli", "index.js"), "utf8"),
+  });
+  return pkg;
+}
 
 function runInstalledFooks(fooksBin, args, options = {}) {
   return execFileSync(fooksBin, args, {
@@ -134,6 +208,12 @@ function assertPackedFiles(packEntry) {
   }
 }
 
+const pkg = assertPrepackSafeReleaseSurface();
+if (prepackOnly) {
+  console.log(JSON.stringify({ ok: true, mode: "prepack", package: `${pkg.name}@${pkg.version}`, bin: pkg.bin }, null, 2));
+  process.exit(0);
+}
+
 function copyReleaseBenchmarkInputs(targetRoot) {
   for (const relativePath of ["dist", "fixtures", path.join("test", "fixtures")]) {
     fs.cpSync(path.join(repoRoot, relativePath), path.join(targetRoot, relativePath), { recursive: true });
@@ -162,7 +242,10 @@ async function buildReleaseBenchmarkPreflightSummary() {
 
 const releaseBenchmarkSmokeSummary = await buildReleaseBenchmarkPreflightSummary();
 
+
 const dryRun = parsePackJson(run("npm", ["pack", "--dry-run", "--json"]));
+assert(dryRun.name === "fxxk-frontend-hooks", `dry-run package name should be fxxk-frontend-hooks, got ${dryRun.name}`);
+assert(dryRun.filename === `fxxk-frontend-hooks-${pkg.version}.tgz`, `package tarball filename should be fxxk-frontend-hooks-${pkg.version}.tgz, got ${dryRun.filename}`);
 assertPackedFiles(dryRun);
 
 const packDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pack-"));
@@ -339,6 +422,7 @@ const doctor = JSON.parse(doctorStdout);
 assert(doctor.command === "doctor", `doctor command should be doctor, got ${doctor.command}`);
 assert(doctor.healthy === true, `doctor should be healthy after setup, got ${doctor.healthy}`);
 assert(doctor.summary?.fail === 0, `doctor should have zero failures after setup, got ${doctor.summary?.fail}`);
+assert(typeof doctor.summary?.warn === "number", "doctor should expose an explicit warning count");
 assert(doctor.claimBoundaries?.some((item) => item.includes("local fooks configuration")), "doctor should expose local-configuration claim boundary");
 assert(fs.existsSync(path.join(codexHome, "hooks.json")), "isolated Codex hooks file should be written under FOOKS_CODEX_HOME");
 const claudeLocalSettings = path.join(project, ".claude", "settings.local.json");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -141,7 +141,7 @@ type SetupScopeSummary = {
   projectRoot: string;
   packageInstall: {
     scope: "global-cli";
-    command: "npm install -g fxxk-frontned-hooks";
+    command: "npm install -g fxxk-frontend-hooks";
     installsCommand: string;
     mutatedBySetup: false;
     note: string;
@@ -226,7 +226,7 @@ function buildSetupScopeSummary(options: {
     projectRoot: options.cwd,
     packageInstall: {
       scope: "global-cli",
-      command: "npm install -g fxxk-frontned-hooks",
+      command: "npm install -g fxxk-frontend-hooks",
       installsCommand: options.displayCliName,
       mutatedBySetup: false,
       note: "The npm package install makes the fooks command available globally; fooks setup does not install or update the npm package.",
@@ -658,7 +658,7 @@ Everyday commands:
   ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} claude-runtime-hook --native-hook
 
-Install: npm install -g fxxk-frontned-hooks
+Install: npm install -g fxxk-frontend-hooks
 CLI command: ${displayCliName}`);
 }
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3013,9 +3013,56 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.equal(pkg.scripts?.postinstall, undefined);
   assert.equal(pkg.scripts?.preinstall, undefined);
   assert.equal(pkg.scripts?.prepare, undefined);
-  assert.equal(pkg.scripts?.prepack, "npm run build");
+  assert.equal(pkg.name, "fxxk-frontend-hooks");
+  assert.equal(pkg.bin?.fooks, "dist/cli/index.js");
+  assert.equal(pkg.scripts?.prepack, "npm run build && node scripts/release-smoke.mjs --prepack");
+  assert.doesNotMatch(pkg.scripts?.prepack, /npm pack|npm install|release:smoke/);
   assert.match(pkg.scripts?.["release:smoke"], /scripts\/release-smoke\.mjs/);
   assert.doesNotMatch(pkg.scripts?.["release:smoke"], /publish|version|tag/);
+});
+
+test("package identity fixes frontend typo while installed CLI remains fooks", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  const lock = JSON.parse(fs.readFileSync(path.join(repoRoot, "package-lock.json"), "utf8"));
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
+  const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
+  const readiness = fs.readFileSync(path.join(repoRoot, "docs", "release-readiness.md"), "utf8");
+  const cli = fs.readFileSync(path.join(repoRoot, "src", "cli", "index.ts"), "utf8");
+  const combinedPublic = `${readme}
+${setup}
+${release}
+${readiness}
+${cli}`;
+  const oldTypoPackageName = `fxxk-${"front"}${"ned"}-hooks`;
+  const oldTypoSegment = `${"front"}${"ned"}`;
+
+  assert.equal(pkg.name, "fxxk-frontend-hooks");
+  assert.equal(lock.name, "fxxk-frontend-hooks");
+  assert.equal(lock.packages[""].name, "fxxk-frontend-hooks");
+  assert.equal(pkg.bin.fooks, "dist/cli/index.js");
+  assert.match(combinedPublic, /npm install -g fxxk-frontend-hooks/);
+  assert.equal(combinedPublic.includes(oldTypoPackageName), false);
+  assert.equal(combinedPublic.includes(oldTypoSegment), false);
+  assert.match(release, /fxxk-frontend-hooks-\*\.tgz/);
+  assert.match(readiness, /fxxk-frontend-hooks-0\.1\.3\.tgz/);
+});
+
+test("release lifecycle guards prevent recursive pack and registry mutation automation", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  assert.equal(pkg.scripts.prepack, "npm run build && node scripts/release-smoke.mjs --prepack");
+  assert.doesNotMatch(pkg.scripts.prepack, /npm\s+pack|npm\s+install|release:smoke/);
+
+  const executableSurfaces = Object.entries(pkg.scripts ?? {}).map(([name, value]) => `package.json scripts.${name}: ${value}`);
+  for (const entry of fs.readdirSync(path.join(repoRoot, "scripts"), { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".mjs")) {
+      const content = fs.readFileSync(path.join(repoRoot, "scripts", entry.name), "utf8");
+      executableSurfaces.push(`scripts/${entry.name}:\n${content}`);
+    }
+  }
+  const executableRegistryMutation = /(?:execFileSync|spawn|spawnSync|run)\s*\([^\n]*(?:publish|deprecate|unpublish)|npm\s+(?:publish|deprecate|unpublish)|package\s+delete/i;
+  const hits = executableSurfaces.filter((surface) => executableRegistryMutation.test(surface));
+  assert.deepEqual(hits, []);
 });
 
 test("status artifacts route reports read-only audit JSON", () => {
@@ -4957,7 +5004,7 @@ test("docs give first-run users a clear support and diagnosis path", () => {
   const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
   const combined = `${readme}\n${setup}`;
 
-  assert.match(readme, /npm install -g fxxk-frontned-hooks/);
+  assert.match(readme, /npm install -g fxxk-frontend-hooks/);
   assert.match(readme, /First-run checklist/);
   assert.match(combined, /fooks setup\s+# short ready \/ partial \/ blocked summary/);
   assert.match(combined, /fooks doctor/);


### PR DESCRIPTION
## Summary
- rename the npm package from the typo-bearing `fxxk-frontned-hooks` to `fxxk-frontend-hooks` while keeping the installed CLI command as `fooks`
- refresh README/setup/release docs around install, scope, doctor readiness, and current support boundaries
- add prepack/release-smoke guards for package identity, tarball naming, dist presence, stale typo strings, and registry-mutation automation

## Verification
- `npm run typecheck`
- `npm test` — 467/467 pass
- `npm run release:smoke` — `fxxk-frontend-hooks@0.1.3`, tarball `fxxk-frontend-hooks-0.1.3.tgz`, isolated doctor `pass 11 / warn 0 / fail 0`
- `npm pack --dry-run --json` — name `fxxk-frontend-hooks`, filename `fxxk-frontend-hooks-0.1.3.tgz`, `dist/cli/index.js` included
- stale scan over package/docs/CLI/tests/scripts: no `@minislively/fooks`, `minislively-fooks`, `fxxk-frontned-hooks`, or `frontned` hits
- npm registry check: `npm view fxxk-frontend-hooks name version --json` returned E404 before publish, so the name is not currently published/visible from this environment

## Release note
Publishing this package will make the global install command:

```bash
npm install -g fxxk-frontend-hooks
```

The executable command remains:

```bash
fooks
```

## Not done
- Did not run `npm publish`.
