### PR TITLE
Prove direct RN state/action relation evidence

### DIFF
--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -69,13 +69,20 @@ function interactionSummary(domainPayload) {
   const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
   const inputBindings = interactions.inputBindings ?? [];
   const actionBindings = interactions.actionBindings ?? [];
+  const stateActionRelations = interactions.stateActionRelations ?? [];
   const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
   const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
   return {
     inputBindings,
     actionBindings,
+    stateActionRelations,
     hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
     hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    hasDirectStateActionRelation: Boolean(
+      stateActionRelations.some(
+        (item) => item.relationKind === "actionReadsInputValue" && item.valueExpr && item.onPressExpr && item.relationBasis?.length > 0,
+      ),
+    ),
     metadataCoverage: {
       textInputFields: textInputMetadataFields,
       pressableFields: pressableMetadataFields,
@@ -169,9 +176,16 @@ export async function buildReactNativePayloadEvidence({
     (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
   );
   const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
+  const directRelationRows = rnFixtures.filter(
+    (row) => row.preRead.primitiveInteractions.hasDirectStateActionRelation && row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
+  );
+  const relationOmittedRows = rnFixtures.filter(
+    (row) => !row.preRead.primitiveInteractions.hasDirectStateActionRelation && !row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
+  );
+  const stateActionRelationsVisible = directRelationRows.length > 0;
 
   return {
-    schemaVersion: "react-native-payload-evidence.v2",
+    schemaVersion: "react-native-payload-evidence.v3",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -208,6 +222,15 @@ export async function buildReactNativePayloadEvidence({
           ? null
           : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
       },
+      stateActionRelationsVisible: {
+        claimable: stateActionRelationsVisible,
+        relationKind: "actionReadsInputValue",
+        directRelationFixtures: directRelationRows.map((row) => row.file),
+        omittedRelationFixtures: relationOmittedRows.map((row) => row.file),
+        blocker: stateActionRelationsVisible
+          ? null
+          : "no measured RN fixture exposed a direct actionReadsInputValue relation in both pre-read and model-facing payloads",
+      },
       broadReactNativeSupport: {
         claimable: false,
         blocker: "evidence is limited to the existing rn-primitive-input-narrow-payload measured lane",
@@ -237,7 +260,10 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       const action = row.preRead.primitiveInteractions.actionBindings
         .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
         .join("; ");
-      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${row.claimable ? "yes" : "no"} |`;
+      const relation = row.preRead.primitiveInteractions.stateActionRelations
+        .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr}`)
+        .join("; ") || "omitted";
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
     })
     .join("\n");
   const boundaryRows = evidence.boundaryFixtures
@@ -264,6 +290,7 @@ ${evidence.claimBoundary}
 - RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
 - Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
 - RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
+- RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
 - RN edit routing claimable: no
@@ -271,8 +298,8 @@ ${evidence.claimBoundary}
 
 ## Measured RN narrow fixtures
 
-| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | claimable |
-| --- | --- | --- | --- | --- | --- | --- |
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | direct relation | claimable |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
 
 ## Metadata anchor coverage

--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -29,6 +29,8 @@ export const RN_TEXT_INPUT_METADATA_FIELDS = [
   "testID",
 ];
 
+export const RN_TEXT_INPUT_CONSTRAINT_FIELDS = ["maxLength", "secureTextEntry", "keyboardType", "autoCapitalize"];
+
 export const RN_PRESSABLE_METADATA_FIELDS = ["disabled", "accessibilityLabel", "accessibilityRole", "testID"];
 
 function loadDist(repoRoot) {
@@ -69,15 +71,27 @@ function interactionSummary(domainPayload) {
   const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
   const inputBindings = interactions.inputBindings ?? [];
   const actionBindings = interactions.actionBindings ?? [];
+  const inputConstraints = interactions.inputConstraints ?? [];
   const stateActionRelations = interactions.stateActionRelations ?? [];
   const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
   const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
+  const constraintFields = presentFields(inputConstraints, RN_TEXT_INPUT_CONSTRAINT_FIELDS);
   return {
     inputBindings,
     actionBindings,
+    inputConstraints,
     stateActionRelations,
     hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
     hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    hasInputConstraintSemantics: Boolean(
+      inputConstraints.some(
+        (item) =>
+          item.primitive === "TextInput" &&
+          item.constraintKind === "textInputMetadataConstraints" &&
+          item.constraintBasis?.length > 0 &&
+          item.evidence?.length > 0,
+      ),
+    ),
     hasDirectStateActionRelation: Boolean(
       stateActionRelations.some(
         (item) => item.relationKind === "actionReadsInputValue" && item.valueExpr && item.onPressExpr && item.relationBasis?.length > 0,
@@ -88,6 +102,9 @@ function interactionSummary(domainPayload) {
       pressableFields: pressableMetadataFields,
       allTextInputMetadataPresent: RN_TEXT_INPUT_METADATA_FIELDS.every((field) => textInputMetadataFields.includes(field)),
       allPressableMetadataPresent: RN_PRESSABLE_METADATA_FIELDS.every((field) => pressableMetadataFields.includes(field)),
+    },
+    constraintCoverage: {
+      fields: constraintFields,
     },
   };
 }
@@ -169,13 +186,25 @@ export async function buildReactNativePayloadEvidence({
   const preReadPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.pressableFields));
   const modelTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields));
   const modelPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields));
+  const preReadConstraintFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.constraintCoverage.fields));
+  const modelConstraintFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.constraintCoverage.fields));
   const missingTextInputFields = RN_TEXT_INPUT_METADATA_FIELDS.filter(
     (field) => !preReadTextInputFields.includes(field) || !modelTextInputFields.includes(field),
   );
   const missingPressableFields = RN_PRESSABLE_METADATA_FIELDS.filter(
     (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
   );
+  const missingConstraintFields = RN_TEXT_INPUT_CONSTRAINT_FIELDS.filter(
+    (field) => !preReadConstraintFields.includes(field) || !modelConstraintFields.includes(field),
+  );
   const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
+  const constraintRows = rnFixtures.filter(
+    (row) => row.preRead.primitiveInteractions.hasInputConstraintSemantics && row.modelFacing.primitiveInteractions.hasInputConstraintSemantics,
+  );
+  const constraintOmittedRows = rnFixtures.filter(
+    (row) => !row.preRead.primitiveInteractions.hasInputConstraintSemantics && !row.modelFacing.primitiveInteractions.hasInputConstraintSemantics,
+  );
+  const inputConstraintsVisible = missingConstraintFields.length === 0 && constraintRows.length > 0;
   const directRelationRows = rnFixtures.filter(
     (row) => row.preRead.primitiveInteractions.hasDirectStateActionRelation && row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
   );
@@ -185,7 +214,7 @@ export async function buildReactNativePayloadEvidence({
   const stateActionRelationsVisible = directRelationRows.length > 0;
 
   return {
-    schemaVersion: "react-native-payload-evidence.v3",
+    schemaVersion: "react-native-payload-evidence.v4",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -221,6 +250,22 @@ export async function buildReactNativePayloadEvidence({
         blocker: metadataAnchorsVisible
           ? null
           : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
+      },
+      inputConstraintsVisible: {
+        claimable: inputConstraintsVisible,
+        scope: "rn-primitive-input-narrow-payload-only",
+        fields: RN_TEXT_INPUT_CONSTRAINT_FIELDS.map((field) => ({
+          field,
+          preRead: preReadConstraintFields.includes(field),
+          modelFacing: modelConstraintFields.includes(field),
+          claimable: preReadConstraintFields.includes(field) && modelConstraintFields.includes(field),
+        })),
+        constraintKind: "textInputMetadataConstraints",
+        directConstraintFixtures: constraintRows.map((row) => row.file),
+        omittedConstraintFixtures: constraintOmittedRows.map((row) => row.file),
+        blocker: inputConstraintsVisible
+          ? null
+          : `missing input constraint fields in rn-primitive-input-narrow-payload-only scope: ${missingConstraintFields.join(",") || "none"}`,
       },
       stateActionRelationsVisible: {
         claimable: stateActionRelationsVisible,
@@ -260,10 +305,19 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       const action = row.preRead.primitiveInteractions.actionBindings
         .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
         .join("; ");
+      const constraints =
+        row.preRead.primitiveInteractions.inputConstraints
+          .map((item) => {
+            const fields = RN_TEXT_INPUT_CONSTRAINT_FIELDS.filter((field) => item[field] !== undefined)
+              .map((field) => `${field}=${item[field]}`)
+              .join(",");
+            return `${item.constraintKind}:${fields || "n/a"}`;
+          })
+          .join("; ") || "omitted";
       const relation = row.preRead.primitiveInteractions.stateActionRelations
         .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr}`)
         .join("; ") || "omitted";
-      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${constraints} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
     })
     .join("\n");
   const boundaryRows = evidence.boundaryFixtures
@@ -280,6 +334,9 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       (row) => `| Pressable | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
     ),
   ].join("\n");
+  const constraintRows = evidence.summary.inputConstraintsVisible.fields
+    .map((row) => `| TextInput | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`)
+    .join("\n");
 
   return `# React Native payload evidence
 
@@ -290,6 +347,7 @@ ${evidence.claimBoundary}
 - RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
 - Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
 - RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
+- Measured RN narrow input constraints visible: ${evidence.summary.inputConstraintsVisible.claimable ? "yes" : "no"}
 - RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
@@ -298,8 +356,8 @@ ${evidence.claimBoundary}
 
 ## Measured RN narrow fixtures
 
-| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | direct relation | claimable |
-| --- | --- | --- | --- | --- | --- | --- | --- |
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | input constraints | direct relation | claimable |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
 
 ## Metadata anchor coverage
@@ -308,6 +366,12 @@ ${fixtureRows}
 | --- | --- | --- | --- | --- |
 ${metadataRows}
 
+## Input constraint coverage
+
+| Primitive | field | pre-read | model-facing | claimable |
+| --- | --- | --- | --- | --- |
+${constraintRows}
+
 ## Boundary fixtures
 
 | Fixture | classification | decision | fallback reason | payload exposed | boundary preserved |
@@ -315,6 +379,8 @@ ${metadataRows}
 ${boundaryRows}
 
 ## Claim boundary
+
+The input constraint claim is scoped to \`${evidence.summary.inputConstraintsVisible.scope}\` and measured only through local fixture pre-read/model-facing visibility.
 
 This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
 `;

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -12,6 +12,7 @@ import type {
   Language,
   ReactNativePrimitiveActionBindingSignal,
   ReactNativePrimitiveInputBindingSignal,
+  ReactNativePrimitiveInputConstraintSignal,
   SourceRange,
   StyleSystem,
   StyleVariantSignal,
@@ -984,6 +985,33 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     rnActionBindings,
     (item) => `${item.primitive}:${item.onPressExpr}:${item.label ?? ""}:${item.loc?.startLine ?? ""}`,
   ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const rnInputConstraints: ReactNativePrimitiveInputConstraintSignal[] = rnInputBindingList
+    .flatMap((inputBinding) => {
+      const constraintBasis = [
+        ...(inputBinding.maxLength !== undefined ? ["jsx.TextInput.maxLength"] : []),
+        ...(inputBinding.secureTextEntry !== undefined ? ["jsx.TextInput.secureTextEntry"] : []),
+        ...(inputBinding.keyboardType !== undefined ? ["jsx.TextInput.keyboardType"] : []),
+        ...(inputBinding.autoCapitalize !== undefined ? ["jsx.TextInput.autoCapitalize"] : []),
+      ];
+      if (constraintBasis.length === 0) return [];
+      const evidence = [...constraintBasis, ...(inputBinding.placeholder !== undefined ? ["jsx.TextInput.placeholder"] : [])];
+      return [
+        {
+          primitive: "TextInput" as const,
+          loc: inputBinding.loc,
+          ...(inputBinding.valueExpr ? { valueExpr: inputBinding.valueExpr } : {}),
+          constraintKind: "textInputMetadataConstraints" as const,
+          ...(inputBinding.maxLength !== undefined ? { maxLength: inputBinding.maxLength } : {}),
+          ...(inputBinding.secureTextEntry !== undefined ? { secureTextEntry: inputBinding.secureTextEntry } : {}),
+          ...(inputBinding.keyboardType !== undefined ? { keyboardType: inputBinding.keyboardType } : {}),
+          ...(inputBinding.autoCapitalize !== undefined ? { autoCapitalize: inputBinding.autoCapitalize } : {}),
+          ...(inputBinding.placeholder !== undefined ? { descriptiveHint: inputBinding.placeholder } : {}),
+          constraintBasis,
+          evidence,
+        },
+      ];
+    })
+    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
   const rnStateActionRelations = rnActionBindingList.flatMap((actionBinding) => {
     const directInputMatches = rnInputBindingList.flatMap((inputBinding) => {
       if (!inputBinding.valueExpr) return [];
@@ -1013,7 +1041,8 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       },
     ];
   }).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnStateActionRelations.length > 0;
+  const hasRnPrimitiveInteractions =
+    rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnInputConstraints.length > 0 || rnStateActionRelations.length > 0;
   return {
     behavior: {
       hooks: [...hooks],
@@ -1038,6 +1067,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
             rnPrimitiveInteractions: {
               ...(rnInputBindingList.length ? { inputBindings: rnInputBindingList } : {}),
               ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
+              ...(rnInputConstraints.length ? { inputConstraints: rnInputConstraints } : {}),
               ...(rnStateActionRelations.length ? { stateActionRelations: rnStateActionRelations } : {}),
             },
           }

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -506,6 +506,9 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const formControls: NonNullable<FormSurface["controls"]> = [];
   const rnInputBindings: ReactNativePrimitiveInputBindingSignal[] = [];
   const rnActionBindings: ReactNativePrimitiveActionBindingSignal[] = [];
+  const functionIdentifierReads = new Map<string, Set<string>>();
+  const ambiguousFunctionReadNames = new Set<string>();
+  const rnActionIdentifierReads = new Map<string, Set<string>>();
   const submitHandlers: NonNullable<FormSurface["submitHandlers"]> = [];
   const validationAnchors: NonNullable<FormSurface["validationAnchors"]> = [];
   const stateConditions: NonNullable<FormSurface["stateConditions"]> = [];
@@ -591,10 +594,87 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     return label || undefined;
   };
 
+  const collectBindingNames = (name: ts.BindingName | undefined, out: Set<string>): void => {
+    if (!name) return;
+    if (ts.isIdentifier(name)) {
+      out.add(name.text);
+      return;
+    }
+    for (const element of name.elements) {
+      if (!ts.isOmittedExpression(element)) collectBindingNames(element.name, out);
+    }
+  };
+
+  const identifierReads = (node: ts.Node | undefined, initialLocalBindings: Iterable<string> = []): Set<string> => {
+    const reads = new Set<string>();
+    if (!node) return reads;
+    const localBindings = new Set(initialLocalBindings);
+    if (ts.isFunctionExpression(node) && node.name) localBindings.add(node.name.text);
+    const visitRead = (child: ts.Node): void => {
+      if (ts.isParameter(child)) collectBindingNames(child.name, localBindings);
+      if (ts.isVariableDeclaration(child)) collectBindingNames(child.name, localBindings);
+      if (child !== node && (ts.isFunctionDeclaration(child) || ts.isFunctionExpression(child) || ts.isArrowFunction(child))) {
+        if (ts.isFunctionDeclaration(child) && child.name) localBindings.add(child.name.text);
+        return;
+      }
+      if (ts.isIdentifier(child)) {
+        const parent = child.parent;
+        const isPropertyName =
+          (ts.isPropertyAccessExpression(parent) && parent.name === child) ||
+          (ts.isPropertyAssignment(parent) && parent.name === child) ||
+          (ts.isBindingElement(parent) && parent.propertyName === child);
+        if (!isPropertyName && !localBindings.has(child.text)) reads.add(child.text);
+      }
+      ts.forEachChild(child, visitRead);
+    };
+    visitRead(node);
+    return reads;
+  };
+
+  const parameterBindingNames = (parameters: ts.NodeArray<ts.ParameterDeclaration>): string[] => {
+    const bindings = new Set<string>();
+    for (const parameter of parameters) collectBindingNames(parameter.name, bindings);
+    return [...bindings];
+  };
+
+  const rememberFunctionReads = (name: string | undefined, body: ts.Node | undefined, localBindings: string[] = []): void => {
+    if (!name || !body) return;
+    if (functionIdentifierReads.has(name)) ambiguousFunctionReadNames.add(name);
+    functionIdentifierReads.set(name, identifierReads(body, localBindings));
+  };
+
+  const actionBindingKey = (onPressExpr: string, loc: SourceRange | undefined): string =>
+    `${onPressExpr}:${loc?.startLine ?? ""}:${loc?.endLine ?? ""}`;
+
+  const handlerReadsValue = (handlerExpr: string, valueExpr: string, actionLoc: SourceRange | undefined): { basis: string[] } | undefined => {
+    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(valueExpr)) return undefined;
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(handlerExpr)) {
+      if (ambiguousFunctionReadNames.has(handlerExpr)) return undefined;
+      const reads = functionIdentifierReads.get(handlerExpr);
+      if (reads?.has(valueExpr)) return { basis: [`handler.${handlerExpr}.reads.${valueExpr}`] };
+      return undefined;
+    }
+    const reads = rnActionIdentifierReads.get(actionBindingKey(handlerExpr, actionLoc));
+    if ((handlerExpr.includes("=>") || handlerExpr.startsWith("function")) && reads?.has(valueExpr)) {
+      return { basis: [`jsx.Pressable.onPress.reads.${valueExpr}`] };
+    }
+    return undefined;
+  };
+
+  const sourceRangeSpan = (ranges: Array<SourceRange | undefined>): SourceRange | undefined => {
+    const present = ranges.filter((range): range is SourceRange => Boolean(range));
+    if (present.length === 0) return undefined;
+    return {
+      startLine: Math.min(...present.map((range) => range.startLine)),
+      endLine: Math.max(...present.map((range) => range.endLine)),
+    };
+  };
+
   const collectRnPrimitiveInteraction = (
     node: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
     tag: string,
     attributeValues: Map<string, string>,
+    attributeExpressions: Map<string, ts.Expression>,
   ): void => {
     if (tag === "TextInput") {
       const valueExpr = attributeValues.get("value");
@@ -656,9 +736,12 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     const testID = attributeValues.get("testID");
 
     const label = ts.isJsxOpeningElement(node) && ts.isJsxElement(node.parent) ? jsxElementTextLabel(node.parent) : undefined;
+    const loc = sourceRangeOf(sourceFile, node);
+    const actionReads = identifierReads(attributeExpressions.get("onPress"));
+    if (actionReads.size > 0) rnActionIdentifierReads.set(actionBindingKey(onPressExpr, loc), actionReads);
     rnActionBindings.push({
       primitive: "Pressable",
-      loc: sourceRangeOf(sourceFile, node),
+      loc,
       onPressExpr,
       ...(label ? { label } : {}),
       ...(disabled ? { disabled } : {}),
@@ -679,10 +762,14 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const collectJsxOpening = (node: ts.JsxOpeningElement | ts.JsxSelfClosingElement): void => {
     const tag = node.tagName.getText(sourceFile);
     const attributeValues = new Map<string, string>();
+    const attributeExpressions = new Map<string, ts.Expression>();
     for (const property of node.attributes.properties) {
       if (!ts.isJsxAttribute(property)) continue;
       const value = jsxAttributeValue(property);
       if (value) attributeValues.set(property.name.getText(sourceFile), value);
+      if (property.initializer && ts.isJsxExpression(property.initializer) && property.initializer.expression) {
+        attributeExpressions.set(property.name.getText(sourceFile), property.initializer.expression);
+      }
     }
     const elementId = attributeValues.get("id");
     if (elementId) {
@@ -691,7 +778,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     if (tag === "Controller") {
       addLocatedAnchor(validationAnchors, "Controller", node);
     }
-    collectRnPrimitiveInteraction(node, tag, attributeValues);
+    collectRnPrimitiveInteraction(node, tag, attributeValues, attributeExpressions);
 
     const propNames: string[] = [];
     const propValues: Record<string, string> = {};
@@ -829,13 +916,24 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       }
     }
 
-    if (ts.isFunctionDeclaration(node) && node.name && /^handle[A-Z]/.test(node.name.text)) {
-      addEventHandlerSignal(node.name.text, node);
-      addSnippet(node.name.text, textOf(sourceFile, node), "event-handler", node);
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      rememberFunctionReads(node.name.text, node.body, parameterBindingNames(node.parameters));
+      if (/^handle[A-Z]/.test(node.name.text)) {
+        addEventHandlerSignal(node.name.text, node);
+        addSnippet(node.name.text, textOf(sourceFile, node), "event-handler", node);
+      }
     }
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && /^handle[A-Z]/.test(node.name.text)) {
-      addEventHandlerSignal(node.name.text, node.parent?.parent ?? node);
-      addSnippet(node.name.text, textOf(sourceFile, node.parent?.parent ?? node), "event-handler", node.parent?.parent ?? node);
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (
+        node.initializer &&
+        (ts.isFunctionExpression(node.initializer) || ts.isArrowFunction(node.initializer))
+      ) {
+        rememberFunctionReads(node.name.text, node.initializer);
+      }
+      if (/^handle[A-Z]/.test(node.name.text)) {
+        addEventHandlerSignal(node.name.text, node.parent?.parent ?? node);
+        addSnippet(node.name.text, textOf(sourceFile, node.parent?.parent ?? node), "event-handler", node.parent?.parent ?? node);
+      }
     }
     if (ts.isJsxAttribute(node)) {
       const attrName = node.name.getText(sourceFile);
@@ -886,7 +984,36 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     rnActionBindings,
     (item) => `${item.primitive}:${item.onPressExpr}:${item.label ?? ""}:${item.loc?.startLine ?? ""}`,
   ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0;
+  const rnStateActionRelations = rnActionBindingList.flatMap((actionBinding) => {
+    const directInputMatches = rnInputBindingList.flatMap((inputBinding) => {
+      if (!inputBinding.valueExpr) return [];
+      const read = handlerReadsValue(actionBinding.onPressExpr, inputBinding.valueExpr, actionBinding.loc);
+      if (!read) return [];
+      return [{ inputBinding, read }];
+    });
+    if (directInputMatches.length !== 1) return [];
+    const { inputBinding, read } = directInputMatches[0];
+    return [
+      {
+        relationKind: "actionReadsInputValue" as const,
+        inputPrimitive: "TextInput" as const,
+        actionPrimitive: "Pressable" as const,
+        valueExpr: inputBinding.valueExpr!,
+        ...(inputBinding.onChangeTextExpr ? { onChangeTextExpr: inputBinding.onChangeTextExpr } : {}),
+        onPressExpr: actionBinding.onPressExpr,
+        ...(actionBinding.label ? { label: actionBinding.label } : {}),
+        relationBasis: read.basis,
+        loc: sourceRangeSpan([inputBinding.loc, actionBinding.loc]),
+        evidence: [
+          "rn.stateActionRelation.actionReadsInputValue",
+          ...inputBinding.evidence,
+          ...actionBinding.evidence,
+          ...read.basis,
+        ],
+      },
+    ];
+  }).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnStateActionRelations.length > 0;
   return {
     behavior: {
       hooks: [...hooks],
@@ -911,6 +1038,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
             rnPrimitiveInteractions: {
               ...(rnInputBindingList.length ? { inputBindings: rnInputBindingList } : {}),
               ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
+              ...(rnStateActionRelations.length ? { stateActionRelations: rnStateActionRelations } : {}),
             },
           }
         : {}),

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -313,12 +313,14 @@ function compactReactNativePrimitiveInteractions(
   if (!interactions) return undefined;
   const inputBindings = interactions.inputBindings?.slice(0, 8);
   const actionBindings = interactions.actionBindings?.slice(0, 8);
+  const inputConstraints = interactions.inputConstraints?.slice(0, 8);
   const stateActionRelations = interactions.stateActionRelations?.slice(0, 8);
 
-  if (!inputBindings?.length && !actionBindings?.length && !stateActionRelations?.length) return undefined;
+  if (!inputBindings?.length && !actionBindings?.length && !inputConstraints?.length && !stateActionRelations?.length) return undefined;
   return {
     ...(inputBindings?.length ? { inputBindings } : {}),
     ...(actionBindings?.length ? { actionBindings } : {}),
+    ...(inputConstraints?.length ? { inputConstraints } : {}),
     ...(stateActionRelations?.length ? { stateActionRelations } : {}),
   };
 }

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -313,11 +313,13 @@ function compactReactNativePrimitiveInteractions(
   if (!interactions) return undefined;
   const inputBindings = interactions.inputBindings?.slice(0, 8);
   const actionBindings = interactions.actionBindings?.slice(0, 8);
+  const stateActionRelations = interactions.stateActionRelations?.slice(0, 8);
 
-  if (!inputBindings?.length && !actionBindings?.length) return undefined;
+  if (!inputBindings?.length && !actionBindings?.length && !stateActionRelations?.length) return undefined;
   return {
     ...(inputBindings?.length ? { inputBindings } : {}),
     ...(actionBindings?.length ? { actionBindings } : {}),
+    ...(stateActionRelations?.length ? { stateActionRelations } : {}),
   };
 }
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -92,9 +92,23 @@ export type ReactNativePrimitiveActionBindingSignal = {
   evidence: string[];
 };
 
+export type ReactNativePrimitiveStateActionRelationSignal = {
+  relationKind: "actionReadsInputValue";
+  inputPrimitive: "TextInput";
+  actionPrimitive: "Pressable";
+  valueExpr: string;
+  onChangeTextExpr?: string;
+  onPressExpr: string;
+  label?: string;
+  relationBasis: string[];
+  loc?: SourceRange;
+  evidence: string[];
+};
+
 export type ReactNativePrimitiveInteractionSignal = {
   inputBindings?: ReactNativePrimitiveInputBindingSignal[];
   actionBindings?: ReactNativePrimitiveActionBindingSignal[];
+  stateActionRelations?: ReactNativePrimitiveStateActionRelationSignal[];
 };
 
 export type A11yAnchorSignal = {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -92,6 +92,20 @@ export type ReactNativePrimitiveActionBindingSignal = {
   evidence: string[];
 };
 
+export type ReactNativePrimitiveInputConstraintSignal = {
+  primitive: "TextInput";
+  loc?: SourceRange;
+  valueExpr?: string;
+  constraintKind: "textInputMetadataConstraints";
+  maxLength?: string;
+  secureTextEntry?: string;
+  keyboardType?: string;
+  autoCapitalize?: string;
+  descriptiveHint?: string;
+  constraintBasis: string[];
+  evidence: string[];
+};
+
 export type ReactNativePrimitiveStateActionRelationSignal = {
   relationKind: "actionReadsInputValue";
   inputPrimitive: "TextInput";
@@ -108,6 +122,7 @@ export type ReactNativePrimitiveStateActionRelationSignal = {
 export type ReactNativePrimitiveInteractionSignal = {
   inputBindings?: ReactNativePrimitiveInputBindingSignal[];
   actionBindings?: ReactNativePrimitiveActionBindingSignal[];
+  inputConstraints?: ReactNativePrimitiveInputConstraintSignal[];
   stateActionRelations?: ReactNativePrimitiveStateActionRelationSignal[];
 };
 

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -148,6 +148,19 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
       ],
     },
   ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 15, endLine: 23 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      descriptiveHint: "Type filter",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      evidence: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize", "jsx.TextInput.placeholder"],
+    },
+  ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
@@ -188,6 +201,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
     },
   ]);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
+  assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
@@ -201,6 +215,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.equal(preReadDecision.payload.domainPayload.claimBoundary, "rn-primitive-input-narrow-payload-only");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].label, "Submit");
+  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.inputConstraints[0].constraintKind, "textInputMetadataConstraints");
   assert.equal(preReadDecision.debug.domainDetection.classification, "react-native");
   assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
 });
