### PR TITLE
Allow delegated maintainers in merge gate

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Validate merge policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MERGE_GATE_ALLOWED_MAINTAINERS: minislively
+          MERGE_GATE_ALLOWED_MAINTAINERS: ${{ vars.MERGE_GATE_ALLOWED_MAINTAINERS || 'minislively,bellman,yeachan,minseol' }}
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -9,6 +9,8 @@ import {
 } from "../scripts/validate-pr-merge-gate.mjs";
 
 const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" } };
+const delegatedMaintainers = ["bellman", "yeachan", "minseol"];
+const allowedMaintainers = ["minislively", ...delegatedMaintainers];
 
 test("merge gate passes when PR links an issue and has maintainer approval", () => {
   const result = evaluatePullRequestMergeGate({
@@ -22,6 +24,37 @@ test("merge gate passes when PR links an issue and has maintainer approval", () 
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.approvingMaintainers, ["minislively"]);
+});
+
+test("merge gate accepts current-head approval from delegated maintainers", () => {
+  for (const maintainer of delegatedMaintainers) {
+    const result = evaluatePullRequestMergeGate({
+      pullRequest: pr,
+      allowedMaintainers,
+      reviews: [
+        { user: { login: "minislively" }, state: "CHANGES_REQUESTED", submitted_at: "2026-05-01T00:01:00Z" },
+        { user: { login: maintainer }, state: "APPROVED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
+      ],
+    });
+
+    assert.equal(result.ok, true, `${maintainer} approval should satisfy the gate`);
+    assert.deepEqual(result.approvingMaintainers, [maintainer]);
+  }
+});
+
+test("merge gate still requires linked issue when delegated maintainer approves", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" } },
+    allowedMaintainers,
+    reviews: [
+      { user: { login: "bellman" }, state: "APPROVED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
+    ],
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /closing issue/);
+  assert.doesNotMatch(result.blockers.join("\n"), /active approval/);
+  assert.deepEqual(result.approvingMaintainers, ["bellman"]);
 });
 
 test("merge gate rejects PRs without a closing issue reference", () => {


### PR DESCRIPTION
Closes #500.

## Summary
- make merge gate maintainer allowlist configurable via repo variable
- keep a safe default that includes the delegated fooks workflow maintainers
- add regression coverage for delegated current-head approval while preserving linked-issue enforcement

## Verification
- `node --test test/pr-merge-gate.test.mjs`
- `npm run build`
- `git diff --check`