### PR TITLE
Lock React Native claim boundaries before widening payload scope

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -122,6 +122,12 @@ Concrete examples:
 
 This is future-facing architecture language, not a declaration that concern-profile extraction exists today. Concern profiles should become another evidence input to policy; they should not bypass the domain resolver, fallback rules, or proof/claim boundary.
 
+## RN claim boundary at the architecture layer
+
+At this architecture layer, safe RN wording is still source-only and policy-scoped. It is acceptable to describe observed RN primitive/input evidence, same-file handler/callback evidence, the measured `F1`/`F13` narrow gate, and the exact `rn-primitive-input-narrow-payload` policy name.
+
+It is not acceptable here to claim that the mobile UI works, a gesture works, a native component behaves correctly, a screen is accessible, the app was run on a device or simulator, cross-file navigation/state behavior is understood, or RN primitives are equivalent to DOM controls or React Web form semantics.
+
 ## Domain scanner
 
 A domain scanner observes facts for one profile family. It should avoid deciding whether a compact payload is allowed.

--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -44,6 +44,27 @@ WebView files are boundary files before they are extraction candidates. `react-n
 
 React Native and TUI/Ink fixtures may be useful evidence for syntax traversal, fixture shape, and future domain-signal design. They are **not support claims**. RN primitive/input `F1` may use the measured `rn-primitive-input-narrow-payload` gate, but RN primitives must not be reinterpreted as DOM controls, React Web form semantics, or broad React Native support. TUI/Ink fixtures must not be generalized into arbitrary terminal UI support, terminal behavior correctness, or runtime-token savings.
 
+## RN PR A claim boundary
+
+For the current RN PR A docs/tests lane, safe wording is limited to source-only evidence and measured policy names. The current allowed claim shapes are:
+
+- This source contains React Native primitive/input evidence.
+- This source contains source-only RN interaction hints inside the measured `F1`/`F13` narrow gate.
+- This source has same-file local handler/callback evidence observed in the same source file.
+- This fixture, payload, or policy record is limited to `rn-primitive-input-narrow-payload` measured evidence with no RN support promotion.
+
+The current forbidden claim shapes are:
+
+- Do not claim that the mobile UI works.
+- Do not claim that the gesture works.
+- Do not claim that the native component behaves correctly.
+- Do not claim that the screen is accessible.
+- Do not claim that the app was run on a device or simulator.
+- Do not claim that cross-file navigation, route, or global-state behavior is understood.
+- Do not claim that RN primitives are equivalent to DOM controls or React Web form semantics.
+
+These boundaries apply to docs, tests, fixture explanations, and payload-policy wording until a later approved PR widens the measured scope.
+
 ## Runtime debug evidence boundary
 
 `custom-wrapper-dom-signal-gap` is a traceability marker for the same-file React Web wrapper payload gate only. When it appears in pre-read or runtime-hook debug output such as `debug.frontendPayloadPolicy.evidenceGates`, it explains why a custom-component TSX fixture stayed inside the current React Web lane; it must not be interpreted as domain-parallel runtime readiness, setup/provider readiness, runtime promotion, or support for RN, WebView, TUI, Mixed, or Unknown lanes.

--- a/docs/frontend-domain-fixture-expectations.md
+++ b/docs/frontend-domain-fixture-expectations.md
@@ -48,6 +48,8 @@ Pre-read behavior must stay conservative for TUI/Ink: `F5` can remain extractabl
 
 The RN fixture lane is a readiness gate, not a support promise. `F1` is the first narrow runtime candidate, and `F13` is the named F1-adjacent same-file handler/callback acceptance check; both are limited to primitive/input payload reuse through `rn-primitive-input-narrow-payload`; that payload may include an RN-shaped `domainPayload` with primitive and input/press evidence, but it is not broad React Native support. Other selected RN fixtures stay fallback/evidence-only until a later detector/profile promotion plan explicitly changes runtime behavior. The current fallback reason, `unsupported-react-native-webview-boundary`, is still the shared source-reading boundary reason for detector evidence and WebView/mixed boundaries; it must not be treated as a permanent domain model for every RN semantic.
 
+For PR A claim-boundary wording, the allowed RN statements stop at source-observed evidence: primitive/input markers, measured narrow-payload policy names, and same-file local handler/callback evidence. The forbidden RN statements include runtime/mobile success, gesture success, accessibility correctness, device/simulator execution, cross-file navigation or state understanding, and DOM/form-equivalence claims.
+
 | Semantics group | Selected slots | Evidence examples | Required boundary |
 | --- | --- | --- | --- |
 | Primitives/input | `F1`, `F13` | `View`, `Text`, `TextInput`, `Pressable`, `onChangeText`, `onPress`, same-file local handler/callback evidence | Only this measured primitive/input fixture family may pass the narrow RN payload policy; it must not be reinterpreted as DOM controls, forms, broad RN support, or React Web extraction evidence. |

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -61,6 +61,28 @@ const conservativeBoundary = /\b(?:not|no|nor|never|without|cannot|can't|does no
 
 const measuredNarrowEvidence = /\b(?:measured\s+`?F1`?|F1`?\s+RN primitive\/input|rn-primitive-input-narrow-payload|narrow\s+(?:RN\s+)?(?:pre-read\s+)?payload|measured\s+(?:primitive\/input|same-file)\s+scope)\b/i;
 