@@ -238,6 +253,32 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
       ],
     },
   ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 14, endLine: 24 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      maxLength: "80",
+      secureTextEntry: "false",
+      keyboardType: "default",
+      autoCapitalize: "none",
+      descriptiveHint: "Filter",
+      constraintBasis: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+      ],
+      evidence: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+      ],
+    },
+  ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
@@ -260,9 +301,44 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
   ]);
   assert.equal("stateActionRelations" in payload.facts.primitiveInteractions, false);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
+  assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
+});
+
+test("React Native input constraints are source-observed and omit placeholder-only hints", () => {
+  const placeholderOnlyPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function PlaceholderOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} placeholder="Search" /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(placeholderOnlyPayload?.domain, "react-native");
+  assert.equal("inputConstraints" in placeholderOnlyPayload.facts.primitiveInteractions, false);
+
+  const valueOnlyPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function ValueOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(valueOnlyPayload?.domain, "react-native");
+  assert.equal("inputConstraints" in valueOnlyPayload.facts.primitiveInteractions, false);
+
+  const noSecureTextEntryPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function KeyboardOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} keyboardType="email-address" /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(noSecureTextEntryPayload?.domain, "react-native");
+  assert.deepEqual(noSecureTextEntryPayload.facts.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 3, endLine: 3 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "email-address",
+      constraintBasis: ["jsx.TextInput.keyboardType"],
+      evidence: ["jsx.TextInput.keyboardType"],
+    },
+  ]);
+  assert.equal("secureTextEntry" in noSecureTextEntryPayload.facts.primitiveInteractions.inputConstraints[0], false);
 });
 
 test("React Native direct state/action relation omits co-located and ambiguous narrow pairs", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -10,7 +10,7 @@ import { createRequire } from "node:module";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
-const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { extractFile, extractSource } = require(path.join(repoRoot, "dist", "core", "extract.js"));
 const {
   assessReactNativePrimitiveInputSignalGate,
   assessReactNativePayloadPolicy,
@@ -45,6 +45,11 @@ function fixturePath(fileName) {
 
 function fixtureSource(fileName) {
   return fs.readFileSync(fixturePath(fileName), "utf8");
+}
+
+function rnPayloadFromSource(source, filePath = "NativeRelation.tsx") {
+  const extracted = extractSource(filePath, source);
+  return buildReactNativePrimitiveInputDomainPayload(extracted, extracted.domainDetection);
 }
 
 function rnPrimitiveInputSource(extraJsx = "") {
@@ -154,6 +159,35 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
       evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
     },
   ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.stateActionRelations, [
+    {
+      relationKind: "actionReadsInputValue",
+      inputPrimitive: "TextInput",
+      actionPrimitive: "Pressable",
+      valueExpr: "value",
+      onChangeTextExpr: "onChangeText",
+      onPressExpr: "submitCurrentValue",
+      label: "Submit",
+      relationBasis: ["handler.submitCurrentValue.reads.value"],
+      loc: { startLine: 15, endLine: 24 },
+      evidence: [
+        "rn.stateActionRelation.actionReadsInputValue",
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.testID",
+        "handler.submitCurrentValue.reads.value",
+      ],
+    },
+  ]);
+  assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
@@ -224,9 +258,95 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
       ],
     },
   ]);
