### PR TITLE
Surface React Web context counts in extract output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -998,12 +998,26 @@ async function run(): Promise<void> {
       const { extractFile } = await import("../core/extract.js");
       const { filePath: file, modelPayload } = parseExtractArgs(rest);
       const result = extractFile(file);
+      const useOriginal = result.useOriginal === true;
+      const { toModelFacingPayload } = await import("../core/payload/model-facing.js");
+      const { reactWebContextSummaryFor } = await import("../core/react-web-context-summary.js");
+      const contextPayload = toModelFacingPayload(result, process.cwd(), {
+        includeDomainPayload: true,
+        includeReactWebContextMetadata: true,
+      });
+      const reactWebContextSummary = reactWebContextSummaryFor(contextPayload, useOriginal);
       if (modelPayload) {
-        const { toModelFacingPayload } = await import("../core/payload/model-facing.js");
-        print(toModelFacingPayload(result, process.cwd(), { includeEditGuidance: true }));
+        const modelFacingPayload = toModelFacingPayload(result, process.cwd(), { includeEditGuidance: true });
+        print({
+          ...modelFacingPayload,
+          ...(reactWebContextSummary ? { reactWebContextSummary } : {}),
+        });
         return;
       }
-      print(result);
+      print({
+        ...result,
+        ...(reactWebContextSummary ? { reactWebContextSummary } : {}),
+      });
       return;
     }
 

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -6,7 +6,12 @@ import {
   estimateTextBytes,
   estimateTokensFromBytes,
 } from "./session-metrics";
-import type { ModelFacingPayload, OutputMode } from "./schema";
+import type { OutputMode } from "./schema";
+import {
+  formatReactWebContextSummary,
+  reactWebContextSummaryFor,
+  type ReactWebContextSummary,
+} from "./react-web-context-summary";
 
 export const FOOKS_COMPARE_CLAIM_BOUNDARY = `${FOOKS_METRIC_CLAIM_BOUNDARY} Compare values are local model-facing payload estimates, not provider tokenizer output, not runtime hook envelope overhead, and not provider invoice/dashboard/charged-cost proof.`;
 
@@ -16,18 +21,7 @@ export type FooksCompareUserSummary = {
   nextAction: string;
 };
 
