### PR TITLE
Define TUI metadata projection boundaries (Closes #484)

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -101,6 +101,7 @@ If a future PR changes any row from fallback/no-payload to payload emission, it 
 
 The evidence matrix above is sufficient to discuss a future payload-design PRD, but it is not itself a payload contract. A payload-design handoff must first prove that the current evidence-only lane stays denied:
 
+- the TUI-safe metadata projection contract in `docs/tui-operational-readiness.md` classifies safe shared metadata, TUI-specific source evidence, caution metadata, fallback-required metadata, and forbidden React Web-only projections before any schema or builder exists;
 - positive Ink concern evidence is mapped to fixtures before design assumptions are made;
 - negative, weak, and mixed fixtures keep fallback/no-payload behavior;
 - the TUI payload policy remains `allowed: false` for current fixtures;

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -14,6 +14,20 @@ The TUI lane is currently a source-evidence lane:
 
 This separation is intentional. Domain evidence can tell reviewers what kind of file they are looking at, but it is not permission to replace source reading with compact context.
 
+## TUI-safe metadata projection contract
+
+This contract names the source-derived metadata that may inform a later TUI payload-design plan. It is **not** a payload schema, **not** compact extraction permission, and **not** model-facing output. Current TUI behavior remains evidence-only, denied by policy, and fallback/no-payload.
+
+| Category | May record | Current boundary |
+| --- | --- | --- |
+| Safe shared metadata | Imports, component/export names, JSX tags, prop names, hook names, handler identifiers, state variable names, source ranges, domain classification, policy decision, and fallback reason. | These facts may help reviewers describe the source shape, but they do not authorize source replacement or compact payload emission. |
+| TUI-specific source evidence | Ink import, `Box`, `Text`, `useInput`, source-observed key branch names, and prompt/list/status concern tags. | These facts identify Ink evidence and fixture concerns only; they do not prove terminal behavior. |
+| Caution metadata | Layout/style props, color/dim/border props, mapped rows, and command/status labels. | Useful as source facts, but terminal layout, styling, wrapping, command progress, and display correctness remain unproven. |
+| Fallback-required metadata | Command execution behavior, TTY/stdin behavior, terminal width/wrapping, key handling correctness, progress/runtime state, and shell side effects. | Keep full-source reading or a later measured plan; do not compress these into trusted TUI context from AST facts alone. |
+| Forbidden projection | DOM roles, ARIA relationships, `htmlFor`/id form relations, browser form semantics, CSS/className meaning, React Web layout region semantics, and browser accessibility assumptions. | React Web-only semantics must not be projected into TUI/Ink context or used to promote TUI payload permission. |
+
+The safe and caution categories are review vocabulary for future planning. A later PR that serializes any of this into model-facing payload must write a separate PRD/test-spec pair, name the schema, preserve fallback regressions, and re-check the public claim boundary before implementation.
+
 ## Fixture roles
 
 These fixture roles are also the current TUI concern taxonomy. Concern labels help reviewers reason about source evidence, but concern evidence is not payload permission.
@@ -47,6 +61,7 @@ Before a TUI payload-design plan is useful, the repo should already have:
 - at least one positive Ink fixture for each evidence category that the design wants to rely on;
 - at least one negative or mixed-domain fixture for every rule that could otherwise over-match;
 - stable policy language describing what source facts are safe to summarize and what facts require full source;
+- a TUI-safe metadata projection contract that separates shared syntax facts, TUI source evidence, caution facts, fallback-required facts, and forbidden React Web-only projections;
 - an explicit list of terminal/runtime facts that remain outside AST-derived evidence;
 - a verification matrix that proves fallback/no-payload still wins for weak, mixed, non-Ink, and behavior-heavy cases;
 - a claim-boundary audit that rejects compact-context, terminal behavior, token, billing, and performance wording until measured evidence exists.

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -129,6 +129,52 @@ const payloadReadinessGateTerms = [
   "separate serialized plan",
 ];
 
+const metadataProjectionCategories = [
+  "TUI-safe metadata projection contract",
+  "Safe shared metadata",
+  "TUI-specific source evidence",
+  "Caution metadata",
+  "Fallback-required metadata",
+  "Forbidden projection",
+];
+
+const metadataProjectionTerms = [
+  "Imports",
+  "component/export names",
+  "JSX tags",
+  "prop names",
+  "hook names",
+  "handler identifiers",
+  "state variable names",
+  "source ranges",
+  "domain classification",
+  "policy decision",
+  "fallback reason",
+  "Ink import",
+  "`Box`",
+  "`Text`",
+  "`useInput`",
+  "source-observed key branch names",
+  "prompt/list/status concern tags",
+  "Layout/style props",
+  "color/dim/border props",
+  "mapped rows",
+  "command/status labels",
+  "Command execution behavior",
+  "TTY/stdin behavior",
+  "terminal width/wrapping",
+  "key handling correctness",
+  "progress/runtime state",
+  "shell side effects",
+  "DOM roles",
+  "ARIA relationships",
+  "`htmlFor`/id form relations",
+  "browser form semantics",
+  "CSS/className meaning",
+  "React Web layout region semantics",
+  "browser accessibility assumptions",
+];
+
 function tuiFixturePath(fileName) {
   return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
 }
@@ -445,6 +491,8 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /Current TUI evidence matrix/);
   assert.match(survey, /Payload design readiness handoff/);
   assert.match(survey, /not itself a payload contract/);
+  assert.match(survey, /TUI-safe metadata projection contract/);
+  assert.match(survey, /forbidden React Web-only projections/);
   assert.match(survey, /pre-read emits no model-facing TUI payload/);
   assert.match(survey, /separate serialized plan/);
   assert.match(survey, /tui-ink-evidence-only-payload/);
@@ -466,7 +514,16 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /## Stop rules/);
   assert.match(guide, /tui-ink-evidence-only-payload/);
   assert.match(guide, /fallback\/no-payload/);
+  assert.match(guide, /\*\*not\*\* a payload schema/);
+  assert.match(guide, /\*\*not\*\* compact extraction permission/);
+  assert.match(guide, /\*\*not\*\* model-facing output/);
   assert.match(guide, /serialized shared-policy plan/);
+  for (const category of metadataProjectionCategories) {
+    assert.ok(guide.includes(category), category);
+  }
+  for (const term of metadataProjectionTerms) {
+    assert.ok(guide.includes(term), term);
+  }
   for (const term of payloadReadinessGateTerms) {
     assert.ok(guide.includes(term), term);
   }


### PR DESCRIPTION
## Summary
- define a TUI-safe metadata projection contract in the operational readiness guide
- classify safe shared metadata, TUI-specific source evidence, caution metadata, fallback-required metadata, and forbidden React Web-only projections
- lock the vocabulary in TUI payload-policy tests while preserving evidence-only/fallback/no-payload behavior

## Claim boundary
- Docs/test-only change.
- No `src/**`, detector, registry, payload builder, payload policy permission, pre-read/runtime, manifest, or fixture classification changes.
- Does not enable TUI compact extraction, model-facing TUI payloads, terminal correctness, token, billing/provider-cost, or performance claims.

## Validation
- `npm run build && node --test test/payload-policy-tui-ink.test.mjs && node --test test/claim-boundary-doc-audit.test.mjs`
- `npm test`
- `npx tsc --noEmit --pretty false --project tsconfig.json && git diff --check`
- Architect verification: APPROVE

Closes #484