### PR TITLE
Route React Web context into runtime reuse

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -24,6 +24,34 @@ const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|mo
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const EDIT_GUIDANCE_CONTEXT_MAX_BYTES = 8_192;
 
+type RuntimeReactWebContext = NonNullable<ModelFacingPayload["reactWebContext"]>;
+type RuntimeReactWebContextArrayKey = Exclude<{
+  [Key in keyof RuntimeReactWebContext]: RuntimeReactWebContext[Key] extends unknown[] | undefined ? Key : never;
+}[keyof RuntimeReactWebContext], undefined>;
+type PackedRuntimeReactWebContext = {
+  schemaVersion: RuntimeReactWebContext["schemaVersion"];
+  freshness: RuntimeReactWebContext["freshness"];
+  scope: {
+    kind: RuntimeReactWebContext["scope"]["kind"];
+    filePath: RuntimeReactWebContext["scope"]["filePath"];
+    componentName?: RuntimeReactWebContext["scope"]["componentName"];
+  };
+} & Partial<Pick<RuntimeReactWebContext, RuntimeReactWebContextArrayKey>>;
+
+const RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY: RuntimeReactWebContextArrayKey[] = [
+  "editTargetRouting",
+  "formStateFlow",
+  "a11yAnchors",
+  "intentTargets",
+  "stateHints",
+  "layoutRegionHints",
+  "componentApiHints",
+  "stylingVariantHints",
+  "importRoleHints",
+  "renderStates",
+  "localDependencies",
+];
+
 function payloadContextMode(payload: ModelFacingPayload): ContextMode {
   return payload.useOriginal ? "light-minimal" : "light";
 }
@@ -41,27 +69,32 @@ function payloadContextModeReason(
     : `${phase}-exact-file-narrow-payload`;
 }
 
-function buildRuntimeContextPayload(payload: ModelFacingPayload, includeReactWebContext = true): { optimized: boolean; payload: unknown } {
+function minimalRuntimeReactWebContext(reactWebContext: RuntimeReactWebContext): PackedRuntimeReactWebContext {
+  return {
+    schemaVersion: reactWebContext.schemaVersion,
+    freshness: reactWebContext.freshness,
+    scope: {
+      kind: reactWebContext.scope.kind,
+      filePath: reactWebContext.scope.filePath,
+      componentName: reactWebContext.scope.componentName,
+    },
+  };
+}
+
+function optimizedReactWebRuntimePayload(payload: ModelFacingPayload, reactWebContext?: PackedRuntimeReactWebContext): unknown {
+  return {
+    filePath: payload.filePath,
+    sourceFingerprint: payload.sourceFingerprint,
+    domainPayload: payload.domainPayload,
+    ...(reactWebContext ? { reactWebContext } : {}),
+  };
+}
+
+function buildRuntimeContextPayload(payload: ModelFacingPayload, reactWebContext?: PackedRuntimeReactWebContext): { optimized: boolean; payload: unknown } {
   if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
-    const reactWebContext = includeReactWebContext && payload.reactWebContext
-      ? {
-          schemaVersion: payload.reactWebContext.schemaVersion,
-          freshness: payload.reactWebContext.freshness,
-          scope: {
-            kind: payload.reactWebContext.scope.kind,
-            filePath: payload.reactWebContext.scope.filePath,
-            componentName: payload.reactWebContext.scope.componentName,
-          },
-        }
-      : undefined;
     return {
       optimized: true,
-      payload: {
-        filePath: payload.filePath,
-        sourceFingerprint: payload.sourceFingerprint,
-        domainPayload: payload.domainPayload,
-        ...(reactWebContext ? { reactWebContext } : {}),
-      },
+      payload: optimizedReactWebRuntimePayload(payload, reactWebContext),
     };
   }
   return { optimized: false, payload };
@@ -79,23 +112,70 @@ function renderAdditionalContext(
   ].join("\n");
 }
 
+function renderOptimizedReactWebAdditionalContext(
+  filePath: string,
+  payload: ModelFacingPayload,
+  contextMode: ContextMode,
+  reactWebContext?: PackedRuntimeReactWebContext,
+): string {
+  return renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload, reactWebContext));
+}
+
+function compactRuntimeReactWebContext(
+  filePath: string,
+  payload: ModelFacingPayload,
+  contextMode: ContextMode,
+  maxOptimizedContextBytes?: number,
+): PackedRuntimeReactWebContext | undefined {
+  if (!payload.reactWebContext) return undefined;
+
+  const fits = (reactWebContext?: PackedRuntimeReactWebContext): boolean => {
+    if (maxOptimizedContextBytes === undefined) return true;
+    const additionalContext = renderOptimizedReactWebAdditionalContext(filePath, payload, contextMode, reactWebContext);
+    return estimateTextBytes(additionalContext) <= maxOptimizedContextBytes;
+  };
+
+  const compactContext = minimalRuntimeReactWebContext(payload.reactWebContext);
+  if (!fits(compactContext)) return undefined;
+
+  for (const field of RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY) {
+    const values = payload.reactWebContext[field];
+    if (!Array.isArray(values) || values.length === 0) continue;
+
+    const fullCandidate = { ...compactContext, [field]: values };
+    if (fits(fullCandidate)) {
+      Object.assign(compactContext, { [field]: values });
+      continue;
+    }
+
+    for (let itemCount = values.length - 1; itemCount > 0; itemCount -= 1) {
+      const partialCandidate = { ...compactContext, [field]: values.slice(0, itemCount) };
+      if (fits(partialCandidate)) {
+        Object.assign(compactContext, { [field]: values.slice(0, itemCount) });
+        break;
+      }
+    }
+  }
+
+  return compactContext;
+}
+
 function buildAdditionalContext(
   filePath: string,
   payload: ModelFacingPayload,
   contextMode: ContextMode,
   maxOptimizedContextBytes?: number,
 ): string {
-  const runtimeContextPayload = buildRuntimeContextPayload(payload);
-  const additionalContext = renderAdditionalContext(filePath, payload.mode, contextMode, runtimeContextPayload);
-  if (
-    runtimeContextPayload.optimized &&
-    payload.reactWebContext &&
-    maxOptimizedContextBytes !== undefined &&
-    estimateTextBytes(additionalContext) > maxOptimizedContextBytes
-  ) {
-    return renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload, false));
+  if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
+    return renderOptimizedReactWebAdditionalContext(
+      filePath,
+      payload,
+      contextMode,
+      compactRuntimeReactWebContext(filePath, payload, contextMode, maxOptimizedContextBytes),
+    );
   }
