### PR TITLE
Add RN payload evidence report

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:integration": "npm run build && node --test test/*.test.mjs",
     "bench:cache": "npm run build && node scripts/benchmark-cache.mjs",
     "evidence:react-web-context": "npm run build && node scripts/react-web-context-evidence.mjs",
+    "evidence:react-native-payload": "npm run build && node scripts/react-native-payload-evidence.mjs",
     "evidence:react-web-reuse": "npm run build && node scripts/react-web-reuse-evidence.mjs",
     "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",

--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const DEFAULT_RN_PAYLOAD_EVIDENCE_FIXTURES = [
+  "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx",
+];
+
+export const DEFAULT_RN_BOUNDARY_FIXTURES = [
+  "test/fixtures/frontend-domain-expectations/rn-style-platform-navigation.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-interaction-gesture.tsx",
+  "test/fixtures/frontend-domain-expectations/rn-image-scrollview.tsx",
+  "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx",
+  "test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx",
+];
+
+function loadDist(repoRoot) {
+  const require = createRequire(import.meta.url);
+  return {
+    preRead: require(path.join(repoRoot, "dist", "adapters", "pre-read.js")),
+    extract: require(path.join(repoRoot, "dist", "core", "extract.js")),
+    modelFacing: require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js")),
+    registry: require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js")),
+  };
+}
+
+function readDomainPayload(decision) {
+  return decision?.payload?.domainPayload ?? null;
+}
+
+function hasStrictRnContracts(domainPayload) {
+  return Boolean(
+    domainPayload?.domain === "react-native" &&
+      domainPayload?.claimBoundary === "rn-primitive-input-narrow-payload-only" &&
+      domainPayload?.sourceAnchorBeta?.contract?.contractVersion === "rn-source-anchor-beta.v0" &&
+      domainPayload?.sourceAnchorBeta?.contract?.scope === "local-proof-only" &&
+      domainPayload?.sourceAnchorBeta?.contract?.runtimeReusePromotion === "not-promoted" &&
+      domainPayload?.reuseContract?.freshnessSource === "sourceFingerprint" &&
+      domainPayload?.reuseContract?.supportBoundary === "measured-evidence-only; no broad RN/WebView/TUI support",
+  );
+}
+
+function interactionSummary(domainPayload) {
+  const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
+  return {
+    inputBindings: interactions.inputBindings ?? [],
+    actionBindings: interactions.actionBindings ?? [],
+    hasTextInputBinding: Boolean(interactions.inputBindings?.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
+    hasPressableAction: Boolean(interactions.actionBindings?.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+  };
+}
+
+function measureRnFixture({ repoRoot, relativeFile, dist }) {
+  const filePath = path.join(repoRoot, relativeFile);
+  const preReadDecision = dist.preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: false });
+  const extracted = dist.extract.extractFile(filePath);
+  const policy = dist.registry.assessFrontendPayloadPolicy(extracted.domainDetection);
+  const modelPayload = dist.modelFacing.toModelFacingPayload(extracted, repoRoot, {
+    includeEditGuidance: false,
+    ...dist.registry.toFrontendPayloadBuildOptions(policy),
+  });
+  const preReadDomainPayload = readDomainPayload(preReadDecision);
+  const modelDomainPayload = modelPayload.domainPayload ?? null;
+  const preReadInteractions = interactionSummary(preReadDomainPayload);
+  const modelInteractions = interactionSummary(modelDomainPayload);
+
+  return {
+    file: relativeFile,
+    classification: preReadDecision.debug?.domainDetection?.classification ?? null,
+    preReadDecision: preReadDecision.decision,
+    payloadPolicy: preReadDecision.debug?.frontendPayloadPolicy?.name ?? null,
+    sourceFingerprintPresent: Boolean(preReadDecision.payload?.sourceFingerprint),
+    preRead: {
+      domain: preReadDomainPayload?.domain ?? null,
+      claimBoundary: preReadDomainPayload?.claimBoundary ?? null,
+      claimStatus: preReadDomainPayload?.claimStatus ?? null,
+      sourceAnchorBetaVersion: preReadDomainPayload?.sourceAnchorBeta?.contract?.contractVersion ?? null,
+      reuseFreshnessSource: preReadDomainPayload?.reuseContract?.freshnessSource ?? null,
+      strictContractsPresent: hasStrictRnContracts(preReadDomainPayload),
+      primitiveInteractions: preReadInteractions,
+    },
+    modelFacing: {
+      domain: modelDomainPayload?.domain ?? null,
+      claimBoundary: modelDomainPayload?.claimBoundary ?? null,
+      strictContractsPresent: hasStrictRnContracts(modelDomainPayload),
+      primitiveInteractions: modelInteractions,
+    },
+    claimable:
+      preReadDecision.decision === "payload" &&
+      preReadInteractions.hasTextInputBinding &&
+      preReadInteractions.hasPressableAction &&
+      modelInteractions.hasTextInputBinding &&
+      modelInteractions.hasPressableAction &&
+      hasStrictRnContracts(preReadDomainPayload) &&
+      hasStrictRnContracts(modelDomainPayload),
+  };
+}
+
+function measureBoundaryFixture({ repoRoot, relativeFile, dist }) {
+  const filePath = path.join(repoRoot, relativeFile);
+  const decision = dist.preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: false });
+  const domainPayload = readDomainPayload(decision);
+  return {
+    file: relativeFile,
+    classification: decision.debug?.domainDetection?.classification ?? null,
+    frontendPayloadPolicy: decision.debug?.frontendPayloadPolicy ?? null,
+    decision: decision.decision,
+    fallbackReason: decision.fallback?.reason ?? null,
+    payloadExposed: Boolean(domainPayload),
+    rnPrimitiveInteractionsExposed: Boolean(domainPayload?.facts?.primitiveInteractions),
+    boundaryPreserved: decision.decision === "fallback" && !domainPayload,
+  };
+}
+
+export async function buildReactNativePayloadEvidence({
+  repoRoot = defaultRepoRoot,
+  fixtures = DEFAULT_RN_PAYLOAD_EVIDENCE_FIXTURES,
+  boundaryFixtures = DEFAULT_RN_BOUNDARY_FIXTURES,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const dist = loadDist(repoRoot);
+  const rnFixtures = fixtures.map((relativeFile) => measureRnFixture({ repoRoot, relativeFile, dist }));
+  const boundaries = boundaryFixtures.map((relativeFile) => measureBoundaryFixture({ repoRoot, relativeFile, dist }));
+  const rnPayloadFactsVisible = rnFixtures.every((row) => row.claimable);
+  const boundaryFallbacksPreserved = boundaries.every((row) => row.boundaryPreserved && !row.rnPrimitiveInteractionsExposed);
+
+  return {
+    schemaVersion: "react-native-payload-evidence.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
+    claimBoundary:
+      "Local fixture payload evidence only: proves RN primitive/input narrow payload facts are visible for measured TextInput/Pressable fixtures and that richer RN/WebView/TUI boundaries remain fallback-only. This is not broad React Native support, not WebView or TUI promotion, not runtime reuse promotion, not edit routing, not provider tokenizer output, not runtime-token savings, and not provider billing or invoice savings.",
+    fixtures: rnFixtures,
+    boundaryFixtures: boundaries,
+    summary: {
+      fixtureCount: rnFixtures.length,
+      boundaryFixtureCount: boundaries.length,
+      rnPayloadFactsVisible: {
+        claimable: rnPayloadFactsVisible,
+        blocker: rnPayloadFactsVisible ? null : "one or more measured RN fixtures did not expose strict primitiveInteractions in both pre-read and model-facing payloads",
+      },
+      boundaryFallbacksPreserved: {
+        claimable: boundaryFallbacksPreserved,
+        blocker: boundaryFallbacksPreserved ? null : "one or more richer RN/WebView/TUI fixtures exposed payload facts or failed to fallback",
+      },
+      broadReactNativeSupport: {
+        claimable: false,
+        blocker: "evidence is limited to the existing rn-primitive-input-narrow-payload measured lane",
+      },
+      runtimeReusePromotion: {
+        claimable: false,
+        blocker: "sourceAnchorBeta remains local-proof-only and runtimeReusePromotion is not-promoted",
+      },
+      editRouting: {
+        claimable: false,
+        blocker: "no RN edit routing or patch guidance is measured or enabled by this artifact",
+      },
+      providerBillingSavings: {
+        claimable: false,
+        blocker: "no provider usage, tokenizer, billing dashboard, invoice, or charged-cost data is measured by this artifact",
+      },
+    },
+  };
+}
+
+export function renderReactNativePayloadEvidenceMarkdown(evidence) {
+  const fixtureRows = evidence.fixtures
+    .map((row) => {
+      const input = row.preRead.primitiveInteractions.inputBindings
+        .map((item) => `${item.primitive}:value=${item.valueExpr ?? "n/a"},onChangeText=${item.onChangeTextExpr ?? "n/a"}`)
+        .join("; ");
+      const action = row.preRead.primitiveInteractions.actionBindings
+        .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
+        .join("; ");
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${row.claimable ? "yes" : "no"} |`;
+    })
+    .join("\n");
+  const boundaryRows = evidence.boundaryFixtures
+    .map(
+      (row) =>
+        `| \`${row.file}\` | ${row.classification} | ${row.decision} | ${row.fallbackReason ?? "n/a"} | ${row.payloadExposed ? "yes" : "no"} | ${row.boundaryPreserved ? "yes" : "no"} |`,
+    )
+    .join("\n");
+
+  return `# React Native payload evidence
+
+${evidence.claimBoundary}
+
+## Summary
+
+- RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
+- Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
+- Broad React Native support claimable: no
+- Runtime reuse promotion claimable: no
+- RN edit routing claimable: no
+- Provider billing savings claimable: no
+
+## Measured RN narrow fixtures
+
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | claimable |
+| --- | --- | --- | --- | --- | --- | --- |
+${fixtureRows}
+
+## Boundary fixtures
+
+| Fixture | classification | decision | fallback reason | payload exposed | boundary preserved |
+| --- | --- | --- | --- | --- | --- |
+${boundaryRows}
+
+## Claim boundary
+
+This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const defaultOutput = path.join(".omx", "reports", `rn-payload-evidence-${runId}.json`);
+  const defaultMarkdown = path.join(".omx", "reports", `rn-payload-evidence-${runId}.md`);
+  const evidence = await buildReactNativePayloadEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  const outputPath = path.resolve(defaultRepoRoot, outputArg ?? defaultOutput);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  const markdownPath = path.resolve(defaultRepoRoot, markdownArg ?? defaultMarkdown);
+  fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+  fs.writeFileSync(markdownPath, renderReactNativePayloadEvidenceMarkdown(evidence));
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -20,6 +20,17 @@ export const DEFAULT_RN_BOUNDARY_FIXTURES = [
   "test/fixtures/frontend-domain-expectations/tui-ink-basic.tsx",
 ];
 
+export const RN_TEXT_INPUT_METADATA_FIELDS = [
+  "keyboardType",
+  "secureTextEntry",
+  "maxLength",
+  "autoCapitalize",
+  "accessibilityLabel",
+  "testID",
+];
+
+export const RN_PRESSABLE_METADATA_FIELDS = ["disabled", "accessibilityLabel", "accessibilityRole", "testID"];
+
 function loadDist(repoRoot) {
   const require = createRequire(import.meta.url);
   return {
@@ -46,13 +57,31 @@ function hasStrictRnContracts(domainPayload) {
   );
 }
 
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function presentFields(bindings, fields) {
+  return uniqueSorted(bindings.flatMap((item) => fields.filter((field) => item[field] !== undefined)));
+}
+
 function interactionSummary(domainPayload) {
   const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
+  const inputBindings = interactions.inputBindings ?? [];
+  const actionBindings = interactions.actionBindings ?? [];
+  const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
+  const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
   return {
-    inputBindings: interactions.inputBindings ?? [],
-    actionBindings: interactions.actionBindings ?? [],
-    hasTextInputBinding: Boolean(interactions.inputBindings?.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
-    hasPressableAction: Boolean(interactions.actionBindings?.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    inputBindings,
+    actionBindings,
+    hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
+    hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    metadataCoverage: {
+      textInputFields: textInputMetadataFields,
+      pressableFields: pressableMetadataFields,
+      allTextInputMetadataPresent: RN_TEXT_INPUT_METADATA_FIELDS.every((field) => textInputMetadataFields.includes(field)),
+      allPressableMetadataPresent: RN_PRESSABLE_METADATA_FIELDS.every((field) => pressableMetadataFields.includes(field)),
+    },
   };
 }
 
@@ -129,9 +158,20 @@ export async function buildReactNativePayloadEvidence({
   const boundaries = boundaryFixtures.map((relativeFile) => measureBoundaryFixture({ repoRoot, relativeFile, dist }));
   const rnPayloadFactsVisible = rnFixtures.every((row) => row.claimable);
   const boundaryFallbacksPreserved = boundaries.every((row) => row.boundaryPreserved && !row.rnPrimitiveInteractionsExposed);
+  const preReadTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.textInputFields));
+  const preReadPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.pressableFields));
+  const modelTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields));
+  const modelPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields));
+  const missingTextInputFields = RN_TEXT_INPUT_METADATA_FIELDS.filter(
+    (field) => !preReadTextInputFields.includes(field) || !modelTextInputFields.includes(field),
+  );
+  const missingPressableFields = RN_PRESSABLE_METADATA_FIELDS.filter(
+    (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
+  );
+  const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
 
   return {
-    schemaVersion: "react-native-payload-evidence.v1",
+    schemaVersion: "react-native-payload-evidence.v2",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -149,6 +189,24 @@ export async function buildReactNativePayloadEvidence({
       boundaryFallbacksPreserved: {
         claimable: boundaryFallbacksPreserved,
         blocker: boundaryFallbacksPreserved ? null : "one or more richer RN/WebView/TUI fixtures exposed payload facts or failed to fallback",
+      },
+      metadataAnchorsVisible: {
+        claimable: metadataAnchorsVisible,
+        textInputFields: RN_TEXT_INPUT_METADATA_FIELDS.map((field) => ({
+          field,
+          preRead: preReadTextInputFields.includes(field),
+          modelFacing: modelTextInputFields.includes(field),
+          claimable: preReadTextInputFields.includes(field) && modelTextInputFields.includes(field),
+        })),
+        pressableFields: RN_PRESSABLE_METADATA_FIELDS.map((field) => ({
+          field,
+          preRead: preReadPressableFields.includes(field),
+          modelFacing: modelPressableFields.includes(field),
+          claimable: preReadPressableFields.includes(field) && modelPressableFields.includes(field),
+        })),
+        blocker: metadataAnchorsVisible
+          ? null
+          : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
       },
       broadReactNativeSupport: {
         claimable: false,
@@ -188,6 +246,14 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
         `| \`${row.file}\` | ${row.classification} | ${row.decision} | ${row.fallbackReason ?? "n/a"} | ${row.payloadExposed ? "yes" : "no"} | ${row.boundaryPreserved ? "yes" : "no"} |`,
     )
     .join("\n");
+  const metadataRows = [
+    ...evidence.summary.metadataAnchorsVisible.textInputFields.map(
+      (row) => `| TextInput | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
+    ),
+    ...evidence.summary.metadataAnchorsVisible.pressableFields.map(
+      (row) => `| Pressable | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
+    ),
+  ].join("\n");
 
   return `# React Native payload evidence
 
@@ -197,6 +263,7 @@ ${evidence.claimBoundary}
 
 - RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
 - Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
+- RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
 - RN edit routing claimable: no
@@ -207,6 +274,12 @@ ${evidence.claimBoundary}
 | Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | claimable |
 | --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
+
+## Metadata anchor coverage
+
+| Primitive | field | pre-read | model-facing | claimable |
+| --- | --- | --- | --- | --- |
+${metadataRows}
 
 ## Boundary fixtures
 

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -600,7 +600,25 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       const valueExpr = attributeValues.get("value");
       const onChangeTextExpr = attributeValues.get("onChangeText");
       const placeholder = attributeValues.get("placeholder");
-      if (!valueExpr && !onChangeTextExpr && !placeholder) return;
+      const keyboardType = attributeValues.get("keyboardType");
+      const secureTextEntry = attributeValues.get("secureTextEntry");
+      const maxLength = attributeValues.get("maxLength");
+      const autoCapitalize = attributeValues.get("autoCapitalize");
+      const accessibilityLabel = attributeValues.get("accessibilityLabel");
+      const testID = attributeValues.get("testID");
+      if (
+        !valueExpr &&
+        !onChangeTextExpr &&
+        !placeholder &&
+        !keyboardType &&
+        !secureTextEntry &&
+        !maxLength &&
+        !autoCapitalize &&
+        !accessibilityLabel &&
+        !testID
+      ) {
+        return;
+      }
 
       rnInputBindings.push({
         primitive: "TextInput",
@@ -608,10 +626,22 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
         ...(valueExpr ? { valueExpr } : {}),
         ...(onChangeTextExpr ? { onChangeTextExpr } : {}),
         ...(placeholder ? { placeholder } : {}),
+        ...(keyboardType ? { keyboardType } : {}),
+        ...(secureTextEntry ? { secureTextEntry } : {}),
+        ...(maxLength ? { maxLength } : {}),
+        ...(autoCapitalize ? { autoCapitalize } : {}),
+        ...(accessibilityLabel ? { accessibilityLabel } : {}),
+        ...(testID ? { testID } : {}),
         evidence: [
           ...(valueExpr ? ["jsx.TextInput.value"] : []),
           ...(onChangeTextExpr ? ["jsx.TextInput.onChangeText"] : []),
           ...(placeholder ? ["jsx.TextInput.placeholder"] : []),
+          ...(keyboardType ? ["jsx.TextInput.keyboardType"] : []),
+          ...(secureTextEntry ? ["jsx.TextInput.secureTextEntry"] : []),
+          ...(maxLength ? ["jsx.TextInput.maxLength"] : []),
+          ...(autoCapitalize ? ["jsx.TextInput.autoCapitalize"] : []),
+          ...(accessibilityLabel ? ["jsx.TextInput.accessibilityLabel"] : []),
+          ...(testID ? ["jsx.TextInput.testID"] : []),
         ],
       });
       return;
@@ -620,6 +650,10 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     if (tag !== "Pressable") return;
     const onPressExpr = attributeValues.get("onPress");
     if (!onPressExpr) return;
+    const disabled = attributeValues.get("disabled");
+    const accessibilityLabel = attributeValues.get("accessibilityLabel");
+    const accessibilityRole = attributeValues.get("accessibilityRole");
+    const testID = attributeValues.get("testID");
 
     const label = ts.isJsxOpeningElement(node) && ts.isJsxElement(node.parent) ? jsxElementTextLabel(node.parent) : undefined;
     rnActionBindings.push({
@@ -627,7 +661,18 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       loc: sourceRangeOf(sourceFile, node),
       onPressExpr,
       ...(label ? { label } : {}),
-      evidence: ["jsx.Pressable.onPress", ...(label ? ["jsx.Pressable.Text.label"] : [])],
+      ...(disabled ? { disabled } : {}),
+      ...(accessibilityLabel ? { accessibilityLabel } : {}),
+      ...(accessibilityRole ? { accessibilityRole } : {}),
+      ...(testID ? { testID } : {}),
+      evidence: [
+        "jsx.Pressable.onPress",
+        ...(label ? ["jsx.Pressable.Text.label"] : []),
+        ...(disabled ? ["jsx.Pressable.disabled"] : []),
+        ...(accessibilityLabel ? ["jsx.Pressable.accessibilityLabel"] : []),
+        ...(accessibilityRole ? ["jsx.Pressable.accessibilityRole"] : []),
+        ...(testID ? ["jsx.Pressable.testID"] : []),
+      ],
     });
   };
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -71,6 +71,12 @@ export type ReactNativePrimitiveInputBindingSignal = {
   valueExpr?: string;
   onChangeTextExpr?: string;
   placeholder?: string;
+  keyboardType?: string;
+  secureTextEntry?: string;
+  maxLength?: string;
+  autoCapitalize?: string;
+  accessibilityLabel?: string;
+  testID?: string;
   evidence: string[];
 };
 
@@ -79,6 +85,10 @@ export type ReactNativePrimitiveActionBindingSignal = {
   loc?: SourceRange;
   onPressExpr: string;
   label?: string;
+  disabled?: string;
+  accessibilityLabel?: string;
+  accessibilityRole?: string;
+  testID?: string;
   evidence: string[];
 };
 

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx
@@ -4,14 +4,31 @@ type SearchRowProps = {
   value: string;
   onChangeText: (value: string) => void;
   onApply: () => void;
+  isApplyDisabled?: boolean;
 };
 
-export function SearchRow({ value, onChangeText, onApply }: SearchRowProps) {
+export function SearchRow({ value, onChangeText, onApply, isApplyDisabled }: SearchRowProps) {
   return (
     <View accessibilityLabel="search row">
       <Text>Search</Text>
-      <TextInput value={value} placeholder="Filter" onChangeText={onChangeText} />
-      <Pressable onPress={onApply}>
+      <TextInput
+        value={value}
+        placeholder="Filter"
+        onChangeText={onChangeText}
+        keyboardType="default"
+        secureTextEntry={false}
+        maxLength={80}
+        autoCapitalize="none"
+        accessibilityLabel="Search filter"
+        testID="search-input"
+      />
+      <Pressable
+        onPress={onApply}
+        disabled={isApplyDisabled}
+        accessibilityLabel="Apply filter"
+        accessibilityRole="button"
+        testID="apply-button"
+      >
         <Text>Apply</Text>
       </Pressable>
     </View>

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
@@ -12,8 +12,16 @@ export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionR
   return (
     <View accessibilityLabel="inline action row">
       <Text>Filter</Text>
-      <TextInput value={value} placeholder="Type filter" onChangeText={onChangeText} />
-      <Pressable onPress={submitCurrentValue}>
+      <TextInput
+        value={value}
+        placeholder="Type filter"
+        onChangeText={onChangeText}
+        keyboardType="web-search"
+        autoCapitalize="sentences"
+        accessibilityLabel="Inline filter"
+        testID="inline-filter-input"
+      />
+      <Pressable onPress={submitCurrentValue} accessibilityLabel="Submit filter" testID="submit-filter-button">
         <Text>Submit</Text>
       </Pressable>
     </View>

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -124,20 +124,34 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 15, endLine: 15 },
+      loc: { startLine: 15, endLine: 23 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       placeholder: "Type filter",
-      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      accessibilityLabel: "Inline filter",
+      testID: "inline-filter-input",
+      evidence: [
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+      ],
     },
   ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 16, endLine: 16 },
+      loc: { startLine: 24, endLine: 24 },
       onPressExpr: "submitCurrentValue",
       label: "Submit",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+      accessibilityLabel: "Submit filter",
+      testID: "submit-filter-button",
+      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
     },
   ]);
   assert.equal("formControls" in payload.facts, false);
@@ -167,20 +181,47 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 13, endLine: 13 },
+      loc: { startLine: 14, endLine: 24 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       placeholder: "Filter",
-      evidence: ["jsx.TextInput.value", "jsx.TextInput.onChangeText", "jsx.TextInput.placeholder"],
+      keyboardType: "default",
+      secureTextEntry: "false",
+      maxLength: "80",
+      autoCapitalize: "none",
+      accessibilityLabel: "Search filter",
+      testID: "search-input",
+      evidence: [
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+      ],
     },
   ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 14, endLine: 14 },
+      loc: { startLine: 25, endLine: 31 },
       onPressExpr: "onApply",
       label: "Apply",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label"],
+      disabled: "isApplyDisabled",
+      accessibilityLabel: "Apply filter",
+      accessibilityRole: "button",
+      testID: "apply-button",
+      evidence: [
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.accessibilityRole",
+        "jsx.Pressable.testID",
+      ],
     },
   ]);
   assert.equal("formControls" in payload.facts, false);
@@ -439,6 +480,6 @@ test("React Native policy and payload seams avoid broad support and web terminol
   ]) {
     const source = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
     assert.doesNotMatch(source, forbiddenSupportClaims, relativePath);
-    assert.doesNotMatch(source, /reactNativeContext|editTargetRouting/i, relativePath);
+    assert.doesNotMatch(source, /reactNativeContext|rnContext|editTargetRouting/i, relativePath);
   }
 });

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  RN_PRESSABLE_METADATA_FIELDS,
+  RN_TEXT_INPUT_METADATA_FIELDS,
   buildReactNativePayloadEvidence,
   renderReactNativePayloadEvidenceMarkdown,
 } from "../scripts/react-native-payload-evidence.mjs";
@@ -8,7 +10,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v1");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v2");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -21,6 +23,24 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.rnPayloadFactsVisible.blocker, null);
   assert.equal(evidence.summary.boundaryFallbacksPreserved.claimable, true);
   assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
+  assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
+  assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
+  assert.deepEqual(
+    evidence.summary.metadataAnchorsVisible.textInputFields.map((row) => row.field),
+    RN_TEXT_INPUT_METADATA_FIELDS,
+  );
+  assert.deepEqual(
+    evidence.summary.metadataAnchorsVisible.pressableFields.map((row) => row.field),
+    RN_PRESSABLE_METADATA_FIELDS,
+  );
+  for (const row of [
+    ...evidence.summary.metadataAnchorsVisible.textInputFields,
+    ...evidence.summary.metadataAnchorsVisible.pressableFields,
+  ]) {
+    assert.equal(row.preRead, true, row.field);
+    assert.equal(row.modelFacing, true, row.field);
+    assert.equal(row.claimable, true, row.field);
+  }
   assert.equal(evidence.summary.broadReactNativeSupport.claimable, false);
   assert.equal(evidence.summary.runtimeReusePromotion.claimable, false);
   assert.equal(evidence.summary.editRouting.claimable, false);
@@ -38,9 +58,13 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     assert.equal(row.preRead.strictContractsPresent, true);
     assert.equal(row.preRead.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
+    assert.ok(row.preRead.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
+    assert.ok(row.preRead.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
     assert.equal(row.modelFacing.strictContractsPresent, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
+    assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
+    assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
     assert.equal(row.claimable, true);
   }
 
@@ -48,13 +72,29 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].valueExpr, "value");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].onChangeTextExpr, "onChangeText");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].placeholder, "Filter");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].keyboardType, "default");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].secureTextEntry, "false");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].maxLength, "80");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "none");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Search filter");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].testID, "search-input");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "onApply");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].label, "Apply");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].disabled, "isApplyDisabled");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Apply filter");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityRole, "button");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].testID, "apply-button");
 
   const inline = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-inline-action.tsx"));
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].placeholder, "Type filter");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].keyboardType, "web-search");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "sentences");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Inline filter");
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].testID, "inline-filter-input");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
 });
 
 test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
@@ -79,6 +119,13 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
 
   assert.match(markdown, /RN primitive interaction facts visible: yes/);
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
+  assert.match(markdown, /RN metadata anchors visible: yes/);
+  assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| maxLength \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| TextInput \| autoCapitalize \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| Pressable \| disabled \| yes \| yes \| yes \|/);
+  assert.match(markdown, /\| Pressable \| accessibilityRole \| yes \| yes \| yes \|/);
   assert.match(markdown, /Broad React Native support claimable: no/);
   assert.match(markdown, /Runtime reuse promotion claimable: no/);
   assert.match(markdown, /RN edit routing claimable: no/);
@@ -87,4 +134,5 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.doesNotMatch(markdown, /Broad React Native support claimable: yes/i);
   assert.doesNotMatch(markdown, /Runtime reuse promotion claimable: yes/i);
   assert.doesNotMatch(markdown, /RN edit routing claimable: yes/i);
+  assert.doesNotMatch(markdown, /reactNativeContext|rnContext|editTargetRouting/i);
 });

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReactNativePayloadEvidence,
+  renderReactNativePayloadEvidenceMarkdown,
+} from "../scripts/react-native-payload-evidence.mjs";
+
+test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v1");
+  assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
+  assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
+  assert.match(evidence.claimBoundary, /not broad React Native support/);
+  assert.match(evidence.claimBoundary, /not runtime reuse promotion/);
+  assert.match(evidence.claimBoundary, /not edit routing/);
+  assert.match(evidence.claimBoundary, /not provider billing or invoice savings/);
+
+  assert.equal(evidence.summary.fixtureCount, 2);
+  assert.equal(evidence.summary.rnPayloadFactsVisible.claimable, true);
+  assert.equal(evidence.summary.rnPayloadFactsVisible.blocker, null);
+  assert.equal(evidence.summary.boundaryFallbacksPreserved.claimable, true);
+  assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
+  assert.equal(evidence.summary.broadReactNativeSupport.claimable, false);
+  assert.equal(evidence.summary.runtimeReusePromotion.claimable, false);
+  assert.equal(evidence.summary.editRouting.claimable, false);
+  assert.equal(evidence.summary.providerBillingSavings.claimable, false);
+
+  for (const row of evidence.fixtures) {
+    assert.equal(row.classification, "react-native");
+    assert.equal(row.preReadDecision, "payload");
+    assert.equal(row.payloadPolicy, "rn-primitive-input-narrow-payload");
+    assert.equal(row.sourceFingerprintPresent, true);
+    assert.equal(row.preRead.domain, "react-native");
+    assert.equal(row.preRead.claimBoundary, "rn-primitive-input-narrow-payload-only");
+    assert.equal(row.preRead.sourceAnchorBetaVersion, "rn-source-anchor-beta.v0");
+    assert.equal(row.preRead.reuseFreshnessSource, "sourceFingerprint");
+    assert.equal(row.preRead.strictContractsPresent, true);
+    assert.equal(row.preRead.primitiveInteractions.hasTextInputBinding, true);
+    assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
+    assert.equal(row.modelFacing.strictContractsPresent, true);
+    assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
+    assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
+    assert.equal(row.claimable, true);
+  }
+
+  const basic = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-basic.tsx"));
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].valueExpr, "value");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].onChangeTextExpr, "onChangeText");
+  assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].placeholder, "Filter");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "onApply");
+  assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].label, "Apply");
+
+  const inline = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-inline-action.tsx"));
+  assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].placeholder, "Type filter");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
+});
+
+test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `boundary-test-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.summary.boundaryFixtureCount, 5);
+  for (const row of evidence.boundaryFixtures) {
+    assert.equal(row.decision, "fallback", row.file);
+    assert.equal(row.payloadExposed, false, row.file);
+    assert.equal(row.rnPrimitiveInteractionsExposed, false, row.file);
+    assert.equal(row.boundaryPreserved, true, row.file);
+  }
+
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "react-native"));
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "webview"));
+  assert.ok(evidence.boundaryFixtures.some((row) => row.classification === "tui-ink"));
+});
+
+test("React Native payload evidence Markdown keeps claim boundaries explicit", async () => {
+  const evidence = await buildReactNativePayloadEvidence({ runId: `markdown-test-${Date.now()}-${Math.random()}` });
+  const markdown = renderReactNativePayloadEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /RN primitive interaction facts visible: yes/);
+  assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
+  assert.match(markdown, /Broad React Native support claimable: no/);
+  assert.match(markdown, /Runtime reuse promotion claimable: no/);
+  assert.match(markdown, /RN edit routing claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /existing `rn-primitive-input-narrow-payload` lane/);
+  assert.doesNotMatch(markdown, /Broad React Native support claimable: yes/i);
+  assert.doesNotMatch(markdown, /Runtime reuse promotion claimable: yes/i);
+  assert.doesNotMatch(markdown, /RN edit routing claimable: yes/i);
+});


### PR DESCRIPTION
## Summary

- Add `evidence:react-native-payload` to generate bounded JSON/Markdown RN payload evidence.
- Prove the existing `rn-primitive-input-narrow-payload` lane exposes `primitiveInteractions` for measured `TextInput`/`Pressable` fixtures in both pre-read and model-facing payloads.
- Preserve richer RN/WebView/TUI boundaries as fallback-only and keep broad RN/runtime/edit/billing claims explicitly non-claimable.

## Stack

Stacked on #471 / `ralph/rn-input-action-payload-facts` because this report consumes the RN `primitiveInteractions` facts from that branch.

## Verification

- `npm run evidence:react-native-payload -- --run-id=ralph-post-deslop`
- `node --test test/react-native-payload-evidence.test.mjs test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/pre-read-phase-order-regression.test.mjs test/payload-policy-webview.test.mjs test/payload-policy-tui-ink.test.mjs` → 44/44 pass
- `npm test` → 484/484 pass
- `git diff --check`
- Ralph architect review: APPROVE

## Claim boundary

This PR is local fixture evidence only. It does not claim broad React Native support, runtime reuse promotion, RN edit routing, runtime-token savings, provider cost, billing, invoice, or charged-cost savings.

Closes #479