### PR TITLE
Define TUI minimal payload design contract

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -108,6 +108,33 @@ The evidence matrix above is sufficient to discuss a future payload-design PRD, 
 - terminal runtime facts, command execution, key handling correctness, token reduction, billing reduction, provider-cost reduction, and performance outcomes are treated as non-claims until measured in a separate plan;
 - any detector, registry, manifest, payload builder, pre-read, runtime, or cross-lane frontend edit is out of scope for a readiness handoff and requires a separate serialized plan.
 
+### Minimal payload candidate vocabulary
+
+The first safe TUI payload design target is a source-only metadata vocabulary. These names are allowed to appear in docs and future dry-run tests, but they are not model-facing payload fields yet:
+
+| Candidate metadata field | Representative fixture evidence | Required boundary |
+| --- | --- | --- |
+| `terminalLayoutEvidence` | `tui-ink-basic.tsx`, `tui-ink-layout-style.tsx`, `tui-ink-status-panel.tsx` | Layout hierarchy evidence only; no terminal rendering correctness claim. |
+| `terminalTextStatusEvidence` | `tui-ink-basic.tsx`, `tui-ink-status-panel.tsx` | Text/status syntax evidence only; no command progress or runtime side-effect claim. |
+| `terminalInputFlowEvidence` | `tui-ink-basic.tsx`, `tui-ink-interactive-list.tsx`, `tui-ink-form-prompt.tsx` | Input-flow source evidence only; no key handling, stdin, TTY, or UX correctness claim. |
+| `terminalStyleEvidence` | `tui-ink-layout-style.tsx` | Style prop evidence only; no color/theme/visual fidelity claim. |
+| `terminalMixedBoundaryEvidence` | `tui-ink-web-dom-mixed.tsx`, `tui-ink-rn-narrow-mixed.tsx` | Mixed-domain fallback evidence only; no TUI, React Web, or RN payload authorization. |
+| `terminalNegativeBoundaryEvidence` | `tui-non-ink-cli-renderer.tsx` | Non-Ink fallback evidence only; no package-surface expansion. |
+
+The vocabulary is deliberately fixture-backed. A later field should not be added until a fixture proves the source shape and a negative or mixed case keeps fallback/no-payload behavior safe.
+
+### Source-only dry-run implementation handoff
+
+A future dry-run PR may implement a non-emitting metadata projection for the vocabulary above, but only if it keeps the current denied lane intact:
+
+1. read source and produce debug/test evidence for candidate metadata fields;
+2. keep `assessTuiInkPayloadPolicy` denied with `allowed: false`;
+3. keep every current TUI fixture fallback/no-payload;
+4. keep mixed and non-Ink cases outside TUI payload authorization;
+5. avoid model-facing payload builders, runtime/pre-read injection, manifest changes, detector/registry promotion, and token/performance/support claims.
+
+If any of those constraints is too narrow, the next artifact should be a new PRD/test-spec pair rather than an opportunistic source edit.
+
 ## Candidate source notes
 
 If a future PR names public repositories, keep the list conservative and verify license, activity, file paths, and commit SHAs at that time. Good seed sources are likely to be established Ink examples, React-based CLI apps, or prompt/status UI components with inspectable TSX/JSX. Do not use curated lists, stale forks, or runtime-only demos as evidence fixtures unless a pinned source file clearly exercises one category above.

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -69,6 +69,33 @@ A future payload-design PRD may start only when all of these checks are true:
 
 The disqualifier list is intentionally strict. Stop the current lane and write a separate serialized plan if a change needs `allowed: true`, a TUI payload builder, runtime/pre-read injection, detector or registry edits, manifest changes, fixture classification changes, cross-lane RN/React Web/WebView edits, or any measured-value claim.
 
+## Minimal payload candidate schema contract
+
+This contract names the first metadata vocabulary a future **source-only dry-run** may prototype. It is a schema target, not permission to emit a payload. Every field below must stay source-derived, fixture-backed, and denied by the current TUI payload policy until a later plan explicitly promotes it.
+
+| Candidate metadata field | What current fixtures can prove | Full-source / non-claim boundary |
+| --- | --- | --- |
+| `terminalLayoutEvidence` | Ink `Box`/`Text` hierarchy, nested rows or columns, spacing props, and repeated display rows. | Does not prove rendered terminal dimensions, wrapping, or layout correctness. |
+| `terminalTextStatusEvidence` | Static text, status labels, progress-like rows, elapsed text, and log-summary rendering visible in TSX. | Does not prove command execution, progress accuracy, shell state, or runtime side effects. |
+| `terminalInputFlowEvidence` | `useInput`, key branches, prompt state, validation/error text, submit/apply, cancel, and selection movement in source. | Does not prove terminal key handling correctness, stdin/TTY behavior, accessibility, or runtime UX safety. |
+| `terminalStyleEvidence` | Ink color, dim text, border, padding, gap, and style-like props visible in JSX. | Does not prove terminal theme support, color rendering, or visual fidelity. |
+| `terminalMixedBoundaryEvidence` | Ink evidence combined with React Web DOM or React Native primitive/input evidence. | Must remain fallback/no-payload and cannot authorize any TUI, React Web, or RN compact path. |
+| `terminalNegativeBoundaryEvidence` | Terminal-looking React or CLI renderer source without Ink import, primitives, or hooks. | Must remain unknown/deferred fallback and cannot broaden package support. |
+
+The schema vocabulary above is intentionally smaller than terminal behavior. It may guide a future metadata projection, but it must not be described as compact context support, token reduction, runtime correctness, provider-cost improvement, or default TUI extraction.
+
+## Source-only dry-run handoff
+
+The next implementation PR may build only a **source-only dry-run** that reports the candidate metadata fields above in debug or test-owned evidence. That PR must continue to keep:
+
+- `tui-ink-evidence-only-payload` denied with `allowed: false`;
+- pre-read fallback/no-payload behavior for every current TUI fixture;
+- mixed and non-Ink cases outside TUI payload authorization;
+- model-facing payload emission out of scope;
+- runtime hooks, detector registries, fixture manifest entries, and cross-lane RN/React Web/WebView files unchanged unless a new serialized plan names owners and fallback regressions first.
+
+If the dry-run needs a payload builder, `allowed: true`, runtime injection, token/performance claims, or shared-seam edits, stop and create a new PRD/test-spec pair before implementation.
+
 ## Stop rules
 
 Stop the current PR and switch to serialized shared-policy planning if the change would:

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -129,6 +129,24 @@ const payloadReadinessGateTerms = [
   "separate serialized plan",
 ];
 
