### PR TITLE
Surface React Web context field contributions

### DIFF
--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -3,6 +3,7 @@
 /// <reference types="node" />
 
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const CLOSING_ISSUE_PATTERN = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
 
@@ -131,4 +132,11 @@ async function main() {
   console.log(`Merge gate passed. Approving maintainer(s): ${result.approvingMaintainers.join(", ")}`);
 }
 
-await main();
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return Boolean(entrypoint) && import.meta.url === pathToFileURL(entrypoint).href;
+}
+
+if (isMainModule()) {
+  await main();
+}

--- a/src/core/react-web-context-summary.ts
+++ b/src/core/react-web-context-summary.ts
@@ -11,6 +11,7 @@ export type ReactWebContextSummary = {
     componentName?: string;
   };
   fieldCounts: Record<string, number>;
+  fieldOrder: string[];
   totalAnchors: number;
   claimBoundary: typeof REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY;
 };
@@ -40,6 +41,10 @@ export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOrigin
     }
   }
 
+  const fieldOrder = REACT_WEB_CONTEXT_SUMMARY_FIELDS.filter((field) => fieldCounts[field] > 0).sort(
+    (left, right) => fieldCounts[right] - fieldCounts[left],
+  );
+
   return {
     present: true,
     schemaVersion: payload.reactWebContext.schemaVersion,
@@ -49,11 +54,17 @@ export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOrigin
       componentName: payload.reactWebContext.scope.componentName,
     },
     fieldCounts,
+    fieldOrder,
     totalAnchors: Object.values(fieldCounts).reduce((total, count) => total + count, 0),
     claimBoundary: REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY,
   };
 }
 
 export function formatReactWebContextSummary(summary: ReactWebContextSummary): string {
-  return `React Web context: ${summary.totalAnchors} source-backed anchors across ${Object.keys(summary.fieldCounts).length} summary fields (counts only; see --json).`;
+  const topFields = summary.fieldOrder
+    .slice(0, 4)
+    .map((field) => `${field}=${summary.fieldCounts[field]}`)
+    .join(", ");
+  const fieldDetails = topFields ? `; top fields: ${topFields}` : "";
+  return `React Web context: ${summary.totalAnchors} source-backed anchors across ${summary.fieldOrder.length} summary fields${fieldDetails} (source-only counts; see --json).`;
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -80,6 +80,17 @@ function runText(args, cwd = repoRoot, envOverrides = {}) {
   return execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } });
 }
 