+  assert.equal("stateActionRelations" in payload.facts.primitiveInteractions, false);
+  assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
+});
+
+test("React Native direct state/action relation omits co-located and ambiguous narrow pairs", () => {
+  const unrelatedPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function UnrelatedNativeInput({ value, onChangeText, onApply }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={onApply}><Text>Apply</Text></Pressable></View>;
+    }`);
+  assert.equal(unrelatedPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in unrelatedPayload.facts.primitiveInteractions, false);
+
+  const ambiguousPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function AmbiguousNativeInput({ value, query, onChangeText, onChangeQuery, onSubmit }) {
+      const submitCurrentValue = () => onSubmit(value, query);
+      return <View><TextInput value={value} onChangeText={onChangeText} /><TextInput value={query} onChangeText={onChangeQuery} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(ambiguousPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in ambiguousPayload.facts.primitiveInteractions, false);
+
+  const propertyNameOnlyPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function PropertyNameOnly({ value, onChangeText, onSubmit }) {
+      const submitCurrentValue = () => onSubmit({ value: "static" });
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(propertyNameOnlyPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in propertyNameOnlyPayload.facts.primitiveInteractions, false);
+
+  const shadowedHandlerPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function ShadowedHandler({ value, onChangeText, onSubmit }) {
+      const submitCurrentValue = (value) => onSubmit(value);
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(shadowedHandlerPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in shadowedHandlerPayload.facts.primitiveInteractions, false);
+
+  const shadowedFunctionPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function ShadowedFunction({ value, onChangeText, onSubmit }) {
+      function submitCurrentValue(value) {
+        onSubmit(value);
+      }
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(shadowedFunctionPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in shadowedFunctionPayload.facts.primitiveInteractions, false);
+
+  const namedFunctionExpressionPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function NamedFunctionExpression({ value, onChangeText, onSubmit }) {
+      const submitCurrentValue = function value() {
+        onSubmit("static");
+      };
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(namedFunctionExpressionPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in namedFunctionExpressionPayload.facts.primitiveInteractions, false);
+
+  const duplicateHandlerNamePayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function DuplicateHandlerA({ value, onChangeText, onSubmit }) {
+      const submitCurrentValue = () => onSubmit("static");
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }
+    export function DuplicateHandlerB({ value, onSubmit }) {
+      const submitCurrentValue = () => onSubmit(value);
+      return <View><Text>{value}</Text></View>;
+    }`);
+  assert.equal(duplicateHandlerNamePayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in duplicateHandlerNamePayload.facts.primitiveInteractions, false);
+
+  const inlineShadowedPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function InlineShadowed({ value, onChangeText, onSubmit }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={(value) => onSubmit(value)}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(inlineShadowedPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in inlineShadowedPayload.facts.primitiveInteractions, false);
+
+  const inputOnlyPayload = rnPayloadFromSource(`import { View, TextInput } from "react-native";
+    export function InputOnly({ value, onChangeText }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} /></View>;
+    }`);
+  assert.equal(inputOnlyPayload, undefined);
+
+  const actionOnlyPayload = rnPayloadFromSource(`import { View, Text, Pressable } from "react-native";
+    export function ActionOnly({ onApply }) {
+      return <View><Pressable onPress={onApply}><Text>Apply</Text></Pressable></View>;
+    }`);
+  assert.equal(actionOnlyPayload, undefined);
 });
 
 test("React Native richer adjacent fixtures stay outside the narrow payload lane", () => {

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -10,7 +10,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v2");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v3");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -25,6 +25,14 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
   assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
   assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
+  assert.equal(evidence.summary.stateActionRelationsVisible.claimable, true);
+  assert.equal(evidence.summary.stateActionRelationsVisible.relationKind, "actionReadsInputValue");
+  assert.ok(
+    evidence.summary.stateActionRelationsVisible.directRelationFixtures.some((file) => file.endsWith("rn-primitive-inline-action.tsx")),
+  );
+  assert.ok(
+    evidence.summary.stateActionRelationsVisible.omittedRelationFixtures.some((file) => file.endsWith("rn-primitive-basic.tsx")),
+  );
   assert.deepEqual(
     evidence.summary.metadataAnchorsVisible.textInputFields.map((row) => row.field),
     RN_TEXT_INPUT_METADATA_FIELDS,
@@ -84,6 +92,8 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Apply filter");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].accessibilityRole, "button");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].testID, "apply-button");
+  assert.deepEqual(basic.preRead.primitiveInteractions.stateActionRelations, []);
+  assert.deepEqual(basic.modelFacing.primitiveInteractions.stateActionRelations, []);
 
   const inline = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-inline-action.tsx"));
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].placeholder, "Type filter");
@@ -95,6 +105,35 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
+  assert.deepEqual(inline.preRead.primitiveInteractions.stateActionRelations, [
+    {
+      relationKind: "actionReadsInputValue",
+      inputPrimitive: "TextInput",
+      actionPrimitive: "Pressable",
+      valueExpr: "value",
+      onChangeTextExpr: "onChangeText",
+      onPressExpr: "submitCurrentValue",
+      label: "Submit",
+      relationBasis: ["handler.submitCurrentValue.reads.value"],
+      loc: { startLine: 15, endLine: 24 },
+      evidence: [
+        "rn.stateActionRelation.actionReadsInputValue",
+        "jsx.TextInput.value",
+        "jsx.TextInput.onChangeText",
+        "jsx.TextInput.placeholder",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.accessibilityLabel",
+        "jsx.TextInput.testID",
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.testID",
+        "handler.submitCurrentValue.reads.value",
+      ],
+    },
+  ]);
+  assert.deepEqual(inline.modelFacing.primitiveInteractions.stateActionRelations, inline.preRead.primitiveInteractions.stateActionRelations);
 });
 
 test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
