### PR TITLE
Prove React Web layout region retention

### DIFF
--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { reactWebFormStateFlowSource } from "./react-web-inline-sources.mjs";
+import { reactWebFormStateFlowSource, reactWebLayoutRegionSource } from "./react-web-inline-sources.mjs";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
@@ -90,6 +90,36 @@ test("pre-read payload builder preserves React Web form state-flow when context 
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
     );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read payload builder preserves React Web layout regions when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-layout-region-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineLayoutPanel.tsx");
+    fs.writeFileSync(target, reactWebLayoutRegionSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
+    assert.ok(Array.isArray(decision.payload.reactWebContext.layoutRegionHints));
+
+    const layoutKinds = new Set(decision.payload.reactWebContext.layoutRegionHints.map((item) => item.kind));
+    assert.equal(layoutKinds.has("semantic-region"), true);
+    assert.equal(layoutKinds.has("list-region"), true);
+    assert.equal(layoutKinds.has("form-region"), true);
+    assert.equal(layoutKinds.has("repeated-region"), true);
+    assert.equal(layoutKinds.has("form-row"), true);
+    assert.equal(layoutKinds.has("state-region"), true);
+    assert.equal(layoutKinds.has("container-region"), true);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -27,3 +27,27 @@ export function InlineRetentionForm({ onSubmit }: Props) {
 /* ${"form flow budget filler ".repeat(140)} */
 `;
 }
+
+export function reactWebLayoutRegionSource() {
+  return `type LayoutItem = { id: string; label: string };
+type LayoutPanelProps = { items: LayoutItem[]; loading?: boolean; error?: string };
+
+export function InlineLayoutPanel({ items, loading, error }: LayoutPanelProps) {
+  return (
+    <main className={loading ? "grid gap-4" : "flex flex-col gap-4"}>
+      <header><h1>Accounts</h1></header>
+      <section>
+        {loading && <p>Loading accounts</p>}
+        {error ? <p role="alert">{error}</p> : null}
+        {items.length === 0 && <p>No accounts yet</p>}
+        <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+      </section>
+      <form><label htmlFor="filter">Filter</label><input id="filter" name="filter" /></form>
+      <footer><button type="button">Refresh</button></footer>
+    </main>
+  );
+}
+
+/* ${"layout budget filler ".repeat(360)} */
+`;
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { cleanupMetricSessions } from "./metric-cleanup.mjs";
-import { reactWebFormStateFlowSource } from "./react-web-inline-sources.mjs";
+import { reactWebFormStateFlowSource, reactWebLayoutRegionSource } from "./react-web-inline-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -324,6 +324,51 @@ test("runtime bridge preserves React Web form state-flow in repeated-read contex
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
     );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime bridge preserves React Web layout regions in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-layout-region-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebLayoutRegionSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineLayoutPanel.tsx"), source);
+
+    const sessionId = `bridge-contract-layout-region-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineLayoutPanel.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineLayoutPanel.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.layoutRegionHints));
+
+    const layoutKinds = new Set(payload.reactWebContext.layoutRegionHints.map((item) => item.kind));
+    assert.equal(layoutKinds.has("semantic-region"), true);
+    assert.equal(layoutKinds.has("list-region"), true);
+    assert.equal(layoutKinds.has("form-region"), true);
+    assert.equal(layoutKinds.has("repeated-region"), true);
     assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary\n\n- Add a shared inline React Web layout panel source for retention tests.\n- Prove pre-read payload packing preserves source-derived layoutRegionHints when the React Web context budget permits.\n- Prove Codex runtime repeated-read compact context preserves layoutRegionHints and stays smaller than the original source.\n\nCloses #485\n\n## Verification\n\n- [x] git diff --check\n- [x] npm run build\n- [x] node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs\n- [x] npm test