### PR TITLE
Prove React Web a11y anchor retention

### DIFF
--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 import {
+  reactWebA11yAnchorSource,
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
   reactWebLayoutRegionSource,
@@ -70,6 +71,79 @@ test("pre-read payload builder omits React Web context metadata when payload bud
     assert.equal(budgeted.debug.reactWebContextBudget.reason, "budget-exceeded");
   } finally {
     JSON.stringify = originalStringify;
+  }
+});
+
+function hasA11yAnchor(anchors, predicate) {
+  return anchors.some(predicate);
+}
+
+test("pre-read payload builder preserves React Web a11y anchors when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-a11y-anchor-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineA11yContactForm.tsx");
+    fs.writeFileSync(target, reactWebA11yAnchorSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(
+      decision.debug.reactWebContextBudget.estimatedPayloadBytes <=
+        decision.debug.reactWebContextBudget.maxPayloadBytes,
+    );
+    assert.ok(Array.isArray(decision.payload.reactWebContext.a11yAnchors));
+
+    const anchors = decision.payload.reactWebContext.a11yAnchors;
+    assert.ok(
+      hasA11yAnchor(
+        anchors,
+        (item) => item.kind === "htmlFor" && item.label === "email" && item.relation?.kind === "label-control",
+      ),
+    );
+    assert.ok(
+      hasA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "aria" &&
+          item.label.startsWith("aria-describedby=email-error email-help") &&
+          item.relation?.kind === "aria-idrefs" &&
+          item.relation.resolvedIds.includes("email-error") &&
+          !item.relation.resolvedIds.includes("missing-id"),
+      ),
+    );
+    assert.ok(
+      hasA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "aria" &&
+          item.label === "aria-labelledby=email-label" &&
+          item.relation?.kind === "aria-idrefs" &&
+          item.relation.resolvedIds.includes("email-label"),
+      ),
+    );
+    assert.ok(
+      hasA11yAnchor(
+        anchors,
+        (item) => item.kind === "aria" && item.label === "aria-invalid=invalid" && item.relation?.kind === "invalid-state",
+      ),
+    );
+    assert.ok(
+      hasA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "role" &&
+          item.label === "alert" &&
+          item.relation?.kind === "alert-region" &&
+          item.relation.sourceId === "email-error",
+      ),
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
 

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -78,3 +78,33 @@ export function InlineComponentApiPanel({ title, items, count = 0, loading, erro
 /* ${"component api budget filler ".repeat(220)} */
 `;
 }
+
+export function reactWebA11yAnchorSource() {
+  return `type ContactA11yFormProps = { email: string; invalid?: boolean; loading?: boolean; error?: string };
+
+export function InlineA11yContactForm({ email, invalid, loading, error }: ContactA11yFormProps) {
+  return (
+    <form className="grid gap-3" aria-busy={loading}>
+      <label htmlFor="email">Email</label>
+      <input
+        id="email"
+        name="email"
+        value={email}
+        readOnly
+        required
+        aria-invalid={invalid}
+        aria-describedby="email-error email-help missing-id"
+        aria-labelledby="email-label"
+      />
+      <span id="email-label">Primary email</span>
+      {loading ? <p>Loading contact details</p> : null}
+      {error ? <p id="email-error" role="alert">{error}</p> : null}
+      <p id="email-help">Use your work email for recovery.</p>
+      <button type="button" disabled={loading}>Refresh</button>
+    </form>
+  );
+}
+
+/* ${"a11y anchor budget filler ".repeat(220)} */
+`;
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { cleanupMetricSessions } from "./metric-cleanup.mjs";
 import {
+  reactWebA11yAnchorSource,
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
   reactWebLayoutRegionSource,
@@ -288,6 +289,94 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
 
   assert.equal(legacyOverride.action, "fallback");
   assert.equal(legacyOverride.fallback.reason, "escape-hatch-full-read");
+});
+
+function hasRuntimeA11yAnchor(anchors, predicate) {
+  return anchors.some(predicate);
+}
+
+test("runtime bridge preserves React Web a11y anchors in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-a11y-anchor-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebA11yAnchorSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineA11yContactForm.tsx"), source);
+
+    const sessionId = `bridge-contract-a11y-anchor-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineA11yContactForm.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineA11yContactForm.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.a11yAnchors));
+
+    const anchors = payload.reactWebContext.a11yAnchors;
+    assert.ok(
+      hasRuntimeA11yAnchor(
+        anchors,
+        (item) => item.kind === "htmlFor" && item.label === "email" && item.relation?.kind === "label-control",
+      ),
+    );
+    assert.ok(
+      hasRuntimeA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "aria" &&
+          item.label.startsWith("aria-describedby=email-error email-help") &&
+          item.relation?.kind === "aria-idrefs" &&
+          item.relation.resolvedIds.includes("email-error") &&
+          !item.relation.resolvedIds.includes("missing-id"),
+      ),
+    );
+    assert.ok(
+      hasRuntimeA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "aria" &&
+          item.label === "aria-labelledby=email-label" &&
+          item.relation?.kind === "aria-idrefs" &&
+          item.relation.resolvedIds.includes("email-label"),
+      ),
+    );
+    assert.ok(
+      hasRuntimeA11yAnchor(
+        anchors,
+        (item) => item.kind === "aria" && item.label === "aria-invalid=invalid" && item.relation?.kind === "invalid-state",
+      ),
+    );
+    assert.ok(
+      hasRuntimeA11yAnchor(
+        anchors,
+        (item) =>
+          item.kind === "role" &&
+          item.label === "alert" &&
+          item.relation?.kind === "alert-region" &&
+          item.relation.sourceId === "email-error",
+      ),
+    );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("runtime bridge preserves React Web form state-flow in repeated-read context when budget permits", () => {


### PR DESCRIPTION
## Summary

- add an inline React Web fixture with source-observed htmlFor, aria id-ref, invalid-state, and role alert anchors
- assert pre-read payloads keep `reactWebContext.a11yAnchors` when the context budget permits
- assert runtime repeated-read injection preserves those same compact a11y anchors and remains smaller than the raw source

Closes #494

## Verification

- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test` (488 pass)

## Boundaries

- source-only/same-file proof
- no accessibility audit or browser DOM validation claims
- no cross-file id resolution, typechecker semantics, budget-priority changes, or extractor semantic changes
