### PR TITLE
Add TUI source-only metadata dry-run projector

### DIFF
--- a/src/core/tui-source-metadata.ts
+++ b/src/core/tui-source-metadata.ts
@@ -1,0 +1,107 @@
+import { detectDomainFromSource } from "./domain-detector";
+import type { DomainDetectionResult, FrontendDomainEvidence } from "./domain-profiles/types";
+
+export type TuiSourceMetadataDryRun = {
+  schemaVersion: 1;
+  mode: "source-only-dry-run";
+  classification: DomainDetectionResult["classification"];
+  claimStatus: DomainDetectionResult["profile"]["claimStatus"];
+  nonEmitting: true;
+  integration: {
+    cliVisible: false;
+    modelFacingPayload: false;
+    runtimeOrPreRead: false;
+  };
+  terminalLayoutEvidence: string[];
+  terminalTextStatusEvidence: string[];
+  terminalInputFlowEvidence: string[];
+  terminalStyleEvidence: string[];
+  terminalMixedBoundaryEvidence: string[];
+  terminalNegativeBoundaryEvidence: string[];
+  omittedRuntimeSemantics: string[];
+};
+
+export type TuiSourceMetadataInput = {
+  sourceText: string;
+  filePath?: string;
+  domainDetection?: DomainDetectionResult;
+};
+
+const OMITTED_RUNTIME_SEMANTICS = [
+  "terminal-rendering-correctness",
+  "tty-stdin-behavior",
+  "key-handling-correctness",
+  "command-execution-semantics",
+  "token-or-performance-value",
+] as const;
+
+const LAYOUT_PROPS = ["flexDirection", "gap", "padding", "paddingX", "paddingY"] as const;
+const STYLE_PROPS = ["color", "dimColor", "bold", "borderStyle", "borderColor"] as const;
+const INPUT_MARKERS = ["useInput", "key.escape", "key.return", "key.upArrow", "key.downArrow", "key.backspace", "key.delete"] as const;
+const TEXT_STATUS_MARKERS = ["statusGlyph", "phase", "elapsedMs", "messages", "errorMessage", "submitted"] as const;
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function detailsFor(evidence: FrontendDomainEvidence[], signal: string): string[] {
+  return evidence.filter((item) => item.signal === signal).map((item) => `${signal}:${item.detail}`);
+}
+
+function sourceMarkers(sourceText: string, markers: readonly string[], prefix: string): string[] {
+  return markers.filter((marker) => sourceText.includes(marker)).map((marker) => `${prefix}:${marker}`);
+}
+
+function hasTuiEvidence(domainDetection: DomainDetectionResult): boolean {
+  return domainDetection.evidence.some((item) => item.domain === "tui-ink");
+}
+
+function nonTuiDomains(domainDetection: DomainDetectionResult): string[] {
+  return unique(domainDetection.evidence.filter((item) => item.domain !== "tui-ink").map((item) => item.domain));
+}
+
+export function projectTuiSourceMetadataDryRun(input: TuiSourceMetadataInput): TuiSourceMetadataDryRun {
+  const filePath = input.filePath ?? "source.tsx";
+  const domainDetection = input.domainDetection ?? detectDomainFromSource(input.sourceText, filePath);
+  const tuiEvidence = domainDetection.evidence.filter((item) => item.domain === "tui-ink");
+  const hasTui = hasTuiEvidence(domainDetection);
+  const nonTuiEvidenceDomains = nonTuiDomains(domainDetection);
+
+  const terminalLayoutEvidence = hasTui
+    ? unique([...detailsFor(tuiEvidence, "primitive"), ...sourceMarkers(input.sourceText, LAYOUT_PROPS, "jsx-prop")])
+    : [];
+  const terminalTextStatusEvidence = hasTui
+    ? unique([...detailsFor(tuiEvidence, "primitive").filter((detail) => detail.endsWith(":Text")), ...sourceMarkers(input.sourceText, TEXT_STATUS_MARKERS, "source-marker")])
+    : [];
+  const terminalInputFlowEvidence = hasTui
+    ? unique([...detailsFor(tuiEvidence, "hook"), ...sourceMarkers(input.sourceText, INPUT_MARKERS, "source-marker")])
+    : [];
+  const terminalStyleEvidence = hasTui ? unique(sourceMarkers(input.sourceText, STYLE_PROPS, "jsx-prop")) : [];
+  const terminalMixedBoundaryEvidence =
+    hasTui && domainDetection.classification === "mixed"
+      ? nonTuiEvidenceDomains.map((domain) => `mixed-with:${domain}`)
+      : [];
+  const terminalNegativeBoundaryEvidence = hasTui
+    ? []
+    : [`no-tui-ink-evidence:${domainDetection.classification}:${domainDetection.profile.claimStatus}`];
+
+  return {
+    schemaVersion: 1,
+    mode: "source-only-dry-run",
+    classification: domainDetection.classification,
+    claimStatus: domainDetection.profile.claimStatus,
+    nonEmitting: true,
+    integration: {
+      cliVisible: false,
+      modelFacingPayload: false,
+      runtimeOrPreRead: false,
+    },
+    terminalLayoutEvidence,
+    terminalTextStatusEvidence,
+    terminalInputFlowEvidence,
+    terminalStyleEvidence,
+    terminalMixedBoundaryEvidence,
+    terminalNegativeBoundaryEvidence,
+    omittedRuntimeSemantics: [...OMITTED_RUNTIME_SEMANTICS],
+  };
+}

