### PR TITLE
Clarify stale dogfood runtime cleanup

### DIFF
--- a/src/core/operator-activity.ts
+++ b/src/core/operator-activity.ts
@@ -51,15 +51,22 @@ export type OperatorActivityWorktree = {
 export type OperatorActivityTmuxPane = {
   path: string;
   exists: boolean;
+  deleted: boolean;
   current: boolean;
   command?: string;
 };
+
+export type OperatorActivityTmuxSessionStatus = "current" | "activeOrUnknown" | "staleRuntimeCandidate";
 
 export type OperatorActivityTmuxSession = {
   session: string;
   paneCount: number;
   current: boolean;
+  status: OperatorActivityTmuxSessionStatus;
+  reasons: string[];
   panes: OperatorActivityTmuxPane[];
+  manualCleanupCommands: string[];
+  cleanupOrder: string[];
 };
 
 export type OperatorActivityTmux = {
@@ -140,6 +147,10 @@ function panePathDeleted(panePath: string): boolean {
 
 function panePathWithoutDeletedMarker(panePath: string): string {
   return panePath.replace(/ \(deleted\)$/u, "").trim();
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 export function defaultOperatorActivityCommandRunner(command: string, args: string[], cwd: string, timeoutMs: number): string {
@@ -232,7 +243,7 @@ function readTmuxActivity(cwd: string, options: OperatorActivityOptions): Operat
     const current = exists && (pathContainsCwd(cleanPanePath, currentCwd) || pathContainsCwd(currentCwd, cleanPanePath));
     if (!includesFooksSignal(pane.session, cwd) && !includesFooksSignal(cleanPanePath, cwd) && !current) continue;
     const panes = panesBySession.get(pane.session) ?? [];
-    panes.push({ path: pane.path, exists, current, command: pane.command });
+    panes.push({ path: pane.path, exists, deleted, current, command: pane.command });
     panesBySession.set(pane.session, panes);
   }
 
@@ -241,12 +252,34 @@ function readTmuxActivity(cwd: string, options: OperatorActivityOptions): Operat
     command: OPERATOR_ACTIVITY_TMUX_COMMAND,
     sessions: [...panesBySession.entries()]
       .sort(([left], [right]) => left.localeCompare(right))
-      .map(([session, panes]) => ({
-        session,
-        paneCount: panes.length,
-        current: panes.some((pane) => pane.current),
-        panes,
-      })),
+      .map(([session, panes]) => {
+        const current = panes.some((pane) => pane.current);
+        const allPanesMissing = panes.length > 0 && panes.every((pane) => pane.deleted || !pane.exists);
+        const status: OperatorActivityTmuxSessionStatus = current ? "current" : allPanesMissing ? "staleRuntimeCandidate" : "activeOrUnknown";
+        const reasons = status === "current"
+          ? ["session has a pane at the current working directory"]
+          : status === "staleRuntimeCandidate"
+            ? ["all panes point at missing or deleted paths"]
+            : ["session has live panes away from the current working directory; activity is unknown"];
+        const manualCleanupCommands = status === "staleRuntimeCandidate" ? [`tmux kill-session -t ${shellQuote(session)}`] : [];
+        const cleanupOrder = status === "staleRuntimeCandidate"
+          ? [
+              "Verify the PR/worktree is no longer active",
+              "Stop the stale tmux/OMX/Codex session manually",
+              "Run any git worktree prune/remove follow-up only after the runtime is stopped",
+            ]
+          : [];
+        return {
+          session,
+          paneCount: panes.length,
+          current,
+          status,
+          reasons,
+          panes,
+          manualCleanupCommands,
+          cleanupOrder,
+        };
+      }),
     blockers: uniqueSorted(blockers),
   };
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -150,6 +150,46 @@ test("idle activity snapshot remains zero and read-only with opt-in remote count
   assert.equal(gitCalls.some((call) => call.includes("fetch")), false);
 });
 
+test("operator activity classifies stale deleted tmux worktree panes with manual cleanup guidance", () => {
+  const tempDir = makeTempProject();
+  const staleWorktree = path.join(tempDir, ".omx-worktrees", "fooks-issue-467-stale-worktree-cleanup");
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command) => {
+      if (command === "tmux") return `fooks-issue-467\t${staleWorktree} (deleted)\tzsh\n`;
+      throw new Error(`unexpected command ${command}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.tmux.sessions.length, 1);
+  assert.equal(snapshot.tmux.sessions[0].session, "fooks-issue-467");
+  assert.equal(snapshot.tmux.sessions[0].current, false);
+  assert.equal(snapshot.tmux.sessions[0].status, "staleRuntimeCandidate");
+  assert.deepEqual(snapshot.tmux.sessions[0].reasons, ["all panes point at missing or deleted paths"]);
+  assert.deepEqual(snapshot.tmux.sessions[0].panes, [
+    {
+      path: `${staleWorktree} (deleted)`,
+      exists: false,
+      deleted: true,
+      current: false,
+      command: "zsh",
+    },
+  ]);
+  assert.deepEqual(snapshot.tmux.sessions[0].manualCleanupCommands, ["tmux kill-session -t 'fooks-issue-467'"]);
+  assert.deepEqual(snapshot.tmux.sessions[0].cleanupOrder, [
+    "Verify the PR/worktree is no longer active",
+    "Stop the stale tmux/OMX/Codex session manually",
+    "Run any git worktree prune/remove follow-up only after the runtime is stopped",
+  ]);
+});
+
 test("operator activity treats tmux and opt-in GitHub count failures as non-fatal blockers", () => {
   const tempDir = makeTempProject();
   const snapshot = readOperatorActivitySnapshot(tempDir, {


### PR DESCRIPTION
## Summary
- classify deleted/missing fooks tmux panes in `status activity` as `staleRuntimeCandidate`
- include manual-only cleanup commands and ordered safety guidance
- preserve read-only behavior; no git/tmux cleanup command is executed

## Verification
- `npm run build`
- `node --test test/operator-activity.test.mjs test/artifact-audit.test.mjs test/worktree-evidence.test.mjs`

Fixes #467