### PR TITLE
Tie release smoke evidence to provenance

### DIFF
--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildReactWebContextEvidence } from "./react-web-context-evidence.mjs";
 import { buildReactWebReuseEvidence } from "./react-web-reuse-evidence.mjs";
+import { buildReleaseProvenance } from "./release-provenance.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +28,7 @@ export async function buildReleaseBenchmarkEvidence({
 } = {}) {
   const contextEvidence = await buildReactWebContextEvidence({ repoRoot, runId: `${runId}-context` });
   const reuseEvidence = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
+  const releaseProvenance = buildReleaseProvenance({ repoRoot });
 
   const releaseClaims = {
     npmUpdateClaimable: contextEvidence.summary.actualInjectedContextReduction.claimable && reuseEvidence.summary.reuseCorrectnessClaimable,
@@ -115,6 +117,7 @@ export async function buildReleaseBenchmarkEvidence({
         blocker: "no provider usage, tokenizer, billing dashboard, invoice, or charged-cost data is measured by this release-facing artifact",
       },
     },
+    releaseProvenance,
   };
 }
 
@@ -128,6 +131,15 @@ export function buildReleaseBenchmarkSmokeSummary(evidence) {
       cachePerformanceImprovement: evidence.nonClaims.cachePerformanceImprovement.claimable,
       runtimeTokenSavings: evidence.nonClaims.runtimeTokenSavings.claimable,
       providerBillingSavings: evidence.nonClaims.providerBillingSavings.claimable,
+    },
+    releaseProvenance: {
+      status: evidence.releaseProvenance.status,
+      claimable: evidence.releaseProvenance.claimable,
+      blockers: evidence.releaseProvenance.blockers,
+      package: evidence.releaseProvenance.package,
+      git: evidence.releaseProvenance.git,
+      github: evidence.releaseProvenance.github,
+      claimBoundary: evidence.releaseProvenance.claimBoundary,
     },
     claimBoundary: evidence.claimBoundary,
   };
@@ -194,6 +206,16 @@ ${fixtureRows}
 - Actual injected runtime context always smaller than source without fixture evidence: no
 - Diagnostic domainPayload reduction proves runtime-token savings: no
 - Broad React Web/RN/WebView support: no
