### PR TITLE
Prove RN input constraint evidence

### DIFF
--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -29,6 +29,8 @@ export const RN_TEXT_INPUT_METADATA_FIELDS = [
   "testID",
 ];
 
+export const RN_TEXT_INPUT_CONSTRAINT_FIELDS = ["maxLength", "secureTextEntry", "keyboardType", "autoCapitalize"];
+
 export const RN_PRESSABLE_METADATA_FIELDS = ["disabled", "accessibilityLabel", "accessibilityRole", "testID"];
 
 function loadDist(repoRoot) {
@@ -69,15 +71,27 @@ function interactionSummary(domainPayload) {
   const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
   const inputBindings = interactions.inputBindings ?? [];
   const actionBindings = interactions.actionBindings ?? [];
+  const inputConstraints = interactions.inputConstraints ?? [];
   const stateActionRelations = interactions.stateActionRelations ?? [];
   const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
   const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
+  const constraintFields = presentFields(inputConstraints, RN_TEXT_INPUT_CONSTRAINT_FIELDS);
   return {
     inputBindings,
     actionBindings,
+    inputConstraints,
     stateActionRelations,
     hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
     hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
+    hasInputConstraintSemantics: Boolean(
+      inputConstraints.some(
+        (item) =>
+          item.primitive === "TextInput" &&
+          item.constraintKind === "textInputMetadataConstraints" &&
+          item.constraintBasis?.length > 0 &&
+          item.evidence?.length > 0,
+      ),
+    ),
     hasDirectStateActionRelation: Boolean(
       stateActionRelations.some(
         (item) => item.relationKind === "actionReadsInputValue" && item.valueExpr && item.onPressExpr && item.relationBasis?.length > 0,
@@ -88,6 +102,9 @@ function interactionSummary(domainPayload) {
       pressableFields: pressableMetadataFields,
       allTextInputMetadataPresent: RN_TEXT_INPUT_METADATA_FIELDS.every((field) => textInputMetadataFields.includes(field)),
       allPressableMetadataPresent: RN_PRESSABLE_METADATA_FIELDS.every((field) => pressableMetadataFields.includes(field)),
+    },
+    constraintCoverage: {
+      fields: constraintFields,
     },
   };
 }
@@ -169,13 +186,25 @@ export async function buildReactNativePayloadEvidence({
   const preReadPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.metadataCoverage.pressableFields));
   const modelTextInputFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields));
   const modelPressableFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields));