@@ -120,6 +159,8 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /RN primitive interaction facts visible: yes/);
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
   assert.match(markdown, /RN metadata anchors visible: yes/);
+  assert.match(markdown, /RN direct state\/action relation visible: yes/);
+  assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| maxLength \| yes \| yes \| yes \|/);

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   RN_PRESSABLE_METADATA_FIELDS,
+  RN_TEXT_INPUT_CONSTRAINT_FIELDS,
   RN_TEXT_INPUT_METADATA_FIELDS,
   buildReactNativePayloadEvidence,
   renderReactNativePayloadEvidenceMarkdown,
@@ -10,7 +11,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v3");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v4");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -25,6 +26,12 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
   assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
   assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
+  assert.equal(evidence.summary.inputConstraintsVisible.claimable, true);
+  assert.equal(evidence.summary.inputConstraintsVisible.scope, "rn-primitive-input-narrow-payload-only");
+  assert.equal(evidence.summary.inputConstraintsVisible.blocker, null);
+  assert.ok(
+    evidence.summary.inputConstraintsVisible.directConstraintFixtures.some((file) => file.endsWith("rn-primitive-basic.tsx")),
+  );
   assert.equal(evidence.summary.stateActionRelationsVisible.claimable, true);
   assert.equal(evidence.summary.stateActionRelationsVisible.relationKind, "actionReadsInputValue");
   assert.ok(
@@ -41,9 +48,14 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     evidence.summary.metadataAnchorsVisible.pressableFields.map((row) => row.field),
     RN_PRESSABLE_METADATA_FIELDS,
   );
