### PR TITLE
Make benchmark live transport blockers explicit

### DIFF
--- a/benchmarks/layer2-frontend-task/run-provider-cost-repeated.js
+++ b/benchmarks/layer2-frontend-task/run-provider-cost-repeated.js
@@ -372,6 +372,32 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function commandAvailability(command, args = ['--version']) {
+  const env = { ...process.env };
+  delete env.FAKE_CODEX_LOG;
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env,
+  });
+  if (result.error) {
+    return {
+      ok: false,
+      command,
+      reason: result.error.code === 'ENOENT'
+        ? `${command} command not found on PATH`
+        : `${command} command preflight failed: ${result.error.message}`,
+      errorCode: result.error.code || null,
+    };
+  }
+  return {
+    ok: true,
+    command,
+    exitCode: result.status,
+    signal: result.signal,
+  };
+}
+
 function openAiChatCompletion({ auth, model, prompt, maxOutputTokens }) {
   const payload = JSON.stringify({
     model,
@@ -558,6 +584,20 @@ async function collectLivePairs({ args, runId, pricing, outputDir, taskManifest 
   const transport = args.transport || args['live-transport'] || (auth.credentialKind === 'codex-oauth' ? 'codex-exec' : 'direct-api');
   const codexWorkDirRoot = resolveCodexWorkDirRoot({ args, outputDir });
   const requireNoToolUse = args['require-no-tool-use'] === 'true' || args['require-no-tool-use'] === true;
+  if (transport === 'codex-exec') {
+    const preflight = commandAvailability('codex');
+    if (!preflight.ok) {
+      return {
+        blockerKind: 'command-unavailable',
+        blocker: `Codex live transport requires the codex command; no provider request was made (${preflight.reason})`,
+        auth,
+        commandPreflight: preflight,
+        pairs: [],
+        requestAttempted: false,
+        ledger: createLiveLedger({ pairs: [], attemptedPairs: [], plannedPairCount }),
+      };
+    }
+  }
   let currentBatchEstimatedUsd = 0;
   let currentCampaignEstimatedUsd = 0;
 
@@ -770,11 +810,15 @@ async function main() {
   let liveAuth = null;
   let liveRequestMade = false;
   let liveRequestAttempted = false;
+  let liveBlockerKind = null;
+  let liveCommandPreflight = null;
   if (args['live-openai']) {
     const liveResult = await collectLivePairs({ args, runId, pricing, outputDir, taskManifest });
     pairs = pairs.concat(liveResult.pairs || []);
     capState = liveResult.capState || null;
     liveBlocker = liveResult.blocker || null;
+    liveBlockerKind = liveResult.blockerKind || null;
+    liveCommandPreflight = liveResult.commandPreflight || null;
     liveLedger = liveResult.ledger || null;
     liveAuth = liveResult.auth || null;
     liveRequestAttempted = Boolean(liveResult.requestAttempted);
@@ -815,12 +859,19 @@ async function main() {
   });
   if (liveBlocker) {
     const authMissing = !liveAuth || liveAuth.ok === false;
+    const commandUnavailable = liveBlockerKind === 'command-unavailable';
     summary = {
       ...summary,
-      status: authMissing ? 'live-openai-credentials-missing' : 'live-openai-request-failed',
+      status: authMissing
+        ? 'live-openai-credentials-missing'
+        : commandUnavailable
+          ? 'live-openai-command-unavailable'
+          : 'live-openai-request-failed',
       statusReasons: [liveBlocker, ...summary.statusReasons],
       diagnostics: [
-        authMissing
+        commandUnavailable
+          ? 'Install the codex CLI or select --transport=direct-api with API-key credentials; no live provider request was made.'
+        : authMissing
           ? 'Set OPENAI_API_KEY or use Codex OAuth via ~/.codex/auth.json; no live provider request was made.'
           : 'A live provider request was attempted but failed; inspect attempted-pair ledger before rerunning.',
         ...summary.diagnostics,
@@ -831,6 +882,15 @@ async function main() {
     summary = {
       ...summary,
       liveAuth: publicAuthSummary(liveAuth),
+    };
+  }
+  if (liveCommandPreflight) {
+    summary = {
+      ...summary,
+      environmentPreflight: {
+        ...(summary.environmentPreflight || {}),
+        command: liveCommandPreflight,
+      },
     };
   }
 
@@ -850,6 +910,7 @@ async function main() {
     claimBoundary: summary.claimBoundary,
     requestMade: liveRequestMade,
     auth: liveAuth ? publicAuthSummary(liveAuth) : null,
+    environmentPreflight: liveCommandPreflight ? { command: liveCommandPreflight } : null,
   }, null, 2));
 }
 

--- a/test/provider-cost-evidence.test.mjs
+++ b/test/provider-cost-evidence.test.mjs
@@ -1480,6 +1480,58 @@ test("provider cost repeated CLI live mode without credentials writes controlled
   }
 });
 
+test("provider cost repeated CLI live codex transport blocks before requests when codex command is unavailable", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-provider-repeated-nocodex-"));
+  try {
+    const taskManifestPath = path.join(tempRoot, "live-campaign-tasks.json");
+    const authJsonPath = path.join(tempRoot, "auth.json");
+    fs.writeFileSync(authJsonPath, JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "oauth-token", account_id: "account-1" },
+    }));
+    fs.writeFileSync(taskManifestPath, JSON.stringify({
+      tasks: [{
+        id: "component",
+        targetPairCount: 1,
+        baselinePrompt: "Summarize the baseline payload.",
+        fooksPrompt: "Summarize the fooks payload.",
+        qualityGate: {
+          id: "provider-cost-imported-artifact-gate",
+          version: "v1",
+          command: "npm run bench:layer2:provider-cost:repeated -- --import-manifest=benchmarks/layer2-frontend-task/fixtures/provider-cost-import-kit/import-manifest.json --run-id=provider-cost-import-kit-smoke",
+        },
+      }],
+    }));
+    const stdout = execFileSync(process.execPath, [
+      path.join(repoRoot, "benchmarks", "layer2-frontend-task", "run-provider-cost-repeated.js"),
+      "--live-openai",
+      "--auth-mode=codex-oauth",
+      "--transport=codex-exec",
+      `--codex-auth-json=${authJsonPath}`,
+      `--task-manifest=${taskManifestPath}`,
+      "--run-id=no-codex-command",
+    ], { cwd: tempRoot, encoding: "utf8", env: { ...process.env, PATH: "", OPENAI_API_KEY: "" } });
+    const result = JSON.parse(stdout);
+    const summaryPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "no-codex-command", "summary.json");
+    const ledgerPath = path.join(tempRoot, ".fooks", "evidence", "provider-cost", "no-codex-command", "campaign-ledger.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    const ledger = JSON.parse(fs.readFileSync(ledgerPath, "utf8"));
+
+    assert.equal(result.status, "live-openai-command-unavailable");
+    assert.equal(result.requestMade, false);
+    assert.equal(result.auth.ok, true);
+    assert.equal(result.environmentPreflight.command.ok, false);
+    assert.match(result.environmentPreflight.command.reason, /codex command not found/);
+    assert.equal(summary.status, "live-openai-command-unavailable");
+    assert.match(summary.statusReasons.join("\n"), /Codex live transport requires the codex command/);
+    assert.equal(summary.environmentPreflight.command.ok, false);
+    assert.equal(ledger.plannedPairCount, 1);
+    assert.equal(ledger.attemptedPairCount, 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("provider cost task manifests use concrete imported-artifact gates instead of manual review commands", () => {
   const manifestPaths = [
     path.join(repoRoot, "benchmarks", "layer2-frontend-task", "provider-cost-live-campaign-tasks.json"),


### PR DESCRIPTION
## Linked issue

Fixes #511

## Summary

- add a Codex command preflight before live benchmark execution uses the `codex-exec` transport
- report a dedicated `live-openai-command-unavailable` blocker with `environmentPreflight.command` evidence when the command is unavailable
- keep request accounting fail-closed: missing command means no provider request was made and the ledger records zero attempted pairs

## Rationale

Recent merged benchmark and release-evidence PRs make mechanics failures explicit instead of letting them masquerade as product regressions or launch-grade evidence. This PR follows that pattern by separating a local shell prerequisite from live provider request failures.

The change keeps dry-run/import-only paths deterministic and credential-free, while making the live Codex transport auditable when an operator machine cannot run the required command.

## Verification

- `git diff --check`
- `node --check benchmarks/layer2-frontend-task/run-provider-cost-repeated.js`
- `node --test --test-name-pattern='live codex transport blocks|live mode without credentials|dry-run live mode' test/provider-cost-evidence.test.mjs`
- `node --test test/provider-cost-evidence.test.mjs`

## Boundaries

- benchmark harness mechanics only
- no public runtime behavior changes
- no provider billing, token, latency, or performance claims
- no live provider request is made by the new unavailable-command path
- no change to dry-run/import-only evidence claimability