+  const preReadConstraintFields = uniqueSorted(rnFixtures.flatMap((row) => row.preRead.primitiveInteractions.constraintCoverage.fields));
+  const modelConstraintFields = uniqueSorted(rnFixtures.flatMap((row) => row.modelFacing.primitiveInteractions.constraintCoverage.fields));
   const missingTextInputFields = RN_TEXT_INPUT_METADATA_FIELDS.filter(
     (field) => !preReadTextInputFields.includes(field) || !modelTextInputFields.includes(field),
   );
   const missingPressableFields = RN_PRESSABLE_METADATA_FIELDS.filter(
     (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
   );
+  const missingConstraintFields = RN_TEXT_INPUT_CONSTRAINT_FIELDS.filter(
+    (field) => !preReadConstraintFields.includes(field) || !modelConstraintFields.includes(field),
+  );
   const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
+  const constraintRows = rnFixtures.filter(
+    (row) => row.preRead.primitiveInteractions.hasInputConstraintSemantics && row.modelFacing.primitiveInteractions.hasInputConstraintSemantics,
+  );
+  const constraintOmittedRows = rnFixtures.filter(
+    (row) => !row.preRead.primitiveInteractions.hasInputConstraintSemantics && !row.modelFacing.primitiveInteractions.hasInputConstraintSemantics,
+  );
+  const inputConstraintsVisible = missingConstraintFields.length === 0 && constraintRows.length > 0;
   const directRelationRows = rnFixtures.filter(
     (row) => row.preRead.primitiveInteractions.hasDirectStateActionRelation && row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
   );
@@ -185,7 +214,7 @@ export async function buildReactNativePayloadEvidence({
   const stateActionRelationsVisible = directRelationRows.length > 0;
 
   return {
-    schemaVersion: "react-native-payload-evidence.v3",
+    schemaVersion: "react-native-payload-evidence.v4",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -221,6 +250,22 @@ export async function buildReactNativePayloadEvidence({
         blocker: metadataAnchorsVisible
           ? null
           : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
+      },
+      inputConstraintsVisible: {
+        claimable: inputConstraintsVisible,
+        scope: "rn-primitive-input-narrow-payload-only",
+        fields: RN_TEXT_INPUT_CONSTRAINT_FIELDS.map((field) => ({
+          field,
+          preRead: preReadConstraintFields.includes(field),
+          modelFacing: modelConstraintFields.includes(field),
+          claimable: preReadConstraintFields.includes(field) && modelConstraintFields.includes(field),
+        })),
+        constraintKind: "textInputMetadataConstraints",
+        directConstraintFixtures: constraintRows.map((row) => row.file),
+        omittedConstraintFixtures: constraintOmittedRows.map((row) => row.file),
+        blocker: inputConstraintsVisible
+          ? null
+          : `missing input constraint fields in rn-primitive-input-narrow-payload-only scope: ${missingConstraintFields.join(",") || "none"}`,
       },
       stateActionRelationsVisible: {
         claimable: stateActionRelationsVisible,
@@ -260,10 +305,19 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       const action = row.preRead.primitiveInteractions.actionBindings
         .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
         .join("; ");
+      const constraints =
+        row.preRead.primitiveInteractions.inputConstraints
+          .map((item) => {
+            const fields = RN_TEXT_INPUT_CONSTRAINT_FIELDS.filter((field) => item[field] !== undefined)
+              .map((field) => `${field}=${item[field]}`)
+              .join(",");
+            return `${item.constraintKind}:${fields || "n/a"}`;
+          })
+          .join("; ") || "omitted";
       const relation = row.preRead.primitiveInteractions.stateActionRelations
         .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr}`)
         .join("; ") || "omitted";
-      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${constraints} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
     })
     .join("\n");
   const boundaryRows = evidence.boundaryFixtures
@@ -280,6 +334,9 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       (row) => `| Pressable | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`,
     ),
   ].join("\n");
+  const constraintRows = evidence.summary.inputConstraintsVisible.fields
+    .map((row) => `| TextInput | ${row.field} | ${row.preRead ? "yes" : "no"} | ${row.modelFacing ? "yes" : "no"} | ${row.claimable ? "yes" : "no"} |`)
+    .join("\n");
 
   return `# React Native payload evidence
 
@@ -290,6 +347,7 @@ ${evidence.claimBoundary}
 - RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
 - Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
 - RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
+- Measured RN narrow input constraints visible: ${evidence.summary.inputConstraintsVisible.claimable ? "yes" : "no"}
 - RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
@@ -298,8 +356,8 @@ ${evidence.claimBoundary}
 
 ## Measured RN narrow fixtures
 
-| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | direct relation | claimable |
-| --- | --- | --- | --- | --- | --- | --- | --- |
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | input constraints | direct relation | claimable |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
 
 ## Metadata anchor coverage
@@ -308,6 +366,12 @@ ${fixtureRows}
 | --- | --- | --- | --- | --- |
 ${metadataRows}
 
+## Input constraint coverage
+
+| Primitive | field | pre-read | model-facing | claimable |
+| --- | --- | --- | --- | --- |
+${constraintRows}
+
 ## Boundary fixtures
 
 | Fixture | classification | decision | fallback reason | payload exposed | boundary preserved |
@@ -315,6 +379,8 @@ ${metadataRows}
 ${boundaryRows}
 
 ## Claim boundary
+
+The input constraint claim is scoped to \`${evidence.summary.inputConstraintsVisible.scope}\` and measured only through local fixture pre-read/model-facing visibility.
 
 This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
 `;

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -12,6 +12,7 @@ import type {
   Language,
   ReactNativePrimitiveActionBindingSignal,
   ReactNativePrimitiveInputBindingSignal,
+  ReactNativePrimitiveInputConstraintSignal,
   SourceRange,
   StyleSystem,
   StyleVariantSignal,
@@ -984,6 +985,33 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     rnActionBindings,
     (item) => `${item.primitive}:${item.onPressExpr}:${item.label ?? ""}:${item.loc?.startLine ?? ""}`,
   ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const rnInputConstraints: ReactNativePrimitiveInputConstraintSignal[] = rnInputBindingList
+    .flatMap((inputBinding) => {
+      const constraintBasis = [
+        ...(inputBinding.maxLength !== undefined ? ["jsx.TextInput.maxLength"] : []),
+        ...(inputBinding.secureTextEntry !== undefined ? ["jsx.TextInput.secureTextEntry"] : []),
+        ...(inputBinding.keyboardType !== undefined ? ["jsx.TextInput.keyboardType"] : []),
+        ...(inputBinding.autoCapitalize !== undefined ? ["jsx.TextInput.autoCapitalize"] : []),
+      ];
+      if (constraintBasis.length === 0) return [];
+      const evidence = [...constraintBasis, ...(inputBinding.placeholder !== undefined ? ["jsx.TextInput.placeholder"] : [])];
+      return [
+        {
+          primitive: "TextInput" as const,
+          loc: inputBinding.loc,
+          ...(inputBinding.valueExpr ? { valueExpr: inputBinding.valueExpr } : {}),
+          constraintKind: "textInputMetadataConstraints" as const,
+          ...(inputBinding.maxLength !== undefined ? { maxLength: inputBinding.maxLength } : {}),
+          ...(inputBinding.secureTextEntry !== undefined ? { secureTextEntry: inputBinding.secureTextEntry } : {}),
+          ...(inputBinding.keyboardType !== undefined ? { keyboardType: inputBinding.keyboardType } : {}),
+          ...(inputBinding.autoCapitalize !== undefined ? { autoCapitalize: inputBinding.autoCapitalize } : {}),
+          ...(inputBinding.placeholder !== undefined ? { descriptiveHint: inputBinding.placeholder } : {}),
+          constraintBasis,
+          evidence,
+        },
+      ];
+    })
+    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
   const rnStateActionRelations = rnActionBindingList.flatMap((actionBinding) => {
     const directInputMatches = rnInputBindingList.flatMap((inputBinding) => {
       if (!inputBinding.valueExpr) return [];
@@ -1013,7 +1041,8 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       },
     ];
   }).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnStateActionRelations.length > 0;
+  const hasRnPrimitiveInteractions =
+    rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnInputConstraints.length > 0 || rnStateActionRelations.length > 0;
   return {
     behavior: {
       hooks: [...hooks],
@@ -1038,6 +1067,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
             rnPrimitiveInteractions: {
               ...(rnInputBindingList.length ? { inputBindings: rnInputBindingList } : {}),
               ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
+              ...(rnInputConstraints.length ? { inputConstraints: rnInputConstraints } : {}),
               ...(rnStateActionRelations.length ? { stateActionRelations: rnStateActionRelations } : {}),
             },
           }

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -313,12 +313,14 @@ function compactReactNativePrimitiveInteractions(
   if (!interactions) return undefined;
   const inputBindings = interactions.inputBindings?.slice(0, 8);
   const actionBindings = interactions.actionBindings?.slice(0, 8);
+  const inputConstraints = interactions.inputConstraints?.slice(0, 8);
   const stateActionRelations = interactions.stateActionRelations?.slice(0, 8);
 
-  if (!inputBindings?.length && !actionBindings?.length && !stateActionRelations?.length) return undefined;
+  if (!inputBindings?.length && !actionBindings?.length && !inputConstraints?.length && !stateActionRelations?.length) return undefined;
   return {
     ...(inputBindings?.length ? { inputBindings } : {}),
     ...(actionBindings?.length ? { actionBindings } : {}),
+    ...(inputConstraints?.length ? { inputConstraints } : {}),
     ...(stateActionRelations?.length ? { stateActionRelations } : {}),
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -92,6 +92,20 @@ export type ReactNativePrimitiveActionBindingSignal = {
   evidence: string[];
 };
 
+export type ReactNativePrimitiveInputConstraintSignal = {
+  primitive: "TextInput";
+  loc?: SourceRange;
+  valueExpr?: string;
+  constraintKind: "textInputMetadataConstraints";
+  maxLength?: string;
+  secureTextEntry?: string;
+  keyboardType?: string;
+  autoCapitalize?: string;
+  descriptiveHint?: string;
+  constraintBasis: string[];
+  evidence: string[];
+};
+
 export type ReactNativePrimitiveStateActionRelationSignal = {
   relationKind: "actionReadsInputValue";
   inputPrimitive: "TextInput";
@@ -108,6 +122,7 @@ export type ReactNativePrimitiveStateActionRelationSignal = {
 export type ReactNativePrimitiveInteractionSignal = {
   inputBindings?: ReactNativePrimitiveInputBindingSignal[];
   actionBindings?: ReactNativePrimitiveActionBindingSignal[];
+  inputConstraints?: ReactNativePrimitiveInputConstraintSignal[];
   stateActionRelations?: ReactNativePrimitiveStateActionRelationSignal[];
 };
 

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -148,6 +148,19 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
       ],
     },
   ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 15, endLine: 23 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      descriptiveHint: "Type filter",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      evidence: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize", "jsx.TextInput.placeholder"],
+    },
+  ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
@@ -188,6 +201,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
     },
   ]);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
+  assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
@@ -201,6 +215,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.equal(preReadDecision.payload.domainPayload.claimBoundary, "rn-primitive-input-narrow-payload-only");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].label, "Submit");
+  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.inputConstraints[0].constraintKind, "textInputMetadataConstraints");
   assert.equal(preReadDecision.debug.domainDetection.classification, "react-native");
   assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
 });
