### PR TITLE
Harden runtime project boundaries and session state

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -396,6 +396,29 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     return runtimeDecision;
   }
 
+  const resolvedTargetPath = path.join(cwd, target);
+  if (!fs.existsSync(resolvedTargetPath)) {
+    const runtimeDecision: CodexRuntimeHookDecision = {
+      runtime: "codex",
+      hookEventName,
+      action: "noop",
+      filePath: target,
+      reasons: ["eligible-file-target-missing"],
+      contextMode: "no-op",
+      contextModeReason: "eligible-file-target-missing",
+      contextBudget: { ...policy.contextBudget, selectedFiles: 0, totalBytes: 0, skippedFiles: policy.contextBudget.selectedFiles },
+      promptSpecificity: policy.promptSpecificity,
+      contextPolicyVersion: policy.contextPolicyVersion,
+      debug: {
+        repeatedFile: false,
+        eligible: false,
+        escapeHatchUsed,
+      },
+    };
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision);
+    return runtimeDecision;
+  }
+
   if (escapeHatchUsed) {
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const originalEstimatedBytes = targetEstimatedBytes(cwd, target);

--- a/src/adapters/pre-read.ts
+++ b/src/adapters/pre-read.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { detectDomainFromSource } from "../core/domain-detector";
+import { isPathInside, isSafeProjectFilePath } from "../core/paths";
 import type { ModelFacingPayloadOptions } from "../core/payload/model-facing";
 import {
   MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
@@ -69,6 +70,15 @@ export function decidePreRead(
       filePath: outputPath,
       eligible: false,
       reasons: ["ineligible-extension"],
+    });
+  }
+
+  if (isPathInside(path.resolve(cwd), resolvedPath) && !isSafeProjectFilePath(resolvedPath, cwd)) {
+    return buildPreReadFallbackDecision({
+      runtime,
+      filePath: outputPath,
+      eligible: false,
+      reasons: ["outside-project-boundary"],
     });
   }
 

--- a/src/core/context-policy.ts
+++ b/src/core/context-policy.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { FileTarget } from "./discover";
+import { isSafeProjectFilePath } from "./paths";
 
 const REACT_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const CODEX_TS_JS_BETA_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
@@ -61,10 +62,12 @@ function normalizeCandidate(token: string, cwd: string, capability: ContextCapab
 
   const relativeToCwd = path.relative(cwd, resolved) || path.basename(resolved);
   if (path.isAbsolute(cleaned) && !fs.existsSync(resolved)) return null;
+  const exists = fs.existsSync(resolved);
+  if (exists && !isSafeProjectFilePath(resolved, cwd)) return null;
 
   return {
     filePath: relativeToCwd,
-    exists: fs.existsSync(resolved),
+    exists,
     source: "explicit-path",
   };
 }

--- a/src/core/discover.ts
+++ b/src/core/discover.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { discoverRelevantFilesByPolicy } from "./context-policy";
+import { isSafeProjectFilePath } from "./paths";
 
 const IGNORE = new Set([".git", "node_modules", "dist", ".omx", ".fooks"]);
 const COMPONENT_EXTS = new Set([".tsx", ".jsx"]);
@@ -24,16 +25,17 @@ export type DiscoveryResult = {
   stats: DiscoveryStats;
 };
 
-function walk(dir: string, out: string[], stats: DiscoveryStats): void {
+function walk(dir: string, out: string[], stats: DiscoveryStats, root: string): void {
   stats.directoriesVisited += 1;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (IGNORE.has(entry.name)) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      walk(full, out, stats);
+      walk(full, out, stats, root);
       continue;
     }
     stats.filesVisited += 1;
+    if (!isSafeProjectFilePath(full, root)) continue;
     out.push(full);
   }
 }
@@ -132,7 +134,7 @@ export function discoverProjectFilesWithStats(cwd = process.cwd()): DiscoveryRes
     importProbeCount: 0,
     importResolveCacheHits: 0,
   };