+const forbiddenReactNativeBehaviorClaims = [
+  {
+    label: "rn-runtime-success",
+    pattern: /\b(?:mobile UI|native component|gesture|press|tap|FlatList|list virtualization)\b[^\n]{0,120}\b(?:works|behaves correctly|is correct|succeeds|successful|verified|validated|proven)\b/i,
+  },
+  {
+    label: "rn-accessibility-correctness",
+    pattern: /\b(?:screen|screen reader|accessibility|a11y|React Native|RN)\b[^\n]{0,120}\b(?:accessible|accessibility-correct|a11y-correct|screen reader verified|verified accessible)\b/i,
+  },
+  {
+    label: "rn-device-simulator-execution",
+    pattern: /\b(?:app|screen|component|UI)\b[^\n]{0,120}\b(?:ran|run|running|executed|tested|verified)\b[^\n]{0,40}\b(?:on|in)\b[^\n]{0,20}\b(?:device|simulator)\b/i,
+  },
+  {
+    label: "rn-cross-file-behavior",
+    pattern: /\b(?:cross-file|navigation|route(?:\.params)?|global state|state flow)\b[^\n]{0,120}\b(?:understood|known|verified|works?|succeeds?|correct(?:ly|ness)?)\b/i,
+  },
+  {
+    label: "rn-dom-form-equivalence",
+    pattern: /\b(?:TextInput|Pressable|TouchableOpacity|React Native|RN)\b[^\n]{0,120}\b(?:same as|equivalent to|maps to|behaves like|treated as)\b[^\n]{0,60}\b(?:DOM|web form|form control|<input>|<button>)\b/i,
+  },
+];
 
 const forbiddenSchemaEditGuidanceClaims = [
   {
@@ -152,6 +174,21 @@ function findBroadSupportClaims(text, relativePath) {
   return findings;
 }
 
+function findReactNativeBehaviorClaims(text, relativePath) {
+  const findings = [];
+  const lines = text.split(/\r?\n/);
+  for (const [index, line] of lines.entries()) {
+    const normalized = line.replace(/\s+/g, " ").trim();
+    if (!normalized) continue;
+    for (const rule of forbiddenReactNativeBehaviorClaims) {
+      if (rule.pattern.test(normalized) && !isNegatedOrScoped(normalized)) {
+        findings.push(`${relativePath}:${index + 1} [${rule.label}] ${normalized}`);
+      }
+    }
+  }
+  return findings;
+}
+
 function findDomainParallelLaunchReadinessClaims(text, relativePath) {
   const findings = [];
   const lines = text.split(/\r?\n/);
@@ -216,6 +253,17 @@ test("current docs do not make broad RN/WebView/TUI support claims", () => {
   assert.deepEqual(findings, [], `forbidden broad support claims found:\n${findings.join("\n")}`);
 });
 
+test("current docs do not imply RN runtime, accessibility, device, cross-file, or DOM-equivalence claims", () => {
+  const markdownFiles = docsRoots.flatMap(collectMarkdownFiles).sort();
+
+  const findings = markdownFiles.flatMap((file) => {
+    const relativePath = path.relative(repoRoot, file);
+    return findReactNativeBehaviorClaims(fs.readFileSync(file, "utf8"), relativePath);
+  });
+
+  assert.deepEqual(findings, [], `forbidden RN behavior claims found:\n${findings.join("\n")}`);
+});
+
 test("current docs do not make broad domain-parallel execution claims", () => {
   const markdownFiles = docsRoots.flatMap(collectMarkdownFiles).sort();
 
@@ -278,6 +326,31 @@ test("claim-boundary doc audit preserves shared scanner planner builder seam res
     architecture,
     /Shared seam changes are serialized by default\.[\s\S]*?must name one shared-policy owner and a merge-order note[\s\S]*?Domain-specific lanes may run in parallel only when they stay in disjoint fixture\/docs\/test surfaces/,
   );
+});
+
+test("claim-boundary doc audit rejects RN runtime/a11y/cross-file/DOM-equivalence examples but allows scoped negatives", () => {
+  assert.deepEqual(findReactNativeBehaviorClaims("React Native gesture works correctly on device.", "synthetic.md"), [
+    "synthetic.md:1 [rn-runtime-success] React Native gesture works correctly on device.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("This screen is accessible and screen reader verified.", "synthetic.md"), [
+    "synthetic.md:1 [rn-accessibility-correctness] This screen is accessible and screen reader verified.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("Route params and global state behavior are understood across files.", "synthetic.md"), [
+    "synthetic.md:1 [rn-cross-file-behavior] Route params and global state behavior are understood across files.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("TextInput is equivalent to a DOM input form control.", "synthetic.md"), [
+    "synthetic.md:1 [rn-dom-form-equivalence] TextInput is equivalent to a DOM input form control.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("FlatList works correctly.", "synthetic.md"), [
+    "synthetic.md:1 [rn-runtime-success] FlatList works correctly.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("The list virtualization works correctly.", "synthetic.md"), [
+    "synthetic.md:1 [rn-runtime-success] The list virtualization works correctly.",
+  ]);
+  assert.deepEqual(findReactNativeBehaviorClaims("Gesture markers remain RN evidence only; no gesture runtime safety claim.", "synthetic.md"), []);
+  assert.deepEqual(findReactNativeBehaviorClaims("Same-file local handler/callback evidence may use the existing narrow payload gate, but this remains source-only evidence.", "synthetic.md"), []);
+  assert.deepEqual(findReactNativeBehaviorClaims("TextInput must not be treated as a DOM input or web form control.", "synthetic.md"), []);
+  assert.deepEqual(findReactNativeBehaviorClaims("The app was not run on a device or simulator.", "synthetic.md"), []);
 });
 
 test("claim-boundary doc audit rejects positive examples but allows negated or measured examples", () => {

--- a/test/domain-profiles.test.mjs
+++ b/test/domain-profiles.test.mjs
@@ -100,6 +100,16 @@ test("domain profile registry preserves existing detector classification outcome
   assert.deepEqual(outcomeForClassification("unknown"), { outcome: "deferred" });
 });
 
+test("React Native narrow taxonomy keeps navigation, interaction/list, and media/layout outside the measured gate", () => {
+  const taxonomy = REACT_NATIVE_SIGNAL_TAXONOMY.primitiveInput;
+  assert.equal(taxonomy.supportBoundary, "measured-evidence-only; no broad RN/WebView/TUI support");
+  assert.ok(taxonomy.forbiddenPrefixes.includes("react-native:navigation-"));
+  assert.ok(taxonomy.forbiddenPrefixes.includes("react-native:api-call:PanResponder."));
+  assert.ok(taxonomy.forbiddenExactSignals.includes("react-native:primitive:FlatList"));
+  assert.ok(taxonomy.forbiddenExactSignals.includes("react-native:primitive:ScrollView"));
+  assert.ok(taxonomy.forbiddenExactSignals.includes("react-native:jsx-prop:activeOpacity"));
+});
+
 test("domain profile metadata remains evidence and policy boundary, not support wording", () => {
   const rnOutcome = outcomeForClassification("react-native");
   assert.deepEqual(profileForClassification("react-native", rnOutcome.outcome, rnOutcome.reason), {

--- a/test/payload-policy-registry.test.mjs
+++ b/test/payload-policy-registry.test.mjs
@@ -26,6 +26,7 @@ const samples = {
   webview: detect(`import { WebView } from "react-native-webview"; export function Preview() { return <WebView source={{ uri: "https://example.com" }} />; }`, "Preview.tsx"),
   "tui-ink": detect(`import { Box } from "ink"; export function Cli() { return <Box />; }`, "Cli.tsx"),
   "react-native": detect(`import { View, TextInput, Text, Pressable } from "react-native"; export function Native() { return <View><TextInput onChangeText={() => null} /><Pressable onPress={() => null}><Text>Save</Text></Pressable></View>; }`, "Native.tsx"),
+  "react-native-interaction": detect(`import { View, Text, TouchableOpacity, FlatList } from "react-native"; export function NativeList() { return <View><TouchableOpacity activeOpacity={0.7}><Text>Save</Text></TouchableOpacity><FlatList data={[]} renderItem={() => null} /></View>; }`, "NativeList.tsx"),
   mixed: detect(`import { Box, Text } from "ink"; export function MixedCliWeb() { return <div><Box><Text>Ready</Text></Box></div>; }`, "MixedCliWeb.tsx"),
   unknown: detect(`export function PlainUnknown() { return null; }`, "PlainUnknown.tsx"),
 };
@@ -48,6 +49,7 @@ test("frontend payload policy registry returns the same decisions as lane-owned 
     webview: assessWebViewPayloadPolicy(samples.webview),
     "tui-ink": assessTuiInkPayloadPolicy(samples["tui-ink"]),
     "react-native": assessReactNativePayloadPolicy(samples["react-native"]),
+    "react-native-interaction": assessReactNativePayloadPolicy(samples["react-native-interaction"]),
     mixed: assessFallbackPayloadPolicy(samples.mixed),
     unknown: assessFallbackPayloadPolicy(samples.unknown),
   };
@@ -94,7 +96,6 @@ test("pre-read compatibility entrypoint exports the core policy registry APIs", 
 test("frontend payload build options include domain payload for React Web and measured RN narrow policies", () => {
   const reactWebPolicy = registry.assessFrontendPayloadPolicy(samples["react-web"]);
   const reactNativePolicy = registry.assessFrontendPayloadPolicy(samples["react-native"]);
-
   assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactWebPolicy), {
     includeDomainPayload: true,
     includeReactWebContextMetadata: true,
@@ -103,6 +104,12 @@ test("frontend payload build options include domain payload for React Web and me
   assert.deepEqual(registry.toFrontendPayloadBuildOptions(reactNativePolicy), {
     includeDomainPayload: true,
     domainPayloadPolicy: reactNativePolicy.name,
+  });
+
+  assert.deepEqual(registry.assessFrontendPayloadPolicy(samples["react-native-interaction"]), {
+    name: "rn-primitive-input-narrow-payload",
+    allowed: false,
+    reason: "forbidden-signal:react-native:primitive:FlatList",
   });
 
   for (const lane of ["webview", "tui-ink", "mixed", "unknown"]) {


### PR DESCRIPTION
## Linked issue

Fixes #

## Summary

- lock React Native PR A claim boundaries as source-only evidence
- add docs wording for allowed vs forbidden RN claims
- add audit coverage for runtime, accessibility, device/simulator, cross-file, DOM-equivalence, and list-correctness overclaims
- keep RN narrow taxonomy and payload policy tests aligned with the measured F1/F13 lane

## Verification

- npm run build
- node --test test/claim-boundary-doc-audit.test.mjs test/domain-profiles.test.mjs test/payload-policy-registry.test.mjs
- npm test
