### PR TITLE
Add RN input/action payload facts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:integration": "npm run build && node --test test/*.test.mjs",
     "bench:cache": "npm run build && node scripts/benchmark-cache.mjs",
     "evidence:react-web-context": "npm run build && node scripts/react-web-context-evidence.mjs",
+    "evidence:react-native-payload": "npm run build && node scripts/react-native-payload-evidence.mjs",
     "evidence:react-web-reuse": "npm run build && node scripts/react-web-reuse-evidence.mjs",
     "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",

--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -1,0 +1,313 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const DEFAULT_RN_PAYLOAD_EVIDENCE_FIXTURES = [
+  "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx",
+];
+
+export const DEFAULT_RN_BOUNDARY_FIXTURES = [
+  "test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx",
+  "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx",
+  "test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx",
+];
+
+export const RN_TEXT_INPUT_METADATA_FIELDS = [
+  "keyboardType",
+  "secureTextEntry",
+  "maxLength",
+  "autoCapitalize",
+  "accessibilityLabel",
+  "testID",
+];
+
+export const RN_PRESSABLE_METADATA_FIELDS = ["disabled", "accessibilityLabel", "accessibilityRole", "testID"];
+
+function loadDist(repoRoot) {
+  const require = createRequire(import.meta.url);
+  return {
+    preRead: require(path.join(repoRoot, "dist", "adapters", "pre-read.js")),
+    extract: require(path.join(repoRoot, "dist", "core", "extract.js")),
+    modelFacing: require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js")),
+    registry: require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js")),
+  };
+}
+
+function readDomainPayload(decision) {
+  return decision?.payload?.domainPayload ?? null;
+}
+
+function hasStrictRnContracts(domainPayload) {
+  return Boolean(
+    domainPayload?.domain === "react-native" &&
+      domainPayload?.claimBoundary === "rn-primitive-input-narrow-payload-only" &&
+      domainPayload?.sourceAnchorBeta?.contract?.contractVersion === "rn-source-anchor-beta.v0" &&
+      domainPayload?.sourceAnchorBeta?.contract?.scope === "local-proof-only" &&
+      domainPayload?.sourceAnchorBeta?.contract?.runtimeReusePromotion === "not-promoted" &&
+      domainPayload?.reuseContract?.freshnessSource === "sourceFingerprint" &&
+      domainPayload?.reuseContract?.supportBoundary === "measured-evidence-only; no broad RN/WebView/TUI support",
+  );
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function presentFields(bindings, fields) {
+  return uniqueSorted(bindings.flatMap((item) => fields.filter((field) => item[field] !== undefined)));
+}
+
+function interactionSummary(domainPayload) {
+  const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
+  const inputBindings = interactions.inputBindings ?? [];
+  const actionBindings = interactions.actionBindings ?? [];
+  const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
+  const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
+  return {
+    inputBindings,
+    actionBindings,
+    hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
+    hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    metadataCoverage: {
+      textInputFields: textInputMetadataFields,
+      pressableFields: pressableMetadataFields,
+      allTextInputMetadataPresent: RN_TEXT_INPUT_METADATA_FIELDS.every((field) => textInputMetadataFields.includes(field)),
+      allPressableMetadataPresent: RN_PRESSABLE_METADATA_FIELDS.every((field) => pressableMetadataFields.includes(field)),
+    },
+  };
+}
+
+function measureRnFixture({ repoRoot, relativeFile, dist }) {
+  const filePath = path.join(repoRoot, relativeFile);
+  const preReadDecision = dist.preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: false });
+  const extracted = dist.extract.extractFile(filePath);
+  const policy = dist.registry.assessFrontendPayloadPolicy(extracted.domainDetection);
+  const modelPayload = dist.modelFacing.toModelFacingPayload(extracted, repoRoot, {
+    includeEditGuidance: false,
+    ...dist.registry.toFrontendPayloadBuildOptions(policy),
+  });
+  const preReadDomainPayload = readDomainPayload(preReadDecision);
+  const modelDomainPayload = modelPayload.domainPayload ?? null;
+  const preReadInteractions = interactionSummary(preReadDomainPayload);
+  const modelInteractions = interactionSummary(modelDomainPayload);
+
+  return {
+    file: relativeFile,
+    classification: preReadDecision.debug?.domainDetection?.classification ?? null,
+    preReadDecision: preReadDecision.decision,
+    payloadPolicy: preReadDecision.debug?.frontendPayloadPolicy?.name ?? null,
+    sourceFingerprintPresent: Boolean(preReadDecision.payload?.sourceFingerprint),
+    preRead: {
+      domain: preReadDomainPayload?.domain ?? null,
+      claimBoundary: preReadDomainPayload?.claimBoundary ?? null,
+      claimStatus: preReadDomainPayload?.claimStatus ?? null,
+      sourceAnchorBetaVersion: preReadDomainPayload?.sourceAnchorBeta?.contract?.contractVersion ?? null,
+      reuseFreshnessSource: preReadDomainPayload?.reuseContract?.freshnessSource ?? null,
+      strictContractsPresent: hasStrictRnContracts(preReadDomainPayload),
+      primitiveInteractions: preReadInteractions,
+    },
+    modelFacing: {
+      domain: modelDomainPayload?.domain ?? null,
+      claimBoundary: modelDomainPayload?.claimBoundary ?? null,
+      strictContractsPresent: hasStrictRnContracts(modelDomainPayload),
+      primitiveInteractions: modelInteractions,
+    },
+    claimable:
+      preReadDecision.decision === "payload" &&
+      preReadInteractions.hasTextInputBinding &&
+      preReadInteractions.hasPressableAction &&
+      modelInteractions.hasTextInputBinding &&
+      modelInteractions.hasPressableAction &&
+      hasStrictRnContracts(preReadDomainPayload) &&
+      hasStrictRnContracts(modelDomainPayload),
+  };
+}
+
+function measureBoundaryFixture({ repoRoot, relativeFile, dist }) {
+  const filePath = path.join(repoRoot, relativeFile);
+  const decision = dist.preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: false });
+  const domainPayload = readDomainPayload(decision);
+  return {
+    file: relativeFile,
+    classification: decision.debug?.domainDetection?.classification ?? null,
+    frontendPayloadPolicy: decision.debug?.frontendPayloadPolicy ?? null,
+    decision: decision.decision,
+    fallbackReason: decision.fallback?.reason ?? null,
+    payloadExposed: Boolean(domainPayload),
+    rnPrimitiveInteractionsExposed: Boolean(domainPayload?.facts?.primitiveInteractions),
+    boundaryPreserved: decision.decision === "fallback" && !domainPayload,
+  };
+}
+
+export async function buildReactNativePayloadEvidence({
+  repoRoot = defaultRepoRoot,
+  fixtures = DEFAULT_RN_PAYLOAD_EVIDENCE_FIXTURES,
+  boundaryFixtures = DEFAULT_RN_BOUNDARY_FIXTURES,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const dist = loadDist(repoRoot);
+  const rnFixtures = fixtures.map((relativeFile) => measureRnFixture({ repoRoot, relativeFile, dist }));
+  const boundaries = boundaryFixtures.map((relativeFile) => measureBoundaryFixture({ repoRoot, relativeFile, dist }));
+  const rnPayloadFactsVisible = rnFixtures.every((row) => row.claimable);
+  const boundaryFallbacksPreserved = boundaries.every((row) => row.boundaryPreserved && !row.rnPrimitiveInteractionsExposed);
+  const preReadTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.textInputFields));
+  const preReadPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.pressableFields));
+  const modelTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields));
+  const modelPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields));
+  const missingTextInputFields = RN_TEXT_INPUT_METADATA_FIELDS.filter(
+    (field) => !preReadTextInputFields.includes(field) || !modelTextInputFields.includes(field),
+  );
+  const missingPressableFields = RN_PRESSABLE_METADATA_FIELDS.filter(
+    (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
+  );
+  const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
+
+  return {
+    schemaVersion: "react-native-payload-evidence.v2",
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
+    claimBoundary:
+      "Local fixture payload evidence only: proves RN primitive/input narrow payload facts are visible for measured TextInput/Pressable fixtures and that richer RN/WebView/TUI boundaries remain fallback-only. This is not broad React Native support, not WebView or TUI promotion, not runtime reuse promotion, not edit routing, not provider tokenizer output, not runtime-token savings, and not provider billing or invoice savings.",
+    fixtures: rnFixtures,
+    boundaryFixtures: boundaries,
+    summary: {
+      fixtureCount: rnFixtures.length,
+      boundaryFixtureCount: boundaries.length,
+      rnPayloadFactsVisible: {
+        claimable: rnPayloadFactsVisible,
+        blocker: rnPayloadFactsVisible ? null : "one or more measured RN fixtures did not expose strict primitiveInteractions in both pre-read and model-facing payloads",
+      },
+      boundaryFallbacksPreserved: {
+        claimable: boundaryFallbacksPreserved,
+        blocker: boundaryFallbacksPreserved ? null : "one or more richer RN/WebView/TUI fixtures exposed payload facts or failed to fallback",
+      },
+      metadataAnchorsVisible: {
+        claimable: metadataAnchorsVisible,
+        textInputFields: RN_TEXT_INPUT_METADATA_FIELDS.map((field) => ({
+          field,
+          preRead: preReadTextInputFields.includes(field),
+          modelFacing: modelTextInputFields.includes(field),
+          claimable: preReadTextInputFields.includes(field) && modelTextInputFields.includes(field),
+        })),
+        pressableFields: RN_PRESSABLE_METADATA_FIELDS.map((field) => ({
+          field,
+          preRead: preReadPressableFields.includes(field),
+          modelFacing: modelPressableFields.includes(field),
+          claimable: preReadPressableFields.includes(field) && modelPressableFields.includes(field),
+        })),
+        blocker: metadataAnchorsVisible
+          ? null
+          : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
+      },
+      broadReactNativeSupport: {
+        claimable: false,
+        blocker: "evidence is limited to the existing rn-primitive-input-narrow-payload measured lane",
+      },
+      runtimeReusePromotion: {
+        claimable: false,
+        blocker: "sourceAnchorBeta remains local-proof-only and runtimeReusePromotion is not-promoted",
+      },
+      editRouting: {
+        claimable: false,
+        blocker: "no RN edit routing or patch guidance is measured or enabled by this artifact",
+      },
+      providerBillingSavings: {
+        claimable: false,
+        blocker: "no provider usage, tokenizer, billing dashboard, invoice, or charged-cost data is measured by this artifact",
+      },
+    },
+  };
+}
+
+export function renderReactNativePayloadEvidenceMarkdown(evidence) {
+  const fixtureRows = evidence.fixtures
+    .map((row) => {
+      const input = row.preRead.primitiveInteractions.inputBindings
+        .map((item) => `${item.primitive}:value=${item.valueExpr ?? "n/a"},onChangeText=${item.onChangeTextExpr ?? "n/a"}`)
+        .join("; ");
+      const action = row.preRead.primitiveInteractions.actionBindings
+        .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
+        .join("; ");
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${row.claimable ? "yes" : "no"} |`;
+    })
+    .join("\n");
+  const boundaryRows = evidence.boundaryFixtures
+    .map(
+      (row) =>
+        `| \`${row.file}\` | ${row.classification} | ${row.decision} | ${row.fallbackReason ?? "n/a"} | ${row.payloadExposed ? "yes" : "no"} | ${row.boundaryPreserved ? "yes" : "no"} |`,
+    )
+    .join("\n");
+  const metadataRows = [
+    ...evidence.summary.metadataAnchorsVisible.textInputFields.map(
+      (row) => `| TextInput | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
+    ),
+    ...evidence.summary.metadataAnchorsVisible.pressableFields.map(
+      (row) => `| Pressable | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
+    ),
+  ].join("\n");
+
+  return `# React Native payload evidence
+
+${evidence.claimBoundary}
+
+## Summary
+
+- RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
+- Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
+- RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
+- Broad React Native support claimable: no
+- Runtime reuse promotion claimable: no
+- RN edit routing claimable: no
+- Provider billing savings claimable: no
+
+## Measured RN narrow fixtures
+
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | claimable |
+| --- | --- | --- | --- | --- | --- | --- |
+${fixtureRows}
+
+## Metadata anchor coverage
+
+| Primitive | field | pre-read | model-facing | claimable |
+| --- | --- | --- | --- | --- |
+${metadataRows}
+
+## Boundary fixtures
+
+| Fixture | classification | decision | fallback reason | payload exposed | boundary preserved |
+| --- | --- | --- | --- | --- | --- |
+${boundaryRows}
+
+## Claim boundary
+
+This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const defaultOutput = path.join(".omx", "reports", `rn-payload-evidence-${runId}.json`);
+  const defaultMarkdown = path.join(".omx", "reports", `rn-payload-evidence-${runId}.md`);
+  const evidence = await buildReactNativePayloadEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  const outputPath = path.resolve(defaultRepoRoot, outputArg ?? defaultOutput);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  const markdownPath = path.resolve(defaultRepoRoot, markdownArg ?? defaultMarkdown);
+  fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+  fs.writeFileSync(markdownPath, renderReactNativePayloadEvidenceMarkdown(evidence));
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -131,4 +131,11 @@ async function main() {
   console.log(`Merge gate passed. Approving maintainer(s): ${result.approvingMaintainers.join(", ")}`);
 }
 
-await main();
+function isDirectCliInvocation() {
+  const invoked = process.argv[1] ? new URL(`file://${process.argv[1]}`).href : undefined;
+  return invoked === import.meta.url;
+}
+
+if (isDirectCliInvocation()) {
+  await main();
+}

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -600,7 +600,25 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       const valueExpr = attributeValues.get("value");
       const onChangeTextExpr = attributeValues.get("onChangeText");
       const placeholder = attributeValues.get("placeholder");
-      if (!valueExpr && !onChangeTextExpr && !placeholder) return;
+      const keyboardType = attributeValues.get("keyboardType");
+      const secureTextEntry = attributeValues.get("secureTextEntry");
+      const maxLength = attributeValues.get("maxLength");
+      const autoCapitalize = attributeValues.get("autoCapitalize");
+      const accessibilityLabel = attributeValues.get("accessibilityLabel");
+      const testID = attributeValues.get("testID");
+      if (
+        !valueExpr &&
+        !onChangeTextExpr &&
+        !placeholder &&
+        !keyboardType &&
+        !secureTextEntry &&
+        !maxLength &&
+        !autoCapitalize &&
+        !accessibilityLabel &&
+        !testID
+      ) {
+        return;
+      }
 
       rnInputBindings.push({
         primitive: "TextInput",
@@ -608,10 +626,22 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
         ...(valueExpr ? { valueExpr } : {}),
         ...(onChangeTextExpr ? { onChangeTextExpr } : {}),
         ...(placeholder ? { placeholder } : {}),
+        ...(keyboardType ? { keyboardType } : {}),
+        ...(secureTextEntry ? { secureTextEntry } : {}),
+        ...(maxLength ? { maxLength } : {}),
+        ...(autoCapitalize ? { autoCapitalize } : {}),
+        ...(accessibilityLabel ? { accessibilityLabel } : {}),
+        ...(testID ? { testID } : {}),
         evidence: [
           ...(valueExpr ? ["jsx.TextInput.value"] : []),
           ...(onChangeTextExpr ? ["jsx.TextInput.onChangeText"] : []),
           ...(placeholder ? ["jsx.TextInput.placeholder"] : []),
+          ...(keyboardType ? ["jsx.TextInput.keyboardType"] : []),
+          ...(secureTextEntry ? ["jsx.TextInput.secureTextEntry"] : []),
+          ...(maxLength ? ["jsx.TextInput.maxLength"] : []),
+          ...(autoCapitalize ? ["jsx.TextInput.autoCapitalize"] : []),
+          ...(accessibilityLabel ? ["jsx.TextInput.accessibilityLabel"] : []),
+          ...(testID ? ["jsx.TextInput.testID"] : []),
         ],
       });
       return;
@@ -620,6 +650,10 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     if (tag !== "Pressable") return;
     const onPressExpr = attributeValues.get("onPress");
     if (!onPressExpr) return;
+    const disabled = attributeValues.get("disabled");
+    const accessibilityLabel = attributeValues.get("accessibilityLabel");
+    const accessibilityRole = attributeValues.get("accessibilityRole");
+    const testID = attributeValues.get("testID");
 
     const label = ts.isJsxOpeningElement(node) && ts.isJsxElement(node.parent) ? jsxElementTextLabel(node.parent) : undefined;
     rnActionBindings.push({
@@ -627,7 +661,18 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       loc: sourceRangeOf(sourceFile, node),
       onPressExpr,
       ...(label ? { label } : {}),
-      evidence: ["jsx.Pressable.onPress", ...(label ? ["jsx.Pressable.Text.label"] : [])],
+      ...(disabled ? { disabled } : {}),
+      ...(accessibilityLabel ? { accessibilityLabel } : {}),
+      ...(accessibilityRole ? { accessibilityRole } : {}),
+      ...(testID ? { testID } : {}),
+      evidence: [
+        "jsx.Pressable.onPress",
+        ...(label ? ["jsx.Pressable.Text.label"] : []),
+        ...(disabled ? ["jsx.Pressable.disabled"] : []),
+        ...(accessibilityLabel ? ["jsx.Pressable.accessibilityLabel"] : []),
+        ...(accessibilityRole ? ["jsx.Pressable.accessibilityRole"] : []),
+        ...(testID ? ["jsx.Pressable.testID"] : []),
+      ],
     });
   };
 

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -4,7 +4,18 @@ import ts from "typescript";
 import { hashText } from "./hash";
 import { decideMode } from "./decide";
 import { detectDomainFromSource } from "./domain-detector";
-import type { A11yAnchorSignal, ExtractionResult, FormSurface, ImportSignal, Language, SourceRange, StyleSystem, StyleVariantSignal } from "./schema";
+import type {
+  A11yAnchorSignal,
+  ExtractionResult,
+  FormSurface,
+  ImportSignal,
+  Language,
+  ReactNativePrimitiveActionBindingSignal,
+  ReactNativePrimitiveInputBindingSignal,
+  SourceRange,
+  StyleSystem,
+  StyleVariantSignal,
+} from "./schema";
 
 const HOOK_NAMES = new Set(["useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer", "useLayoutEffect", "useContext", "useId", "useTransition"]);
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
@@ -21,6 +32,7 @@ const MAX_CONTROL_PROPS = 8;
 const MAX_TEXT_LENGTH = 48;
 const STYLE_VARIANT_PROP_NAMES = new Set(["variant", "size", "tone", "intent", "disabled", "selected", "loading", "compact"]);
 const MAX_STYLE_VARIANT_SIGNALS = 16;
+const MAX_RN_PRIMITIVE_BINDINGS = 8;
 
 function getLanguage(filePath: string): Language {
   const ext = path.extname(filePath);
@@ -492,6 +504,8 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const callbackSignals: NonNullable<NonNullable<ExtractionResult["behavior"]>["callbackSignals"]> = [];
   const eventHandlerSignals: NonNullable<NonNullable<ExtractionResult["behavior"]>["eventHandlerSignals"]> = [];
   const formControls: NonNullable<FormSurface["controls"]> = [];
+  const rnInputBindings: ReactNativePrimitiveInputBindingSignal[] = [];
+  const rnActionBindings: ReactNativePrimitiveActionBindingSignal[] = [];
   const submitHandlers: NonNullable<FormSurface["submitHandlers"]> = [];
   const validationAnchors: NonNullable<FormSurface["validationAnchors"]> = [];
   const stateConditions: NonNullable<FormSurface["stateConditions"]> = [];
@@ -560,6 +574,63 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     return compactText(attribute.initializer.getText(sourceFile));
   };
 
+  const jsxElementTextLabel = (element: ts.JsxElement): string | undefined => {
+    const parts: string[] = [];
+    const visitText = (child: ts.Node): void => {
+      if (ts.isJsxExpression(child)) return;
+      if (ts.isJsxText(child)) {
+        const text = compactText(child.getFullText(sourceFile));
+        if (text) parts.push(text);
+        return;
+      }
+      ts.forEachChild(child, visitText);
+    };
+
+    for (const child of element.children) visitText(child);
+    const label = compactText(parts.join(" "));
+    return label || undefined;
+  };
+
+  const collectRnPrimitiveInteraction = (
+    node: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+    tag: string,
+    attributeValues: Map<string, string>,
+  ): void => {
+    if (tag === "TextInput") {
+      const valueExpr = attributeValues.get("value");
+      const onChangeTextExpr = attributeValues.get("onChangeText");
+      const placeholder = attributeValues.get("placeholder");
+      if (!valueExpr && !onChangeTextExpr && !placeholder) return;
+
+      rnInputBindings.push({
+        primitive: "TextInput",
+        loc: sourceRangeOf(sourceFile, node),
+        ...(valueExpr ? { valueExpr } : {}),
+        ...(onChangeTextExpr ? { onChangeTextExpr } : {}),
+        ...(placeholder ? { placeholder } : {}),
+        evidence: [
+          ...(valueExpr ? ["jsx.TextInput.value"] : []),
+          ...(onChangeTextExpr ? ["jsx.TextInput.onChangeText"] : []),
+          ...(placeholder ? ["jsx.TextInput.placeholder"] : []),
+        ],
+      });
+      return;
+    }
+
+    if (tag !== "Pressable") return;
+    const onPressExpr = attributeValues.get("onPress");
+    if (!onPressExpr) return;
+
+    const label = ts.isJsxOpeningElement(node) && ts.isJsxElement(node.parent) ? jsxElementTextLabel(node.parent) : undefined;
+    rnActionBindings.push({
+      primitive: "Pressable",
+      loc: sourceRangeOf(sourceFile, node),
+      onPressExpr,
+      ...(label ? { label } : {}),
+      evidence: ["jsx.Pressable.onPress", ...(label ? ["jsx.Pressable.Text.label"] : [])],
+    });
+  };
+
   const collectJsxOpening = (node: ts.JsxOpeningElement | ts.JsxSelfClosingElement): void => {
     const tag = node.tagName.getText(sourceFile);
     const attributeValues = new Map<string, string>();
@@ -575,6 +646,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     if (tag === "Controller") {
       addLocatedAnchor(validationAnchors, "Controller", node);
     }
+    collectRnPrimitiveInteraction(node, tag, attributeValues);
 
     const propNames: string[] = [];
     const propValues: Record<string, string> = {};
@@ -761,6 +833,15 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const eventHandlerSignalList = dedupeBy(eventHandlerSignals, (item) => `${item.name}:${item.trigger ?? ""}:${item.loc?.startLine ?? ""}`).slice(0, MAX_EVENT_HANDLER_SIGNALS);
   const a11yAnchorList = dedupeBy(a11yAnchors, (item) => `${item.kind}:${item.label}:${item.loc?.startLine ?? ""}`).slice(0, 16);
   const a11ySourceIdList = dedupeBy(a11ySourceIds, (item) => `${item.value}:${item.loc?.startLine ?? ""}`).slice(0, 16);
+  const rnInputBindingList = dedupeBy(
+    rnInputBindings,
+    (item) => `${item.primitive}:${item.valueExpr ?? ""}:${item.onChangeTextExpr ?? ""}:${item.placeholder ?? ""}:${item.loc?.startLine ?? ""}`,
+  ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const rnActionBindingList = dedupeBy(
+    rnActionBindings,
+    (item) => `${item.primitive}:${item.onPressExpr}:${item.label ?? ""}:${item.loc?.startLine ?? ""}`,
+  ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0;
   return {
     behavior: {
       hooks: [...hooks],
@@ -777,6 +858,14 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
               ...(formSurface.submitHandlers.length ? { submitHandlers: formSurface.submitHandlers } : {}),
               ...(formSurface.validationAnchors.length ? { validationAnchors: formSurface.validationAnchors } : {}),
               ...(formSurface.stateConditions.length ? { stateConditions: formSurface.stateConditions } : {}),
+            },
+          }
+        : {}),
+      ...(hasRnPrimitiveInteractions
+        ? {
+            rnPrimitiveInteractions: {
+              ...(rnInputBindingList.length ? { inputBindings: rnInputBindingList } : {}),
+              ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
             },
           }
         : {}),

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -6,7 +6,7 @@ import {
   RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
   RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
 } from "../payload-policy/react-native";
-import type { ExtractionResult, FormControlSignal, StyleSystem } from "../schema";
+import type { ExtractionResult, FormControlSignal, ReactNativePrimitiveInteractionSignal, StyleSystem } from "../schema";
 
 export const DOMAIN_PAYLOAD_SCHEMA_VERSION = "domain-payload.v1";
 export const REACT_WEB_DOMAIN_PAYLOAD_POLICY = "react-web-current-supported-lane";
@@ -113,6 +113,7 @@ export type ReactNativePrimitiveInputDomainPayload = {
     exports?: Pick<ExtractionResult["exports"][number], "name" | "kind" | "type">[];
     hooks?: string[];
     eventHandlers?: string[];
+    primitiveInteractions?: ReactNativePrimitiveInteractionSignal;
     jsxDepth?: number;
   };
   warnings: string[];
@@ -306,6 +307,20 @@ function buildReactNativePrimitiveInputReuseContract(): ReactNativePrimitiveInpu
   };
 }
 
+function compactReactNativePrimitiveInteractions(
+  interactions: ReactNativePrimitiveInteractionSignal | undefined,
+): ReactNativePrimitiveInputDomainPayload["facts"]["primitiveInteractions"] {
+  if (!interactions) return undefined;
+  const inputBindings = interactions.inputBindings?.slice(0, 8);
+  const actionBindings = interactions.actionBindings?.slice(0, 8);
+
+  if (!inputBindings?.length && !actionBindings?.length) return undefined;
+  return {
+    ...(inputBindings?.length ? { inputBindings } : {}),
+    ...(actionBindings?.length ? { actionBindings } : {}),
+  };
+}
+
 function buildReactNativePayloadFacts(
   result: ExtractionResult,
   evidenceFacts: ReactNativePayloadEvidenceFacts,
@@ -313,6 +328,7 @@ function buildReactNativePayloadFacts(
   const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
   const hooks = uniqueSorted(result.behavior?.hooks ?? []);
   const exportFacts = compactExports(result.exports);
+  const primitiveInteractions = compactReactNativePrimitiveInteractions(result.behavior?.rnPrimitiveInteractions);
 
   return {
     primitives: evidenceFacts.primitives,
@@ -321,6 +337,7 @@ function buildReactNativePayloadFacts(
     ...(exportFacts && exportFacts.length > 0 ? { exports: exportFacts } : {}),
     ...(hooks.length > 0 ? { hooks } : {}),
     ...(eventHandlers.length > 0 ? { eventHandlers } : {}),
+    ...(primitiveInteractions ? { primitiveInteractions } : {}),
     ...(typeof result.structure?.jsxDepth === "number" ? { jsxDepth: result.structure.jsxDepth } : {}),
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -65,6 +65,28 @@ export type FormSurface = {
   stateConditions?: LocatedString[];
 };
 
+export type ReactNativePrimitiveInputBindingSignal = {
+  primitive: "TextInput";
+  loc?: SourceRange;
+  valueExpr?: string;
+  onChangeTextExpr?: string;
+  placeholder?: string;
+  evidence: string[];
+};
+
+export type ReactNativePrimitiveActionBindingSignal = {
+  primitive: "Pressable";
+  loc?: SourceRange;
+  onPressExpr: string;
+  label?: string;
+  evidence: string[];
+};
+
+export type ReactNativePrimitiveInteractionSignal = {
+  inputBindings?: ReactNativePrimitiveInputBindingSignal[];
+  actionBindings?: ReactNativePrimitiveActionBindingSignal[];
+};
+
 export type A11yAnchorSignal = {
   kind: "label" | "htmlFor" | "aria" | "role" | "required" | "disabled" | "readonly" | "error-text";
   label: string;
@@ -307,6 +329,7 @@ export type ExtractionResult = {
     eventHandlers?: string[];
     eventHandlerSignals?: EventHandlerSignal[];
     formSurface?: FormSurface;
+    rnPrimitiveInteractions?: ReactNativePrimitiveInteractionSignal;
     a11yAnchors?: A11yAnchorSignal[];
     a11ySourceIds?: LocatedString[];
     hasSideEffects?: boolean;
@@ -363,6 +386,7 @@ export type ModelFacingPayload = {
     eventHandlers?: string[];
     eventHandlerSignals?: EventHandlerSignal[];
     formSurface?: FormSurface;
+    rnPrimitiveInteractions?: ReactNativePrimitiveInteractionSignal;
     hasSideEffects?: boolean;
   };
   structure?: {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -71,6 +71,12 @@ export type ReactNativePrimitiveInputBindingSignal = {
   valueExpr?: string;
   onChangeTextExpr?: string;
   placeholder?: string;
+  keyboardType?: string;
+  secureTextEntry?: string;
+  maxLength?: string;
+  autoCapitalize?: string;
+  accessibilityLabel?: string;
+  testID?: string;
   evidence: string[];
 };
 
@@ -79,6 +85,10 @@ export type ReactNativePrimitiveActionBindingSignal = {
   loc?: SourceRange;
   onPressExpr: string;
   label?: string;
+  disabled?: string;
+  accessibilityLabel?: string;
+  accessibilityRole?: string;
+  testID?: string;
   evidence: string[];
 };
 

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
@@ -4,14 +4,31 @@ type SearchRowProps = {
   value: string;
   onChangeText: (value: string) => void;
   onApply: () => void;
+  isApplyDisabled?: boolean;
 };
 
-export function SearchRow({ value, onChangeText, onApply }: SearchRowProps) {
+export function SearchRow({ value, onChangeText, onApply, isApplyDisabled }: SearchRowProps) {
   return (
     <View accessibilityLabel="search row">
       <Text>Search</Text>
-      <TextInput value={value} placeholder="Filter" onChangeText={onChangeText} />
-      <Pressable onPress={onApply}>
+      <TextInput
+        value={value}
+        placeholder="Filter"
+        onChangeText={onChangeText}
+        keyboardType="default"
+        secureTextEntry={false}
+        maxLength={80}
+        autoCapitalize="none"
+        accessibilityLabel="Search filter"
+        testID="search-input"
+      />
+      <Pressable
+        onPress={onApply}
+        disabled={isApplyDisabled}
+        accessibilityLabel="Apply filter"
+        accessibilityRole="button"
+        testID="apply-button"
+      >
         <Text>Apply</Text>
       </Pressable>
     </View>

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
@@ -12,8 +12,16 @@ export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionR
   return (
     <View accessibilityLabel="inline action row">
       <Text>Filter</Text>
-      <TextInput value={value} placeholder="Type filter" onChangeText={onChangeText} />
-      <Pressable onPress={submitCurrentValue}>
+      <TextInput
+        value={value}
+        placeholder="Type filter"
+        onChangeText={onChangeText}
+        keyboardType="web-search"
+        autoCapitalize="sentences"
+        accessibilityLabel="Inline filter"
+        testID="inline-filter-input"
+      />
+      <Pressable onPress={submitCurrentValue} accessibilityLabel="Submit filter" testID="submit-filter-button">
         <Text>Submit</Text>
       </Pressable>
     </View>

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -74,6 +74,28 @@ test("frontend profile gate allows narrow allowed non-web frontend policies", ()
   assert.equal(payload.domainPayload.policy, policy.name);
   assert.deepEqual(payload.domainPayload.facts.primitives, ["Pressable", "Text", "TextInput", "View"]);
   assert.deepEqual(payload.domainPayload.facts.jsxProps, ["onChangeText", "onPress"]);
+  assert.deepEqual(payload.domainPayload.facts.primitiveInteractions, {
+    inputBindings: [
+      {
+        primitive: "TextInput",
+        loc: { startLine: 1, endLine: 1 },
+        onChangeTextExpr: "() => null",
+        evidence: ["jsx.TextInput.onChangeText"],
+      },
+    ],
+    actionBindings: [
+      {
+        primitive: "Pressable",
+        loc: { startLine: 1, endLine: 1 },
+        onPressExpr: "() => null",
+        label: "Save",
+        evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+      },
+    ],
+  });
+  assert.equal("formControls" in payload.domainPayload.facts, false);
+  assert.equal("domTags" in payload.domainPayload.facts, false);
+  assert.equal("reactNativeContext" in payload, false);
   assert.equal(payload.domainPayload.sourceAnchorBeta.contract.contractVersion, "rn-source-anchor-beta.v0");
   assert.equal(payload.domainPayload.sourceAnchorBeta.contract.scope, "local-proof-only");
   assert.deepEqual(payload.domainPayload.sourceAnchorBeta.contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -10,6 +10,7 @@ import { createRequire } from "node:module";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
 const {
   assessReactNativePrimitiveInputSignalGate,
   assessReactNativePayloadPolicy,
@@ -83,16 +84,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
     allowed: true,
   });
 
-  const payload = buildReactNativePrimitiveInputDomainPayload(
-    {
-      componentName: "InlineActionRow",
-      exports: [],
-      behavior: {},
-      structure: {},
-      domainDetection,
-    },
-    domainDetection,
-  );
+  const payload = buildReactNativePrimitiveInputDomainPayload(extractFile(filePath), domainDetection);
 
   assert.equal(payload?.domain, "react-native");
   assert.equal(payload?.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
@@ -129,6 +121,28 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.sourceAnchorBeta.anchors.primitives, ["Pressable", "Text", "TextInput", "View"]);
   assert.deepEqual(payload?.sourceAnchorBeta.anchors.jsxProps, ["onChangeText", "onPress"]);
   assert.equal(payload?.sourceAnchorBeta.anchors.sourceFingerprintRequired, true);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 15, endLine: 15 },
+      valueExpr: "value",
+      onChangeTextExpr: "onChangeText",
+      placeholder: "Type filter",
+      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+    },
+  ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
+    {
+      primitive: "Pressable",
+      loc: { startLine: 16, endLine: 16 },
+      onPressExpr: "submitCurrentValue",
+      label: "Submit",
+      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+    },
+  ]);
+  assert.equal("formControls" in payload.facts, false);
+  assert.equal("domTags" in payload.facts, false);
+  assert.equal("reactNativeContext" in payload, false);
   assert.equal(payload?.reuseContract.supportBoundary, "measured-evidence-only; no broad RN/WebView/TUI support");
   assert.deepEqual(payload?.reuseContract.requiredSignals, [...RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS]);
 
@@ -137,8 +151,41 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.equal(preReadDecision.payload.domainPayload.domain, "react-native");
   assert.equal(preReadDecision.payload.domainPayload.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
   assert.equal(preReadDecision.payload.domainPayload.claimBoundary, "rn-primitive-input-narrow-payload-only");
+  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
+  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].label, "Submit");
   assert.equal(preReadDecision.debug.domainDetection.classification, "react-native");
   assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
+});
+
+
+test("React Native primitive basic fixture emits TextInput and Pressable interaction facts", () => {
+  const filePath = fixturePath("rn-primitive-basic.tsx");
+  const domainDetection = detect(fixtureSource("rn-primitive-basic.tsx"), filePath);
+  const payload = buildReactNativePrimitiveInputDomainPayload(extractFile(filePath), domainDetection);
+
+  assert.equal(payload?.domain, "react-native");
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 13, endLine: 13 },
+      valueExpr: "value",
+      onChangeTextExpr: "onChangeText",
+      placeholder: "Filter",
+      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+    },
+  ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
+    {
+      primitive: "Pressable",
+      loc: { startLine: 14, endLine: 14 },
+      onPressExpr: "onApply",
+      label: "Apply",
+      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+    },
+  ]);
+  assert.equal("formControls" in payload.facts, false);
+  assert.equal("domTags" in payload.facts, false);
+  assert.equal("reactNativeContext" in payload, false);
 });
 
 test("React Native richer adjacent fixtures stay outside the narrow payload lane", () => {
@@ -385,8 +432,13 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
   }
 });
 
-test("React Native policy seam source avoids broad React Native support claims", () => {
-  for (const relativePath of [path.join("src", "core", "payload-policy", "react-native.ts")]) {
-    assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"), forbiddenSupportClaims, relativePath);
+test("React Native policy and payload seams avoid broad support and web terminology", () => {
+  for (const relativePath of [
+    path.join("src", "core", "payload-policy", "react-native.ts"),
+    path.join("src", "core", "payload", "domain-payload.ts"),
+  ]) {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+    assert.doesNotMatch(source, forbiddenSupportClaims, relativePath);
+    assert.doesNotMatch(source, /reactNativeContext|editTargetRouting/i, relativePath);
   }
 });

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -124,20 +124,34 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 15, endLine: 15 },
+      loc: { startLine: 15, endLine: 23 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       placeholder: "Type filter",
-      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      accessibilityLabel: "Inline filter",
+      testID: "inline-filter-input",
+      evidence: [
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+      ],
     },
   ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 16, endLine: 16 },
+      loc: { startLine: 24, endLine: 24 },
       onPressExpr: "submitCurrentValue",
       label: "Submit",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+      accessibilityLabel: "Submit filter",
+      testID: "submit-filter-button",
+      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
     },
   ]);
   assert.equal("formControls" in payload.facts, false);
@@ -167,20 +181,47 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 13, endLine: 13 },
+      loc: { startLine: 14, endLine: 24 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       placeholder: "Filter",
-      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+      keyboardType: "default",
+      secureTextEntry: "false",
+      maxLength: "80",
+      autoCapitalize: "none",
+      accessibilityLabel: "Search filter",
+      testID: "search-input",
+      evidence: [
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+      ],
     },
   ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 14, endLine: 14 },
+      loc: { startLine: 25, endLine: 31 },
       onPressExpr: "onApply",
       label: "Apply",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+      disabled: "isApplyDisabled",
+      accessibilityLabel: "Apply filter",
+      accessibilityRole: "button",
+      testID: "apply-button",
+      evidence: [
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.accessibilityRole",
+        "jsx.Pressable.testID",
+      ],
     },
   ]);
   assert.equal("formControls" in payload.facts, false);
@@ -439,6 +480,6 @@ test("React Native policy and payload seams avoid broad support and web terminol
   ]) {
     const source = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
     assert.doesNotMatch(source, forbiddenSupportClaims, relativePath);
-    assert.doesNotMatch(source, /reactNativeContext|editTargetRouting/i, relativePath);
+    assert.doesNotMatch(source, /reactNativeContext|rnContext|editTargetRouting/i, relativePath);
   }
 });

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  RN_PRESSABLE_METADATA_FIELDS,
+  RN_TEXT_INPUT_METADATA_FIELDS,
+  buildReactNativePayloadEvidence,
+  renderReactNativePayloadEvidenceMarkdown,
+} from "../scripts/react-native-payload-evidence.mjs";
+
+test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v2");
+  assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
+  assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
+  assert.match(evidence.claimBoundary, /not broad React Native support/);
+  assert.match(evidence.claimBoundary, /not runtime reuse promotion/);
+  assert.match(evidence.claimBoundary, /not edit routing/);
+  assert.match(evidence.claimBoundary, /not provider billing or invoice savings/);
+
+  assert.equal(evidence.summary.fixtureCount, 2);
+  assert.equal(evidence.summary.rnPayloadFactsVisible.claimable, true);
+  assert.equal(evidence.summary.rnPayloadFactsVisible.blocker, null);
+  assert.equal(evidence.summary.boundaryFallbacksPreserved.claimable, true);
+  assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
+  assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
+  assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
+  assert.deepEqual(
+    evidence.summary.metadataAnchorsVisible.textInputFields.map((row) => row.field),
+    RN_TEXT_INPUT_METADATA_FIELDS,
+  );
+  assert.deepEqual(
+    evidence.summary.metadataAnchorsVisible.pressableFields.map((row) => row.field),
+    RN_PRESSABLE_METADATA_FIELDS,
+  );
+  for (const row of [
+    ...evidence.summary.metadataAnchorsVisible.textInputFields,
+    ...evidence.summary.metadataAnchorsVisible.pressableFields,
+  ]) {
+    assert.equal(row.preRead, true, row.field);
+    assert.equal(row.modelFacing, true, row.field);
+    assert.equal(row.claimable, true, row.field);
+  }
+  assert.equal(evidence.summary.broadReactNativeSupport.claimable, false);
+  assert.equal(evidence.summary.runtimeReusePromotion.claimable, false);
+  assert.equal(evidence.summary.editRouting.claimable, false);
+  assert.equal(evidence.summary.providerBillingSavings.claimable, false);
+
+  for (const row of evidence.fixtures) {
+    assert.equal(row.classification, "react-native");
+    assert.equal(row.preReadDecision, "payload");
+    assert.equal(row.payloadPolicy, "rn-primitive-input-narrow-payload");
+    assert.equal(row.sourceFingerprintPresent, true);
+    assert.equal(row.preRead.domain, "react-native");
+    assert.equal(row.preRead.claimBoundary, "rn-primitive-input-narrow-payload-only");
+    assert.equal(row.preRead.sourceAnchorBetaVersion, "rn-source-anchor-beta.v0");
+    assert.equal(row.preRead.reuseFreshnessSource, "sourceFingerprint");
+    assert.equal(row.preRead.strictContractsPresent, true);
+    assert.equal(row.preRead.primitiveInteractions.hasTextInputBinding, true);
+    assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
+    assert.ok(row.preRead.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
+    assert.ok(row.preRead.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.equal(row.modelFacing.strictContractsPresent, true);
+    assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
+    assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
+    assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
+    assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.equal(row.claimable, true);
+  }
+
+  const basic = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-basic.tsx"));
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].valueExpr, "value");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].onChangeTextExpr, "onChangeText");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].placeholder, "Filter");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].keyboardType, "default");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].secureTextEntry, "false");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].maxLength, "80");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "none");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Search filter");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].testID, "search-input");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "onApply");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].label, "Apply");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].disabled, "isApplyDisabled");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Apply filter");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityRole, "button");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].testID, "apply-button");
+
+  const inline = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-inline-action.tsx"));
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].placeholder, "Type filter");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].keyboardType, "web-search");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "sentences");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Inline filter");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].testID, "inline-filter-input");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
+});
+
+test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `boundary-test-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.summary.boundaryFixtureCount, 5);
+  for (const row of evidence.boundaryFixtures) {
+    assert.equal(row.decision, "fallback", row.file);
+    assert.equal(row.payloadExposed, false, row.file);
+    assert.equal(row.rnPrimitiveInteractionsExposed, false, row.file);
+    assert.equal(row.boundaryPreserved, true, row.file);
+  }
+
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "react-native"));
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "webview"));
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "tui-ink"));
+});
+
+test("React Native payload evidence Markdown keeps claim boundaries explicit", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `markdown-test-${Date.now()}-${Math.random()}` });
+  const markdown = renderReactNativePayloadEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /RN primitive interaction facts visible: yes/);
+  assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
+  assert.match(markdown, /RN metadata anchors visible: yes/);
+  assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| maxLength \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| autoCapitalize \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| Pressable \| disabled \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| Pressable \| accessibilityRole \| yes \| yes \| yes \|/);
+  assert.match(markdown, /Broad React Native support claimable: no/);
+  assert.match(markdown, /Runtime reuse promotion claimable: no/);
+  assert.match(markdown, /RN edit routing claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /existing `rn-primitive-input-narrow-payload` lane/);
+  assert.doesNotMatch(markdown, /Broad React Native support claimable: yes/i);
+  assert.doesNotMatch(markdown, /Runtime reuse promotion claimable: yes/i);
+  assert.doesNotMatch(markdown, /RN edit routing claimable: yes/i);
+  assert.doesNotMatch(markdown, /reactNativeContext|rnContext|editTargetRouting/i);
+});


### PR DESCRIPTION
## Summary
- add narrow RN `primitiveInteractions` facts for `TextInput` value/onChangeText/placeholder bindings
- add narrow RN `Pressable` onPress/label action facts from local JSX source
- keep RN support claim boundary unchanged: existing measured primitive/input payload lane only, no gate widening, no `reactNativeContext`, no DOM/form facts in RN payloads

## Verification
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/runtime-bridge-contract.test.mjs test/react-web-context-metadata.test.mjs test/release-benchmark-evidence.test.mjs` — 53/53 pass
- `npm test` — 481/481 pass
- post-deslop `npm test` — 481/481 pass
- `git diff --check`
- affected TS LSP diagnostics — 0 errors
- Ralph architect review — APPROVE

## Boundaries
- No dependency changes
- No detector/policy-gate widening
- No edit routing or runtime reuse promotion
- No broad React Native/WebView/TUI support claim

Closes #473
