### PR TITLE
Add React Web routing concern profile evidence

### DIFF
--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -121,8 +121,9 @@ Concrete examples:
 - `react-hook-form` plus DOM-like `<form>` and `<input>` signals can be React Web domain evidence plus a form-state concern.
 - `react-hook-form` plus React Native `TextInput` and `onChangeText` signals can be React Native domain evidence plus a form-state concern, but it still remains bounded by the measured RN `F1` policy gate.
 - A Zustand store file can be a client-state concern without being a UI-domain payload candidate at all.
+- Next/React Router imports plus `Link`, `useNavigate`, `useRouter`, or same-file route/search param usage can be routing concern evidence, but they are not route-existence proof, runtime navigation proof, App Router/Pages Router verification, or compact-payload authorization.
 
-Current concern-profile extraction may surface bounded metadata such as form-state or validation/schema evidence. Those profiles remain non-authorizing metadata only; they must not bypass the domain resolver, fallback rules, or proof/claim boundary.
+Current concern-profile extraction may surface bounded metadata such as form-state, validation/schema, or routing evidence. Those profiles remain non-authorizing metadata only; they must not bypass the domain resolver, fallback rules, or proof/claim boundary.
 
 ## RN claim boundary at the architecture layer
 

--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -25,6 +25,7 @@ The frontend-domain contract separates **where code runs** from **what task-rele
 - **Concern profile** owns task-relevant library/dataflow evidence only.
 - Concern evidence such as `react-hook-form`, `useForm`, `register`, `control`, `handleSubmit`, default values, error display, or submit handlers is **not** React Web runtime evidence by itself.
 - Concern evidence such as Zod/Yup/Valibot imports, resolver usage, or same-file schema keys is **not** runtime validation proof, backend-contract proof, or compact-payload authorization by itself.
+- Concern evidence such as Next/React Router imports, `Link`, `useNavigate`, `useRouter`, or same-file route/search param usage is **not** route-existence proof, runtime navigation proof, App Router/Pages Router verification, or compact-payload authorization by itself.
 - Concern evidence alone must **not** authorize compact payload reuse.
 - The payload-policy architecture target is to evaluate **domain + concern + source fingerprint + lane gate** together. This wording is a boundary/architecture rule, not a claim that the current React Web lane already requires every one of those inputs as an allow condition today.
 

--- a/src/core/concern-profiles/index.ts
+++ b/src/core/concern-profiles/index.ts
@@ -1,5 +1,6 @@
 import type { ExtractionResult } from "../schema";
 import { collectFormStateConcernProfile } from "./form-state";
+import { collectRoutingConcernProfile } from "./routing";
 import type { FrontendConcernProfile } from "./types";
 import { collectValidationSchemaConcernProfile } from "./validation-schema";
 
@@ -7,6 +8,7 @@ export function collectFrontendConcernProfiles(result: ExtractionResult): Fronte
   const profiles = [
     collectFormStateConcernProfile(result),
     collectValidationSchemaConcernProfile(result),
+    collectRoutingConcernProfile(result),
   ].filter((value): value is FrontendConcernProfile => Boolean(value));
 
   return profiles.length > 0 ? profiles : undefined;

