### PR TITLE
Allow docs/test-only self-maintainer merge gate path (Closes #487)

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -38,5 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_GATE_ALLOWED_MAINTAINERS: minislively
+          MERGE_GATE_APPROVAL_MODE: docs-tests-self-ok
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -18,6 +18,31 @@ function parseAllowedMaintainers(value) {
     .filter(Boolean);
 }
 
+function normalizePath(value) {
+  return String(value || "").replace(/^\/+/, "");
+}
+
+const DOCS_TESTS_ONLY_ALLOWED_PREFIXES = ["docs/", "test/"];
+const DOCS_TESTS_ONLY_ALLOWED_FILES = ["README.md"];
+const DOCS_TESTS_ONLY_FORBIDDEN_PATHS = new Set([
+  "test/fixtures/frontend-domain-expectations/manifest.json",
+]);
+
+export function classifyDocsTestsOnlyChange(changedFiles = []) {
+  const files = (changedFiles || []).map(normalizePath).filter(Boolean);
+  const disallowedFiles = files.filter((file) => {
+    if (DOCS_TESTS_ONLY_FORBIDDEN_PATHS.has(file)) return true;
+    if (DOCS_TESTS_ONLY_ALLOWED_FILES.includes(file)) return false;
+    return !DOCS_TESTS_ONLY_ALLOWED_PREFIXES.some((prefix) => file.startsWith(prefix));
+  });
+
+  return {
+    docsTestsOnly: files.length > 0 && disallowedFiles.length === 0,
+    changedFiles: files,
+    disallowedFiles,
+  };
+}
+
 function latestReviewStateByUser(reviews) {
   const latest = new Map();
   for (const review of reviews || []) {
@@ -45,11 +70,20 @@ export function pullRequestHasLinkedClosingIssue(pullRequest) {
 export function evaluatePullRequestMergeGate({
   pullRequest,
   reviews = [],
+  changedFiles = [],
   allowedMaintainers,
   requireLinkedIssue = true,
+  approvalMode = "strict",
 }) {
   const allowed = new Set((allowedMaintainers || []).map(normalizeLogin).filter(Boolean));
   const blockers = [];
+  const author = normalizeLogin(pullRequest?.user?.login);
+  const pathClassification = classifyDocsTestsOnlyChange(changedFiles);
+  const allowDocsTestsSelfApproval =
+    approvalMode === "docs-tests-self-ok" &&
+    pathClassification.docsTestsOnly &&
+    author &&
+    allowed.has(author);
 
   if (allowed.size === 0) {
     blockers.push("Configure MERGE_GATE_ALLOWED_MAINTAINERS with at least one GitHub login.");
@@ -65,7 +99,7 @@ export function evaluatePullRequestMergeGate({
     const latest = latestByUser.get(login);
     return latest?.state === "APPROVED" && (!headSha || latest.commitId === headSha);
   });
-  if (approvingMaintainers.length === 0) {
+  if (approvingMaintainers.length === 0 && !allowDocsTestsSelfApproval) {
     blockers.push(`PR must have an active approval on the current head commit from one of: ${[...allowed].join(", ") || "<none>"}.`);
   }
 
@@ -73,6 +107,8 @@ export function evaluatePullRequestMergeGate({
     ok: blockers.length === 0,
     blockers,
     approvingMaintainers,
+    approvalBypassReason: allowDocsTestsSelfApproval ? "docs-tests-only-self-maintainer" : undefined,
+    pathClassification,
   };
 }
 
@@ -90,6 +126,28 @@ async function fetchPullRequestReviews({ repository, pullNumber, token }) {
     throw new Error(`Failed to fetch PR reviews: ${response.status} ${response.statusText}`);
   }
   return response.json();
+}
+
+async function fetchPullRequestChangedFiles({ repository, pullNumber, token }) {
+  const files = [];
+  for (let page = 1; ; page += 1) {
+    const url = `https://api.github.com/repos/${repository}/pulls/${pullNumber}/files?per_page=100&page=${page}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "fooks-merge-gate",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch PR files: ${response.status} ${response.statusText}`);
+    }
+    const pageFiles = await response.json();
+    files.push(...pageFiles.map((file) => file.filename).filter(Boolean));
+    if (pageFiles.length < 100) break;
+  }
+  return files;
 }
 
 async function main() {
@@ -114,12 +172,19 @@ async function main() {
     pullNumber: pullRequest.number,
     token,
   });
+  const changedFiles = await fetchPullRequestChangedFiles({
+    repository,
+    pullNumber: pullRequest.number,
+    token,
+  });
 
   const result = evaluatePullRequestMergeGate({
     pullRequest,
     reviews,
+    changedFiles,
     allowedMaintainers: parseAllowedMaintainers(process.env.MERGE_GATE_ALLOWED_MAINTAINERS),
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
+    approvalMode: process.env.MERGE_GATE_APPROVAL_MODE || "strict",
   });
 
   if (!result.ok) {
@@ -129,7 +194,10 @@ async function main() {
     return;
   }
 
-  console.log(`Merge gate passed. Approving maintainer(s): ${result.approvingMaintainers.join(", ")}`);
+  const approvalSummary = result.approvingMaintainers.length > 0
+    ? `Approving maintainer(s): ${result.approvingMaintainers.join(", ")}`
+    : `Approval bypass: ${result.approvalBypassReason}`;
+  console.log(`Merge gate passed. ${approvalSummary}`);
 }
 
 function isMainModule() {

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -4,11 +4,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  classifyDocsTestsOnlyChange,
   evaluatePullRequestMergeGate,
   pullRequestHasLinkedClosingIssue,
 } from "../scripts/validate-pr-merge-gate.mjs";
 
-const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" } };
+const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } };
 
 test("merge gate passes when PR links an issue and has maintainer approval", () => {
   const result = evaluatePullRequestMergeGate({
@@ -60,6 +61,113 @@ test("merge gate requires approval on the current head commit", () => {
   assert.match(result.blockers.join("\n"), /current head commit/);
 });
 
+test("merge gate can allow docs/test-only self-maintainer PRs when explicitly configured", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: {
+      title: "Clarify TUI metadata boundaries",
+      body: "Closes #484",
+      head: { sha: "head-sha" },
+      user: { login: "minislively" },
+    },
+    allowedMaintainers: ["minislively"],
+    changedFiles: [
+      "docs/tui-operational-readiness.md",
+      "docs/tui-fixture-candidates.md",
+      "test/payload-policy-tui-ink.test.mjs",
+    ],
+    reviews: [],
+    approvalMode: "docs-tests-self-ok",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.approvalBypassReason, "docs-tests-only-self-maintainer");
+  assert.deepEqual(result.approvingMaintainers, []);
+});
+
+test("merge gate keeps docs/test-only self-maintainer exception disabled in strict mode", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: {
+      title: "Clarify TUI metadata boundaries",
+      body: "Closes #484",
+      head: { sha: "head-sha" },
+      user: { login: "minislively" },
+    },
+    allowedMaintainers: ["minislively"],
+    changedFiles: ["docs/tui-operational-readiness.md", "test/payload-policy-tui-ink.test.mjs"],
+    reviews: [],
+    approvalMode: "strict",
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /active approval/);
+});
+
+test("merge gate does not bypass approval for code or shared policy files", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: {
+      title: "Change merge gate",
+      body: "Closes #485",
+      head: { sha: "head-sha" },
+      user: { login: "minislively" },
+    },
+    allowedMaintainers: ["minislively"],
+    changedFiles: [".github/workflows/merge-gate.yml", "scripts/validate-pr-merge-gate.mjs", "AGENTS.md", "test/pr-merge-gate.test.mjs"],
+    reviews: [],
+    approvalMode: "docs-tests-self-ok",
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /active approval/);
+  assert.deepEqual(result.pathClassification.disallowedFiles, [
+    ".github/workflows/merge-gate.yml",
+    "scripts/validate-pr-merge-gate.mjs",
+    "AGENTS.md",
+  ]);
+});
+
+test("merge gate does not bypass approval for non-maintainer authors", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: {
+      title: "Clarify docs",
+      body: "Closes #486",
+      head: { sha: "head-sha" },
+      user: { login: "external-contributor" },
+    },
+    allowedMaintainers: ["minislively"],
+    changedFiles: ["docs/tui-operational-readiness.md", "test/payload-policy-tui-ink.test.mjs"],
+    reviews: [],
+    approvalMode: "docs-tests-self-ok",
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /active approval/);
+});
+
+test("docs/test-only classifier excludes manifest and non-doc non-test paths", () => {
+  assert.deepEqual(classifyDocsTestsOnlyChange(["docs/a.md", "test/a.test.mjs"]), {
+    docsTestsOnly: true,
+    changedFiles: ["docs/a.md", "test/a.test.mjs"],
+    disallowedFiles: [],
+  });
+
+  assert.deepEqual(classifyDocsTestsOnlyChange(["test/fixtures/frontend-domain-expectations/manifest.json"]), {
+    docsTestsOnly: false,
+    changedFiles: ["test/fixtures/frontend-domain-expectations/manifest.json"],
+    disallowedFiles: ["test/fixtures/frontend-domain-expectations/manifest.json"],
+  });
+
+  assert.deepEqual(classifyDocsTestsOnlyChange(["src/core/domain-detector.ts"]), {
+    docsTestsOnly: false,
+    changedFiles: ["src/core/domain-detector.ts"],
+    disallowedFiles: ["src/core/domain-detector.ts"],
+  });
+
+  assert.deepEqual(classifyDocsTestsOnlyChange(["AGENTS.md"]), {
+    docsTestsOnly: false,
+    changedFiles: ["AGENTS.md"],
+    disallowedFiles: ["AGENTS.md"],
+  });
+});
 
 test("closing issue detector accepts GitHub issue URLs", () => {
   assert.equal(


### PR DESCRIPTION
## Summary
- add an opt-in `MERGE_GATE_APPROVAL_MODE=docs-tests-self-ok` path for solo maintainer docs/test-only PRs
- fetch PR changed files and classify whether the change is limited to `docs/`, `test/`, or `README.md`
- keep code, workflow, script, manifest, `AGENTS.md`, and non-maintainer PRs behind approval

## Safety boundary
- Linked issue requirement remains required.
- Default approval mode remains `strict` unless workflow explicitly opts in.
- This PR itself still requires approval because it changes workflow/script policy files.

## Validation
- `npm run build && node --test test/pr-merge-gate.test.mjs && node --test test/claim-boundary-doc-audit.test.mjs`
- `npm test` => 489/489
- `npx tsc --noEmit --pretty false --project tsconfig.json && git diff --check`
- Architect verification: APPROVE

Closes #487
