### PR TITLE
Prove React Web component API hint retention

### DIFF
--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -7,7 +7,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { reactWebFormStateFlowSource, reactWebLayoutRegionSource } from "./react-web-inline-sources.mjs";
+import {
+  reactWebComponentApiSource,
+  reactWebFormStateFlowSource,
+  reactWebLayoutRegionSource,
+} from "./react-web-inline-sources.mjs";
 
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
@@ -90,6 +94,33 @@ test("pre-read payload builder preserves React Web form state-flow when context 
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
     );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read payload builder preserves React Web component API hints when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-component-api-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineComponentApiPanel.tsx");
+    fs.writeFileSync(target, reactWebComponentApiSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
+    assert.ok(Array.isArray(decision.payload.reactWebContext.componentApiHints));
+
+    const apiKinds = new Set(decision.payload.reactWebContext.componentApiHints.map((item) => item.kind));
+    assert.equal(apiKinds.has("prop"), true);
+    assert.equal(apiKinds.has("custom-component-usage"), true);
+    assert.ok(decision.payload.reactWebContext.componentApiHints.some((item) => item.propName === "title"));
+    assert.ok(decision.payload.reactWebContext.componentApiHints.some((item) => item.label === "StatusBadge"));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -51,3 +51,30 @@ export function InlineLayoutPanel({ items, loading, error }: LayoutPanelProps) {
 /* ${"layout budget filler ".repeat(360)} */
 `;
 }
+
+export function reactWebComponentApiSource() {
+  return `type StatusBadgeProps = { label: string };
+type ComponentApiItem = { id: string; label: string };
+type ComponentApiPanelProps = { title: string; items: ComponentApiItem[]; count?: number; loading?: boolean; error?: string };
+
+function StatusBadge({ label }: StatusBadgeProps) {
+  return <span className="badge">{label}</span>;
+}
+
+export function InlineComponentApiPanel({ title, items, count = 0, loading, error }: ComponentApiPanelProps) {
+  return (
+    <section aria-label={title}>
+      <h2>{title}</h2>
+      <StatusBadge label={count > 0 ? "active" : "empty"} />
+      {loading ? <p>Loading accounts</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+      <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+      <p>{count} linked accounts</p>
+      <button type="button">Refresh</button>
+    </section>
+  );
+}
+
+/* ${"component api budget filler ".repeat(220)} */
+`;
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -5,7 +5,11 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { cleanupMetricSessions } from "./metric-cleanup.mjs";
-import { reactWebFormStateFlowSource, reactWebLayoutRegionSource } from "./react-web-inline-sources.mjs";
+import {
+  reactWebComponentApiSource,
+  reactWebFormStateFlowSource,
+  reactWebLayoutRegionSource,
+} from "./react-web-inline-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -324,6 +328,51 @@ test("runtime bridge preserves React Web form state-flow in repeated-read contex
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
     );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime bridge preserves React Web component API hints in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-component-api-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebComponentApiSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineComponentApiPanel.tsx"), source);
+
+    const sessionId = `bridge-contract-component-api-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineComponentApiPanel.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineComponentApiPanel.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.componentApiHints));
+
+    const apiKinds = new Set(payload.reactWebContext.componentApiHints.map((item) => item.kind));
+    assert.equal(apiKinds.has("prop"), true);
+    assert.equal(apiKinds.has("custom-component-usage"), true);
+    assert.ok(payload.reactWebContext.componentApiHints.some((item) => item.propName === "title"));
+    assert.ok(payload.reactWebContext.componentApiHints.some((item) => item.label === "StatusBadge"));
     assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary\n\n- Add a shared inline React Web component API source for retention tests.\n- Prove pre-read payload packing preserves source-derived componentApiHints when the React Web context budget permits.\n- Prove Codex runtime repeated-read compact context preserves componentApiHints and stays no larger than the original source.\n\nCloses #489\n\n## Verification\n\n- [x] git diff --check\n- [x] npm run build\n- [x] node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs\n- [x] npm test\n- [x] architect APPROVE\n- [x] changed-files-only deslop review\n- [x] post-deslop regression