--- a/src/core/concern-profiles/routing.ts
+++ b/src/core/concern-profiles/routing.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import ts from "typescript";
+import type { ExtractionResult } from "../schema";
+import {
+  FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS,
+  FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION,
+  type FrontendConcernProfile,
+  type FrontendConcernSignal,
+} from "./types";
+
+type RoutingModule = "next/navigation" | "next/link" | "react-router" | "react-router-dom";
+
+type ImportRecord = {
+  moduleSpecifier: RoutingModule;
+  defaultImport?: string;
+  namedImports: Map<string, string>;
+};
+
+const ROUTING_MODULE_SIGNALS: Record<RoutingModule, FrontendConcernSignal> = {
+  "next/navigation": "next-navigation",
+  "next/link": "next-link",
+  "react-router": "react-router",
+  "react-router-dom": "react-router-dom",
+};
+
+function uniqueSorted<T extends string>(values: Iterable<T>): T[] {
+  return [...new Set(values)].sort() as T[];
+}
+
+function readSourceText(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function collectRoutingImports(sourceFile: ts.SourceFile): ImportRecord[] {
+  const records: ImportRecord[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const moduleSpecifier = statement.moduleSpecifier.text;
+    if (moduleSpecifier !== "next/navigation" && moduleSpecifier !== "next/link" && moduleSpecifier !== "react-router" && moduleSpecifier !== "react-router-dom") {
+      continue;
+    }
+
+    const record: ImportRecord = {
+      moduleSpecifier,
+      namedImports: new Map<string, string>(),
+    };
+
+    const clause = statement.importClause;
+    if (clause?.name) record.defaultImport = clause.name.text;
+    if (clause?.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        record.namedImports.set(element.propertyName?.text ?? element.name.text, element.name.text);
+      }
+    }
+
+    records.push(record);
+  }
+
+  return records;
+}
+
+function hasHookCall(sourceFile: ts.SourceFile, localName: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === localName) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function hasJsxElementUsage(sourceFile: ts.SourceFile, localName: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if ((ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) && ts.isIdentifier(node.tagName) && node.tagName.text === localName) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+export function collectRoutingConcernProfile(result: ExtractionResult): FrontendConcernProfile | undefined {
+  const sourceText = readSourceText(result.filePath);
+  if (!sourceText) return undefined;
+
+  const sourceFile = ts.createSourceFile(result.filePath, sourceText, ts.ScriptTarget.Latest, true, result.language === "tsx" || result.language === "jsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  const imports = collectRoutingImports(sourceFile);
+  if (imports.length === 0) return undefined;
+
+  const signals = new Set<FrontendConcernSignal>();
+  let sawExplicitParamHook = false;
+  let sawExplicitSearchParamHook = false;
+
+  for (const record of imports) {
+    signals.add(ROUTING_MODULE_SIGNALS[record.moduleSpecifier]);
+
+    if (record.moduleSpecifier === "next/link") {
+      if ((record.defaultImport && hasJsxElementUsage(sourceFile, record.defaultImport)) || record.defaultImport) {
+        signals.add("Link");
+      }
+    }
+
+    const linkLocal = record.namedImports.get("Link");
+    if (linkLocal) {
+      signals.add("Link");
+    }
+
+    const navigateLocal = record.namedImports.get("useNavigate");
+    if (navigateLocal && hasHookCall(sourceFile, navigateLocal)) {
+      signals.add("useNavigate");
+    }
+
+    const routerLocal = record.namedImports.get("useRouter");
+    if (routerLocal && hasHookCall(sourceFile, routerLocal)) {
+      signals.add("useRouter");
+    }
+
+    const paramsLocal = record.namedImports.get("useParams");
+    if (paramsLocal && hasHookCall(sourceFile, paramsLocal)) {
+      sawExplicitParamHook = true;
+    }
+
+    const searchParamsLocal = record.namedImports.get("useSearchParams");
+    if (searchParamsLocal && hasHookCall(sourceFile, searchParamsLocal)) {
+      sawExplicitSearchParamHook = true;
+    }
+  }
+
+  if (sawExplicitParamHook) signals.add("route-param");
+  if (sawExplicitSearchParamHook) signals.add("search-param");
+
+  return {
+    kind: "concern",
+    id: "routing",
+    claim: FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS.routing,
+    signals: uniqueSorted(signals),
+    nonAuthorizationBoundary: FRONTEND_CONCERN_PROFILE_NON_AUTHORIZATION,
+  };
+}

--- a/src/core/concern-profiles/types.ts
+++ b/src/core/concern-profiles/types.ts
@@ -13,9 +13,10 @@ export type FrontendConcernProfileContract = {
 export const FRONTEND_CONCERN_PROFILE_ALLOWED_CLAIMS = {
   formState: "This source contains form-state concern evidence.",
   validationSchema: "This source contains validation/schema concern evidence.",
+  routing: "This source contains routing concern evidence.",
 } as const;
 
-export type FrontendConcernProfileId = "form-state" | "validation-schema";
+export type FrontendConcernProfileId = "form-state" | "validation-schema" | "routing";
 
 export type FrontendConcernSignal =
   | "react-hook-form"
@@ -31,7 +32,16 @@ export type FrontendConcernSignal =
   | "yup"
   | "valibot"
   | "resolver"
-  | "same-file-schema-keys";
+  | "same-file-schema-keys"
+  | "next-navigation"
+  | "next-link"
+  | "react-router"
+  | "react-router-dom"
+  | "Link"
+  | "useRouter"
+  | "useNavigate"
+  | "route-param"
+  | "search-param";
 
 export type FrontendConcernProfile = {
   kind: "concern";

--- a/test/domain-profiles.test.mjs
+++ b/test/domain-profiles.test.mjs
@@ -159,3 +159,13 @@ test("concern-only validation/schema fixture stays outside React Web domain evid
   assert.equal(result.outcome, "deferred");
   assert.deepEqual(result.evidence, []);
 });
+
+
+test("concern-only routing fixture stays outside React Web domain evidence", () => {
+  const { detectDomain } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+  const result = detectDomain(path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "concern-only-routing-non-authorizing.tsx"));
+
+  assert.equal(result.classification, "unknown");
+  assert.equal(result.outcome, "deferred");
+  assert.deepEqual(result.evidence, []);
+});

--- a/test/fixtures/frontend-domain-expectations/concern-only-routing-non-authorizing.tsx
+++ b/test/fixtures/frontend-domain-expectations/concern-only-routing-non-authorizing.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+
+export function ConcernOnlyRoutingNote() {
+  const params = useParams<{ slug: string }>();
+  const searchParams = useSearchParams();
+  return {
+    slug: params.slug,
+    tab: searchParams.get("tab"),
+    href: `/users/${params.slug}`,
+    Link,
+  };
+}

--- a/test/routing-concern-claim-boundary.test.mjs
+++ b/test/routing-concern-claim-boundary.test.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docsRoots = ["README.md", "docs"];
+
+const forbiddenRoutingConcernClaims = [
+  {
+    label: "route-existence-proof",
+    pattern: /\b(?:next\/navigation|next\/link|react-router|react-router-dom|Link|useNavigate|useRouter|route params?|search params?)\b[^\n]{0,100}\b(?:proves?|guarantees?|means|establishes?)\b[^\n]{0,100}\b(?:route exists?|valid route|existing route)\b/i,
+  },
+  {
+    label: "runtime-navigation-proof",
+    pattern: /\b(?:next\/navigation|next\/link|react-router|react-router-dom|Link|useNavigate|useRouter|route params?|search params?)\b[^\n]{0,100}\b(?:proves?|guarantees?|means|establishes?)\b[^\n]{0,100}\b(?:navigation works?|runtime navigation|redirect works?|router works?)\b/i,
+  },
+  {
+    label: "app-pages-router-verification",
+    pattern: /\b(?:next\/navigation|next\/link|react-router|react-router-dom|useRouter|route params?|search params?)\b[^\n]{0,100}\b(?:proves?|guarantees?|means|establishes?)\b[^\n]{0,100}\b(?:App Router|Pages Router)\b/i,
+  },
+  {
+    label: "authorization-broadening",
+    pattern: /\b(?:next\/navigation|next\/link|react-router|react-router-dom|Link|useNavigate|useRouter|route params?|search params?)\b[^\n]{0,100}\b(?:authorizes?|unlocks?|allows?|counts\s+as|proves?)\b[^\n]{0,100}\b(?:compact\s+payload|payload\s+reuse|React\s*Web)\b/i,
+  },
+];
+
+const boundedClaimBoundary = /\b(?:same-file|claim boundary|does not|do not|not|no|without|cannot|must not|only|metadata|non-authorizing|fail-closed)\b/i;
+
+function collectMarkdownFiles(entry) {
+  const absolute = path.join(repoRoot, entry);
+  const stat = fs.statSync(absolute);
+  if (stat.isFile()) return [absolute];
+
+  const files = [];
+  for (const name of fs.readdirSync(absolute)) {
+    const child = path.join(absolute, name);
+    const childStat = fs.statSync(child);
+    if (childStat.isDirectory()) {
+      files.push(...collectMarkdownFiles(path.relative(repoRoot, child)));
+    } else if (name.endsWith(".md")) {
+      files.push(child);
+    }
+  }
+  return files;
+}
+
+function findForbiddenRoutingConcernClaims(text, relativePath) {
+  const findings = [];
+  const lines = text.split(/\r?\n/);
+
+  for (const [index, line] of lines.entries()) {
+    const normalized = line.replace(/\s+/g, " ").trim();
+    if (!normalized) continue;
+
+    for (const rule of forbiddenRoutingConcernClaims) {
+      if (rule.pattern.test(normalized) && !boundedClaimBoundary.test(normalized)) {
+        findings.push(`${relativePath}:${index + 1} [${rule.label}] ${normalized}`);
+      }
+    }
+  }
+
+  return findings;
+}
+
+test("routing concern docs stay inside the metadata-only claim boundary", () => {
+  const markdownFiles = docsRoots.flatMap(collectMarkdownFiles).sort();
+  const findings = markdownFiles.flatMap((file) => {
+    const relativePath = path.relative(repoRoot, file);
+    return findForbiddenRoutingConcernClaims(fs.readFileSync(file, "utf8"), relativePath);
+  });
+
+  assert.deepEqual(findings, [], `forbidden routing concern claims found:\n${findings.join("\n")}`);
+});
+
+test("routing concern docs explicitly forbid route/runtime/authorization overreach", () => {
+  const contract = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-contract.md"), "utf8");
+  const architecture = fs.readFileSync(path.join(repoRoot, "docs", "domain-payload-architecture.md"), "utf8");
+  const combined = `${contract}\n${architecture}`;
+
+  assert.match(combined, /Next\/React Router imports, `Link`, `useNavigate`, `useRouter`, or same-file route\/search param usage/);
+  assert.match(combined, /not\*\* route-existence proof, runtime navigation proof, App Router\/Pages Router verification, or compact-payload authorization by itself/i);
+  assert.match(combined, /Current concern-profile extraction may surface bounded metadata such as form-state, validation\/schema, or routing evidence\./);
+});
+
+test("routing concern claim audit rejects broad examples but allows bounded examples", () => {
+  assert.deepEqual(
+    findForbiddenRoutingConcernClaims("useRouter proves the route exists and navigation works.", "synthetic.md"),
+    [
+      "synthetic.md:1 [route-existence-proof] useRouter proves the route exists and navigation works.",
+      "synthetic.md:1 [runtime-navigation-proof] useRouter proves the route exists and navigation works.",
+    ],
+  );
+  assert.deepEqual(
+    findForbiddenRoutingConcernClaims("react-router authorizes compact payload reuse and proves App Router behavior.", "synthetic.md"),
+    [
+      "synthetic.md:1 [app-pages-router-verification] react-router authorizes compact payload reuse and proves App Router behavior.",
+      "synthetic.md:1 [authorization-broadening] react-router authorizes compact payload reuse and proves App Router behavior.",
+    ],
+  );
+  assert.deepEqual(
+    findForbiddenRoutingConcernClaims(
+      "same-file route/search param usage is metadata only; it does not prove route existence, runtime navigation, or compact payload authorization.",
+      "synthetic.md",
+    ),
+    [],
+  );
+});

--- a/test/routing-concern-profile.test.mjs
+++ b/test/routing-concern-profile.test.mjs
@@ -1,0 +1,147 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
+const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
+const { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
+const { assessFrontendProfilePayloadReuse } = require(path.join(repoRoot, "dist", "core", "payload-policy", "profile-gate.js"));
+const { UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON } = require(path.join(repoRoot, "dist", "core", "payload-policy", "fallback.js"));
+
+function buildPayloadForSource(source, fileName, options = {}) {
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-routing-concern-"));
+  try {
+    const filePath = path.join(tempDir, fileName);
+    fs.writeFileSync(filePath, source);
+    const domainDetection = detectDomainFromSource(source, filePath);
+    const policy = assessFrontendPayloadPolicy(domainDetection);
+    const payload = toModelFacingPayload(extractFile(filePath), tempDir, {
+      includeEditGuidance: false,
+      includeReactWebContextMetadata: true,
+      ...toFrontendPayloadBuildOptions(policy),
+      ...options,
+    });
+    return { domainDetection, policy, payload };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function profileById(payload, id) {
+  return payload.concernProfiles?.find((profile) => profile.id === id);
+}
+
+test("concern-only Next routing source emits non-authorizing routing concern evidence", () => {
+  const source = `
+    import Link from "next/link";
+    import { useParams, useSearchParams } from "next/navigation";
+
+    export function ConcernOnlyRoutingNote() {
+      const params = useParams<{ slug: string }>();
+      const searchParams = useSearchParams();
+      return { slug: params.slug, tab: searchParams.get("tab"), href: "/users/" + params.slug, Link };
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "ConcernOnlyRoutingNote.tsx");
+  const routingProfile = profileById(payload, "routing");
+
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(policy.allowed, false);
+  assert.equal(payload.reactWebContext, undefined);
+  assert.deepEqual(routingProfile, {
+    kind: "concern",
+    id: "routing",
+    claim: "This source contains routing concern evidence.",
+    nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+    signals: ["Link", "next-link", "next-navigation", "route-param", "search-param"],
+  });
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), {
+    allowed: false,
+    reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  });
+});
+
+test("concern-only React Router source emits non-authorizing routing concern evidence", () => {
+  const source = `
+    import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+    export function ConcernOnlyRouterNote() {
+      const navigate = useNavigate();
+      const params = useParams();
+      const [searchParams] = useSearchParams();
+      return { navigate, slug: params.slug, tab: searchParams.get("tab"), Link };
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "ConcernOnlyRouterNote.tsx");
+  const routingProfile = profileById(payload, "routing");
+
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(policy.allowed, false);
+  assert.deepEqual(routingProfile, {
+    kind: "concern",
+    id: "routing",
+    claim: "This source contains routing concern evidence.",
+    nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+    signals: ["Link", "react-router-dom", "route-param", "search-param", "useNavigate"],
+  });
+});
+
+test("React Web plus routing concern keeps concern metadata separate from authorization", () => {
+  const source = `
+    import Link from "next/link";
+    import { useParams, useRouter, useSearchParams } from "next/navigation";
+
+    export function UserNav() {
+      const params = useParams<{ slug: string }>();
+      const router = useRouter();
+      const searchParams = useSearchParams();
+      return (
+        <div>
+          <button onClick={() => router.push('/users/' + params.slug + '?tab=' + (searchParams.get('tab') ?? 'overview'))}>Go</button>
+          <Link href={'/users/' + params.slug}>Profile</Link>
+        </div>
+      );
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "UserNav.tsx");
+  const withoutDomainPayload = { ...payload };
+  delete withoutDomainPayload.domainPayload;
+  const routingProfile = profileById(payload, "routing");
+
+  assert.equal(domainDetection.classification, "react-web");
+  assert.equal(policy.allowed, true);
+  assert.deepEqual(routingProfile, {
+    kind: "concern",
+    id: "routing",
+    claim: "This source contains routing concern evidence.",
+    nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+    signals: ["Link", "next-link", "next-navigation", "route-param", "search-param", "useRouter"],
+  });
+  assert.ok(payload.domainPayload);
+  assert.equal("concernProfiles" in payload.domainPayload, false);
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutDomainPayload, policy).allowed, false);
+});
+
+test("routing concern stays fail-closed for weak param-only names and route-like strings", () => {
+  const source = `
+    const params = { slug: "local-only" };
+    const searchParams = new URLSearchParams("tab=overview");
+    const routeQuery = "/users/[slug]";
+
+    export function NotesOnly() {
+      return { params, tab: searchParams.get("tab"), routeQuery };
+    }
+  `;
+  const { payload } = buildPayloadForSource(source, "NotesOnly.tsx");
+
+  assert.equal(profileById(payload, "routing"), undefined);
+});

--- a/test/validation-schema-concern-claim-boundary.test.mjs
+++ b/test/validation-schema-concern-claim-boundary.test.mjs
@@ -87,7 +87,7 @@ test("validation/schema concern docs explicitly forbid correctness and authoriza
 
   assert.match(combined, /Zod\/Yup\/Valibot imports, resolver usage, or same-file schema keys/);
   assert.match(combined, /not\*\* runtime validation proof, backend-contract proof, or compact-payload authorization by itself/i);
-  assert.match(combined, /Current concern-profile extraction may surface bounded metadata such as form-state or validation\/schema evidence\./);
+  assert.match(combined, /Current concern-profile extraction may surface bounded metadata such as form-state, validation\/schema, or routing evidence\./);
 });
 
 test("validation/schema concern claim audit rejects broad examples but allows bounded examples", () => {


### PR DESCRIPTION
## Summary
- add a React Web routing concern profile for Next and React Router evidence
- keep routing concern output metadata-only and non-authorizing
- add docs, fixtures, and claim-boundary regressions for routing overreach

## Testing
- npm run typecheck -- --pretty false
- npm test

Closes #529