@@ -238,6 +253,32 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
       ],
     },
   ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 14, endLine: 24 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      maxLength: "80",
+      secureTextEntry: "false",
+      keyboardType: "default",
+      autoCapitalize: "none",
+      descriptiveHint: "Filter",
+      constraintBasis: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+      ],
+      evidence: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+      ],
+    },
+  ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
@@ -260,9 +301,44 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
   ]);
   assert.equal("stateActionRelations" in payload.facts.primitiveInteractions, false);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
+  assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
+});
+
+test("React Native input constraints are source-observed and omit placeholder-only hints", () => {
+  const placeholderOnlyPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function PlaceholderOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} placeholder="Search" /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(placeholderOnlyPayload?.domain, "react-native");
+  assert.equal("inputConstraints" in placeholderOnlyPayload.facts.primitiveInteractions, false);
+
+  const valueOnlyPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function ValueOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(valueOnlyPayload?.domain, "react-native");
+  assert.equal("inputConstraints" in valueOnlyPayload.facts.primitiveInteractions, false);
+
+  const noSecureTextEntryPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function KeyboardOnly({ value, onChangeText, onPress }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} keyboardType="email-address" /><Pressable onPress={onPress}><Text>Go</Text></Pressable></View>;
+    }`);
+  assert.equal(noSecureTextEntryPayload?.domain, "react-native");
+  assert.deepEqual(noSecureTextEntryPayload.facts.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 3, endLine: 3 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "email-address",
+      constraintBasis: ["jsx.TextInput.keyboardType"],
+      evidence: ["jsx.TextInput.keyboardType"],
+    },
+  ]);
+  assert.equal("secureTextEntry" in noSecureTextEntryPayload.facts.primitiveInteractions.inputConstraints[0], false);
 });
 
 test("React Native direct state/action relation omits co-located and ambiguous narrow pairs", () => {

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   RN_PRESSABLE_METADATA_FIELDS,
+  RN_TEXT_INPUT_CONSTRAINT_FIELDS,
   RN_TEXT_INPUT_METADATA_FIELDS,
   buildReactNativePayloadEvidence,
   renderReactNativePayloadEvidenceMarkdown,
@@ -10,7 +11,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v3");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v4");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -25,6 +26,12 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
   assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
   assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
+  assert.equal(evidence.summary.inputConstraintsVisible.claimable, true);
+  assert.equal(evidence.summary.inputConstraintsVisible.scope, "rn-primitive-input-narrow-payload-only");
+  assert.equal(evidence.summary.inputConstraintsVisible.blocker, null);
+  assert.ok(
+    evidence.summary.inputConstraintsVisible.directConstraintFixtures.some((file) => file.endsWith("rn-primitive-basic.tsx")),
+  );
   assert.equal(evidence.summary.stateActionRelationsVisible.claimable, true);
   assert.equal(evidence.summary.stateActionRelationsVisible.relationKind, "actionReadsInputValue");
   assert.ok(
@@ -41,9 +48,14 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     evidence.summary.metadataAnchorsVisible.pressableFields.map((row) => row.field),
     RN_PRESSABLE_METADATA_FIELDS,
   );
+  assert.deepEqual(
+    evidence.summary.inputConstraintsVisible.fields.map((row) => row.field),
+    RN_TEXT_INPUT_CONSTRAINT_FIELDS,
+  );
   for (const row of [
     ...evidence.summary.metadataAnchorsVisible.textInputFields,
     ...evidence.summary.metadataAnchorsVisible.pressableFields,
+    ...evidence.summary.inputConstraintsVisible.fields,
   ]) {
     assert.equal(row.preRead, true, row.field);
     assert.equal(row.modelFacing, true, row.field);
@@ -68,11 +80,13 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.ok(row.preRead.primitiveInteractions.inputConstraints.length > 0, row.file);
     assert.equal(row.modelFacing.strictContractsPresent, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
+    assert.ok(row.modelFacing.primitiveInteractions.inputConstraints.length > 0, row.file);
     assert.equal(row.claimable, true);
   }
 
@@ -86,6 +100,32 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "none");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Search filter");
   assert.equal(basic.preRead.primitiveInteractions.inputBindings[0].testID, "search-input");
+  assert.deepEqual(basic.preRead.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 14, endLine: 24 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      maxLength: "80",
+      secureTextEntry: "false",
+      keyboardType: "default",
+      autoCapitalize: "none",
+      descriptiveHint: "Filter",
+      constraintBasis: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+      ],
+      evidence: [
+        "jsx.TextInput.maxLength",
+        "jsx.TextInput.secureTextEntry",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+      ],
+    },
+  ]);
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "onApply");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].label, "Apply");
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].disabled, "isApplyDisabled");
@@ -101,6 +141,20 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].autoCapitalize, "sentences");
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].accessibilityLabel, "Inline filter");
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].testID, "inline-filter-input");
+  assert.deepEqual(inline.preRead.primitiveInteractions.inputConstraints, [
+    {
+      primitive: "TextInput",
+      loc: { startLine: 15, endLine: 23 },
+      valueExpr: "value",
+      constraintKind: "textInputMetadataConstraints",
+      keyboardType: "web-search",
+      autoCapitalize: "sentences",
+      descriptiveHint: "Type filter",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      evidence: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize", "jsx.TextInput.placeholder"],
+    },
+  ]);
+  assert.equal("secureTextEntry" in inline.preRead.primitiveInteractions.inputConstraints[0], false);
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
@@ -159,7 +213,10 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /RN primitive interaction facts visible: yes/);
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
   assert.match(markdown, /RN metadata anchors visible: yes/);
+  assert.match(markdown, /Measured RN narrow input constraints visible: yes/);
   assert.match(markdown, /RN direct state\/action relation visible: yes/);
+  assert.match(markdown, /rn-primitive-input-narrow-payload-only/);
+  assert.match(markdown, /textInputMetadataConstraints:maxLength=80,secureTextEntry=false,keyboardType=default,autoCapitalize=none/);
   assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);


### PR DESCRIPTION
## Summary
- add source-observed RN `TextInput` constraint facts under `domainPayload.facts.primitiveInteractions.inputConstraints`
- upgrade RN payload evidence to `react-native-payload-evidence.v4` with scoped `inputConstraintsVisible.scope === "rn-primitive-input-narrow-payload-only"`
- add positive/negative coverage for `maxLength`, source-observed `secureTextEntry`, `keyboardType`, `autoCapitalize`, and placeholder-only omission

## Boundaries
- stacked on #491 (`deep/rn-state-action-relation`)
- no broad React Native support promotion
- no runtime reuse promotion, RN edit routing, RN context surface, sourceAnchor widening, detector/gate widening, or new dependency
- no provider billing/token savings claim

## Verification
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/react-native-payload-evidence.test.mjs` → 15 pass
- `node scripts/react-native-payload-evidence.mjs --run-id=rn-input-constraints-v4-post-deslop ...` → schema v4, input constraints claimable within narrow scope, broad/support/runtime/edit claims false
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `git diff --check`
- `npm test` → 486 pass
- LSP diagnostics → 0 errors / 0 warnings
- Ralph architect verification → APPROVE
- deslop pass scoped to changed files → fallback-like scan 0 findings, removed one unused evidence-summary field, post-deslop regression green
