### PR TITLE
Guard merged dogfood cleanup alert echoes

### DIFF
--- a/scripts/guard-pr-alerts.mjs
+++ b/scripts/guard-pr-alerts.mjs
@@ -104,14 +104,26 @@ function fetchIssue(ref) {
   return JSON.parse(stdout);
 }
 
-function alertLooksLikeNewToMergedEcho(alertText, ref) {
-  if (!/<new>\s*->\s*merged/i.test(alertText)) return false;
+function alertMentionsRef(alertText, ref) {
   const refPatterns = [
     new RegExp(`\\b${escapeRegExp(ref.repo)}#${ref.number}\\b`, "i"),
     new RegExp(`\\b${escapeRegExp(ref.owner)}/${escapeRegExp(ref.repo)}#${ref.number}\\b`, "i"),
     new RegExp(`github\\.com/${escapeRegExp(ref.owner)}/${escapeRegExp(ref.repo)}/(?:issues|pull)/${ref.number}\\b`, "i"),
   ];
   return refPatterns.some((pattern) => pattern.test(alertText));
+}
+
+function alertLooksLikeNewToMergedEcho(alertText, ref) {
+  return /<new>\s*->\s*merged/i.test(alertText) && alertMentionsRef(alertText, ref);
+}
+
+function alertLooksLikePrunedDogfoodRuntimeCleanupEcho(alertText, ref) {
+  return (
+    alertMentionsRef(alertText, ref) &&
+    /\bmerged\b/i.test(alertText) &&
+    /\bdogfood\b/i.test(alertText) &&
+    /\b(?:stale|runtime|zombie|pruned|prune|cleanup)\b/i.test(alertText)
+  );
 }
 
 function githubStateIsMerged(issue) {
@@ -125,7 +137,9 @@ function githubStateIsMerged(issue) {
 
 function classifyIssue(ref, issue, alertText) {
   const isPullRequest = Boolean(issue?.pull_request);
-  const isNewToMergedEcho = isPullRequest && githubStateIsMerged(issue) && alertLooksLikeNewToMergedEcho(alertText, ref);
+  const isMerged = isPullRequest && githubStateIsMerged(issue);
+  const isNewToMergedEcho = isMerged && alertLooksLikeNewToMergedEcho(alertText, ref);
+  const isPrunedDogfoodRuntimeCleanupEcho = isMerged && alertLooksLikePrunedDogfoodRuntimeCleanupEcho(alertText, ref);
   return {
     repo: `${ref.owner}/${ref.repo}`,
     number: ref.number,
@@ -134,10 +148,12 @@ function classifyIssue(ref, issue, alertText) {
     state: issue?.state ?? "unknown",
     htmlUrl: issue?.html_url ?? `https://github.com/${ref.owner}/${ref.repo}/issues/${ref.number}`,
     kind: isPullRequest ? "pull_request" : "issue",
-    prHandling: isNewToMergedEcho ? "echo" : isPullRequest ? "allow" : "skip",
+    prHandling: isNewToMergedEcho || isPrunedDogfoodRuntimeCleanupEcho ? "echo" : isPullRequest ? "allow" : "skip",
     reason: isNewToMergedEcho
       ? "Alert reports <new> -> merged and GitHub state is already merged; verification-only echo"
-      : isPullRequest ? "GitHub issue API response includes pull_request" : "GitHub issue API response has no pull_request field",
+      : isPrunedDogfoodRuntimeCleanupEcho
+        ? "Alert reports merged dogfood stale runtime cleanup and GitHub state is already merged; no-action echo"
+        : isPullRequest ? "GitHub issue API response includes pull_request" : "GitHub issue API response has no pull_request field",
   };
 }
 

--- a/test/pr-alert-guard.test.mjs
+++ b/test/pr-alert-guard.test.mjs
@@ -139,3 +139,50 @@ test("PR alert guard treats new-to-merged alerts for already merged PRs as verif
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+
+test("PR alert guard treats already merged pruned dogfood runtime cleanup as no-action echo", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-dogfood-runtime-"));
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const eventsPath = path.join(tempDir, "events.json");
+
+  fs.writeFileSync(alertsPath, "relay: PR fooks#220 merged cleanup echo for already-pruned stale dogfood zombie runtime cleanup");
+  fs.writeFileSync(eventsPath, JSON.stringify({
+    number: 220,
+    title: "Document stale runtime cleanup in artifact audit",
+    state: "closed",
+    html_url: "https://github.com/minislively/fooks/pull/220",
+    pull_request: {
+      url: "https://api.github.com/repos/minislively/fooks/pulls/220",
+      html_url: "https://github.com/minislively/fooks/pull/220",
+      merged_at: "2026-04-27T14:30:00Z",
+    },
+  }));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      guardScript,
+      "--repo",
+      "minislively/fooks",
+      "--alerts",
+      alertsPath,
+      "--events",
+      eventsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.totalRefs, 1);
+    assert.equal(result.counts.pull_request, 1);
+    assert.equal(result.counts.echo, 1);
+    assert.equal(result.rows[0].kind, "pull_request");
+    assert.equal(result.rows[0].prHandling, "echo");
+    assert.equal(result.rows[0].reason, "Alert reports merged dogfood stale runtime cleanup and GitHub state is already merged; no-action echo");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #469.

## Summary
- classify merged/pruned dogfood runtime cleanup alerts as no-action echo when GitHub already reports the PR merged
- share alert ref matching between existing new→merged echo detection and the dogfood cleanup echo guard
- add focused regression coverage for the cleanup echo case

## Verification
- `node --test test/pr-alert-guard.test.mjs`
- `git diff --check`