### PR TITLE
Constrain RN source-anchor beta to local proof

### DIFF
--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -1,8 +1,10 @@
 import type { DomainDetectionResult } from "../domain-detector";
 import {
   DOMAIN_PAYLOAD_SCHEMA_VERSION,
+  RN_SOURCE_ANCHOR_BETA_CONTRACT_VERSION,
   type ReactNativePrimitiveInputDomainPayload,
   type ReactNativePrimitiveInputReuseContract,
+  type ReactNativeSourceAnchorBetaPayload,
 } from "../payload/domain-payload";
 import {
   RN_PRIMITIVE_INPUT_DENIED_BY_SIGNALS,
@@ -20,7 +22,7 @@ export const MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON = "missing-react-native-
 
 export type FrontendProfilePayloadReuseDecision = { allowed: true } | { allowed: false; reason: string };
 
-function arraysEqual(left: string[] | undefined, right: readonly string[]): boolean {
+function arraysEqual(left: readonly string[] | undefined, right: readonly string[]): boolean {
   if (!left || left.length !== right.length) return false;
   return left.every((value, index) => value === right[index]);
 }
@@ -28,6 +30,50 @@ function arraysEqual(left: string[] | undefined, right: readonly string[]): bool
 function sourceFingerprintsEqual(left: SourceFingerprint | undefined, right: SourceFingerprint | undefined): boolean {
   if (!left || !right) return false;
   return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
+}
+
+function arraysContainValues(left: string[] | readonly string[] | undefined, right: readonly string[]): boolean {
+  if (!left) return false;
+  return right.every((value) => left.includes(value));
+}
+
+function isReactNativeSourceAnchorBetaPayload(value: unknown): value is ReactNativeSourceAnchorBetaPayload {
+  if (!value || typeof value !== "object") return false;
+  const payload = value as Partial<ReactNativeSourceAnchorBetaPayload>;
+  const contract = payload.contract as Partial<ReactNativeSourceAnchorBetaPayload["contract"]> | undefined;
+  const anchors = payload.anchors as Partial<ReactNativeSourceAnchorBetaPayload["anchors"]> | undefined;
+
+  return (
+    Boolean(contract) &&
+    contract?.contractVersion === RN_SOURCE_ANCHOR_BETA_CONTRACT_VERSION &&
+    contract.scope === "local-proof-only" &&
+    arraysEqual(contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]) &&
+    contract.runtimeReusePromotion === "not-promoted" &&
+    contract.sourceDerivedOnly === true &&
+    arraysEqual(contract.anchorKinds, [
+      "component-name",
+      "props-interface",
+      "hooks-effects",
+      "event-handlers",
+      "rn-primitive-outline",
+      "source-fingerprint-ranges",
+    ]) &&
+    arraysEqual(contract.fallbackFirstBoundaries, [
+      "webview",
+      "native-bridge",
+      "platform-specific",
+      "navigation",
+      "gesture-list-image-scrollview",
+      "mixed-react-web-dom",
+      "tui-ink",
+    ]) &&
+    contract.nextImplementationStep ===
+      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates" &&
+    Boolean(anchors) &&
+    anchors?.sourceFingerprintRequired === true &&
+    arraysContainValues(anchors?.primitives, ["Pressable", "Text", "TextInput", "View"]) &&
+    arraysContainValues(anchors?.jsxProps, ["onChangeText", "onPress"])
+  );
 }
 
 function isReactNativePrimitiveInputReuseContract(value: unknown): value is ReactNativePrimitiveInputReuseContract {
@@ -63,6 +109,7 @@ function isReactNativePrimitiveInputDomainPayload(
   if (domainPayload.plannerDecision !== "narrow-primitive-input-payload") return false;
   if (domainPayload.claimStatus !== "measured-evidence-only") return false;
   if (domainPayload.claimBoundary !== "rn-primitive-input-narrow-payload-only") return false;
+  if (!isReactNativeSourceAnchorBetaPayload(domainPayload.sourceAnchorBeta)) return false;
   if (!isReactNativePrimitiveInputReuseContract(domainPayload.reuseContract)) return false;
   if (!payload.sourceFingerprint) return false;
   if (payload.editGuidance?.freshness && !sourceFingerprintsEqual(payload.sourceFingerprint, payload.editGuidance.freshness)) return false;

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -10,6 +10,26 @@ import type { ExtractionResult, FormControlSignal, StyleSystem } from "../schema
 
 export const DOMAIN_PAYLOAD_SCHEMA_VERSION = "domain-payload.v1";
 export const REACT_WEB_DOMAIN_PAYLOAD_POLICY = "react-web-current-supported-lane";
+export const RN_SOURCE_ANCHOR_BETA_CONTRACT_VERSION = "rn-source-anchor-beta.v0";
+
+const RN_SOURCE_ANCHOR_BETA_ALLOWED_PROOF_SURFACES = ["extract", "compare", "inspect-domain"] as const;
+const RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS = [
+  "component-name",
+  "props-interface",
+  "hooks-effects",
+  "event-handlers",
+  "rn-primitive-outline",
+  "source-fingerprint-ranges",
+] as const;
+const RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES = [
+  "webview",
+  "native-bridge",
+  "platform-specific",
+  "navigation",
+  "gesture-list-image-scrollview",
+  "mixed-react-web-dom",
+  "tui-ink",
+] as const;
 
 export type ReactWebDomainPayload = {
   schemaVersion: typeof DOMAIN_PAYLOAD_SCHEMA_VERSION;
@@ -37,6 +57,30 @@ export type ReactWebDomainPayload = {
   warnings: string[];
 };
 
+export type ReactNativeSourceAnchorBetaContract = {
+  contractVersion: typeof RN_SOURCE_ANCHOR_BETA_CONTRACT_VERSION;
+  scope: "local-proof-only";
+  allowedProofSurfaces: readonly (typeof RN_SOURCE_ANCHOR_BETA_ALLOWED_PROOF_SURFACES)[number][];
+  runtimeReusePromotion: "not-promoted";
+  sourceDerivedOnly: true;
+  anchorKinds: readonly (typeof RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS)[number][];
+  fallbackFirstBoundaries: readonly (typeof RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES)[number][];
+  nextImplementationStep: "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates";
+};
+
+export type ReactNativeSourceAnchorBetaPayload = {
+  contract: ReactNativeSourceAnchorBetaContract;
+  anchors: {
+    componentName?: string;
+    propsName?: string;
+    hooks?: string[];
+    eventHandlers?: string[];
+    primitives: string[];
+    jsxProps: string[];
+    sourceFingerprintRequired: true;
+  };
+};
+
 export type ReactNativePrimitiveInputReuseContract = {
   sourceDerivedOnly: true;
   policy: typeof RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY;
@@ -60,6 +104,7 @@ export type ReactNativePrimitiveInputDomainPayload = {
   claimStatus: "measured-evidence-only";
   claimBoundary: "rn-primitive-input-narrow-payload-only";
   evidence: string[];
+  sourceAnchorBeta: ReactNativeSourceAnchorBetaPayload;
   reuseContract: ReactNativePrimitiveInputReuseContract;
   facts: {
     primitives: string[];
@@ -209,6 +254,41 @@ function buildReactWebPayloadFacts(
   };
 }
 
+function buildReactNativeSourceAnchorBetaContract(): ReactNativeSourceAnchorBetaContract {
+  return {
+    contractVersion: RN_SOURCE_ANCHOR_BETA_CONTRACT_VERSION,
+    scope: "local-proof-only",
+    allowedProofSurfaces: [...RN_SOURCE_ANCHOR_BETA_ALLOWED_PROOF_SURFACES],
+    runtimeReusePromotion: "not-promoted",
+    sourceDerivedOnly: true,
+    anchorKinds: [...RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS],
+    fallbackFirstBoundaries: [...RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES],
+    nextImplementationStep:
+      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+  };
+}
+
+function buildReactNativeSourceAnchorBetaPayload(
+  result: ExtractionResult,
+  evidenceFacts: ReactNativePayloadEvidenceFacts,
+): ReactNativeSourceAnchorBetaPayload {
+  const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
+  const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+
+  return {
+    contract: buildReactNativeSourceAnchorBetaContract(),
+    anchors: {
+      ...(result.componentName ? { componentName: result.componentName } : {}),
+      ...(result.contract?.propsName ? { propsName: result.contract.propsName } : {}),
+      ...(hooks.length > 0 ? { hooks } : {}),
+      ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
+      primitives: evidenceFacts.primitives,
+      jsxProps: evidenceFacts.jsxProps,
+      sourceFingerprintRequired: true,
+    },
+  };
+}
+
 function buildReactNativePrimitiveInputReuseContract(): ReactNativePrimitiveInputReuseContract {
   return {
     sourceDerivedOnly: true,
@@ -285,9 +365,11 @@ export function buildReactNativePrimitiveInputDomainPayload(
     claimStatus: "measured-evidence-only",
     claimBoundary: "rn-primitive-input-narrow-payload-only",
     evidence: plan.evidenceFacts.evidence,
+    sourceAnchorBeta: buildReactNativeSourceAnchorBetaPayload(plan.result, plan.evidenceFacts),
     reuseContract: buildReactNativePrimitiveInputReuseContract(),
     facts: buildReactNativePayloadFacts(plan.result, plan.evidenceFacts),
     warnings: [
+      "React Native source anchors are a local-proof beta contract only, not a runtime reuse promotion.",
       "React Native primitive/input payload reuse is limited to the measured F1-style gate.",
       "Do not reinterpret React Native primitives as DOM controls, web form semantics, navigation behavior, native platform behavior, or WebView bridge behavior.",
       "Planner decision depends on current extractor readiness and domain profile evidence; rerun extraction if the source changes.",

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -74,6 +74,13 @@ test("frontend profile gate allows narrow allowed non-web frontend policies", ()
   assert.equal(payload.domainPayload.policy, policy.name);
   assert.deepEqual(payload.domainPayload.facts.primitives, ["Pressable", "Text", "TextInput", "View"]);
   assert.deepEqual(payload.domainPayload.facts.jsxProps, ["onChangeText", "onPress"]);
+  assert.equal(payload.domainPayload.sourceAnchorBeta.contract.contractVersion, "rn-source-anchor-beta.v0");
+  assert.equal(payload.domainPayload.sourceAnchorBeta.contract.scope, "local-proof-only");
+  assert.deepEqual(payload.domainPayload.sourceAnchorBeta.contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(payload.domainPayload.sourceAnchorBeta.contract.runtimeReusePromotion, "not-promoted");
+  assert.deepEqual(payload.domainPayload.sourceAnchorBeta.anchors.primitives, ["Pressable", "Text", "TextInput", "View"]);
+  assert.deepEqual(payload.domainPayload.sourceAnchorBeta.anchors.jsxProps, ["onChangeText", "onPress"]);
+  assert.equal(payload.domainPayload.sourceAnchorBeta.anchors.sourceFingerprintRequired, true);
   assert.equal(payload.domainPayload.reuseContract.sourceDerivedOnly, true);
   assert.equal(payload.domainPayload.reuseContract.policy, policy.name);
   assert.equal(payload.domainPayload.reuseContract.freshnessSource, "sourceFingerprint");
@@ -129,6 +136,31 @@ test("frontend profile gate rejects adversarial RN narrow payload contract and f
     ["wrong policy", () => {
       const stale = clonePayload(payload);
       stale.domainPayload.policy = "react-web-current-supported-lane";
+      return stale;
+    }],
+    ["missing source-anchor beta contract", () => {
+      const stale = clonePayload(payload);
+      delete stale.domainPayload.sourceAnchorBeta;
+      return stale;
+    }],
+    ["wrong source-anchor beta scope", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.sourceAnchorBeta.contract.scope = "runtime";
+      return stale;
+    }],
+    ["wrong source-anchor runtime promotion", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.sourceAnchorBeta.contract.runtimeReusePromotion = "promoted";
+      return stale;
+    }],
+    ["missing source-anchor primitive", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.sourceAnchorBeta.anchors.primitives = stale.domainPayload.sourceAnchorBeta.anchors.primitives.slice(1);
+      return stale;
+    }],
+    ["missing source-anchor fingerprint requirement", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.sourceAnchorBeta.anchors.sourceFingerprintRequired = false;
       return stale;
     }],
     ["missing reuse contract", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -99,6 +99,36 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.equal(payload?.plannerDecision, "narrow-primitive-input-payload");
   assert.equal(payload?.claimStatus, "measured-evidence-only");
   assert.equal(payload?.claimBoundary, "rn-primitive-input-narrow-payload-only");
+  assert.equal(payload?.sourceAnchorBeta.contract.contractVersion, "rn-source-anchor-beta.v0");
+  assert.equal(payload?.sourceAnchorBeta.contract.scope, "local-proof-only");
+  assert.deepEqual(payload?.sourceAnchorBeta.contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(payload?.sourceAnchorBeta.contract.runtimeReusePromotion, "not-promoted");
+  assert.equal(payload?.sourceAnchorBeta.contract.sourceDerivedOnly, true);
+  assert.deepEqual(payload?.sourceAnchorBeta.contract.anchorKinds, [
+    "component-name",
+    "props-interface",
+    "hooks-effects",
+    "event-handlers",
+    "rn-primitive-outline",
+    "source-fingerprint-ranges",
+  ]);
+  assert.deepEqual(payload?.sourceAnchorBeta.contract.fallbackFirstBoundaries, [
+    "webview",
+    "native-bridge",
+    "platform-specific",
+    "navigation",
+    "gesture-list-image-scrollview",
+    "mixed-react-web-dom",
+    "tui-ink",
+  ]);
+  assert.equal(
+    payload?.sourceAnchorBeta.contract.nextImplementationStep,
+    "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+  );
+  assert.equal(payload?.sourceAnchorBeta.anchors.componentName, "InlineActionRow");
+  assert.deepEqual(payload?.sourceAnchorBeta.anchors.primitives, ["Pressable", "Text", "TextInput", "View"]);
+  assert.deepEqual(payload?.sourceAnchorBeta.anchors.jsxProps, ["onChangeText", "onPress"]);
+  assert.equal(payload?.sourceAnchorBeta.anchors.sourceFingerprintRequired, true);
   assert.equal(payload?.reuseContract.supportBoundary, "measured-evidence-only; no broad RN/WebView/TUI support");
   assert.deepEqual(payload?.reuseContract.requiredSignals, [...RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS]);
 
@@ -273,6 +303,39 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
   });
   const payload = buildReactNativePrimitiveInputDomainPayload(extractionResult, allowedDetection);
   assert.equal(payload?.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
+  assert.deepEqual(payload?.sourceAnchorBeta.contract, {
+    contractVersion: "rn-source-anchor-beta.v0",
+    scope: "local-proof-only",
+    allowedProofSurfaces: ["extract", "compare", "inspect-domain"],
+    runtimeReusePromotion: "not-promoted",
+    sourceDerivedOnly: true,
+    anchorKinds: [
+      "component-name",
+      "props-interface",
+      "hooks-effects",
+      "event-handlers",
+      "rn-primitive-outline",
+      "source-fingerprint-ranges",
+    ],
+    fallbackFirstBoundaries: [
+      "webview",
+      "native-bridge",
+      "platform-specific",
+      "navigation",
+      "gesture-list-image-scrollview",
+      "mixed-react-web-dom",
+      "tui-ink",
+    ],
+    nextImplementationStep:
+      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+  });
+  assert.deepEqual(payload?.sourceAnchorBeta.anchors, {
+    componentName: "NativeInput",
+    primitives: ["Pressable", "Text", "TextInput", "View"],
+    jsxProps: ["onChangeText", "onPress"],
+    sourceFingerprintRequired: true,
+  });
+
   assert.deepEqual(payload?.reuseContract, {
     sourceDerivedOnly: true,
     policy: RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY,


### PR DESCRIPTION
Closes #463

## Summary
- adds an `rn-source-anchor-beta.v0` local-proof contract to the measured RN primitive/input domain payload
- requires the frontend profile reuse gate to reject missing, promoted, or stale RN source-anchor beta payloads
- expands targeted RN payload-policy tests without claiming broad RN/WebView/native runtime support

## Verification
- `npm run build && node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs`

## Scope
- bounded to issue #463 RN source-anchor beta payload/gate/test coverage
- left `.fooks-session-task.txt` untracked