### PR TITLE
Expose React Web edit-intent packing evidence

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -161,25 +161,55 @@ function compactRuntimeReactWebContext(
   return compactContext;
 }
 
+type RuntimeReactWebContextPackingSummary = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebContextPacking"]>;
+
+function summarizeRuntimeReactWebContextPacking(
+  reactWebContext: PackedRuntimeReactWebContext | undefined,
+): RuntimeReactWebContextPackingSummary {
+  if (!reactWebContext) {
+    return {
+      included: false,
+      reason: "not-emitted",
+      fields: [],
+      totalAnchors: 0,
+      priority: [...RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY],
+    };
+  }
+
+  const fields = RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY.flatMap((field) => {
+    const values = reactWebContext[field];
+    return Array.isArray(values) && values.length > 0 ? [{ name: field, count: values.length }] : [];
+  });
+
+  return {
+    included: true,
+    reason: "packed",
+    fields,
+    totalAnchors: fields.reduce((total, field) => total + field.count, 0),
+    priority: [...RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY],
+  };
+}
+
 function buildAdditionalContext(
   filePath: string,
   payload: ModelFacingPayload,
   contextMode: ContextMode,
   maxOptimizedContextBytes?: number,
-): string {
+): { additionalContext: string; reactWebContextPacking?: RuntimeReactWebContextPackingSummary } {
   if (payload.domainPayload?.domain === "react-web" && !payload.useOriginal) {
     const runtimeReactWebContextBudget = payload.editGuidance
       ? editGuidanceBudgetLimit(maxOptimizedContextBytes)
       : maxOptimizedContextBytes;
-    return renderOptimizedReactWebAdditionalContext(
-      filePath,
-      payload,
-      contextMode,
-      compactRuntimeReactWebContext(filePath, payload, contextMode, runtimeReactWebContextBudget),
-    );
+    const reactWebContext = compactRuntimeReactWebContext(filePath, payload, contextMode, runtimeReactWebContextBudget);
+    return {
+      additionalContext: renderOptimizedReactWebAdditionalContext(filePath, payload, contextMode, reactWebContext),
+      reactWebContextPacking: summarizeRuntimeReactWebContextPacking(reactWebContext),
+    };
   }
 
-  return renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload));
+  return {
+    additionalContext: renderAdditionalContext(filePath, payload.mode, contextMode, buildRuntimeContextPayload(payload)),
+  };
 }
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
@@ -458,7 +488,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       if (optInDecision.decision === "payload" && optInDecision.payload && hasMatchingEditGuidance(optInDecision.payload)) {
         const optInContextMode = payloadContextMode(optInDecision.payload);
         const optInAdditionalContext = buildAdditionalContext(target, optInDecision.payload, optInContextMode, originalEstimatedBytes);
-        const estimatedContextBytes = estimateTextBytes(optInAdditionalContext);
+        const estimatedContextBytes = estimateTextBytes(optInAdditionalContext.additionalContext);
         if (estimatedContextBytes <= editGuidanceBudgetLimit(originalEstimatedBytes)) {
           decision = optInDecision;
         }
@@ -470,7 +500,8 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    const additionalContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
+    const runtimeContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
+    const { additionalContext, reactWebContextPacking } = runtimeContext;
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
     const runtimeDecision: CodexRuntimeHookDecision = {
@@ -495,6 +526,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         eligible: true,
         escapeHatchUsed: false,
         decision,
+        ...(reactWebContextPacking ? { reactWebContextPacking } : {}),
       },
     };
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -477,6 +477,13 @@ export type CodexRuntimeHookDecision = {
     eligible: boolean;
     escapeHatchUsed: boolean;
     decision?: PreReadDecision;
+    reactWebContextPacking?: {
+      included: boolean;
+      reason: "packed" | "not-emitted";
+      fields: Array<{ name: string; count: number }>;
+      totalAnchors: number;
+      priority: string[];
+    };
   };
   fallback?: {
     action: "full-read";

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -86,6 +86,19 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(optimizedEditPayload.editGuidance.freshness.fileHash, optimizedEditPayload.sourceFingerprint.fileHash);
   assert.ok(Array.isArray(optimizedEditPayload.reactWebContext.editTargetRouting));
   assert.ok(optimizedEditPayload.reactWebContext.editTargetRouting.length > 0);
+  assert.equal(secondInject.debug.reactWebContextPacking.included, true);
+  assert.equal(secondInject.debug.reactWebContextPacking.reason, "packed");
+  assert.equal(secondInject.debug.reactWebContextPacking.priority[0], "editTargetRouting");
+  assert.equal(secondInject.debug.reactWebContextPacking.fields[0].name, "editTargetRouting");
+  assert.equal(
+    secondInject.debug.reactWebContextPacking.fields.find((field) => field.name === "editTargetRouting")?.count,
+    optimizedEditPayload.reactWebContext.editTargetRouting.length,
+  );
+  assert.equal(
+    secondInject.debug.reactWebContextPacking.totalAnchors,
+    secondInject.debug.reactWebContextPacking.fields.reduce((total, field) => total + field.count, 0),
+  );
+  assert.doesNotMatch(JSON.stringify(secondInject.debug.reactWebContextPacking), /provider|billing|latency|edit-quality|typechecker|cross-file/i);
 
   const contextSession = `bridge-contract-react-web-context-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: contextSession }, repoRoot);
@@ -115,6 +128,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   const optimizedContextPayload = JSON.parse(secondContext.additionalContext.split("\n").slice(1).join("\n"));
   assert.equal(optimizedContextPayload.reactWebContext.schemaVersion, "react-web-context.v0");
   assert.equal("editTargetRouting" in optimizedContextPayload.reactWebContext, false);
+  assert.equal(secondContext.debug.reactWebContextPacking.included, true);
+  assert.deepEqual(secondContext.debug.reactWebContextPacking.fields, []);
   assert.ok(
     Buffer.byteLength(secondContext.additionalContext, "utf8") <= fs.statSync(path.join(repoRoot, "fixtures/compressed/FormSection.tsx")).size,
   );
@@ -176,6 +191,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
     assert.equal(packedContext.contextModeReason, "repeated-exact-file-react-web-payload");
     assert.ok(Array.isArray(packedPayload.reactWebContext.editTargetRouting));
     assert.ok(packedPayload.reactWebContext.editTargetRouting.length > 0);
+    assert.equal(packedContext.debug.reactWebContextPacking.fields[0].name, "editTargetRouting");
     assert.ok(Array.isArray(packedPayload.reactWebContext.a11yAnchors));
     assert.ok(Buffer.byteLength(packedContext.additionalContext, "utf8") <= Buffer.byteLength(largeReactSource, "utf8"));
     assert.equal("sourceRanges" in packedPayload.reactWebContext, false);
@@ -257,6 +273,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondSmallRaw.action, "inject");
   assert.match(secondSmallRaw.additionalContext, /^fooks: reused pre-read \(raw\)/);
   assert.match(secondSmallRaw.additionalContext, /"useOriginal": true/);
+  assert.equal("reactWebContextPacking" in secondSmallRaw.debug, false);
 
   const overrideSession = `bridge-contract-override-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: overrideSession }, repoRoot);


### PR DESCRIPTION
## Summary
- Add optional runtime `debug.reactWebContextPacking` evidence for optimized React Web repeated-read payload injections.
- Preserve existing `additionalContext` behavior while exposing packed field order, counts, total anchors, and packing priority.
- Lock edit-intent evidence around `editTargetRouting` first, source-only boundaries, and raw/useOriginal omission.

## Boundaries
- Same-file React Web runtime evidence only.
- No cross-file usage, typechecker/LSP semantics, provider token/billing/latency, or edit-quality claims.
- Additive debug/test shape only; no public payload contract expansion intended.

## Verification
- `git diff --check`
- `npm run build`
- `npm test` — 480 pass / 0 fail
- `node --test test/runtime-bridge-contract.test.mjs test/fooks.test.mjs test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs`
- LSP diagnostics: 0 errors on `src/adapters/codex-runtime-hook.ts` and `src/core/schema.ts`
- Ralph architect verification: APPROVE

Closes #474