### PR TITLE
Bridge React Web edit prompts to route context

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -86,12 +86,13 @@ function optimizedReactWebRuntimePayload(payload: ModelFacingPayload, reactWebCo
     filePath: payload.filePath,
     sourceFingerprint: payload.sourceFingerprint,
     domainPayload: payload.domainPayload,
+    ...(payload.editGuidance ? { editGuidance: payload.editGuidance } : {}),
     ...(reactWebContext ? { reactWebContext } : {}),
   };
 }
 
 function buildRuntimeContextPayload(payload: ModelFacingPayload, reactWebContext?: PackedRuntimeReactWebContext): { optimized: boolean; payload: unknown } {
-  if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
+  if (payload.domainPayload?.domain === "react-web" && !payload.useOriginal) {
     return {
       optimized: true,
       payload: optimizedReactWebRuntimePayload(payload, reactWebContext),
@@ -166,12 +167,15 @@ function buildAdditionalContext(
   contextMode: ContextMode,
   maxOptimizedContextBytes?: number,
 ): string {
-  if (payload.domainPayload?.domain === "react-web" && !payload.editGuidance && !payload.useOriginal) {
+  if (payload.domainPayload?.domain === "react-web" && !payload.useOriginal) {
+    const runtimeReactWebContextBudget = payload.editGuidance
+      ? editGuidanceBudgetLimit(maxOptimizedContextBytes)
+      : maxOptimizedContextBytes;
     return renderOptimizedReactWebAdditionalContext(
       filePath,
       payload,
       contextMode,
-      compactRuntimeReactWebContext(filePath, payload, contextMode, maxOptimizedContextBytes),
+      compactRuntimeReactWebContext(filePath, payload, contextMode, runtimeReactWebContextBudget),
     );
   }
 
@@ -449,7 +453,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     try {
       const optInDecision = decidePreRead(path.join(cwd, target), cwd, "codex", {
         includeEditGuidance: true,
-        includeReactWebContextMetadata: false,
+        includeReactWebContextMetadata: true,
       });
       if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
         const optInContextMode = payloadContextMode(optInDecision.payload);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1821,10 +1821,16 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.additionalContext.includes("#fooks-full-read"), false);
   assert.equal(second.additionalContext.includes("#fooks-disable-pre-read"), false);
   assert.equal(second.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(second.additionalContext.includes("\"reactWebContext\""), true);
   assert.ok(second.reasons.includes("edit-guidance-opt-in"));
   assert.equal(second.debug.repeatedFile, true);
   assert.deepEqual(second.debug.decision.payload.editGuidance.freshness, second.debug.decision.payload.sourceFingerprint);
   assert.ok(second.debug.decision.payload.editGuidance.patchTargets.length <= 12);
+  assert.equal(second.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
+  assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+  const runtimePayload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+  assert.ok(Array.isArray(runtimePayload.reactWebContext.editTargetRouting));
+  assert.ok(runtimePayload.reactWebContext.editTargetRouting.length > 0);
 
   fs.writeFileSync(second.statePath, "{not-json");
   const afterCorruptState = handleCodexRuntimeHook(
@@ -1884,6 +1890,7 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
   assert.equal(implementSecond.action, "inject");
   assert.equal(implementSecond.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(implementSecond.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(implementSecond.additionalContext.includes("\"reactWebContext\""), true);
   assert.equal(implementSecond.reasons.includes("edit-guidance-opt-in"), true);
 
   const renameSession = `hook-rename-edit-guidance-${Date.now()}`;
@@ -1907,6 +1914,7 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
   assert.equal(renameSecond.action, "inject");
   assert.equal(renameSecond.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(renameSecond.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(renameSecond.additionalContext.includes("\"reactWebContext\""), true);
   assert.equal(renameSecond.reasons.includes("edit-guidance-opt-in"), true);
 });
 

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -77,8 +77,15 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.debug.decision.payload.domainPayload.domain, "react-web");
   assert.equal(secondInject.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(secondInject.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(secondInject.additionalContext.includes("\"reactWebContext\""), true);
   assert.ok(secondInject.reasons.includes("edit-guidance-opt-in"));
   assert.deepEqual(secondInject.debug.decision.payload.editGuidance.freshness, secondInject.debug.decision.payload.sourceFingerprint);
+  assert.equal(secondInject.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
+  assert.equal(secondInject.debug.decision.debug.reactWebContextBudget.included, true);
+  const optimizedEditPayload = JSON.parse(secondInject.additionalContext.split("\n").slice(1).join("\n"));
+  assert.equal(optimizedEditPayload.editGuidance.freshness.fileHash, optimizedEditPayload.sourceFingerprint.fileHash);
+  assert.ok(Array.isArray(optimizedEditPayload.reactWebContext.editTargetRouting));
+  assert.ok(optimizedEditPayload.reactWebContext.editTargetRouting.length > 0);
 
   const contextSession = `bridge-contract-react-web-context-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: contextSession }, repoRoot);
@@ -199,7 +206,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondWrapper.action, "inject");
   assert.equal(secondWrapper.debug.decision.debug.domainDetection.classification, "react-web");
   assert.deepEqual(secondWrapper.debug.decision.debug.frontendPayloadPolicy.evidenceGates, [CUSTOM_WRAPPER_DOM_SIGNAL_GAP]);
-  assert.equal(secondWrapper.contextModeReason, "repeated-exact-file-react-web-payload");
+  assert.equal(secondWrapper.contextModeReason, "repeated-exact-file-edit-guidance");
+  assert.equal(secondWrapper.additionalContext.includes("\"editGuidance\""), true);
 
   const readOnlySession = `bridge-contract-readonly-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: readOnlySession }, repoRoot);


### PR DESCRIPTION
## Summary
- include bounded React Web context metadata alongside matching editGuidance for repeated exact-file Codex edit-intent prompts
- keep the optimized React Web runtime payload compact while preserving sourceFingerprint, domainPayload, and editGuidance
- strengthen runtime regressions for edit prompts plus existing non-edit/fallback boundaries

## Boundaries
- no schema, extract output, or compare output changes
- no cross-file, LSP/typechecker, visual/DOM/a11y-audit, provider-token, billing, latency, or edit-quality claims

## Verification
- git diff --check
- npm run build
- node --test test/runtime-bridge-contract.test.mjs
- node --test test/fooks.test.mjs
- npm test
- LSP diagnostics: 0 errors for src/adapters/codex-runtime-hook.ts