-  return additionalContext;
+
+  return renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload));
 }
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -105,6 +105,76 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondContext.additionalContext.includes("\"reactWebContext\""), true);
   assert.equal(secondContext.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
   assert.equal(secondContext.debug.decision.debug.reactWebContextBudget.included, true);
+  const optimizedContextPayload = JSON.parse(secondContext.additionalContext.split("\n").slice(1).join("\n"));
+  assert.equal(optimizedContextPayload.reactWebContext.schemaVersion, "react-web-context.v0");
+  assert.equal("editTargetRouting" in optimizedContextPayload.reactWebContext, false);
+  assert.ok(
+    Buffer.byteLength(secondContext.additionalContext, "utf8") <= fs.statSync(path.join(repoRoot, "fixtures/compressed/FormSection.tsx")).size,
+  );
+
+  const pressureSession = `bridge-contract-react-web-context-pressure-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: pressureSession }, repoRoot);
+  handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: pressureSession,
+      prompt: "Inspect fixtures/compressed/HookEffectPanel.tsx",
+    },
+    repoRoot,
+  );
+  const pressureContext = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId: pressureSession,
+      prompt: "Inspect fixtures/compressed/HookEffectPanel.tsx again",
+    },
+    repoRoot,
+  );
+  const pressurePayload = JSON.parse(pressureContext.additionalContext.split("\n").slice(1).join("\n"));
+  assert.equal(pressureContext.contextModeReason, "repeated-exact-file-react-web-payload");
+  assert.equal("reactWebContext" in pressurePayload, false);
+  assert.ok(
+    Buffer.byteLength(pressureContext.additionalContext, "utf8") <= fs.statSync(path.join(repoRoot, "fixtures/compressed/HookEffectPanel.tsx")).size,
+  );
+
+  const runtimePackingTempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-context-routing-"));
+  try {
+    fs.mkdirSync(path.join(runtimePackingTempDir, "src"), { recursive: true });
+    const largeReactSource = `${fs.readFileSync(path.join(repoRoot, "fixtures/compressed/FormSection.tsx"), "utf8")}
+{/* ${"routing budget filler ".repeat(200)} */}
+`;
+    fs.writeFileSync(path.join(runtimePackingTempDir, "src", "LargeFormSection.tsx"), largeReactSource);
+
+    const packedSession = `bridge-contract-react-web-context-packed-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: packedSession }, runtimePackingTempDir);
+    handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: packedSession,
+        prompt: "Inspect src/LargeFormSection.tsx",
+      },
+      runtimePackingTempDir,
+    );
+    const packedContext = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: packedSession,
+        prompt: "Inspect src/LargeFormSection.tsx again",
+      },
+      runtimePackingTempDir,
+    );
+    const packedPayload = JSON.parse(packedContext.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(packedContext.action, "inject");
+    assert.equal(packedContext.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.ok(Array.isArray(packedPayload.reactWebContext.editTargetRouting));
+    assert.ok(packedPayload.reactWebContext.editTargetRouting.length > 0);
+    assert.ok(Array.isArray(packedPayload.reactWebContext.a11yAnchors));
+    assert.ok(Buffer.byteLength(packedContext.additionalContext, "utf8") <= Buffer.byteLength(largeReactSource, "utf8"));
+    assert.equal("sourceRanges" in packedPayload.reactWebContext, false);
+  } finally {
+    fs.rmSync(runtimePackingTempDir, { recursive: true, force: true });
+  }
 
   const wrapperSession = `bridge-contract-wrapper-debug-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: wrapperSession }, repoRoot);


### PR DESCRIPTION
## Summary
- routes a compact subset of existing source-backed React Web context into optimized Codex runtime `additionalContext`
- preserves source-byte compactness by degrading to minimal or domainPayload-only React Web context under pressure
- adds runtime bridge regressions for packed-context inclusion and byte-pressure omission

## Boundaries
- no new React Web metadata fields
- no cross-file, typechecker/LSP, visual, runtime DOM, design-system, or accessibility-correctness claims
- no provider-token, billing, latency, or runtime savings claim

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/react-web-context-evidence.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test` → 472 passed
- LSP diagnostics on changed files → 0 errors
- Architect verification → APPROVED