+
+## Release provenance
+
+- Status: ${evidence.releaseProvenance.status}
+- Package: ${evidence.releaseProvenance.package.name}@${evidence.releaseProvenance.package.version}
+- Expected tag: ${evidence.releaseProvenance.package.expectedVersionTag}
+- Commit: ${evidence.releaseProvenance.git.commitSha || "unavailable"}
+- Tags at HEAD: ${evidence.releaseProvenance.git.tagsAtHead.length > 0 ? evidence.releaseProvenance.git.tagsAtHead.join(", ") : "none"}
+- GitHub release URL: ${evidence.releaseProvenance.github.releaseUrl || "unavailable"}
+- Claimable: ${evidence.releaseProvenance.claimable ? "yes" : "no"}
 `;
 }
 

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -1,0 +1,109 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const defaultRepoRoot = path.resolve(path.dirname(__filename), "..");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function defaultGit(repoRoot, args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function optionalGit(repoRoot, args, runGit = defaultGit) {
+  try {
+    return { ok: true, value: runGit(repoRoot, args) };
+  } catch (error) {
+    return { ok: false, value: "", error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function normalizeLines(value) {
+  return String(value || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function githubReleaseUrl(repository, tagName) {
+  return repository && tagName ? `https://github.com/${repository}/releases/tag/${encodeURIComponent(tagName)}` : null;
+}
+
+export function buildReleaseProvenance({ repoRoot = defaultRepoRoot, env = process.env, runGit = defaultGit } = {}) {
+  const pkg = readJson(path.join(repoRoot, "package.json"));
+  const commit = optionalGit(repoRoot, ["rev-parse", "HEAD"], runGit);
+  const exactTags = optionalGit(repoRoot, ["tag", "--points-at", "HEAD"], runGit);
+  const expectedVersionTag = `v${pkg.version}`;
+  const tagsAtHead = normalizeLines(exactTags.value);
+  const versionTagPresent = tagsAtHead.includes(expectedVersionTag);
+  const repository = env.GITHUB_REPOSITORY || null;
+  const blockers = [];
+
+  if (!commit.ok || !commit.value) blockers.push("git commit SHA unavailable");
+  if (!exactTags.ok) blockers.push("git tags at HEAD unavailable");
+  if (!versionTagPresent) blockers.push(`${expectedVersionTag} does not point at HEAD`);
+
+  const releaseUrl = githubReleaseUrl(repository, expectedVersionTag);
+  const status = blockers.length === 0 ? "release-provenance-ready" : "release-provenance-blocked";
+
+  return {
+    schemaVersion: "release-provenance.v1",
+    generatedAt: new Date().toISOString(),
+    status,
+    claimable: blockers.length === 0,
+    blockers,
+    package: {
+      name: pkg.name,
+      version: pkg.version,
+      expectedVersionTag,
+    },
+    git: {
+      commitSha: commit.value || null,
+      tagsAtHead,
+      versionTagPresent,
+    },
+    github: {
+      repository,
+      releaseUrl,
+      releaseStatus: releaseUrl ? "release-url-derived-from-version-tag" : "repository-unavailable",
+    },
+    claimBoundary:
+      "Release provenance only: ties local smoke evidence to package version, git commit, and exact version tag; it does not publish, tag, mutate releases, or claim provider billing, runtime-token, latency, or broad performance results.",
+  };
+}
+
+export function assertReleaseProvenanceGate(provenance) {
+  if (provenance?.claimable === true) return;
+  throw new Error(`release provenance gate failed: ${(provenance?.blockers || ["unknown blocker"]).join("; ")}`);
+}
+
+export function renderReleaseProvenanceMarkdown(provenance) {
+  return `# Release provenance\n\n${provenance.claimBoundary}\n\n- status: ${provenance.status}\n- package: ${provenance.package.name}@${provenance.package.version}\n- expected tag: ${provenance.package.expectedVersionTag}\n- commit: ${provenance.git.commitSha || "unavailable"}\n- tags at HEAD: ${provenance.git.tagsAtHead.length > 0 ? provenance.git.tagsAtHead.join(", ") : "none"}\n- GitHub release URL: ${provenance.github.releaseUrl || "unavailable"}\n- claimable: ${provenance.claimable ? "yes" : "no"}\n\n## Blockers\n\n${provenance.blockers.length > 0 ? provenance.blockers.map((blocker) => `- ${blocker}`).join("\n") : "- none"}\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const provenance = buildReleaseProvenance({ repoRoot: defaultRepoRoot });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(provenance, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReleaseProvenanceMarkdown(provenance));
+  }
+
+  process.stdout.write(`${JSON.stringify(provenance, null, 2)}\n`);
+}

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -48,6 +48,9 @@ test("release benchmark evidence gates npm wording on actual injected context an
   assert.equal(evidence.nonClaims.cachePerformanceImprovement.claimable, false);
   assert.equal(evidence.nonClaims.runtimeTokenSavings.claimable, false);
   assert.equal(evidence.nonClaims.providerBillingSavings.claimable, false);
+  assert.equal(evidence.releaseProvenance.schemaVersion, "release-provenance.v1");
+  assert.equal(evidence.releaseProvenance.package.expectedVersionTag, `v${evidence.releaseProvenance.package.version}`);
+  assert.match(evidence.releaseProvenance.claimBoundary, /Release provenance only/);
   assert.ok(evidence.releaseClaims.forbidden.includes("Caching performance improved."));
   assert.ok(evidence.releaseClaims.forbidden.includes("Provider cost or billing is reduced."));
   assert.ok(evidence.releaseClaims.forbidden.includes("Diagnostic domainPayload reduction proves runtime-token savings."));
@@ -72,6 +75,8 @@ test("release benchmark smoke summary exposes only release-safe compact evidence
   assert.match(summary.claimBoundary, /not provider tokenizer output/);
   assert.match(summary.claimBoundary, /not runtime-token savings/);
   assert.match(summary.claimBoundary, /not provider cost, billing, invoice, or charged-cost evidence/);
+  assert.equal(summary.releaseProvenance.package.expectedVersionTag, `v${summary.releaseProvenance.package.version}`);
+  assert.match(summary.releaseProvenance.claimBoundary, /Release provenance only/);
 });
 
 test("release benchmark smoke gate fails closed when npm update wording is not claimable", () => {
@@ -107,6 +112,8 @@ test("release benchmark evidence Markdown gives safe public wording and explicit
   assert.match(markdown, /Cache performance improvement: no/);
   assert.match(markdown, /Runtime-token savings: no/);
   assert.match(markdown, /Provider billing\/cost savings: no/);
+  assert.match(markdown, /Release provenance/);
+  assert.match(markdown, /Expected tag:/);
   assert.match(markdown, /Actual injected runtime context always smaller than source without fixture evidence: no/);
   assert.match(markdown, /Diagnostic domainPayload reduction proves runtime-token savings: no/);
   assert.doesNotMatch(markdown, /Cache performance improvement: yes/i);

--- a/test/release-provenance.test.mjs
+++ b/test/release-provenance.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertReleaseProvenanceGate,
+  buildReleaseProvenance,
+  renderReleaseProvenanceMarkdown,
+} from "../scripts/release-provenance.mjs";
+
+function makePackageRoot(version = "1.2.3") {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-release-provenance-"));
+  fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "fooks-test", version }, null, 2));
+  return tempRoot;
+}
+
+function fakeGit(outputs) {
+  return (_repoRoot, args) => {
+    const key = args.join(" ");
+    if (outputs[key] instanceof Error) throw outputs[key];
+    return outputs[key] ?? "";
+  };
+}
+
+test("release provenance is claimable only when the package version tag points at HEAD", () => {
+  const repoRoot = makePackageRoot("1.2.3");
+  try {
+    const provenance = buildReleaseProvenance({
+      repoRoot,
+      env: { GITHUB_REPOSITORY: "minislively/fooks" },
+      runGit: fakeGit({
+        "rev-parse HEAD": "abc123",
+        "tag --points-at HEAD": "v1.2.3\nlatest",
+      }),
+    });
+
+    assert.equal(provenance.status, "release-provenance-ready");
+    assert.equal(provenance.claimable, true);
+    assert.deepEqual(provenance.blockers, []);
+    assert.equal(provenance.package.expectedVersionTag, "v1.2.3");
+    assert.equal(provenance.git.commitSha, "abc123");
+    assert.equal(provenance.git.versionTagPresent, true);
+    assert.equal(provenance.github.releaseUrl, "https://github.com/minislively/fooks/releases/tag/v1.2.3");
+    assert.doesNotThrow(() => assertReleaseProvenanceGate(provenance));
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("release provenance fails closed when the version tag is missing from HEAD", () => {
+  const repoRoot = makePackageRoot("1.2.3");
+  try {
+    const provenance = buildReleaseProvenance({
+      repoRoot,
+      env: { GITHUB_REPOSITORY: "minislively/fooks" },
+      runGit: fakeGit({
+        "rev-parse HEAD": "abc123",
+        "tag --points-at HEAD": "v1.2.2",
+      }),
+    });
+    const markdown = renderReleaseProvenanceMarkdown(provenance);
+
+    assert.equal(provenance.status, "release-provenance-blocked");
+    assert.equal(provenance.claimable, false);
+    assert.ok(provenance.blockers.includes("v1.2.3 does not point at HEAD"));
+    assert.throws(() => assertReleaseProvenanceGate(provenance), /v1\.2\.3 does not point at HEAD/);
+    assert.match(markdown, /claimable: no/);
+    assert.match(markdown, /v1\.2\.3 does not point at HEAD/);
+    assert.doesNotMatch(markdown, /Provider billing.*yes/i);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Linked issue

Fixes #512

## Summary

- add a read-only release provenance artifact that records package identity, current commit SHA, tags pointing at HEAD, expected `v<package.version>` tag, and derived GitHub release URL when repository context is available
- include release provenance in release benchmark evidence and smoke summaries so release wording can be tied back to the exact local source state
- fail closed when the package version tag does not point at HEAD, without creating tags, releases, or other remote mutations

## Rationale

Recent release-facing PRs in this repository make claimability depend on concrete evidence and explicit non-claims. This PR applies the same pattern to release provenance: local smoke evidence should identify the commit and version tag it belongs to before it is used as release-safe wording support.

The implementation is intentionally read-only. It reports blockers for missing or stale tag state instead of trying to publish, tag, or repair release surfaces automatically.

## Verification

- `git diff --check`
- `npm run build`
- `node --test test/release-provenance.test.mjs test/release-benchmark-evidence.test.mjs test/react-web-release-smoke.test.mjs`

## Boundaries

- release evidence provenance only
- no npm publish, git tag creation, GitHub release creation, or registry mutation
- no provider billing, runtime-token, latency, or performance claims
- no broad React Web, React Native, WebView, or TUI support claim changes
- no live GitHub release API requirement; the artifact derives local provenance and release URL/status from available local/env state
