### PR TITLE
Allow maintainer approvals from all approved reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Keep repository-wide ownership explicit. GitHub branch protection must enable
 # "Require review from Code Owners" for this to be an enforcement point.
-* @minislively
+* @minislively @bellman @Yeachan-Heo

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Validate merge policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MERGE_GATE_ALLOWED_MAINTAINERS: minislively
+          MERGE_GATE_ALLOWED_MAINTAINERS: minislively,bellman,Yeachan-Heo
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
+
+test("merge gate workflow allowlist includes the approved maintainer accounts", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  assert.match(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS: minislively,bellman,Yeachan-Heo/);
+  assert.doesNotMatch(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS: minislively\s*$/m);
+});
+
+const codeownersPath = path.join(repoRoot, ".github", "CODEOWNERS");
+
+test("code owners include the approved maintainer accounts", () => {
+  const codeowners = fs.readFileSync(codeownersPath, "utf8");
+  assert.match(codeowners, /\* @minislively @bellman @Yeachan-Heo/);
+});


### PR DESCRIPTION
## Summary
- expand the merge-gate maintainer allowlist to include `minislively`, `bellman`, and `Yeachan-Heo`
- lock the workflow contract with a regression test so the allowlist does not drift back to a single login

Closes #500

## Verification
- `git diff --check`
- `node --test test/pr-merge-gate.test.mjs test/merge-gate-workflow.test.mjs`

## Boundaries
- workflow/config only
- no runtime or package behavior changes