+  assert.deepEqual(
+    evidence.summary.inputConstraintsVisible.fields.map((row) => row.field),
+    RN_TEXT_INPUT_CONSTRAINT_FIELDS,
+  );
   for (const row of [
     ...evidence.summary.metadataAnchorsVisible.textInputFields,
     ...evidence.summary.metadataAnchorsVisible.pressableFields,
+    ...evidence.summary.inputConstraintsVisible.fields,
   ]) {
     assert.equal(row.preRead, true, row.field);
     assert.equal(row.modelFacing, true, row.field);
@@ -68,11 +80,13 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.ok(row.preRead.primitiveInteractions.inputConstraints.length > 0, row.file);
     assert.equal(row.modelFacing.strictContractsPresent, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.ok(row.modelFacing.primitiveInteractions.inputConstraints.length > 0, row.file);
     assert.equal(row.claimable, true);
   }
 
@@ -86,6 +100,32 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "none");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Search filter");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].testID, "search-input");
+  assert.deepEqual(basic.preRead.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 14, endLine: 24 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      maxLength: "80",
+      secureTextEntry: "false",
+      keyboardType: "default",
+      autoCapitalize: "none",
+      descriptiveHint: "Filter",
+      constraintBasis: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+      ],
+      evidence: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+      ],
+    },
+  ]);
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "onApply");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].label, "Apply");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].disabled, "isApplyDisabled");
@@ -101,6 +141,20 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "sentences");
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Inline filter");
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].testID, "inline-filter-input");
+  assert.deepEqual(inline.preRead.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 15, endLine: 23 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      descriptiveHint: "Type filter",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      evidence: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize", "jsx.TextInput.placeholder"],
+    },
+  ]);
+  assert.equal("secureTextEntry" in inline.preRead.primitiveInteractions.inputConstraints[0], false);
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
@@ -159,7 +213,10 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /RN primitive interaction facts visible: yes/);
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
   assert.match(markdown, /RN metadata anchors visible: yes/);
