### PR TITLE
Show React Web context in compare output

### DIFF
--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -6,7 +6,7 @@ import {
   estimateTextBytes,
   estimateTokensFromBytes,
 } from "./session-metrics";
-import type { OutputMode } from "./schema";
+import type { ModelFacingPayload, OutputMode } from "./schema";
 
 export const FOOKS_COMPARE_CLAIM_BOUNDARY = `${FOOKS_METRIC_CLAIM_BOUNDARY} Compare values are local model-facing payload estimates, not provider tokenizer output, not runtime hook envelope overhead, and not provider invoice/dashboard/charged-cost proof.`;
 
@@ -14,6 +14,19 @@ export type FooksCompareUserSummary = {
   verdict: "estimated-reduction" | "no-estimated-reduction";
   headline: string;
   nextAction: string;
+};
+
+export type FooksCompareReactWebContextSummary = {
+  present: boolean;
+  schemaVersion: string;
+  scope: {
+    kind: "same-file" | "same-component";
+    filePath: string;
+    componentName?: string;
+  };
+  fieldCounts: Record<string, number>;
+  totalAnchors: number;
+  claimBoundary: "source-backed-react-web-context-counts-only";
 };
 
 export type FooksCompareResult = {
@@ -30,11 +43,52 @@ export type FooksCompareResult = {
   reductionPercent: number;
   payloadLarger: boolean;
   nonSavingReason?: "original-source-preserved-for-small-raw-file" | "model-facing-payload-not-smaller";
+  reactWebContextSummary?: FooksCompareReactWebContextSummary;
   metricTier: typeof FOOKS_SESSION_METRIC_TIER;
   measurement: "local-model-facing-payload";
   excludes: string[];
   claimBoundary: string;
 };
+
+
+const REACT_WEB_CONTEXT_SUMMARY_FIELDS = [
+  "editTargetRouting",
+  "formStateFlow",
+  "a11yAnchors",
+  "intentTargets",
+  "stateHints",
+  "layoutRegionHints",
+  "componentApiHints",
+  "stylingVariantHints",
+  "importRoleHints",
+  "renderStates",
+  "localDependencies",
+] as const;
+
+function reactWebContextSummaryFor(payload: ModelFacingPayload, useOriginal: boolean): FooksCompareReactWebContextSummary | undefined {
+  if (useOriginal || !payload.reactWebContext) return undefined;
+
+  const fieldCounts: Record<string, number> = {};
+  for (const field of REACT_WEB_CONTEXT_SUMMARY_FIELDS) {
+    const values = payload.reactWebContext[field];
+    if (Array.isArray(values) && values.length > 0) {
+      fieldCounts[field] = values.length;
+    }
+  }
+
+  return {
+    present: true,
+    schemaVersion: payload.reactWebContext.schemaVersion,
+    scope: {
+      kind: payload.reactWebContext.scope.kind,
+      filePath: payload.reactWebContext.scope.filePath,
+      componentName: payload.reactWebContext.scope.componentName,
+    },
+    fieldCounts,
+    totalAnchors: Object.values(fieldCounts).reduce((total, count) => total + count, 0),
+    claimBoundary: "source-backed-react-web-context-counts-only",
+  };
+}
 
 function roundPercent(value: number): number {
   return Number(value.toFixed(2));
@@ -80,6 +134,9 @@ export function formatCompare(result: FooksCompareResult): string {
   const proofLine = result.userSummary.verdict === "estimated-reduction"
     ? `Local proof: source ${result.sourceBytes} bytes / ${result.estimatedSourceTokens} est tokens → model-facing ${result.modelFacingBytes} bytes / ${result.estimatedModelFacingTokens} est tokens; saved ${result.savedEstimatedBytes} bytes / ${result.savedEstimatedTokens} est tokens.`
     : `Local proof: source ${result.sourceBytes} bytes / ${result.estimatedSourceTokens} est tokens → model-facing ${result.modelFacingBytes} bytes / ${result.estimatedModelFacingTokens} est tokens; no local estimate savings for this file.`;
+  const reactWebContextLine = result.reactWebContextSummary
+    ? `React Web context: ${result.reactWebContextSummary.totalAnchors} source-backed anchors across ${Object.keys(result.reactWebContextSummary.fieldCounts).length} summary fields (counts only; see --json).`
+    : undefined;
   const lines = [
     `fooks compare ${result.filePath}`,
     "",
@@ -87,6 +144,7 @@ export function formatCompare(result: FooksCompareResult): string {
     `Why: ${result.userSummary.headline}`,
     `Mode: ${result.mode}${result.useOriginal ? " (original source preserved)" : ""}`,
     proofLine,
+    ...(reactWebContextLine ? [reactWebContextLine] : []),
     `Next action: ${result.userSummary.nextAction}`,
     "",
     "Boundary: Local model-facing payload estimate only; not provider tokenizer output, billing tokens, invoices, dashboards, or charged costs.",
@@ -98,6 +156,12 @@ export function formatCompare(result: FooksCompareResult): string {
 export function compareModelFacingPayload(filePath: string, cwd = process.cwd()): FooksCompareResult {
   const extracted = extractFile(filePath);
   const payload = toModelFacingPayload(extracted, cwd);
+  const useOriginal = extracted.useOriginal === true;
+  const contextPayload = toModelFacingPayload(extracted, cwd, {
+    includeDomainPayload: true,
+    includeReactWebContextMetadata: true,
+  });
+  const reactWebContextSummary = reactWebContextSummaryFor(contextPayload, useOriginal);
   const sourceBytes = extracted.meta.rawSizeBytes;
   const modelFacingBytes = estimateTextBytes(JSON.stringify(payload));
   const estimatedSourceTokens = estimateTokensFromBytes(sourceBytes);
@@ -106,7 +170,6 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
   const savedEstimatedTokens = Math.max(0, estimatedSourceTokens - estimatedModelFacingTokens);
   const reductionPercent = sourceBytes === 0 ? 0 : roundPercent((savedEstimatedBytes / sourceBytes) * 100);
   const payloadLarger = modelFacingBytes >= sourceBytes;
-  const useOriginal = extracted.useOriginal === true;
 
   return {
     filePath: payload.filePath,
@@ -122,6 +185,7 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
     reductionPercent,
     payloadLarger,
     ...(payloadLarger || useOriginal ? { nonSavingReason: nonSavingReason(useOriginal, payloadLarger) } : {}),
+    ...(reactWebContextSummary ? { reactWebContextSummary } : {}),
     metricTier: FOOKS_SESSION_METRIC_TIER,
     measurement: "local-model-facing-payload",
     excludes: [

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -513,6 +513,14 @@ test("compare reports local estimated model-facing payload reduction", () => {
   assert.ok(result.savedEstimatedTokens > 0);
   assert.ok(result.reductionPercent > 0);
   assert.equal(result.payloadLarger, false);
+  assert.equal(result.reactWebContextSummary.present, true);
+  assert.equal(result.reactWebContextSummary.schemaVersion, "react-web-context.v0");
+  assert.equal(result.reactWebContextSummary.scope.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(result.reactWebContextSummary.scope.componentName, "FormSection");
+  assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
+  assert.ok(result.reactWebContextSummary.fieldCounts.a11yAnchors > 0);
+  assert.ok(result.reactWebContextSummary.totalAnchors > 0);
+  assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
   assert.match(result.claimBoundary, /not provider usage\/billing tokens/);
   assert.match(result.claimBoundary, /not provider usage\/billing tokens, invoices, dashboards, charged costs/);
   assert.ok(result.excludes.includes("provider-tokenizer-behavior"));
@@ -531,6 +539,7 @@ test("compare keeps tiny raw fallback from reporting false positive savings", ()
   assert.equal(result.reductionPercent, 0);
   assert.equal(result.payloadLarger, true);
   assert.equal(result.nonSavingReason, "original-source-preserved-for-small-raw-file");
+  assert.equal("reactWebContextSummary" in result, false);
   assert.equal(result.userSummary.verdict, "no-estimated-reduction");
   assert.match(result.userSummary.headline, /original source/);
   assert.match(result.claimBoundary, /not provider usage\/billing tokens/);
@@ -542,6 +551,8 @@ test("compare default output is a concise human verdict with json details opt-in
   assert.match(output, /Verdict: estimated-reduction/);
   assert.match(output, /Why: Estimated \d+(?:\.\d+)?% smaller model-facing payload/);
   assert.match(output, /Local proof: source \d+ bytes \/ \d+ est tokens → model-facing \d+ bytes \/ \d+ est tokens; saved \d+ bytes \/ \d+ est tokens\./);
+  assert.match(output, /React Web context: \d+ source-backed anchors across \d+ summary fields \(counts only; see --json\)\./);
+  assert.doesNotMatch(output, /correctness|billing savings|provider token savings|latency/i);
   assert.match(output, /Next action: Use fooks setup/);
   assert.match(output, /Boundary: Local model-facing payload estimate only/);
   assert.match(output, /fooks compare <file> --json/);
@@ -556,6 +567,7 @@ test("compare default output avoids reduction claims for no-savings files", () =
   assert.match(output, /Mode: raw \(original source preserved\)/);
   assert.match(output, /Local proof: source \d+ bytes \/ \d+ est tokens → model-facing \d+ bytes \/ \d+ est tokens; no local estimate savings for this file\./);
   assert.match(output, /Boundary: Local model-facing payload estimate only/);
+  assert.doesNotMatch(output, /React Web context:/);
   assert.doesNotMatch(output, /0(?:\.0+)?% smaller/);
   assert.doesNotMatch(output, /saved 0 bytes \/ 0 est tokens/);
   assert.doesNotMatch(output.trim(), /^\{/);


### PR DESCRIPTION
## Summary
- adds `reactWebContextSummary` to `fooks compare --json` for eligible React Web payloads
- summarizes only existing source-backed `reactWebContext` scope and field counts
- adds one concise human compare line for counts-only React Web context visibility

## Boundaries
- no new React Web metadata fields
- no `extract` output shape change
- no cross-file, typechecker/LSP, visual, runtime DOM, design-system, accessibility-correctness, edit-quality, provider-token, billing, latency, cache-performance, or runtime-token claims

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/fooks.test.mjs` → 145 passed
- `npm test` → 473 passed
- LSP diagnostics on `src/core/compare.ts` → 0 errors
- Architect verification → APPROVED