--- a/test/tui-source-metadata.test.mjs
+++ b/test/tui-source-metadata.test.mjs
@@ -1,0 +1,155 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { projectTuiSourceMetadataDryRun } = require(path.join(repoRoot, "dist", "core", "tui-source-metadata.js"));
+const { assessTuiInkPayloadPolicy } = require(path.join(repoRoot, "dist", "core", "payload-policy", "tui-ink.js"));
+const preRead = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+
+const forbiddenSupportClaims = /TUI support is available|TUI is supported today|TUI\/Ink is supported today|terminal correctness is guaranteed|terminal UX safety is guaranteed|runtime-token savings are available|provider-token savings are available|billing savings are available|TUI performance improvement is available|default TUI compact extraction is enabled/i;
+
+function fixturePath(fileName) {
+  return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
+}
+
+function readFixture(fileName) {
+  return fs.readFileSync(path.join(repoRoot, fixturePath(fileName)), "utf8");
+}
+
+function projectFixture(fileName) {
+  const sourceText = readFixture(fileName);
+  const domainDetection = detectDomainFromSource(sourceText, fileName);
+  return {
+    domainDetection,
+    metadata: projectTuiSourceMetadataDryRun({
+      sourceText,
+      filePath: fileName,
+      domainDetection,
+    }),
+  };
+}
+
+function assertNonEmitting(metadata) {
+  assert.equal(metadata.mode, "source-only-dry-run");
+  assert.equal(metadata.nonEmitting, true);
+  assert.deepEqual(metadata.integration, {
+    cliVisible: false,
+    modelFacingPayload: false,
+    runtimeOrPreRead: false,
+  });
+  assert.ok(metadata.omittedRuntimeSemantics.includes("terminal-rendering-correctness"));
+  assert.ok(metadata.omittedRuntimeSemantics.includes("tty-stdin-behavior"));
+  assert.ok(metadata.omittedRuntimeSemantics.includes("key-handling-correctness"));
+  assert.ok(metadata.omittedRuntimeSemantics.includes("command-execution-semantics"));
+  assert.ok(metadata.omittedRuntimeSemantics.includes("token-or-performance-value"));
+}
+
+test("TUI source metadata projector derives safe source facts from basic Ink fixture", () => {
+  const { domainDetection, metadata } = projectFixture("tui-ink-basic.tsx");
+
+  assert.equal(domainDetection.classification, "tui-ink");
+  assert.equal(metadata.classification, "tui-ink");
+  assert.equal(metadata.claimStatus, "evidence-only");
+  assertNonEmitting(metadata);
+  assert.ok(metadata.terminalLayoutEvidence.includes("primitive:Box"));
+  assert.ok(metadata.terminalLayoutEvidence.includes("primitive:Text"));
+  assert.ok(metadata.terminalLayoutEvidence.includes("jsx-prop:flexDirection"));
+  assert.ok(metadata.terminalTextStatusEvidence.includes("primitive:Text"));
+  assert.ok(metadata.terminalInputFlowEvidence.includes("hook:useInput"));
+  assert.ok(metadata.terminalInputFlowEvidence.includes("source-marker:useInput"));
+  assert.deepEqual(metadata.terminalMixedBoundaryEvidence, []);
+  assert.deepEqual(metadata.terminalNegativeBoundaryEvidence, []);
+});
+
+test("TUI source metadata projector maps prompt and style fixtures without behavior claims", () => {
+  const prompt = projectFixture("tui-ink-form-prompt.tsx").metadata;
+  const styled = projectFixture("tui-ink-layout-style.tsx").metadata;
+
+  assertNonEmitting(prompt);
+  assert.ok(prompt.terminalInputFlowEvidence.includes("source-marker:key.escape"));
+  assert.ok(prompt.terminalInputFlowEvidence.includes("source-marker:key.return"));
+  assert.ok(prompt.terminalTextStatusEvidence.includes("source-marker:errorMessage"));
+  assert.ok(prompt.terminalTextStatusEvidence.includes("source-marker:submitted"));
+  assert.ok(prompt.terminalStyleEvidence.includes("jsx-prop:color"));
+  assert.ok(prompt.omittedRuntimeSemantics.includes("key-handling-correctness"));
+
+  assertNonEmitting(styled);
+  assert.ok(styled.terminalLayoutEvidence.includes("jsx-prop:flexDirection"));
+  assert.ok(styled.terminalLayoutEvidence.includes("jsx-prop:gap"));
+  assert.ok(styled.terminalLayoutEvidence.includes("jsx-prop:padding"));
+  assert.ok(styled.terminalLayoutEvidence.includes("jsx-prop:paddingX"));
+  assert.ok(styled.terminalStyleEvidence.includes("jsx-prop:color"));
+  assert.ok(styled.terminalStyleEvidence.includes("jsx-prop:dimColor"));
+  assert.ok(styled.terminalStyleEvidence.includes("jsx-prop:borderStyle"));
+  assert.ok(styled.terminalStyleEvidence.includes("jsx-prop:borderColor"));
+});
+
+test("TUI source metadata projector records status text evidence without command semantics", () => {
+  const { metadata } = projectFixture("tui-ink-status-panel.tsx");
+
+  assertNonEmitting(metadata);
+  assert.ok(metadata.terminalTextStatusEvidence.includes("source-marker:statusGlyph"));
+  assert.ok(metadata.terminalTextStatusEvidence.includes("source-marker:phase"));
+  assert.ok(metadata.terminalTextStatusEvidence.includes("source-marker:elapsedMs"));
+  assert.ok(metadata.terminalTextStatusEvidence.includes("source-marker:messages"));
+  assert.ok(metadata.omittedRuntimeSemantics.includes("command-execution-semantics"));
+});
+
+test("TUI source metadata projector keeps mixed and non-Ink cases as boundary evidence", () => {
+  const webMixed = projectFixture("tui-ink-web-dom-mixed.tsx").metadata;
+  const rnMixed = projectFixture("tui-ink-rn-narrow-mixed.tsx").metadata;
+  const nonInk = projectFixture("tui-non-ink-cli-renderer.tsx").metadata;
+
+  assertNonEmitting(webMixed);
+  assert.equal(webMixed.classification, "mixed");
+  assert.ok(webMixed.terminalMixedBoundaryEvidence.includes("mixed-with:react-web"));
+  assert.deepEqual(webMixed.terminalNegativeBoundaryEvidence, []);
+
+  assertNonEmitting(rnMixed);
+  assert.equal(rnMixed.classification, "mixed");
+  assert.ok(rnMixed.terminalMixedBoundaryEvidence.includes("mixed-with:react-native"));
+  assert.deepEqual(rnMixed.terminalNegativeBoundaryEvidence, []);
+
+  assertNonEmitting(nonInk);
+  assert.equal(nonInk.classification, "unknown");
+  assert.deepEqual(nonInk.terminalLayoutEvidence, []);
+  assert.deepEqual(nonInk.terminalTextStatusEvidence, []);
+  assert.deepEqual(nonInk.terminalInputFlowEvidence, []);
+  assert.deepEqual(nonInk.terminalStyleEvidence, []);
+  assert.deepEqual(nonInk.terminalMixedBoundaryEvidence, []);
+  assert.ok(nonInk.terminalNegativeBoundaryEvidence.includes("no-tui-ink-evidence:unknown:deferred"));
+});
+
+test("TUI source metadata projector does not change denied policy or pre-read fallback", () => {
+  const fileName = "tui-ink-basic.tsx";
+  const sourceText = readFixture(fileName);
+  const domainDetection = detectDomainFromSource(sourceText, fileName);
+  const decision = preRead.decidePreRead(path.join(repoRoot, fixturePath(fileName)), repoRoot, "codex");
+
+  assert.deepEqual(assessTuiInkPayloadPolicy(domainDetection), {
+    name: "tui-ink-evidence-only-payload",
+    allowed: false,
+    reason: "tui-ink-evidence-only",
+  });
+  assert.equal(decision.decision, "fallback");
+  assert.equal(decision.fallback.action, "full-read");
+  assert.equal("payload" in decision, false);
+});
+
+test("TUI source metadata projector stays internal and avoids broad terminal claims", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "src", "core", "tui-source-metadata.ts"), "utf8");
+
+  assert.doesNotMatch(source, forbiddenSupportClaims);
+  assert.match(source, /source-only-dry-run/);
+  assert.match(source, /modelFacingPayload: false/);
+  assert.match(source, /runtimeOrPreRead: false/);
+  assert.match(source, /cliVisible: false/);
+});


### PR DESCRIPTION
## Summary

- Adds `projectTuiSourceMetadataDryRun`, an internal TUI/Ink source-only metadata projector.
- Captures safe source facts for layout props, text/status markers, input-flow markers, style props, mixed-domain boundaries, and non-Ink negative boundaries.
- Locks the boundary that this is non-emitting: no CLI-visible surface, no runtime/pre-read integration, no model-facing payload, and existing TUI policy remains denied/fallback.

## Scope boundary

This does **not** make TUI supported, does **not** emit compact TUI payloads, and does **not** claim terminal rendering, key-handling, performance, token, or billing value.

## Validation

- `npm run build`
- `node --test test/tui-source-metadata.test.mjs test/payload-policy-tui-ink.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test` — 498/498 pass
- Ralph architect verification: APPROVE
- Changed-files-only deslop pass + post-deslop full regression: PASS

Closes #502