+  assert.match(markdown, /Measured RN narrow input constraints visible: yes/);
   assert.match(markdown, /RN direct state\/action relation visible: yes/);
+  assert.match(markdown, /rn-primitive-input-narrow-payload-only/);
+  assert.match(markdown, /textInputMetadataConstraints:maxLength=80,secureTextEntry=false,keyboardType=default,autoCapitalize=none/);
   assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);


### PR DESCRIPTION
## Summary
- add RN `stateActionRelations` facts for the measured narrow TextInput/Pressable payload lane
- emit only `actionReadsInputValue` when a Pressable `onPress` handler directly reads the matching TextInput `valueExpr`
- keep co-located, unrelated, ambiguous, shadowed, duplicate-handler, broader RN, runtime reuse, edit-routing, and sourceAnchor/rnContext cases omitted
- upgrade RN payload evidence to v3 with direct/omitted relation fixture reporting

## Scope / Boundary
Stacked on #482 (`deep/rn-metadata-expansion`). This is local fixture payload evidence only for `rn-primitive-input-narrow-payload`; it does not promote broad RN support, runtime reuse, edit routing, provider token savings, or billing claims.

## Verification
- `npm run build`
- `npm run evidence:react-native-payload -- --run-id=ralph-rn-state-action-relation-final`
- `node --test test/react-native-payload-evidence.test.mjs test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/pre-read-phase-order-regression.test.mjs test/payload-policy-webview.test.mjs test/payload-policy-tui-ink.test.mjs test/payload-policy-react-web.test.mjs` → 50 pass
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `git diff --check`
- `npm test` → 485 pass
- LSP diagnostics on changed TS files → 0 errors
- Architect review → APPROVE
