### PR TITLE
Prove remaining React Web context retention axes

### DIFF
--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -12,6 +12,8 @@ import {
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
   reactWebLayoutRegionSource,
+  reactWebStylingVariantSource,
+  reactWebImportRoleSource,
 } from "./react-web-inline-sources.mjs";
 
 const repoRoot = process.cwd();
@@ -142,6 +144,65 @@ test("pre-read payload builder preserves React Web a11y anchors when context bud
           item.relation.sourceId === "email-error",
       ),
     );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read payload builder preserves React Web styling variant hints when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-styling-variant-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineVariantPanel.tsx");
+    fs.writeFileSync(target, reactWebStylingVariantSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(decision.payload.reactWebContext.stylingVariantHints));
+
+    const hints = decision.payload.reactWebContext.stylingVariantHints;
+    assert.ok(hints.some((item) => item.kind === "props-contract" && item.propName === "variant"));
+    assert.ok(hints.some((item) => item.kind === "props-contract" && item.propName === "size"));
+    assert.ok(hints.some((item) => item.kind === "data-state" && item.propName === "data-state"));
+    assert.ok(hints.some((item) => item.kind === "className-branch" && item.propName === "className" && item.loc));
+    assert.ok(hints.some((item) => item.kind === "inline-style" && item.propName === "style" && item.loc));
+    assert.ok(hints.some((item) => item.kind === "variant-prop" && item.propName === "disabled"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read payload builder preserves React Web import role hints when context budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-import-role-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineImportRolePanel.tsx");
+    fs.writeFileSync(target, reactWebImportRoleSource());
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: false,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(decision.payload.reactWebContext.importRoleHints));
+
+    const rolesByModule = new Map(
+      decision.payload.reactWebContext.importRoleHints.map((item) => [item.moduleSpecifier, item.role]),
+    );
+    assert.equal(rolesByModule.get("react-hook-form"), "form-library");
+    assert.equal(rolesByModule.get("zod"), "validation-library");
+    assert.equal(rolesByModule.get("next/link"), "routing");
+    assert.equal(rolesByModule.get("@/components/ui/button"), "ui-kit");
+    assert.equal(rolesByModule.get("lucide-react"), "icon-library");
+    assert.equal(rolesByModule.get("./FieldShell"), "local-component");
+    assert.equal(rolesByModule.has("date-fns"), false);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -108,3 +108,75 @@ export function InlineA11yContactForm({ email, invalid, loading, error }: Contac
 /* ${"a11y anchor budget filler ".repeat(220)} */
 `;
 }
+
+export function reactWebStylingVariantSource() {
+  return `type VariantPanelProps = {
+  variant?: "primary" | "secondary";
+  size?: "sm" | "lg";
+  disabled?: boolean;
+  selected?: boolean;
+};
+
+export function InlineVariantPanel({ variant = "primary", size = "sm", disabled, selected }: VariantPanelProps) {
+  const toneClass = variant === "primary" ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-900";
+  const sizeClass = size === "lg" ? "px-4 py-3" : "px-2 py-1";
+  return (
+    <section
+      data-state={selected ? "selected" : "idle"}
+      className={disabled ? "opacity-50 pointer-events-none" : toneClass + " " + sizeClass}
+      style={{ opacity: disabled ? 0.5 : 1 }}
+    >
+      <button variant={variant} size={size} disabled={disabled} className="rounded-md border">
+        Save
+      </button>
+      <p>Styling hints stay source-derived and avoid design-system semantics.</p>
+      <p>Conditional className branches remain source facts only.</p>
+      <p>Inline style anchors remain local source facts only.</p>
+      <p>Variant props are retained without design-system interpretation.</p>
+      <p>Extra body copy keeps this fixture in the compact metadata lane.</p>
+    </section>
+  );
+}
+
+/* ${"styling variant budget filler ".repeat(520)} */
+`;
+}
+
+export function reactWebImportRoleSource() {
+  return `import { useForm } from "react-hook-form";
+import { z } from "zod";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Mail } from "lucide-react";
+import FieldShell from "./FieldShell";
+import { format } from "date-fns";
+
+type ImportRoleItem = { id: string; label: string };
+type ImportRolePanelProps = { email: string; items?: ImportRoleItem[]; loading?: boolean; error?: string };
+
+export function InlineImportRolePanel({ email, items = [], loading, error }: ImportRolePanelProps) {
+  const form = useForm();
+  const schema = z.object({ email: z.string() });
+  return (
+    <FieldShell className="grid gap-3 rounded-lg border p-4" data-form={String(Boolean(form))} data-schema={String(Boolean(schema))}>
+      <Button type="button" className="inline-flex items-center gap-2">
+        <Mail aria-hidden="true" />
+        {email}
+      </Button>
+      <Link href="/settings" className="text-sm underline">Settings</Link>
+      {loading ? <p>Loading imports</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+      <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+      <p className="text-xs text-slate-500">{format(new Date(), "yyyy-MM-dd")}</p>
+      <p className="text-xs text-slate-500">Import role hints are source facts only.</p>
+      <p className="text-xs text-slate-500">Runtime library behavior is intentionally not inferred.</p>
+      <p className="text-xs text-slate-500">Unknown utility imports must stay out of role hints.</p>
+      <p className="text-xs text-slate-500">This fixture stays long enough for compact metadata.</p>
+      <p className="text-xs text-slate-500">The same source facts should survive repeated-read context.</p>
+    </FieldShell>
+  );
+}
+
+/* ${"import role budget filler ".repeat(640)} */
+`;
+}

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -10,6 +10,8 @@ import {
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
   reactWebLayoutRegionSource,
+  reactWebStylingVariantSource,
+  reactWebImportRoleSource,
 } from "./react-web-inline-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -373,6 +375,102 @@ test("runtime bridge preserves React Web a11y anchors in repeated-read context w
           item.relation.sourceId === "email-error",
       ),
     );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime bridge preserves React Web styling variant hints in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-styling-variant-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebStylingVariantSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineVariantPanel.tsx"), source);
+
+    const sessionId = `bridge-contract-styling-variant-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineVariantPanel.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineVariantPanel.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.stylingVariantHints));
+
+    const hints = payload.reactWebContext.stylingVariantHints;
+    assert.ok(hints.some((item) => item.kind === "props-contract" && item.propName === "variant"));
+    assert.ok(hints.some((item) => item.kind === "data-state" && item.propName === "data-state"));
+    assert.ok(hints.some((item) => item.kind === "className-branch" && item.propName === "className" && item.loc));
+    assert.ok(hints.some((item) => item.kind === "inline-style" && item.propName === "style" && item.loc));
+    assert.ok(hints.some((item) => item.kind === "variant-prop" && item.propName === "disabled"));
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime bridge preserves React Web import role hints in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-import-role-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebImportRoleSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineImportRolePanel.tsx"), source);
+
+    const sessionId = `bridge-contract-import-role-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineImportRolePanel.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineImportRolePanel.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.importRoleHints));
+
+    const rolesByModule = new Map(
+      payload.reactWebContext.importRoleHints.map((item) => [item.moduleSpecifier, item.role]),
+    );
+    assert.equal(rolesByModule.get("react-hook-form"), "form-library");
+    assert.equal(rolesByModule.get("zod"), "validation-library");
+    assert.equal(rolesByModule.get("next/link"), "routing");
+    assert.equal(rolesByModule.get("@/components/ui/button"), "ui-kit");
+    assert.equal(rolesByModule.get("lucide-react"), "icon-library");
+    assert.equal(rolesByModule.get("./FieldShell"), "local-component");
+    assert.equal(rolesByModule.has("date-fns"), false);
     assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- add inline React Web fixtures for source-only styling variant and import role context facts
- assert pre-read payloads retain `stylingVariantHints` and `importRoleHints` when the context budget permits
- assert runtime repeated-read injection preserves both fields in compact additionalContext

Closes #496

## Verification

- `git diff --check`
- `npm run build`
- `node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm test` (492 pass)

## Boundaries

- source-only/same-file proof
- no design-system interpretation or imported-library runtime semantics
- no cross-file usage, typechecker semantics, budget-priority changes, or extractor semantic changes
