### PR TITLE
Prove React Web form flow runtime retention

### DIFF
--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
+import { reactWebFormStateFlowSource } from "./react-web-inline-sources.mjs";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
@@ -65,6 +66,32 @@ test("pre-read payload builder omits React Web context metadata when payload bud
     assert.equal(budgeted.debug.reactWebContextBudget.reason, "budget-exceeded");
   } finally {
     JSON.stringify = originalStringify;
+  }
+});
+
+test("pre-read payload builder preserves React Web form state-flow when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-form-flow-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineRetentionForm.tsx");
+    fs.writeFileSync(target, reactWebFormStateFlowSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
+    assert.ok(Array.isArray(decision.payload.reactWebContext.formStateFlow));
+    assert.ok(
+      decision.payload.reactWebContext.formStateFlow.some(
+        (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
+      ),
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
 

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -1,0 +1,29 @@
+export function reactWebFormStateFlowSource() {
+  return `import { useMemo, useState } from "react";
+
+type Props = { onSubmit?: (value: string) => void };
+
+export function InlineRetentionForm({ onSubmit }: Props) {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const disabled = loading || email.length === 0;
+  const label = useMemo(() => email.trim() || "guest", [email]);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    onSubmit?.(label);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} aria-busy={loading}>
+      <label htmlFor="email">Email</label>
+      <input id="email" name="email" value={email} onChange={(event) => setEmail(event.target.value)} disabled={loading} aria-invalid={email.length === 0} />
+      <button type="submit" disabled={disabled}>Save</button>
+    </form>
+  );
+}
+
+/* ${"form flow budget filler ".repeat(140)} */
+`;
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { cleanupMetricSessions } from "./metric-cleanup.mjs";
+import { reactWebFormStateFlowSource } from "./react-web-inline-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -283,6 +284,50 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
 
   assert.equal(legacyOverride.action, "fallback");
   assert.equal(legacyOverride.fallback.reason, "escape-hatch-full-read");
+});
+
+test("runtime bridge preserves React Web form state-flow in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-form-flow-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebFormStateFlowSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineRetentionForm.tsx"), source);
+
+    const sessionId = `bridge-contract-form-flow-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineRetentionForm.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineRetentionForm.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.formStateFlow));
+    assert.ok(
+      payload.reactWebContext.formStateFlow.some(
+        (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
+      ),
+    );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("runtime bridge preserves React Web custom-wrapper domainPayload parity for F11/F12", () => {


### PR DESCRIPTION
## Summary
- add an inline React Web form-flow source helper for retention tests
- assert pre-read payloads keep `reactWebContext.formStateFlow` when the context budget permits
- assert Codex repeated-read additional context keeps `formStateFlow` while existing pressure behavior remains bounded

Closes #480

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test`
- Ralph architect review: APPROVE
- Ralph changed-file deslop pass + post-deslop regression: PASS

## Claim boundaries
- Existing React Web `formStateFlow` field only
- No schema axis, committed fixture expansion, budget-policy change, provider/billing/latency/token-savings/edit-quality claim, typechecker/LSP semantic claim, or cross-file usage claim
