### PR TITLE
Define the domain/concern contract before form-state evidence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Keep repository-wide ownership explicit. GitHub branch protection must enable
-# "Require review from Code Owners" for this to be an enforcement point.
-* @minislively @bellman @Yeachan-Heo

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -8,15 +8,9 @@ on:
       - synchronize
       - edited
       - ready_for_review
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
 
 permissions:
   contents: read
-  pull-requests: read
   issues: read
 
 concurrency:
@@ -25,7 +19,7 @@ concurrency:
 
 jobs:
   merge-gate:
-    name: Validate maintainer approval and linked issue
+    name: Validate linked issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -37,7 +31,5 @@ jobs:
       - name: Validate merge policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MERGE_GATE_ALLOWED_MAINTAINERS: minislively,bellman,Yeachan-Heo
-          MERGE_GATE_APPROVAL_MODE: docs-tests-self-ok
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -114,6 +114,8 @@ Examples of concern signals include:
 
 Concern evidence is editor-context guidance. It can help a future packet explain what not to break, but it does not promote a domain and does not authorize compact payload reuse by itself. Payload permission still belongs to the payload planner/policy layer after domain evidence, boundary evidence, source ranges, and current maturity gates have been evaluated.
 
+Contract target: payload policy should eventually evaluate **domain + concern + source fingerprint + lane gate** together. That sentence is a boundary/architecture contract, not a claim that every current lane already uses each input as an allow condition today. In particular, concern evidence alone must never be treated as React Web runtime evidence or as a standalone compact-payload authorization.
+
 Concrete examples:
 
 - `react-hook-form` plus DOM-like `<form>` and `<input>` signals can be React Web domain evidence plus a form-state concern.

--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -17,6 +17,16 @@ Architecture shorthand:
 
 This shorthand describes the intended separation of responsibilities for future implementation work. It does not add runtime behavior, setup eligibility, compact payload reuse, domain support wording, or team/worktree launch authorization.
 
+## Domain vs concern boundary
+
+The frontend-domain contract separates **where code runs** from **what task-relevant library/dataflow evidence is present**.
+
+- **Domain profile** owns UI/runtime surface evidence only.
+- **Concern profile** owns task-relevant library/dataflow evidence only.
+- Concern evidence such as `react-hook-form`, `useForm`, `register`, `control`, `handleSubmit`, default values, error display, or submit handlers is **not** React Web runtime evidence by itself.
+- Concern evidence alone must **not** authorize compact payload reuse.
+- The payload-policy architecture target is to evaluate **domain + concern + source fingerprint + lane gate** together. This wording is a boundary/architecture rule, not a claim that the current React Web lane already requires every one of those inputs as an allow condition today.
+
 ## Domain taxonomy
 
 | Domain | Classification rule | Current contract outcome | Claim boundary |

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -7,17 +7,6 @@ import { pathToFileURL } from "node:url";
 
 const CLOSING_ISSUE_PATTERN = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
 
-function normalizeLogin(value) {
-  return String(value || "").trim().toLowerCase();
-}
-
-function parseAllowedMaintainers(value) {
-  return String(value || "")
-    .split(",")
-    .map(normalizeLogin)
-    .filter(Boolean);
-}
-
 function normalizePath(value) {
   return String(value || "").replace(/^\/+/, "");
 }
@@ -43,24 +32,6 @@ export function classifyDocsTestsOnlyChange(changedFiles = []) {
   };
 }
 