-export type FooksCompareReactWebContextSummary = {
-  present: boolean;
-  schemaVersion: string;
-  scope: {
-    kind: "same-file" | "same-component";
-    filePath: string;
-    componentName?: string;
-  };
-  fieldCounts: Record<string, number>;
-  totalAnchors: number;
-  claimBoundary: "source-backed-react-web-context-counts-only";
-};
+export type FooksCompareReactWebContextSummary = ReactWebContextSummary;
 
 export type FooksCompareResult = {
   filePath: string;
@@ -50,45 +44,6 @@ export type FooksCompareResult = {
   claimBoundary: string;
 };
 
-
-const REACT_WEB_CONTEXT_SUMMARY_FIELDS = [
-  "editTargetRouting",
-  "formStateFlow",
-  "a11yAnchors",
-  "intentTargets",
-  "stateHints",
-  "layoutRegionHints",
-  "componentApiHints",
-  "stylingVariantHints",
-  "importRoleHints",
-  "renderStates",
-  "localDependencies",
-] as const;
-
-function reactWebContextSummaryFor(payload: ModelFacingPayload, useOriginal: boolean): FooksCompareReactWebContextSummary | undefined {
-  if (useOriginal || !payload.reactWebContext) return undefined;
-
-  const fieldCounts: Record<string, number> = {};
-  for (const field of REACT_WEB_CONTEXT_SUMMARY_FIELDS) {
-    const values = payload.reactWebContext[field];
-    if (Array.isArray(values) && values.length > 0) {
-      fieldCounts[field] = values.length;
-    }
-  }
-
-  return {
-    present: true,
-    schemaVersion: payload.reactWebContext.schemaVersion,
-    scope: {
-      kind: payload.reactWebContext.scope.kind,
-      filePath: payload.reactWebContext.scope.filePath,
-      componentName: payload.reactWebContext.scope.componentName,
-    },
-    fieldCounts,
-    totalAnchors: Object.values(fieldCounts).reduce((total, count) => total + count, 0),
-    claimBoundary: "source-backed-react-web-context-counts-only",
-  };
-}
 
 function roundPercent(value: number): number {
   return Number(value.toFixed(2));
@@ -135,7 +90,7 @@ export function formatCompare(result: FooksCompareResult): string {
     ? `Local proof: source ${result.sourceBytes} bytes / ${result.estimatedSourceTokens} est tokens → model-facing ${result.modelFacingBytes} bytes / ${result.estimatedModelFacingTokens} est tokens; saved ${result.savedEstimatedBytes} bytes / ${result.savedEstimatedTokens} est tokens.`
     : `Local proof: source ${result.sourceBytes} bytes / ${result.estimatedSourceTokens} est tokens → model-facing ${result.modelFacingBytes} bytes / ${result.estimatedModelFacingTokens} est tokens; no local estimate savings for this file.`;
   const reactWebContextLine = result.reactWebContextSummary
-    ? `React Web context: ${result.reactWebContextSummary.totalAnchors} source-backed anchors across ${Object.keys(result.reactWebContextSummary.fieldCounts).length} summary fields (counts only; see --json).`
+    ? formatReactWebContextSummary(result.reactWebContextSummary)
     : undefined;
   const lines = [
     `fooks compare ${result.filePath}`,

--- a/src/core/react-web-context-summary.ts
+++ b/src/core/react-web-context-summary.ts
@@ -1,0 +1,59 @@
+import type { ModelFacingPayload } from "./schema";
+
+export const REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY = "source-backed-react-web-context-counts-only" as const;
+
+export type ReactWebContextSummary = {
+  present: boolean;
+  schemaVersion: string;
+  scope: {
+    kind: "same-file" | "same-component";
+    filePath: string;
+    componentName?: string;
+  };
+  fieldCounts: Record<string, number>;
+  totalAnchors: number;
+  claimBoundary: typeof REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY;
+};
+
+const REACT_WEB_CONTEXT_SUMMARY_FIELDS = [
+  "editTargetRouting",
+  "formStateFlow",
+  "a11yAnchors",
+  "intentTargets",
+  "stateHints",
+  "layoutRegionHints",
+  "componentApiHints",
+  "stylingVariantHints",
+  "importRoleHints",
+  "renderStates",
+  "localDependencies",
+] as const;
+
+export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOriginal: boolean): ReactWebContextSummary | undefined {
+  if (useOriginal || !payload.reactWebContext) return undefined;
+
+  const fieldCounts: Record<string, number> = {};
+  for (const field of REACT_WEB_CONTEXT_SUMMARY_FIELDS) {
+    const values = payload.reactWebContext[field];
+    if (Array.isArray(values) && values.length > 0) {
+      fieldCounts[field] = values.length;
+    }
+  }
+
+  return {
+    present: true,
+    schemaVersion: payload.reactWebContext.schemaVersion,
+    scope: {
+      kind: payload.reactWebContext.scope.kind,
+      filePath: payload.reactWebContext.scope.filePath,
+      componentName: payload.reactWebContext.scope.componentName,
+    },
+    fieldCounts,
+    totalAnchors: Object.values(fieldCounts).reduce((total, count) => total + count, 0),
+    claimBoundary: REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY,
+  };
+}
+
+export function formatReactWebContextSummary(summary: ReactWebContextSummary): string {
+  return `React Web context: ${summary.totalAnchors} source-backed anchors across ${Object.keys(summary.fieldCounts).length} summary fields (counts only; see --json).`;
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -331,6 +331,7 @@ test("extract keeps small fixture raw", () => {
   assert.equal(result.meta.decideConfidence, "high");
   assert.ok(result.contract.propsSummary.some((item) => item.includes("label")));
   assert.ok(result.style.summary.some((item) => item.includes("tailwind")));
+  assert.equal("reactWebContextSummary" in result, false);
 });
 
 test("extract accepts --json before and after the file path", () => {
@@ -372,6 +373,18 @@ test("extract can return model-facing payload without engine metadata", () => {
   assert.ok(result.structure.sections.includes("section"));
   assert.ok(result.structure.repeatedBlocks.includes("array-map-render"));
   assert.equal(result.style.system, "tailwind");
+  assert.equal(result.reactWebContextSummary.present, true);
+  assert.equal(result.reactWebContextSummary.schemaVersion, "react-web-context.v0");
+  assert.equal(result.reactWebContextSummary.scope.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(result.reactWebContextSummary.scope.componentName, "FormSection");
+  assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
+  assert.ok(result.reactWebContextSummary.fieldCounts.componentApiHints > 0);
+  assert.ok(result.reactWebContextSummary.fieldCounts.a11yAnchors > 0);
+  assert.ok(result.reactWebContextSummary.totalAnchors > 0);
+  assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
+  assert.doesNotMatch(JSON.stringify(result.reactWebContextSummary), /cross-file|typechecker|lsp|visual proof|billing|latency/i);
+  assert.equal("reactWebContext" in result, false);
+  assert.equal("domainPayload" in result, false);
 });
 
 test("file commands accept --json before or after the file path", () => {
@@ -580,6 +593,15 @@ test("extract produces compressed output for boilerplate-heavy fixture", () => {
   assert.equal(result.style.system, "tailwind");
   assert.ok(result.structure.repeatedBlocks.includes("array-map-render"));
   assert.equal(result.rawText, undefined);
+  assert.equal(result.reactWebContextSummary.present, true);
+  assert.equal(result.reactWebContextSummary.schemaVersion, "react-web-context.v0");
+  assert.equal(result.reactWebContextSummary.scope.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(result.reactWebContextSummary.scope.componentName, "FormSection");
+  assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
+  assert.ok(result.reactWebContextSummary.fieldCounts.layoutRegionHints > 0);
+  assert.ok(result.reactWebContextSummary.totalAnchors > 0);
+  assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
+  assert.doesNotMatch(JSON.stringify(result.reactWebContextSummary), /cross-file|typechecker|lsp|visual proof|billing|latency/i);
 });
 
 test("extract produces hybrid output for complex fixture", () => {
@@ -969,6 +991,7 @@ test("design-review helper remains internal and default model-facing payloads st
   assert.equal("editGuidance" in guidedPayload, true);
   assert.equal("editGuidance" in cliPayload && "designReviewMetadata" in cliPayload.editGuidance, false);
   assert.equal("editGuidance" in modulePayload, false);
+  assert.equal("reactWebContextSummary" in modulePayload, false);
 });
 
 test("model-facing payload can explicitly opt into design-review metadata", () => {


### PR DESCRIPTION
## Summary\n- Add a shared React Web context summary helper used by compare and extract\n- Surface counts-only `reactWebContextSummary` in extract JSON and `--model-payload` output when React Web context exists\n- Keep raw/useOriginal and non-React module payloads from reporting React Web summaries\n\n## Boundaries\n- Counts only; no full `reactWebContext` or `domainPayload` added to extract model payloads\n- No cross-file usage, typechecker/LSP semantics, visual proof, performance, latency, billing, or edit-quality claims\n\n## Tests\n- `git diff --check`\n- `npm run build`\n- `node --test test/fooks.test.mjs`\n- `npm test`