-  walk(cwd, allFiles, stats);
+  walk(cwd, allFiles, stats, cwd);
   const existingFiles = new Set(allFiles);
   const resolutionCache = new Map<string, string | null>();
   const componentFiles = allFiles.filter((file) => COMPONENT_EXTS.has(path.extname(file)));

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import fs from "node:fs";
+import { hashText } from "./hash";
 
 export const FOOKS_DIR = ".fooks";
+const DATA_KEY_MAX_LENGTH = 120;
+const DATA_KEY_HASH_LENGTH = 12;
 
 export function projectRoot(cwd = process.cwd()): string {
   return cwd;
@@ -17,7 +20,29 @@ export function ensureProjectDataDirs(cwd = process.cwd()): void {
 }
 
 export function sanitizeDataKey(key: string): string {
-  return key.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase() || "default-session";
+  const sanitized = key.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase() || "default-session";
+  if (sanitized.length <= DATA_KEY_MAX_LENGTH) {
+    return sanitized;
+  }
+  const hash = hashText(key).slice(0, DATA_KEY_HASH_LENGTH);
+  const prefixLength = DATA_KEY_MAX_LENGTH - DATA_KEY_HASH_LENGTH - 1;
+  const prefix = sanitized.slice(0, prefixLength).replace(/[-._]+$/u, "") || "session";
+  return `${prefix}-${hash}`;
+}
+
+export function isPathInside(parentPath: string, childPath: string): boolean {
+  const relative = path.relative(parentPath, childPath);
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+export function isSafeProjectFilePath(filePath: string, cwd = process.cwd()): boolean {
+  try {
+    const realProjectRoot = fs.realpathSync(cwd);
+    const realFilePath = fs.realpathSync(filePath);
+    return isPathInside(realProjectRoot, realFilePath);
+  } catch {
+    return false;
+  }
 }
 
 export function configPath(cwd = process.cwd()): string {

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { discoverProjectFilesWithStats } from "./discover";
 import { hashText } from "./hash";
+import { isSafeProjectFilePath } from "./paths";
 import { readCachedExtraction, readScanIndex, writeCachedExtraction, writeScanIndex } from "./cache";
 import type { IndexEntry, ScanObservability, ScanResult } from "./schema";
 import fs from "node:fs";
@@ -49,6 +50,9 @@ export function scanProject(cwd = process.cwd()): ScanResult {
   for (const target of targets) {
     const startedTargetAt = performance.now();
     const relativePath = path.relative(cwd, target.filePath);
+    if (!isSafeProjectFilePath(target.filePath, cwd)) {
+      continue;
+    }
     const statStartedAt = performance.now();
     const stat = fs.statSync(target.filePath);
     statMs += performance.now() - statStartedAt;

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -38,6 +38,8 @@ const {
 const {
   codexRuntimeSessionPath,
 } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-session.js"));
+const { claudeRuntimeSessionPath } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-session.js"));
+const { scanProject } = require(path.join(repoRoot, "dist", "core", "scan.js"));
 const {
   handleCodexRuntimeHook,
   isEditIntentPrompt,
@@ -1815,6 +1817,96 @@ test("runtime hook falls back when repeated-file payload build throws", () => {
     assert.equal(summary.totals.actualEstimatedBytes, targetBytes);
     assert.equal(summary.totals.savedEstimatedBytes, 0);
   });
+});
+
+test("scan and runtime policy ignore supported symlinks resolving outside the project root", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-symlink-project-"));
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-symlink-outside-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  const outsideTarget = path.join(outsideDir, "Leak.tsx");
+  fs.writeFileSync(
+    outsideTarget,
+    [
+      'import React from "react";',
+      "export function Leak() {",
+      '  return <div>OUT_OF_PROJECT_SECRET_CONTEXT</div>;',
+      "}",
+      "",
+    ].join("\n"),
+  );
+  fs.symlinkSync(outsideTarget, path.join(tempDir, "src", "Leak.tsx"));
+
+  const scan = scanProject(tempDir);
+  assert.equal(scan.files.some((entry) => entry.filePath === path.join("src", "Leak.tsx")), false);
+  assert.doesNotMatch(JSON.stringify(scan), /OUT_OF_PROJECT_SECRET_CONTEXT/);
+
+  const sessionId = `hook-symlink-boundary-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Please inspect src/Leak.tsx",
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "noop");
+  assert.deepEqual(first.reasons, ["no-eligible-file-in-prompt"]);
+  assert.equal(first.debug.eligible, false);
+
+  const directPreRead = preReadModule.decidePreRead(path.join(tempDir, "src", "Leak.tsx"), tempDir);
+  assert.equal(directPreRead.decision, "fallback");
+  assert.equal(directPreRead.eligible, false);
+  assert.deepEqual(directPreRead.reasons, ["outside-project-boundary"]);
+});
+
+test("runtime session filenames are bounded for long provider session ids", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `long-session-${"s".repeat(300)}`;
+
+  const codexStart = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(codexStart.action, "noop");
+  assert.ok(fs.existsSync(codexStart.statePath));
+  assert.ok(path.basename(codexRuntimeSessionPath(tempDir, sessionId)).length < 140);
+
+  const claudeStart = handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  assert.equal(claudeStart.action, "inject");
+  assert.ok(fs.existsSync(claudeStart.statePath));
+  assert.ok(path.basename(claudeRuntimeSessionPath(tempDir, sessionId)).length < 140);
+});
+
+test("codex runtime hook no-ops missing exact-file targets without recording repeated state", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-missing-target-${Date.now()}`;
+  const target = path.join("src", "components", "NewPanel.tsx");
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please implement ${target}`,
+    },
+    tempDir,
+  );
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, implement ${target}`,
+    },
+    tempDir,
+  );
+
+  for (const decision of [first, second]) {
+    assert.equal(decision.action, "noop");
+    assert.equal(decision.filePath, target);
+    assert.deepEqual(decision.reasons, ["eligible-file-target-missing"]);
+    assert.equal(decision.contextMode, "no-op");
+    assert.equal(decision.contextModeReason, "eligible-file-target-missing");
+    assert.equal(decision.debug.repeatedFile, false);
+    assert.equal(decision.debug.eligible, false);
+  }
 });
 
 test("runtime hook reuses payload only on repeated same-file prompts in one session", () => {


### PR DESCRIPTION
## Linked issue

Fixes #510

## Summary

- reject project-local symlinked files whose realpath resolves outside the project root before discovery, scan, prompt-target selection, or runtime pre-read can treat them as project context
- bound sanitized session-state filename components with a stable hash suffix so unusually long provider session IDs do not crash hook startup
- keep Codex missing exact-file prompts on the explicit no-op path instead of recording repeated state and later falling back as payload-build failure

## Rationale

Recent merged PRs in this repository tend to be accepted when they keep a narrow scope, state the source/claim boundary explicitly, and lock behavior with focused regression tests. This PR follows that pattern: it is runtime boundary/state hardening only, with no frontend-domain support expansion and no release or provider-token claims.

The changes align with the current project direction because fooks context should stay local to the project, runtime hooks should fail closed with controlled decisions, and new or missing exact-file targets should not be treated as existing repeated-read candidates.

## Verification

- `git diff --check`
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test --test-name-pattern='symlinks|long provider session ids|missing exact-file targets' test/fooks.test.mjs`
- `node --test test/pre-read-payload-builder.test.mjs`
- `node --test test/*.test.mjs` (514 pass)

## Boundaries

- runtime boundary and state-path resilience only
- no payload schema expansion
- no React Web, React Native, WebView, or TUI support promotion
- no provider billing, token, latency, performance, or release-claim changes
- no live provider hook invocation beyond the existing local runtime hook harness