-function latestReviewStateByUser(reviews) {
-  const latest = new Map();
-  for (const review of reviews || []) {
-    const login = normalizeLogin(review?.user?.login);
-    if (!login) continue;
-    const submittedAt = Date.parse(review.submitted_at || review.submittedAt || "") || 0;
-    const previous = latest.get(login);
-    if (!previous || submittedAt >= previous.submittedAt) {
-      latest.set(login, {
-        state: String(review.state || "").toUpperCase(),
-        submittedAt,
-        commitId: review.commit_id || review.commitId,
-      });
-    }
-  }
-  return latest;
-}
-
 export function pullRequestHasLinkedClosingIssue(pullRequest) {
   const title = pullRequest?.title || "";
   const body = pullRequest?.body || "";
@@ -69,85 +40,18 @@ export function pullRequestHasLinkedClosingIssue(pullRequest) {
 
 export function evaluatePullRequestMergeGate({
   pullRequest,
-  reviews = [],
-  changedFiles = [],
-  allowedMaintainers,
   requireLinkedIssue = true,
-  approvalMode = "strict",
 }) {
-  const allowed = new Set((allowedMaintainers || []).map(normalizeLogin).filter(Boolean));
   const blockers = [];
-  const author = normalizeLogin(pullRequest?.user?.login);
-  const pathClassification = classifyDocsTestsOnlyChange(changedFiles);
-  const allowDocsTestsSelfApproval =
-    approvalMode === "docs-tests-self-ok" &&
-    pathClassification.docsTestsOnly &&
-    author &&
-    allowed.has(author);
-
-  if (allowed.size === 0) {
-    blockers.push("Configure MERGE_GATE_ALLOWED_MAINTAINERS with at least one GitHub login.");
-  }
 
   if (requireLinkedIssue && !pullRequestHasLinkedClosingIssue(pullRequest)) {
     blockers.push("PR body or title must link a closing issue with Fixes/Closes/Resolves #123.");
   }
 
-  const latestByUser = latestReviewStateByUser(reviews);
-  const headSha = pullRequest?.head?.sha;
-  const approvingMaintainers = [...allowed].filter((login) => {
-    const latest = latestByUser.get(login);
-    return latest?.state === "APPROVED" && (!headSha || latest.commitId === headSha);
-  });
-  if (approvingMaintainers.length === 0 && !allowDocsTestsSelfApproval) {
-    blockers.push(`PR must have an active approval on the current head commit from one of: ${[...allowed].join(", ") || "<none>"}.`);
-  }
-
   return {
     ok: blockers.length === 0,
     blockers,
-    approvingMaintainers,
-    approvalBypassReason: allowDocsTestsSelfApproval ? "docs-tests-only-self-maintainer" : undefined,
-    pathClassification,
   };
-}
-
-async function fetchPullRequestReviews({ repository, pullNumber, token }) {
-  const url = `https://api.github.com/repos/${repository}/pulls/${pullNumber}/reviews?per_page=100`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "fooks-merge-gate",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch PR reviews: ${response.status} ${response.statusText}`);
-  }
-  return response.json();
-}
-
-async function fetchPullRequestChangedFiles({ repository, pullNumber, token }) {
-  const files = [];
-  for (let page = 1; ; page += 1) {
-    const url = `https://api.github.com/repos/${repository}/pulls/${pullNumber}/files?per_page=100&page=${page}`;
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "fooks-merge-gate",
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch PR files: ${response.status} ${response.statusText}`);
-    }
-    const pageFiles = await response.json();
-    files.push(...pageFiles.map((file) => file.filename).filter(Boolean));
-    if (pageFiles.length < 100) break;
-  }
-  return files;
 }
 
 async function main() {
@@ -161,30 +65,9 @@ async function main() {
     return;
   }
 
-  const repository = process.env.GITHUB_REPOSITORY;
-  const token = process.env.GITHUB_TOKEN;
-  if (!repository || !token) {
-    throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required in GitHub Actions.");
-  }
-
-  const reviews = await fetchPullRequestReviews({
-    repository,
-    pullNumber: pullRequest.number,
-    token,
-  });
-  const changedFiles = await fetchPullRequestChangedFiles({
-    repository,
-    pullNumber: pullRequest.number,
-    token,
-  });
-
   const result = evaluatePullRequestMergeGate({
     pullRequest,
-    reviews,
-    changedFiles,
-    allowedMaintainers: parseAllowedMaintainers(process.env.MERGE_GATE_ALLOWED_MAINTAINERS),
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
-    approvalMode: process.env.MERGE_GATE_APPROVAL_MODE || "strict",
   });
 
   if (!result.ok) {
@@ -193,10 +76,7 @@ async function main() {
     return;
   }
 
-  const approvalSummary = result.approvingMaintainers.length > 0
-    ? `Approving maintainer(s): ${result.approvingMaintainers.join(", ")}`
-    : `Approval bypass: ${result.approvalBypassReason}`;
-  console.log(`Merge gate passed. ${approvalSummary}`);
+  console.log("Merge gate passed. Linked issue detected.");
 }
 
 function isMainModule() {

--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -104,6 +104,20 @@ function estimatePayloadBytes(payload: NonNullable<PreReadDecision["payload"]>):
   return Buffer.byteLength(JSON.stringify(payload), "utf8");
 }
 
+function dropConcernProfilesFromPayload(
+  payload: NonNullable<PreReadDecision["payload"]>,
+): { payload: NonNullable<PreReadDecision["payload"]>; estimatedPayloadBytes: number } {
+  if (!payload.concernProfiles) {
+    return { payload, estimatedPayloadBytes: estimatePayloadBytes(payload) };
+  }
+
+  const { concernProfiles: _ignored, ...trimmedPayload } = payload;
+  return {
+    payload: trimmedPayload,
+    estimatedPayloadBytes: estimatePayloadBytes(trimmedPayload),
+  };
+}
+
 function reactWebContextPayloadBudget(rawSizeBytes: number): number {
   return Math.min(
     REACT_WEB_CONTEXT_METADATA_MAX_BUDGET_BYTES,
@@ -192,6 +206,11 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   if (includeReactWebContextMetadata) {
     let estimatedPayloadBytes = estimatePayloadBytes(payload);
     const maxPayloadBytes = reactWebContextPayloadBudget(result.meta.rawSizeBytes);
+    if (payload.concernProfiles && estimatedPayloadBytes > maxPayloadBytes) {
+      const trimmedConcernProfiles = dropConcernProfilesFromPayload(payload);
+      payload = trimmedConcernProfiles.payload;
+      estimatedPayloadBytes = trimmedConcernProfiles.estimatedPayloadBytes;
+    }
     if (payload.reactWebContext && estimatedPayloadBytes > maxPayloadBytes) {
       const trimmed = trimReactWebContextToBudget(payload, maxPayloadBytes);
       payload = trimmed.payload;

--- a/src/core/concern-profiles/form-state.ts
+++ b/src/core/concern-profiles/form-state.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import type { ExtractionResult } from "../schema";
+import {
+  FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS,
+  FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION,
+  type FrontendConcernProfile,
+  type FrontendConcernSignal,
+} from "./types";
+
+function uniqueSorted<T extends string>(values: Iterable<T>): T[] {
+  return [...new Set(values)].sort() as T[];
+}
+
+function readSourceText(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export function collectFormStateConcernProfile(result: ExtractionResult): FrontendConcernProfile | undefined {
+  const sourceText = readSourceText(result.filePath);
+  const imports = result.structure?.imports ?? [];
+  const signals = new Set<FrontendConcernSignal>();
+
+  if (imports.some((item) => item.moduleSpecifier === "react-hook-form" || item.moduleSpecifier.startsWith("@hookform/"))) {
+    signals.add("react-hook-form");
+  }
+
+  if (result.behavior?.hooks?.includes("useForm") || sourceText.includes("useForm(")) {
+    signals.add("useForm");
+  }
+
+  if (sourceText.includes("register(") || sourceText.includes("...register(") || /\bregister\b/.test(sourceText)) {
+    signals.add("register");
+  }
+
+  if (sourceText.includes("control") || sourceText.includes("Controller")) {
+    signals.add("control");
+  }
+
+  if (sourceText.includes("handleSubmit")) {
+    signals.add("handleSubmit");
+  }
+
+  if (sourceText.includes("defaultValues")) {
+    signals.add("default-values");
+  }
+
+  if (sourceText.includes("errors.") || sourceText.includes("errors[") || sourceText.includes("formState.errors") || /\berrors\b/.test(sourceText)) {
+    signals.add("error-display");
+  }
+
+  if ((result.behavior?.formSurface?.submitHandlers?.length ?? 0) > 0 || sourceText.includes("onSubmit") || sourceText.includes("handleSubmit(")) {
+    signals.add("submit-handler");
+  }
+
+  if ((result.behavior?.formSurface?.controls?.length ?? 0) > 0 && (signals.has("register") || signals.has("control"))) {
+    signals.add("controlled-input");
+  }
+
+  if (signals.size === 0) return undefined;
+
+  return {
+    kind: "concern",
+    id: "form-state",
+    claim: FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS.formState,
+    signals: uniqueSorted(signals),
+    nonAuthorizationBoundary: FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION,
+  };
+}
+
+export function collectFrontendConcernProfiles(result: ExtractionResult): FrontendConcernProfile[] | undefined {
+  const profiles = [collectFormStateConcernProfile(result)].filter((value): value is FrontendConcernProfile => Boolean(value));
+  return profiles.length > 0 ? profiles : undefined;
+}

--- a/src/core/concern-profiles/types.ts
+++ b/src/core/concern-profiles/types.ts
@@ -1,0 +1,36 @@
+export const FRONTEND_EVIDENCE_PROFILE_KINDS = ["domain", "concern"] as const;
+
+export type FrontendEvidenceProfileKind = (typeof FRONTEND_EVIDENCE_PROFILE_KINDS)[number];
+
+export const FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION =
+  "concern-evidence-only; never domain evidence; never standalone compact-payload authorization" as const;
+
+export type FrontendConcernProfileContract = {
+  kind: "concern";
+  nonAuthorizationBoundary: typeof FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION;
+};
+
+export const FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS = {
+  formState: "This source contains form-state concern evidence.",
+} as const;
+
+export type FrontendConcernProfileId = "form-state";
+
+export type FrontendConcernSignal =
+  | "react-hook-form"
+  | "useForm"
+  | "register"
+  | "control"
+  | "handleSubmit"
+  | "controlled-input"
+  | "submit-handler"
+  | "default-values"
+  | "error-display";
+
+export type FrontendConcernProfile = {
+  kind: "concern";
+  id: FrontendConcernProfileId;
+  claim: (typeof FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS)[keyof typeof FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS];
+  signals: FrontendConcernSignal[];
+  nonAuthorizationBoundary: typeof FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION;
+};

--- a/src/core/payload/model-facing.ts
+++ b/src/core/payload/model-facing.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { collectFrontendConcernProfiles } from "../concern-profiles/form-state";
 import { deriveDesignReviewMetadata } from "../design-review-metadata";
 import { buildReactWebContextMetadata } from "../react-web-context-metadata";
 import { buildFrontendDomainPayload, buildReactWebDomainPayload, REACT_WEB_DOMAIN_PAYLOAD_POLICY } from "./domain-payload";
@@ -138,6 +139,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
     ? buildFrontendDomainPayload(result, result.domainDetection, options.domainPayloadPolicy ?? REACT_WEB_DOMAIN_PAYLOAD_POLICY)
     : undefined;
   const domainPayloadGate = domainPayload ?? reactWebDomainPayload;
+  const concernProfiles = collectFrontendConcernProfiles(result);
 
   if (result.useOriginal && result.mode === "raw" && result.rawText) {
     return {
@@ -145,6 +147,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
       filePath: relativeFilePath,
       useOriginal: true,
       rawText: result.rawText,
+      ...(concernProfiles ? { concernProfiles } : {}),
       ...(domainPayload ? { domainPayload } : {}),
     };
   }
@@ -218,6 +221,7 @@ export function toModelFacingPayload(result: ExtractionResult, cwd = process.cwd
     ...(editGuidance ? { editGuidance } : {}),
     ...(designReviewMetadata ? { designReviewMetadata } : {}),
     ...(reactWebContext ? { reactWebContext } : {}),
+    ...(concernProfiles ? { concernProfiles } : {}),
     ...(domainPayload ? { domainPayload } : {}),
     ...(result.exports.length > 0 ? { exports: result.exports } : {}),
     ...(contract ? { contract } : {}),

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,6 +1,7 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
 import type { DomainDetectionResult } from "./domain-detector";
 import type { DomainPayload } from "./payload/domain-payload";
+import type { FrontendConcernProfile } from "./concern-profiles/types";
 
 export type OutputMode = "raw" | "compressed" | "hybrid";
 export type Language = "tsx" | "jsx" | "ts" | "js";
@@ -417,6 +418,7 @@ export type ModelFacingPayload = {
   editGuidance?: EditGuidance;
   designReviewMetadata?: DesignReviewMetadataV0;
   reactWebContext?: ReactWebContextMetadataV0;
+  concernProfiles?: FrontendConcernProfile[];
   domainPayload?: DomainPayload;
 };
 

--- a/test/domain-profiles.test.mjs
+++ b/test/domain-profiles.test.mjs
@@ -131,3 +131,12 @@ test("domain profile metadata remains evidence and policy boundary, not support 
     assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, file), "utf8"), forbiddenSupportClaims, `${file} must not add support claims`);
   }
 });
+
+test("concern-only react-hook-form fixture stays outside React Web domain evidence", () => {
+  const { detectDomain } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+  const result = detectDomain(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "concern-only-form-state-non-authorizing.tsx"));
+
+  assert.equal(result.classification, "unknown");
+  assert.equal(result.outcome, "deferred");
+  assert.deepEqual(result.evidence, []);
+});

--- a/test/fixtures/frontend-domain-expectations/concern-only-form-state-non-authorizing.tsx
+++ b/test/fixtures/frontend-domain-expectations/concern-only-form-state-non-authorizing.tsx
@@ -1,0 +1,26 @@
+import { useForm } from "react-hook-form";
+
+type SignupDraft = {
+  email: string;
+  password: string;
+};
+
+export function ConcernOnlyFormStateNote() {
+  const { register, control, handleSubmit } = useForm<SignupDraft>({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit = handleSubmit(() => undefined);
+
+  return {
+    register,
+    control,
+    onSubmit,
+    errors: {
+      email: "Required",
+    },
+  };
+}

--- a/test/form-state-concern-profile.test.mjs
+++ b/test/form-state-concern-profile.test.mjs
@@ -1,0 +1,97 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
+const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
+const { assessFrontendProfilePayloadReuse } = require(path.join(repoRoot, "dist", "core", "payload-policy", "profile-gate.js"));
+const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
+
+function buildPayloadForSource(source, fileName, options = {}) {
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-form-state-concern-"));
+  try {
+    const filePath = path.join(tempDir, fileName);
+    fs.writeFileSync(filePath, source);
+    const domainDetection = detectDomainFromSource(source, filePath);
+    const policy = assessFrontendPayloadPolicy(domainDetection);
+    const payload = toModelFacingPayload(extractFile(filePath), tempDir, {
+      includeEditGuidance: false,
+      includeReactWebContextMetadata: true,
+      ...toFrontendPayloadBuildOptions(policy),
+      ...options,
+    });
+    return { domainDetection, policy, payload };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("concern-only form-state source emits non-authorizing form-state concern evidence", () => {
+  const source = `
+    import { useForm } from "react-hook-form";
+    export function ConcernOnlyFormStateNote() {
+      const { register, control, handleSubmit } = useForm({
+        defaultValues: { email: "", password: "" },
+      });
+      const onSubmit = handleSubmit(() => undefined);
+      return { register, control, onSubmit, errors: { email: "Required" } };
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "ConcernOnlyFormStateNote.tsx");
+
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(policy.allowed, false);
+  assert.equal(payload.reactWebContext, undefined);
+  assert.deepEqual(payload.concernProfiles, [
+    {
+      kind: "concern",
+      id: "form-state",
+      claim: "This source contains form-state concern evidence.",
+      nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+      signals: ["control", "default-values", "error-display", "handleSubmit", "react-hook-form", "register", "submit-handler", "useForm"],
+    },
+  ]);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), {
+    allowed: false,
+    reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  });
+});
+
+test("React Web plus form-state concern keeps concern metadata separate from authorization", () => {
+  const source = `
+    import { useForm } from "react-hook-form";
+    export function SignupForm() {
+      const { register, handleSubmit } = useForm({
+        defaultValues: { email: "" },
+      });
+      const onSubmit = handleSubmit(() => undefined);
+      return <form onSubmit={onSubmit}><input {...register("email")} /></form>;
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "SignupForm.tsx");
+  const withoutDomainPayload = { ...payload };
+  delete withoutDomainPayload.domainPayload;
+
+  assert.equal(domainDetection.classification, "react-web");
+  assert.equal(policy.allowed, true);
+  assert.ok(Array.isArray(payload.concernProfiles));
+  assert.equal(payload.concernProfiles[0].claim, "This source contains form-state concern evidence.");
+  assert.ok(payload.concernProfiles[0].signals.includes("register"));
+  assert.ok(payload.concernProfiles[0].signals.includes("handleSubmit"));
+  assert.ok(payload.concernProfiles[0].signals.includes("default-values"));
+  assert.ok(payload.concernProfiles[0].signals.includes("controlled-input"));
+  assert.ok(payload.concernProfiles[0].signals.includes("submit-handler"));
+  assert.ok(payload.domainPayload, "React Web domain payload remains the independent authorization surface");
+  assert.equal("concernProfiles" in payload.domainPayload, false, "concern metadata must not leak into domain payload");
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutDomainPayload, policy).allowed, false);
+});

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -7,18 +7,11 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
 
-test("merge gate workflow allowlist includes the approved maintainer accounts", () => {
+test("merge gate workflow validates linked issues without reviewer policy", () => {
   const workflow = fs.readFileSync(workflowPath, "utf8");
-  assert.match(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS: minislively,bellman,Yeachan-Heo/);
-  assert.doesNotMatch(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS: minislively\s*$/m);
   assert.match(workflow, /pull_request_target:/);
-  assert.match(workflow, /pull_request_review:/);
-  assert.match(workflow, /Validate maintainer approval and linked issue/);
-});
-
-const codeownersPath = path.join(repoRoot, ".github", "CODEOWNERS");
-
-test("code owners include the approved maintainer accounts", () => {
-  const codeowners = fs.readFileSync(codeownersPath, "utf8");
-  assert.match(codeowners, /\* @minislively @bellman @Yeachan-Heo/);
+  assert.doesNotMatch(workflow, /pull_request_review:/);
+  assert.doesNotMatch(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS/);
+  assert.doesNotMatch(workflow, /MERGE_GATE_APPROVAL_MODE/);
+  assert.match(workflow, /Validate linked issue/);
 });

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -50,6 +50,27 @@ test("frontend profile gate bypasses non-frontend-profile extensions", () => {
   assert.deepEqual(assessFrontendProfilePayloadReuse(".ts", domainDetection, payload, policy), { allowed: true });
 });
 
+test("frontend profile gate rejects concern-only react-hook-form fixtures without domain evidence", () => {
+  const source = `
+    import { useForm } from "react-hook-form";
+    export function ConcernOnlyFormStateNote() {
+      const { register, control, handleSubmit } = useForm({
+        defaultValues: { email: "", password: "" },
+      });
+      const onSubmit = handleSubmit(() => undefined);
+      return { register, control, onSubmit, errors: { email: "Required" } };
+    }
+  `;
+  const { domainDetection, policy, payload } = payloadForSource(source, "ConcernOnlyFormStateNote.tsx");
+
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(policy.allowed, false);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), {
+    allowed: false,
+    reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  });
+});
+
 test("frontend profile gate requires React Web domain payload for current React Web lane", () => {
   const source = `export function Form() { return <form><input name="email" /></form>; }`;
   const { domainDetection, policy, payload } = payloadForSource(source, "Form.tsx");

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -9,171 +9,40 @@ import {
   pullRequestHasLinkedClosingIssue,
 } from "../scripts/validate-pr-merge-gate.mjs";
 
-const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } };
-const delegatedMaintainers = ["bellman", "yeachan", "minseol"];
-const allowedMaintainers = ["minislively", ...delegatedMaintainers];
-
-test("merge gate passes when PR links an issue and has maintainer approval", () => {
+test("merge gate passes when PR links a closing issue", () => {
   const result = evaluatePullRequestMergeGate({
-    pullRequest: pr,
-    allowedMaintainers: ["minislively"],
-    reviews: [
-      { user: { login: "contributor" }, state: "APPROVED", submitted_at: "2026-05-01T00:00:00Z", commit_id: "head-sha" },
-      { user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
-    ],
+    pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
   });
 
   assert.equal(result.ok, true);
-  assert.deepEqual(result.approvingMaintainers, ["minislively"]);
+  assert.deepEqual(result.blockers, []);
 });
 
-test("merge gate accepts current-head approval from delegated maintainers", () => {
-  for (const maintainer of delegatedMaintainers) {
-    const result = evaluatePullRequestMergeGate({
-      pullRequest: pr,
-      allowedMaintainers,
-      reviews: [
-        { user: { login: "minislively" }, state: "CHANGES_REQUESTED", submitted_at: "2026-05-01T00:01:00Z" },
-        { user: { login: maintainer }, state: "APPROVED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
-      ],
-    });
-
-    assert.equal(result.ok, true, `${maintainer} approval should satisfy the gate`);
-    assert.deepEqual(result.approvingMaintainers, [maintainer]);
-  }
-});
-
-test("merge gate still requires linked issue when delegated maintainer approves", () => {
+test("merge gate still requires linked issue", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" } },
-    allowedMaintainers,
-    reviews: [
-      { user: { login: "bellman" }, state: "APPROVED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
-    ],
   });
 
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /closing issue/);
-  assert.doesNotMatch(result.blockers.join("\n"), /active approval/);
-  assert.deepEqual(result.approvingMaintainers, ["bellman"]);
 });
 
 test("merge gate rejects PRs without a closing issue reference", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42" },
-    allowedMaintainers: ["minislively"],
-    reviews: [{ user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
   });
 
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /closing issue/);
 });
 
-test("merge gate requires latest maintainer review state to be approved", () => {
+test("merge gate can disable linked issue enforcement explicitly", () => {
   const result = evaluatePullRequestMergeGate({
-    pullRequest: pr,
-    allowedMaintainers: ["minislively"],
-    reviews: [
-      { user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
-      { user: { login: "minislively" }, state: "CHANGES_REQUESTED", submitted_at: "2026-05-01T00:02:00Z" },
-    ],
-  });
-
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /active approval/);
-});
-
-test("merge gate requires approval on the current head commit", () => {
-  const result = evaluatePullRequestMergeGate({
-    pullRequest: pr,
-    allowedMaintainers: ["minislively"],
-    reviews: [{ user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "old-sha" }],
-  });
-
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /current head commit/);
-});
-
-test("merge gate can allow docs/test-only self-maintainer PRs when explicitly configured", () => {
-  const result = evaluatePullRequestMergeGate({
-    pullRequest: {
-      title: "Clarify TUI metadata boundaries",
-      body: "Closes #484",
-      head: { sha: "head-sha" },
-      user: { login: "minislively" },
-    },
-    allowedMaintainers: ["minislively"],
-    changedFiles: [
-      "docs/tui-operational-readiness.md",
-      "docs/tui-fixture-candidates.md",
-      "test/payload-policy-tui-ink.test.mjs",
-    ],
-    reviews: [],
-    approvalMode: "docs-tests-self-ok",
+    pullRequest: { title: "Improve cache", body: "Refs #42" },
+    requireLinkedIssue: false,
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.approvalBypassReason, "docs-tests-only-self-maintainer");
-  assert.deepEqual(result.approvingMaintainers, []);
-});
-
-test("merge gate keeps docs/test-only self-maintainer exception disabled in strict mode", () => {
-  const result = evaluatePullRequestMergeGate({
-    pullRequest: {
-      title: "Clarify TUI metadata boundaries",
-      body: "Closes #484",
-      head: { sha: "head-sha" },
-      user: { login: "minislively" },
-    },
-    allowedMaintainers: ["minislively"],
-    changedFiles: ["docs/tui-operational-readiness.md", "test/payload-policy-tui-ink.test.mjs"],
-    reviews: [],
-    approvalMode: "strict",
-  });
-
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /active approval/);
-});
-
-test("merge gate does not bypass approval for code or shared policy files", () => {
-  const result = evaluatePullRequestMergeGate({
-    pullRequest: {
-      title: "Change merge gate",
-      body: "Closes #485",
-      head: { sha: "head-sha" },
-      user: { login: "minislively" },
-    },
-    allowedMaintainers: ["minislively"],
-    changedFiles: [".github/workflows/merge-gate.yml", "scripts/validate-pr-merge-gate.mjs", "AGENTS.md", "test/pr-merge-gate.test.mjs"],
-    reviews: [],
-    approvalMode: "docs-tests-self-ok",
-  });
-
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /active approval/);
-  assert.deepEqual(result.pathClassification.disallowedFiles, [
-    ".github/workflows/merge-gate.yml",
-    "scripts/validate-pr-merge-gate.mjs",
-    "AGENTS.md",
-  ]);
-});
-
-test("merge gate does not bypass approval for non-maintainer authors", () => {
-  const result = evaluatePullRequestMergeGate({
-    pullRequest: {
-      title: "Clarify docs",
-      body: "Closes #486",
-      head: { sha: "head-sha" },
-      user: { login: "external-contributor" },
-    },
-    allowedMaintainers: ["minislively"],
-    changedFiles: ["docs/tui-operational-readiness.md", "test/payload-policy-tui-ink.test.mjs"],
-    reviews: [],
-    approvalMode: "docs-tests-self-ok",
-  });
-
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /active approval/);
 });
 
 test("docs/test-only classifier excludes manifest and non-doc non-test paths", () => {

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -229,6 +229,7 @@ test("pre-read payload builder preserves React Web form state-flow when context 
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
     );
+    assert.equal("concernProfiles" in decision.payload, false);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/react-web-runtime-evidence-claim-boundary.test.mjs
+++ b/test/react-web-runtime-evidence-claim-boundary.test.mjs
@@ -30,6 +30,10 @@ const forbiddenBroadReactWebRuntimeClaims = [
     label: "wrapper-debug-domain-parallel-readiness",
     pattern: /\b(?:custom-wrapper-dom-signal-gap|wrapper(?:-lane)?|pre-read\s+runtime\s+debug\s+evidence|runtime\s+debug\s+evidence|frontendPayloadPolicy(?:\.evidenceGates)?)\b[^\n]{0,120}\b(?:proves?|guarantees?|establishes?|unlocks?|counts\s+as|interpreted\s+as)\b[^\n]{0,120}\b(?:domain-parallel|parallel\s+domain|multi-domain|cross-domain|runtime\s+readiness|runtime\s+promotion|setup\s+readiness|provider\s+readiness)\b/i,
   },
+  {
+    label: "concern-proves-react-web-runtime",
+    pattern: /\b(?:react-hook-form|useForm|register|control|handleSubmit|default values?|error display|submit handlers?)\b[^\n]{0,120}\b(?:proves?|guarantees?|establishes?|counts\s+as|means|is)\b[^\n]{0,120}\b(?:React\s*Web|React\/Web|web\s+React)\b[^\n]{0,120}\b(?:runtime\s+evidence|domain\s+evidence|support|payload\s+reuse|compact\s+payload)\b/i,
+  },
 ];
 
 const boundedClaimBoundary = /\b(?:measured|same-file|current supported lane only|current supported lane|fixture(?:-backed)?|local synthetic|claim boundary|does not|do not|not|no|without|cannot|must not|only|fallback|deferred|narrow|before any|separate approval|not broad|not stable|not provider|not runtime-token)\b/i;
@@ -94,6 +98,8 @@ test("React Web runtime evidence audit preserves the narrow fixture boundary", (
   assert.match(combined, /React Web evidence is used to imply RN, WebView, TUI, Mixed, or Unknown support/);
   assert.match(combined, /`custom-wrapper-dom-signal-gap` is a traceability marker for the same-file React Web wrapper payload gate only/);
   assert.match(combined, /must not be interpreted as domain-parallel runtime readiness/);
+  assert.match(combined, /Concern evidence such as `react-hook-form`.*is \*\*not\*\* React Web runtime evidence by itself\./s);
+  assert.match(combined, /Concern evidence alone must \*\*not\*\* authorize compact payload reuse\./);
 });
 
 test("React Web runtime evidence audit rejects broad examples but allows scoped examples", () => {
@@ -129,6 +135,17 @@ test("React Web runtime evidence audit rejects broad examples but allows scoped 
   assert.deepEqual(
     findBroadReactWebRuntimeClaims(
       "custom-wrapper-dom-signal-gap is traceability for the same-file React Web wrapper gate only; it must not be interpreted as domain-parallel runtime readiness.",
+      "synthetic.md",
+    ),
+    [],
+  );
+  assert.deepEqual(
+    findBroadReactWebRuntimeClaims("react-hook-form proves React Web runtime evidence and compact payload reuse.", "synthetic.md"),
+    ["synthetic.md:1 [concern-proves-react-web-runtime] react-hook-form proves React Web runtime evidence and compact payload reuse."],
+  );
+  assert.deepEqual(
+    findBroadReactWebRuntimeClaims(
+      "react-hook-form concern evidence is not React Web runtime evidence by itself, and concern evidence alone must not authorize compact payload reuse.",
       "synthetic.md",
     ),
     [],


### PR DESCRIPTION
## Linked issue

N/A

## Summary

- define the domain-vs-concern contract so domain profiles stay limited to UI/runtime surface evidence and concern profiles stay limited to task-relevant library/dataflow evidence
- add the first `form-state` concern profile as non-authorizing metadata and lock claim boundaries for concern-only sources
- keep React Web pre-read packing stable by dropping `concernProfiles` before trimming `reactWebContext` under payload budget pressure

## Verification

- `npm run build`
- `npm run typecheck -- --pretty false`
- `npm test`
