### PR TITLE
Prove RN constraint action readiness without widening support

### DIFF
--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -73,6 +73,7 @@ function interactionSummary(domainPayload) {
   const actionBindings = interactions.actionBindings ?? [];
   const inputConstraints = interactions.inputConstraints ?? [];
   const stateActionRelations = interactions.stateActionRelations ?? [];
+  const constraintActionReadiness = interactions.constraintActionReadiness ?? [];
   const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
   const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
   const constraintFields = presentFields(inputConstraints, RN_TEXT_INPUT_CONSTRAINT_FIELDS);
@@ -81,6 +82,7 @@ function interactionSummary(domainPayload) {
     actionBindings,
     inputConstraints,
     stateActionRelations,
+    constraintActionReadiness,
     hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
     hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
     hasInputConstraintSemantics: Boolean(
@@ -95,6 +97,18 @@ function interactionSummary(domainPayload) {
     hasDirectStateActionRelation: Boolean(
       stateActionRelations.some(
         (item) => item.relationKind === "actionReadsInputValue" && item.valueExpr && item.onPressExpr && item.relationBasis?.length > 0,
+      ),
+    ),
+    hasConstraintActionReadiness: Boolean(
+      constraintActionReadiness.some(
+        (item) =>
+          item.relationKind === "constraintActionReadiness" &&
+          item.valueExpr &&
+          item.onPressExpr &&
+          item.disabledExpr &&
+          item.constraintBasis?.length > 0 &&
+          item.readinessBasis?.length > 0 &&
+          item.relationBasis?.length > 0,
       ),
     ),
     metadataCoverage: {
@@ -212,9 +226,16 @@ export async function buildReactNativePayloadEvidence({
     (row) => !row.preRead.primitiveInteractions.hasDirectStateActionRelation && !row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
   );
   const stateActionRelationsVisible = directRelationRows.length > 0;
+  const readinessRows = rnFixtures.filter(
+    (row) => row.preRead.primitiveInteractions.hasConstraintActionReadiness && row.modelFacing.primitiveInteractions.hasConstraintActionReadiness,
+  );
+  const readinessOmittedRows = rnFixtures.filter(
+    (row) => !row.preRead.primitiveInteractions.hasConstraintActionReadiness && !row.modelFacing.primitiveInteractions.hasConstraintActionReadiness,
+  );
+  const constraintActionReadinessVisible = readinessRows.length > 0;
 
   return {
-    schemaVersion: "react-native-payload-evidence.v4",
+    schemaVersion: "react-native-payload-evidence.v5",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -276,6 +297,16 @@ export async function buildReactNativePayloadEvidence({
           ? null
           : "no measured RN fixture exposed a direct actionReadsInputValue relation in both pre-read and model-facing payloads",
       },
+      constraintActionReadinessVisible: {
+        claimable: constraintActionReadinessVisible,
+        scope: "rn-primitive-input-narrow-payload-only",
+        relationKind: "constraintActionReadiness",
+        directReadinessFixtures: readinessRows.map((row) => row.file),
+        omittedReadinessFixtures: readinessOmittedRows.map((row) => row.file),
+        blocker: constraintActionReadinessVisible
+          ? null
+          : "no measured RN fixture exposed constraintActionReadiness in both pre-read and model-facing payloads",
+      },
       broadReactNativeSupport: {
         claimable: false,
         blocker: "evidence is limited to the existing rn-primitive-input-narrow-payload measured lane",
@@ -317,7 +348,10 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       const relation = row.preRead.primitiveInteractions.stateActionRelations
         .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr}`)
         .join("; ") || "omitted";
-      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${constraints} | ${relation} | ${row.claimable ? "yes" : "no"} |`;
+      const readiness = row.preRead.primitiveInteractions.constraintActionReadiness
+        .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr},disabled=${item.disabledExpr}`)
+        .join("; ") || "omitted";
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${constraints} | ${relation} | ${readiness} | ${row.claimable ? "yes" : "no"} |`;
     })
     .join("\n");
   const boundaryRows = evidence.boundaryFixtures
@@ -349,6 +383,7 @@ ${evidence.claimBoundary}
 - RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
 - Measured RN narrow input constraints visible: ${evidence.summary.inputConstraintsVisible.claimable ? "yes" : "no"}
 - RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
+- Measured RN narrow constraint/action readiness visible: ${evidence.summary.constraintActionReadinessVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
 - RN edit routing claimable: no
@@ -356,8 +391,8 @@ ${evidence.claimBoundary}
 
 ## Measured RN narrow fixtures
 
-| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | input constraints | direct relation | claimable |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | input constraints | direct relation | constraint/action readiness | claimable |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
 
 ## Metadata anchor coverage
@@ -380,7 +415,7 @@ ${boundaryRows}
 
 ## Claim boundary
 
-The input constraint claim is scoped to \`${evidence.summary.inputConstraintsVisible.scope}\` and measured only through local fixture pre-read/model-facing visibility.
+The input constraint claim is scoped to \`${evidence.summary.inputConstraintsVisible.scope}\` and measured only through local fixture pre-read/model-facing visibility. The constraint/action readiness claim is scoped to \`${evidence.summary.constraintActionReadinessVisible.scope}\` and requires source-observed TextInput constraints, a direct actionReadsInputValue relation, and a source-observed Pressable disabled expression.
 
 This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
 `;

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -11,6 +11,7 @@ import type {
   ImportSignal,
   Language,
   ReactNativePrimitiveActionBindingSignal,
+  ReactNativePrimitiveConstraintActionReadinessSignal,
   ReactNativePrimitiveInputBindingSignal,
   ReactNativePrimitiveInputConstraintSignal,
   SourceRange,
@@ -1041,8 +1042,45 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       },
     ];
   }).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
+  const rnConstraintActionReadiness: ReactNativePrimitiveConstraintActionReadinessSignal[] = rnActionBindingList
+    .flatMap((actionBinding) => {
+      if (!actionBinding.disabled) return [];
+      const relationMatches = rnStateActionRelations.filter((relation) => relation.onPressExpr === actionBinding.onPressExpr);
+      if (relationMatches.length !== 1) return [];
+      const relation = relationMatches[0];
+      const inputConstraintMatches = rnInputConstraints.filter((constraint) => constraint.valueExpr === relation.valueExpr);
+      if (inputConstraintMatches.length !== 1) return [];
+      const inputConstraint = inputConstraintMatches[0];
+      return [
+        {
+          relationKind: "constraintActionReadiness" as const,
+          inputPrimitive: "TextInput" as const,
+          actionPrimitive: "Pressable" as const,
+          valueExpr: relation.valueExpr,
+          onPressExpr: actionBinding.onPressExpr,
+          constraintKind: "textInputMetadataConstraints" as const,
+          readinessKind: "pressableDisabledReadiness" as const,
+          disabledExpr: actionBinding.disabled,
+          constraintBasis: inputConstraint.constraintBasis,
+          readinessBasis: ["jsx.Pressable.disabled"],
+          relationBasis: relation.relationBasis,
+          loc: sourceRangeSpan([inputConstraint.loc, actionBinding.loc]),
+          evidence: [
+            "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
+            ...inputConstraint.evidence,
+            ...actionBinding.evidence,
+            ...relation.relationBasis,
+          ],
+        },
+      ];
+    })
+    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
   const hasRnPrimitiveInteractions =
-    rnInputBindingList.length > 0 || rnActionBindingList.length > 0 || rnInputConstraints.length > 0 || rnStateActionRelations.length > 0;
+    rnInputBindingList.length > 0 ||
+    rnActionBindingList.length > 0 ||
+    rnInputConstraints.length > 0 ||
+    rnStateActionRelations.length > 0 ||
+    rnConstraintActionReadiness.length > 0;
   return {
     behavior: {
       hooks: [...hooks],
@@ -1069,6 +1107,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
               ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
               ...(rnInputConstraints.length ? { inputConstraints: rnInputConstraints } : {}),
               ...(rnStateActionRelations.length ? { stateActionRelations: rnStateActionRelations } : {}),
+              ...(rnConstraintActionReadiness.length ? { constraintActionReadiness: rnConstraintActionReadiness } : {}),
             },
           }
         : {}),

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -315,13 +315,23 @@ function compactReactNativePrimitiveInteractions(
   const actionBindings = interactions.actionBindings?.slice(0, 8);
   const inputConstraints = interactions.inputConstraints?.slice(0, 8);
   const stateActionRelations = interactions.stateActionRelations?.slice(0, 8);
+  const constraintActionReadiness = interactions.constraintActionReadiness?.slice(0, 8);
 
-  if (!inputBindings?.length && !actionBindings?.length && !inputConstraints?.length && !stateActionRelations?.length) return undefined;
+  if (
+    !inputBindings?.length &&
+    !actionBindings?.length &&
+    !inputConstraints?.length &&
+    !stateActionRelations?.length &&
+    !constraintActionReadiness?.length
+  ) {
+    return undefined;
+  }
   return {
     ...(inputBindings?.length ? { inputBindings } : {}),
     ...(actionBindings?.length ? { actionBindings } : {}),
     ...(inputConstraints?.length ? { inputConstraints } : {}),
     ...(stateActionRelations?.length ? { stateActionRelations } : {}),
+    ...(constraintActionReadiness?.length ? { constraintActionReadiness } : {}),
   };
 }
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -119,11 +119,28 @@ export type ReactNativePrimitiveStateActionRelationSignal = {
   evidence: string[];
 };
 
+export type ReactNativePrimitiveConstraintActionReadinessSignal = {
+  relationKind: "constraintActionReadiness";
+  inputPrimitive: "TextInput";
+  actionPrimitive: "Pressable";
+  valueExpr: string;
+  onPressExpr: string;
+  constraintKind: "textInputMetadataConstraints";
+  readinessKind: "pressableDisabledReadiness";
+  disabledExpr: string;
+  constraintBasis: string[];
+  readinessBasis: string[];
+  relationBasis: string[];
+  loc?: SourceRange;
+  evidence: string[];
+};
+
 export type ReactNativePrimitiveInteractionSignal = {
   inputBindings?: ReactNativePrimitiveInputBindingSignal[];
   actionBindings?: ReactNativePrimitiveActionBindingSignal[];
   inputConstraints?: ReactNativePrimitiveInputConstraintSignal[];
   stateActionRelations?: ReactNativePrimitiveStateActionRelationSignal[];
+  constraintActionReadiness?: ReactNativePrimitiveConstraintActionReadinessSignal[];
 };
 
 export type A11yAnchorSignal = {

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
@@ -8,6 +8,7 @@ type InlineActionRowProps = {
 
 export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionRowProps) {
   const submitCurrentValue = () => onSubmit(value.trim());
+  const isSubmitDisabled = value.trim().length === 0;
 
   return (
     <View accessibilityLabel="inline action row">
@@ -21,7 +22,7 @@ export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionR
         accessibilityLabel="Inline filter"
         testID="inline-filter-input"
       />
-      <Pressable onPress={submitCurrentValue} accessibilityLabel="Submit filter" testID="submit-filter-button">
+      <Pressable onPress={submitCurrentValue} disabled={isSubmitDisabled} accessibilityLabel="Submit filter" testID="submit-filter-button">
         <Text>Submit</Text>
       </Pressable>
     </View>

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -129,7 +129,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 15, endLine: 23 },
+      loc: { startLine: 16, endLine: 24 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       placeholder: "Type filter",
@@ -151,7 +151,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
     {
       primitive: "TextInput",
-      loc: { startLine: 15, endLine: 23 },
+      loc: { startLine: 16, endLine: 24 },
       valueExpr: "value",
       constraintKind: "textInputMetadataConstraints",
       keyboardType: "web-search",
@@ -164,12 +164,19 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 24, endLine: 24 },
+      loc: { startLine: 25, endLine: 25 },
       onPressExpr: "submitCurrentValue",
       label: "Submit",
+      disabled: "isSubmitDisabled",
       accessibilityLabel: "Submit filter",
       testID: "submit-filter-button",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
+      evidence: [
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.testID",
+      ],
     },
   ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.stateActionRelations, [
@@ -182,7 +189,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
       onPressExpr: "submitCurrentValue",
       label: "Submit",
       relationBasis: ["handler.submitCurrentValue.reads.value"],
-      loc: { startLine: 15, endLine: 24 },
+      loc: { startLine: 16, endLine: 25 },
       evidence: [
         "rn.stateActionRelation.actionReadsInputValue",
         "jsx.TextInput.value",
@@ -194,6 +201,35 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
         "jsx.TextInput.testID",
         "jsx.Pressable.onPress",
         "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.testID",
+        "handler.submitCurrentValue.reads.value",
+      ],
+    },
+  ]);
+  assert.deepEqual(payload?.facts.primitiveInteractions?.constraintActionReadiness, [
+    {
+      relationKind: "constraintActionReadiness",
+      inputPrimitive: "TextInput",
+      actionPrimitive: "Pressable",
+      valueExpr: "value",
+      onPressExpr: "submitCurrentValue",
+      constraintKind: "textInputMetadataConstraints",
+      readinessKind: "pressableDisabledReadiness",
+      disabledExpr: "isSubmitDisabled",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      readinessBasis: ["jsx.Pressable.disabled"],
+      relationBasis: ["handler.submitCurrentValue.reads.value"],
+      loc: { startLine: 16, endLine: 25 },
+      evidence: [
+        "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
         "jsx.Pressable.accessibilityLabel",
         "jsx.Pressable.testID",
         "handler.submitCurrentValue.reads.value",
@@ -202,6 +238,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   ]);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
   assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
+  assert.equal("constraintActionReadiness" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
   assert.equal("domTags" in payload.facts, false);
   assert.equal("reactNativeContext" in payload, false);
@@ -300,6 +337,7 @@ test("React Native primitive basic fixture emits TextInput and Pressable interac
     },
   ]);
   assert.equal("stateActionRelations" in payload.facts.primitiveInteractions, false);
+  assert.equal("constraintActionReadiness" in payload.facts.primitiveInteractions, false);
   assert.equal("stateActionRelations" in payload.sourceAnchorBeta, false);
   assert.equal("inputConstraints" in payload.sourceAnchorBeta, false);
   assert.equal("formControls" in payload.facts, false);
@@ -339,6 +377,74 @@ test("React Native input constraints are source-observed and omit placeholder-on
     },
   ]);
   assert.equal("secureTextEntry" in noSecureTextEntryPayload.facts.primitiveInteractions.inputConstraints[0], false);
+});
+
+
+test("React Native constraint/action readiness requires disabled, constraints, and a direct relation per action", () => {
+  const noDisabledPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function NoDisabled({ value, onChangeText, onSubmit }) {
+      const submitCurrentValue = () => onSubmit(value);
+      return <View><TextInput value={value} onChangeText={onChangeText} keyboardType="email-address" /><Pressable onPress={submitCurrentValue}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(noDisabledPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in noDisabledPayload.facts.primitiveInteractions, true);
+  assert.equal("constraintActionReadiness" in noDisabledPayload.facts.primitiveInteractions, false);
+
+  const noRelationPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function NoRelation({ value, onChangeText, onSubmit, disabled }) {
+      return <View><TextInput value={value} onChangeText={onChangeText} keyboardType="email-address" /><Pressable onPress={onSubmit} disabled={disabled}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(noRelationPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in noRelationPayload.facts.primitiveInteractions, false);
+  assert.equal("constraintActionReadiness" in noRelationPayload.facts.primitiveInteractions, false);
+
+  const noConstraintsPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function NoConstraints({ value, onChangeText, onSubmit, disabled }) {
+      const submitCurrentValue = () => onSubmit(value);
+      return <View><TextInput value={value} onChangeText={onChangeText} /><Pressable onPress={submitCurrentValue} disabled={disabled}><Text>Submit</Text></Pressable></View>;
+    }`);
+  assert.equal(noConstraintsPayload?.domain, "react-native");
+  assert.equal("stateActionRelations" in noConstraintsPayload.facts.primitiveInteractions, true);
+  assert.equal("inputConstraints" in noConstraintsPayload.facts.primitiveInteractions, false);
+  assert.equal("constraintActionReadiness" in noConstraintsPayload.facts.primitiveInteractions, false);
+
+  const unrelatedIndependentRelationPayload = rnPayloadFromSource(`import { View, Text, TextInput, Pressable } from "react-native";
+    export function MultipleRelations({ value, query, onChangeText, onChangeQuery, onSubmit, onSearch, disabled }) {
+      const submitCurrentValue = () => onSubmit(value);
+      const searchQuery = () => onSearch(query);
+      return <View>
+        <TextInput value={value} onChangeText={onChangeText} keyboardType="email-address" />
+        <Pressable onPress={submitCurrentValue} disabled={disabled}><Text>Submit</Text></Pressable>
+        <TextInput value={query} onChangeText={onChangeQuery} />
+        <Pressable onPress={searchQuery}><Text>Search</Text></Pressable>
+      </View>;
+    }`);
+  assert.equal(unrelatedIndependentRelationPayload?.domain, "react-native");
+  assert.equal(unrelatedIndependentRelationPayload.facts.primitiveInteractions.stateActionRelations.length, 2);
+  assert.deepEqual(unrelatedIndependentRelationPayload.facts.primitiveInteractions.constraintActionReadiness, [
+    {
+      relationKind: "constraintActionReadiness",
+      inputPrimitive: "TextInput",
+      actionPrimitive: "Pressable",
+      valueExpr: "value",
+      onPressExpr: "submitCurrentValue",
+      constraintKind: "textInputMetadataConstraints",
+      readinessKind: "pressableDisabledReadiness",
+      disabledExpr: "disabled",
+      constraintBasis: ["jsx.TextInput.keyboardType"],
+      readinessBasis: ["jsx.Pressable.disabled"],
+      relationBasis: ["handler.submitCurrentValue.reads.value"],
+      loc: { startLine: 6, endLine: 7 },
+      evidence: [
+        "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
+        "jsx.TextInput.keyboardType",
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "handler.submitCurrentValue.reads.value",
+      ],
+    },
+  ]);
 });
 
 test("React Native direct state/action relation omits co-located and ambiguous narrow pairs", () => {

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -11,7 +11,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v4");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v5");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -39,6 +39,16 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   );
   assert.ok(
     evidence.summary.stateActionRelationsVisible.omittedRelationFixtures.some((file) => file.endsWith("rn-primitive-basic.tsx")),
+  );
+  assert.equal(evidence.summary.constraintActionReadinessVisible.claimable, true);
+  assert.equal(evidence.summary.constraintActionReadinessVisible.scope, "rn-primitive-input-narrow-payload-only");
+  assert.equal(evidence.summary.constraintActionReadinessVisible.relationKind, "constraintActionReadiness");
+  assert.equal(evidence.summary.constraintActionReadinessVisible.blocker, null);
+  assert.ok(
+    evidence.summary.constraintActionReadinessVisible.directReadinessFixtures.some((file) => file.endsWith("rn-primitive-inline-action.tsx")),
+  );
+  assert.ok(
+    evidence.summary.constraintActionReadinessVisible.omittedReadinessFixtures.some((file) => file.endsWith("rn-primitive-basic.tsx")),
   );
   assert.deepEqual(
     evidence.summary.metadataAnchorsVisible.textInputFields.map((row) => row.field),
@@ -134,6 +144,8 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(basic.preRead.primitiveInteractions.actionBindings[0].testID, "apply-button");
   assert.deepEqual(basic.preRead.primitiveInteractions.stateActionRelations, []);
   assert.deepEqual(basic.modelFacing.primitiveInteractions.stateActionRelations, []);
+  assert.deepEqual(basic.preRead.primitiveInteractions.constraintActionReadiness, []);
+  assert.deepEqual(basic.modelFacing.primitiveInteractions.constraintActionReadiness, []);
 
   const inline = evidence.fixtures.find((row) => row.file.endsWith("rn-primitive-inline-action.tsx"));
   assert.equal(inline.preRead.primitiveInteractions.inputBindings[0].placeholder, "Type filter");
@@ -144,7 +156,7 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.deepEqual(inline.preRead.primitiveInteractions.inputConstraints, [
     {
       primitive: "TextInput",
-      loc: { startLine: 15, endLine: 23 },
+      loc: { startLine: 16, endLine: 24 },
       valueExpr: "value",
       constraintKind: "textInputMetadataConstraints",
       keyboardType: "web-search",
@@ -157,6 +169,7 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal("secureTextEntry" in inline.preRead.primitiveInteractions.inputConstraints[0], false);
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
+  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].disabled, "isSubmitDisabled");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
   assert.deepEqual(inline.preRead.primitiveInteractions.stateActionRelations, [
@@ -169,7 +182,7 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
       onPressExpr: "submitCurrentValue",
       label: "Submit",
       relationBasis: ["handler.submitCurrentValue.reads.value"],
-      loc: { startLine: 15, endLine: 24 },
+      loc: { startLine: 16, endLine: 25 },
       evidence: [
         "rn.stateActionRelation.actionReadsInputValue",
         "jsx.TextInput.value",
@@ -181,6 +194,7 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
         "jsx.TextInput.testID",
         "jsx.Pressable.onPress",
         "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
         "jsx.Pressable.accessibilityLabel",
         "jsx.Pressable.testID",
         "handler.submitCurrentValue.reads.value",
@@ -188,6 +202,35 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     },
   ]);
   assert.deepEqual(inline.modelFacing.primitiveInteractions.stateActionRelations, inline.preRead.primitiveInteractions.stateActionRelations);
+  assert.deepEqual(inline.preRead.primitiveInteractions.constraintActionReadiness, [
+    {
+      relationKind: "constraintActionReadiness",
+      inputPrimitive: "TextInput",
+      actionPrimitive: "Pressable",
+      valueExpr: "value",
+      onPressExpr: "submitCurrentValue",
+      constraintKind: "textInputMetadataConstraints",
+      readinessKind: "pressableDisabledReadiness",
+      disabledExpr: "isSubmitDisabled",
+      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
+      readinessBasis: ["jsx.Pressable.disabled"],
+      relationBasis: ["handler.submitCurrentValue.reads.value"],
+      loc: { startLine: 16, endLine: 25 },
+      evidence: [
+        "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
+        "jsx.TextInput.keyboardType",
+        "jsx.TextInput.autoCapitalize",
+        "jsx.TextInput.placeholder",
+        "jsx.Pressable.onPress",
+        "jsx.Pressable.Text.label",
+        "jsx.Pressable.disabled",
+        "jsx.Pressable.accessibilityLabel",
+        "jsx.Pressable.testID",
+        "handler.submitCurrentValue.reads.value",
+      ],
+    },
+  ]);
+  assert.deepEqual(inline.modelFacing.primitiveInteractions.constraintActionReadiness, inline.preRead.primitiveInteractions.constraintActionReadiness);
 });
 
 test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
@@ -215,9 +258,11 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /RN metadata anchors visible: yes/);
   assert.match(markdown, /Measured RN narrow input constraints visible: yes/);
   assert.match(markdown, /RN direct state\/action relation visible: yes/);
+  assert.match(markdown, /Measured RN narrow constraint\/action readiness visible: yes/);
   assert.match(markdown, /rn-primitive-input-narrow-payload-only/);
   assert.match(markdown, /textInputMetadataConstraints:maxLength=80,secureTextEntry=false,keyboardType=default,autoCapitalize=none/);
   assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
+  assert.match(markdown, /constraintActionReadiness:submitCurrentValue->value,disabled=isSubmitDisabled/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| maxLength \| yes \| yes \| yes \|/);


### PR DESCRIPTION
## Summary
- Add narrow RN `constraintActionReadiness` payload facts for source-observed `TextInput` constraints + direct `actionReadsInputValue` + `Pressable.disabled` readiness.
- Keep the signal scoped to `rn-primitive-input-narrow-payload-only`; no broad RN support, runtime reuse promotion, sourceAnchor widening, or edit routing.
- Upgrade RN payload evidence artifact/schema to `react-native-payload-evidence.v5` and expose the measured readiness row in JSON/Markdown evidence.

## Stack
- Base: `deep/rn-input-constraints` (#504)
- Head: `deep/rn-constraint-action-readiness`

## Verification
- `npm run build`
- `node scripts/react-native-payload-evidence.mjs --run-id=rn-constraint-action-readiness-v5 --output=.omx/reports/rn-constraint-action-readiness-v5.json --markdown-output=.omx/reports/rn-constraint-action-readiness-v5.md`
- `node --test test/payload-policy-react-native.test.mjs test/react-native-payload-evidence.test.mjs`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `git diff --check`
- `npm test` → 487 pass, 0 fail
- `lsp_diagnostics_directory` → totalErrors=0, totalWarnings=0

## Non-claims
- No broad React Native support
- No RN edit routing
- No sourceAnchor promotion
- No runtime/provider/billing savings claim
- No new dependency

Closes #506