+const tuiMinimalPayloadCandidateFields = [
+  "terminalLayoutEvidence",
+  "terminalTextStatusEvidence",
+  "terminalInputFlowEvidence",
+  "terminalStyleEvidence",
+  "terminalMixedBoundaryEvidence",
+  "terminalNegativeBoundaryEvidence",
+];
+
+const tuiMinimalPayloadFixtureMap = [
+  ["terminalLayoutEvidence", "tui-ink-layout-style.tsx"],
+  ["terminalTextStatusEvidence", "tui-ink-status-panel.tsx"],
+  ["terminalInputFlowEvidence", "tui-ink-form-prompt.tsx"],
+  ["terminalStyleEvidence", "tui-ink-layout-style.tsx"],
+  ["terminalMixedBoundaryEvidence", "tui-ink-rn-narrow-mixed.tsx"],
+  ["terminalNegativeBoundaryEvidence", "tui-non-ink-cli-renderer.tsx"],
+];
+
 function tuiFixturePath(fileName) {
   return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
 }
@@ -445,10 +463,22 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /Current TUI evidence matrix/);
   assert.match(survey, /Payload design readiness handoff/);
   assert.match(survey, /not itself a payload contract/);
+  assert.match(survey, /Minimal payload candidate vocabulary/);
+  assert.match(survey, /Source-only dry-run implementation handoff/);
   assert.match(survey, /pre-read emits no model-facing TUI payload/);
   assert.match(survey, /separate serialized plan/);
   assert.match(survey, /tui-ink-evidence-only-payload/);
   assert.match(survey, /mixed frontend boundary/);
+  for (const field of tuiMinimalPayloadCandidateFields) {
+    assert.ok(survey.includes(field), field);
+  }
+  for (const [field, fixture] of tuiMinimalPayloadFixtureMap) {
+    assert.ok(survey.includes(field), field);
+    assert.ok(survey.includes(fixture), fixture);
+  }
+  assert.match(survey, /not model-facing payload fields yet/);
+  assert.match(survey, /non-emitting metadata projection/);
+  assert.match(survey, /keep `assessTuiInkPayloadPolicy` denied with `allowed: false`/);
   assert.doesNotMatch(survey, forbiddenSupportClaims);
 });
 
@@ -463,6 +493,8 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /## Allowed next work/);
   assert.match(guide, /## Promotion criteria before payload-design planning/);
   assert.match(guide, /## Payload design readiness gate/);
+  assert.match(guide, /## Minimal payload candidate schema contract/);
+  assert.match(guide, /## Source-only dry-run handoff/);
   assert.match(guide, /## Stop rules/);
   assert.match(guide, /tui-ink-evidence-only-payload/);
   assert.match(guide, /fallback\/no-payload/);
@@ -475,5 +507,11 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   }
   assert.match(guide, /no TUI or React Web payload authorization/);
   assert.match(guide, /no TUI or RN narrow payload authorization/);
+  for (const field of tuiMinimalPayloadCandidateFields) {
+    assert.ok(guide.includes(field), field);
+  }
+  assert.match(guide, /source-derived, fixture-backed, and denied/);
+  assert.match(guide, /It may guide a future metadata projection/);
+  assert.match(guide, /model-facing payload emission out of scope/);
   assert.doesNotMatch(guide, forbiddenSupportClaims);
 });


### PR DESCRIPTION
## Summary
- Define the TUI minimal payload candidate schema contract as docs/test-owned vocabulary.
- Map existing TUI fixtures to candidate metadata fields and fallback boundaries.
- Add TUI policy tests that lock the schema vocabulary, source-only dry-run handoff, and no-support-claim boundary.

Closes #492

## Scope boundary
- Docs/test-only.
- No `allowed: true` policy.
- No runtime/pre-read integration.
- No model-facing TUI payload builder or payload emission.
- No broad TUI support, token, billing, performance, or terminal correctness claim.

## Validation
- `npm run build && node --test test/payload-policy-tui-ink.test.mjs` — 15/15 pass
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test` — 486/486 pass
- Architect verification — APPROVE
- Deslop pass over changed files — no edits needed; fallback terms classified as grounded claim-boundary language
