### PR TITLE
Run CI on branch pushes, not only main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
 
 permissions:


### PR DESCRIPTION
Constraint: Feature branches need pre-PR validation in GitHub Actions

Rejected: Keep main-only push trigger | misses branch-level CI feedback before PR
Confidence: high
Scope-risk: narrow
Directive: Preserve pull_request coverage while keeping branch push validation enabled
Tested: Inspected workflow trigger diff for push and pull_request coverage
Not-tested: End-to-end GitHub Actions execution after branch push and PR checks