+function assertReactWebContextFieldOrder(summary, expectedFields) {
+  for (const field of expectedFields) {
+    assert.ok(summary.fieldOrder.includes(field));
+  }
+  assert.ok(
+    summary.fieldOrder.every((field, index, fields) =>
+      index === 0 || summary.fieldCounts[fields[index - 1]] >= summary.fieldCounts[field],
+    ),
+  );
+}
+
 function runTextWithInput(args, input, cwd = repoRoot, envOverrides = {}) {
   return execFileSync(process.execPath, [cli, ...args], {
     cwd,
@@ -380,6 +391,7 @@ test("extract can return model-facing payload without engine metadata", () => {
   assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
   assert.ok(result.reactWebContextSummary.fieldCounts.componentApiHints > 0);
   assert.ok(result.reactWebContextSummary.fieldCounts.a11yAnchors > 0);
+  assertReactWebContextFieldOrder(result.reactWebContextSummary, ["editTargetRouting", "componentApiHints"]);
   assert.ok(result.reactWebContextSummary.totalAnchors > 0);
   assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
   assert.doesNotMatch(JSON.stringify(result.reactWebContextSummary), /cross-file|typechecker|lsp|visual proof|billing|latency/i);
@@ -532,6 +544,7 @@ test("compare reports local estimated model-facing payload reduction", () => {
   assert.equal(result.reactWebContextSummary.scope.componentName, "FormSection");
   assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
   assert.ok(result.reactWebContextSummary.fieldCounts.a11yAnchors > 0);
+  assertReactWebContextFieldOrder(result.reactWebContextSummary, ["editTargetRouting", "a11yAnchors"]);
   assert.ok(result.reactWebContextSummary.totalAnchors > 0);
   assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
   assert.match(result.claimBoundary, /not provider usage\/billing tokens/);
@@ -564,8 +577,9 @@ test("compare default output is a concise human verdict with json details opt-in
   assert.match(output, /Verdict: estimated-reduction/);
   assert.match(output, /Why: Estimated \d+(?:\.\d+)?% smaller model-facing payload/);
   assert.match(output, /Local proof: source \d+ bytes \/ \d+ est tokens → model-facing \d+ bytes \/ \d+ est tokens; saved \d+ bytes \/ \d+ est tokens\./);
-  assert.match(output, /React Web context: \d+ source-backed anchors across \d+ summary fields \(counts only; see --json\)\./);
-  assert.doesNotMatch(output, /correctness|billing savings|provider token savings|latency/i);
+  assert.match(output, /React Web context: \d+ source-backed anchors across \d+ summary fields; top fields: [A-Za-z]+\w*=\d+/);
+  assert.match(output, /source-only counts; see --json/);
+  assert.doesNotMatch(output, /correctness|billing savings|provider token savings|latency|cross-file|typechecker/i);
   assert.match(output, /Next action: Use fooks setup/);
   assert.match(output, /Boundary: Local model-facing payload estimate only/);
   assert.match(output, /fooks compare <file> --json/);
@@ -599,6 +613,7 @@ test("extract produces compressed output for boilerplate-heavy fixture", () => {
   assert.equal(result.reactWebContextSummary.scope.componentName, "FormSection");
   assert.ok(result.reactWebContextSummary.fieldCounts.editTargetRouting > 0);
   assert.ok(result.reactWebContextSummary.fieldCounts.layoutRegionHints > 0);
+  assertReactWebContextFieldOrder(result.reactWebContextSummary, ["editTargetRouting", "layoutRegionHints"]);
   assert.ok(result.reactWebContextSummary.totalAnchors > 0);
   assert.equal(result.reactWebContextSummary.claimBoundary, "source-backed-react-web-context-counts-only");
   assert.doesNotMatch(JSON.stringify(result.reactWebContextSummary), /cross-file|typechecker|lsp|visual proof|billing|latency/i);


### PR DESCRIPTION
## Summary

- Add `fieldOrder` to the existing source-only React Web context summary.
- Sort non-empty React Web context fields by descending source-backed anchor count.
- Show the top contributing React Web context fields in human `fooks compare` output while keeping exact details in `--json`.
- Guard the merge-gate script entrypoint so CI tests can import its exported evaluators without running live GitHub validation as an import side effect.

## Boundaries

- No new React Web context axes.
- No cross-file usage analysis.
- No typechecker/LSP semantics.
- No provider billing, latency, runtime-token, or edit-quality claims.
- Merge-gate behavior remains unchanged for direct script execution; the CI fix only removes import side effects.

## Verification

- `git diff --check`
- `npm run build`
- `GITHUB_EVENT_PATH=/tmp/nonexistent GITHUB_REPOSITORY= GITHUB_TOKEN= node --test test/pr-merge-gate.test.mjs` — 5 pass
- `node --test test/fooks.test.mjs test/react-web-context-metadata.test.mjs test/pre-read-payload-builder.test.mjs test/pr-merge-gate.test.mjs` — 177 pass
- `npm test` — 480 pass
- LSP diagnostics on `src/core/react-web-context-summary.ts` — 0 errors
- Architect review — APPROVE after fixing schema-order top-field blocker and CI import-side-effect blocker
- GitHub CI — Validate (Node 20) pass; Validate (Node 24) pass

## Merge gate

The linked-issue requirement is satisfied by `Closes #476`. The remaining failing merge-gate check is expected until a maintainer approval is submitted on the current head commit.

Closes #476
