### PR TITLE
Revert #540 and restore upstream-owned update path

### DIFF
--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -30,7 +30,6 @@ export const RN_TEXT_INPUT_METADATA_FIELDS = [
 ];
 
 export const RN_PRESSABLE_METADATA_FIELDS = ["disabled", "accessibilityLabel", "accessibilityRole", "testID"];
-export const RN_TEXT_INPUT_CONSTRAINT_FIELDS = ["maxLength", "secureTextEntry", "keyboardType", "autoCapitalize"];
 
 function loadDist(repoRoot) {
   const require = createRequire(import.meta.url);
@@ -70,49 +69,18 @@ function interactionSummary(domainPayload) {
   const interactions = domainPayload?.facts?.primitiveInteractions ?? {};
   const inputBindings = interactions.inputBindings ?? [];
   const actionBindings = interactions.actionBindings ?? [];
-  const inputConstraints = interactions.inputConstraints ?? [];
-  const stateActionRelations = interactions.stateActionRelations ?? [];
-  const constraintActionReadiness = interactions.constraintActionReadiness ?? [];
   const textInputMetadataFields = presentFields(inputBindings, RN_TEXT_INPUT_METADATA_FIELDS);
   const pressableMetadataFields = presentFields(actionBindings, RN_PRESSABLE_METADATA_FIELDS);
-  const constraintFields = presentFields(inputConstraints, RN_TEXT_INPUT_CONSTRAINT_FIELDS);
   return {
     inputBindings,
     actionBindings,
-    inputConstraints,
-    stateActionRelations,
-    constraintActionReadiness,
     hasTextInputBinding: Boolean(inputBindings.some((item) => item.primitive === "TextInput" && item.onChangeTextExpr)),
     hasPressableAction: Boolean(actionBindings.some((item) => item.primitive === "Pressable" && item.onPressExpr)),
-    hasInputConstraintSemantics: Boolean(
-      inputConstraints.some(
-        (item) => item.constraintKind === "textInputMetadataConstraints" && item.constraintBasis?.length > 0 && item.valueExpr,
-      ),
-    ),
-    hasDirectStateActionRelation: Boolean(
-      stateActionRelations.some(
-        (item) => item.relationKind === "actionReadsInputValue" && item.valueExpr && item.onPressExpr && item.relationBasis?.length > 0,
-      ),
-    ),
-    hasConstraintActionReadiness: Boolean(
-      constraintActionReadiness.some(
-        (item) =>
-          item.relationKind === "constraintActionReadiness" &&
-          item.valueExpr &&
-          item.onPressExpr &&
-          item.disabledExpr &&
-          item.constraintBasis?.length > 0 &&
-          item.readinessBasis?.length > 0 &&
-          item.relationBasis?.length > 0,
-      ),
-    ),
     metadataCoverage: {
       textInputFields: textInputMetadataFields,
       pressableFields: pressableMetadataFields,
-      constraintFields,
       allTextInputMetadataPresent: RN_TEXT_INPUT_METADATA_FIELDS.every((field) => textInputMetadataFields.includes(field)),
       allPressableMetadataPresent: RN_PRESSABLE_METADATA_FIELDS.every((field) => pressableMetadataFields.includes(field)),
-      allConstraintFieldsPresent: RN_TEXT_INPUT_CONSTRAINT_FIELDS.every((field) => constraintFields.includes(field)),
     },
   };
 }
@@ -201,18 +169,9 @@ export async function buildReactNativePayloadEvidence({
     (field) => !preReadPressableFields.includes(field) || !modelPressableFields.includes(field),
   );
   const metadataAnchorsVisible = missingTextInputFields.length === 0 && missingPressableFields.length === 0;
-  const constraintRows = rnFixtures.filter(
-    (row) => row.preRead.primitiveInteractions.hasInputConstraintSemantics && row.modelFacing.primitiveInteractions.hasInputConstraintSemantics,
-  );
-  const relationRows = rnFixtures.filter(
-    (row) => row.preRead.primitiveInteractions.hasDirectStateActionRelation && row.modelFacing.primitiveInteractions.hasDirectStateActionRelation,
-  );
-  const readinessRows = rnFixtures.filter(
-    (row) => row.preRead.primitiveInteractions.hasConstraintActionReadiness && row.modelFacing.primitiveInteractions.hasConstraintActionReadiness,
-  );
 
   return {
-    schemaVersion: "react-native-payload-evidence.v3",
+    schemaVersion: "react-native-payload-evidence.v2",
     generatedAt: new Date().toISOString(),
     runId,
     measurement: "local-fixture-pre-read-and-model-facing-domain-payload-evidence",
@@ -249,26 +208,6 @@ export async function buildReactNativePayloadEvidence({
           ? null
           : `missing metadata fields: TextInput=${missingTextInputFields.join(",") || "none"}; Pressable=${missingPressableFields.join(",") || "none"}`,
       },
-      inputConstraintsVisible: {
-        claimable: constraintRows.length > 0,
-        scope: "rn-primitive-input-narrow-payload-only",
-        constraintKind: "textInputMetadataConstraints",
-        directConstraintFixtures: constraintRows.map((row) => row.file),
-        blocker: constraintRows.length > 0 ? null : "no measured RN fixture exposed TextInput constraint metadata in both pre-read and model-facing payloads",
-      },
-      stateActionRelationsVisible: {
-        claimable: relationRows.length > 0,
-        relationKind: "actionReadsInputValue",
-        directRelationFixtures: relationRows.map((row) => row.file),
-        blocker: relationRows.length > 0 ? null : "no measured RN fixture exposed a direct actionReadsInputValue relation in both pre-read and model-facing payloads",
-      },
-      constraintActionReadinessVisible: {
-        claimable: readinessRows.length > 0,
-        scope: "rn-primitive-input-narrow-payload-only",
-        relationKind: "constraintActionReadiness",
-        directReadinessFixtures: readinessRows.map((row) => row.file),
-        blocker: readinessRows.length > 0 ? null : "no measured RN fixture exposed constraintActionReadiness in both pre-read and model-facing payloads",
-      },
       broadReactNativeSupport: {
         claimable: false,
         blocker: "evidence is limited to the existing rn-primitive-input-narrow-payload measured lane",
@@ -298,16 +237,7 @@ export function renderReactNativePayloadEvidenceMarkdown(evidence) {
       const action = row.preRead.primitiveInteractions.actionBindings
         .map((item) => `${item.primitive}:onPress=${item.onPressExpr}${item.label ? `,label=${item.label}` : ""}`)
         .join("; ");
-      const constraints = row.preRead.primitiveInteractions.inputConstraints
-        .map((item) => `${item.constraintKind}:${item.constraintBasis.join(",")}`)
-        .join("; ") || "omitted";
-      const relation = row.preRead.primitiveInteractions.stateActionRelations
-        .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr}`)
-        .join("; ") || "omitted";
-      const readiness = row.preRead.primitiveInteractions.constraintActionReadiness
-        .map((item) => `${item.relationKind}:${item.onPressExpr}->${item.valueExpr},disabled=${item.disabledExpr}`)
-        .join("; ") || "omitted";
-      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${constraints} | ${relation} | ${readiness} | ${row.claimable ? "yes" : "no"} |`;
+      return `| \`${row.file}\` | ${row.preReadDecision} | ${row.sourceFingerprintPresent ? "yes" : "no"} | ${row.preRead.strictContractsPresent ? "yes" : "no"} | ${input} | ${action} | ${row.claimable ? "yes" : "no"} |`;
     })
     .join("\n");
   const boundaryRows = evidence.boundaryFixtures
@@ -334,9 +264,6 @@ ${evidence.claimBoundary}
 - RN primitive interaction facts visible: ${evidence.summary.rnPayloadFactsVisible.claimable ? "yes" : "no"}
 - Richer RN/WebView/TUI boundaries preserved: ${evidence.summary.boundaryFallbacksPreserved.claimable ? "yes" : "no"}
 - RN metadata anchors visible: ${evidence.summary.metadataAnchorsVisible.claimable ? "yes" : "no"}
-- Measured RN narrow input constraints visible: ${evidence.summary.inputConstraintsVisible.claimable ? "yes" : "no"}
-- RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
-- Measured RN narrow constraint/action readiness visible: ${evidence.summary.constraintActionReadinessVisible.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no
 - RN edit routing claimable: no
@@ -344,8 +271,8 @@ ${evidence.claimBoundary}
 
 ## Measured RN narrow fixtures
 
-| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | constraints | action relation | readiness | claimable |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Fixture | pre-read decision | source fingerprint | strict RN contracts | input bindings | action bindings | claimable |
+| --- | --- | --- | --- | --- | --- | --- |
 ${fixtureRows}
 
 ## Metadata anchor coverage
@@ -361,8 +288,6 @@ ${metadataRows}
 ${boundaryRows}
 
 ## Claim boundary
-
-The constraint/action readiness claim is scoped to \`${evidence.summary.constraintActionReadinessVisible.scope}\` and requires source-observed TextInput constraints, a direct actionReadsInputValue relation, and a source-observed Pressable disabled expression.
 
 This artifact supports bounded local statements only for the existing \`rn-primitive-input-narrow-payload\` lane. It does not support broad React Native support, WebView/TUI promotion, runtime reuse promotion, RN edit routing, runtime-token savings, provider-cost, billing, invoice, or charged-cost claims.
 `;

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -13,10 +13,7 @@ import type {
   ReactNativeAccessibilityTestAnchorSignal,
   ReactNativeNavigationConcernSignal,
   ReactNativePrimitiveActionBindingSignal,
-  ReactNativePrimitiveConstraintActionReadinessSignal,
   ReactNativePrimitiveInputBindingSignal,
-  ReactNativePrimitiveInputConstraintSignal,
-  ReactNativePrimitiveStateActionRelationSignal,
   ReactNativeStateActionConcernSignal,
   ReactNativeRelationExpressionKind,
   ReactNativeRelationSource,
@@ -528,7 +525,6 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
   const formControls: NonNullable<FormSurface["controls"]> = [];
   const rnInputBindings: ReactNativePrimitiveInputBindingSignal[] = [];
   const rnActionBindings: ReactNativePrimitiveActionBindingSignal[] = [];
-  const rnActionIdentifierReads = new Map<string, Set<string>>();
   const rnAccessibilityTestAnchors: ReactNativeAccessibilityTestAnchorSignal[] = [];
   const rnStateActionConcerns: ReactNativeStateActionConcernSignal[] = [];
   const rnNavigationConcerns: ReactNativeNavigationConcernSignal[] = [];
@@ -661,69 +657,6 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     if (parameterNames.has(rootIdentifier)) return "component-prop";
     if (localDeclaredNames.has(rootIdentifier)) return "same-file-local";
     return "unknown";
-  };
-
-  const identifierReads = (node: ts.Node | undefined, initialLocalBindings: Iterable<string> = []): Set<string> => {
-    const reads = new Set<string>();
-    if (!node) return reads;
-    const localBindings = new Set(initialLocalBindings);
-    if (ts.isFunctionExpression(node) && node.name) localBindings.add(node.name.text);
-
-    const visitRead = (child: ts.Node): void => {
-      if (ts.isParameter(child)) collectBindingNames(child.name, localBindings);
-      if (ts.isVariableDeclaration(child)) collectBindingNames(child.name, localBindings);
-      if (child !== node && (ts.isFunctionDeclaration(child) || ts.isFunctionExpression(child) || ts.isArrowFunction(child))) {
-        if (ts.isFunctionDeclaration(child) && child.name) localBindings.add(child.name.text);
-        return;
-      }
-      if (ts.isIdentifier(child)) {
-        const parent = child.parent;
-        const isPropertyName =
-          (ts.isPropertyAccessExpression(parent) && parent.name === child) ||
-          (ts.isPropertyAssignment(parent) && parent.name === child) ||
-          (ts.isBindingElement(parent) && parent.propertyName === child);
-        if (!isPropertyName && !localBindings.has(child.text)) reads.add(child.text);
-      }
-      ts.forEachChild(child, visitRead);
-    };
-
-    visitRead(node);
-    return reads;
-  };
-
-  const parameterBindingNames = (parameters: ts.NodeArray<ts.ParameterDeclaration>): string[] => {
-    const bindings = new Set<string>();
-    for (const parameter of parameters) collectBindingNames(parameter.name, bindings);
-    return [...bindings];
-  };
-
-  const actionBindingKey = (onPressExpr: string, loc: SourceRange | undefined): string =>
-    `${onPressExpr}:${loc?.startLine ?? ""}:${loc?.endLine ?? ""}`;
-
-  const handlerReadsValue = (handlerExpr: string, valueExpr: string, actionLoc: SourceRange | undefined): { basis: string[] } | undefined => {
-    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(valueExpr)) return undefined;
-    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(handlerExpr)) {
-      const localBody = localFunctionBodies.get(handlerExpr);
-      if (!localBody?.body) return undefined;
-      const bindings = "parameters" in localBody ? parameterBindingNames(localBody.parameters) : [];
-      const reads = identifierReads(localBody.body, bindings);
-      if (reads.has(valueExpr)) return { basis: [`handler.${handlerExpr}.reads.${valueExpr}`] };
-      return undefined;
-    }
-    const reads = rnActionIdentifierReads.get(actionBindingKey(handlerExpr, actionLoc));
-    if ((handlerExpr.includes("=>") || handlerExpr.startsWith("function")) && reads?.has(valueExpr)) {
-      return { basis: [`jsx.Pressable.onPress.reads.${valueExpr}`] };
-    }
-    return undefined;
-  };
-
-  const sourceRangeSpan = (ranges: Array<SourceRange | undefined>): SourceRange | undefined => {
-    const present = ranges.filter((range): range is SourceRange => Boolean(range));
-    if (present.length === 0) return undefined;
-    return {
-      startLine: Math.min(...present.map((range) => range.startLine)),
-      endLine: Math.max(...present.map((range) => range.endLine)),
-    };
   };
 
   const collectMutatorRefs = (expression: ts.Expression | undefined): Array<{ stateBinding: string; mutatorBinding: string; hook: "useState" | "useReducer"; mutatorKind: "setter" | "dispatch" }> => {
@@ -884,12 +817,9 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     const testID = attributeValues.get("testID");
     const title = attributeValues.get("title");
     const label = title ?? (ts.isJsxOpeningElement(node) && ts.isJsxElement(node.parent) ? jsxElementTextLabel(node.parent) : undefined);
-    const loc = sourceRangeOf(sourceFile, node);
-    const actionReads = identifierReads(onPressNode);
-    if (actionReads.size > 0) rnActionIdentifierReads.set(actionBindingKey(onPressExpr, loc), actionReads);
     rnActionBindings.push({
       primitive: tag as ReactNativePrimitiveActionBindingSignal["primitive"],
-      loc,
+      loc: sourceRangeOf(sourceFile, node),
       onPressExpr,
       ...(onPressNode ? { onPressKind: expressionKindOf(onPressNode) } : {}),
       ...(onPressNode ? { onPressSource: relationSourceOf(node, onPressNode) } : {}),
@@ -1253,97 +1183,6 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
     (item) =>
       `${item.hook}:${item.stateBinding}:${item.mutatorBinding}:${item.primitive}:${item.trigger}:${item.actionExpr}:${item.actionSource ?? ""}:${item.loc?.startLine ?? ""}`,
   ).slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const rnInputConstraints: ReactNativePrimitiveInputConstraintSignal[] = rnInputBindingList
-    .flatMap((inputBinding) => {
-      const constraintBasis = [
-        ...(inputBinding.maxLength !== undefined ? ["jsx.TextInput.maxLength"] : []),
-        ...(inputBinding.secureTextEntry !== undefined ? ["jsx.TextInput.secureTextEntry"] : []),
-        ...(inputBinding.keyboardType !== undefined ? ["jsx.TextInput.keyboardType"] : []),
-        ...(inputBinding.autoCapitalize !== undefined ? ["jsx.TextInput.autoCapitalize"] : []),
-      ];
-      if (constraintBasis.length === 0) return [];
-      return [
-        {
-          primitive: "TextInput" as const,
-          loc: inputBinding.loc,
-          ...(inputBinding.valueExpr ? { valueExpr: inputBinding.valueExpr } : {}),
-          constraintKind: "textInputMetadataConstraints" as const,
-          ...(inputBinding.maxLength !== undefined ? { maxLength: inputBinding.maxLength } : {}),
-          ...(inputBinding.secureTextEntry !== undefined ? { secureTextEntry: inputBinding.secureTextEntry } : {}),
-          ...(inputBinding.keyboardType !== undefined ? { keyboardType: inputBinding.keyboardType } : {}),
-          ...(inputBinding.autoCapitalize !== undefined ? { autoCapitalize: inputBinding.autoCapitalize } : {}),
-          ...(inputBinding.placeholder !== undefined ? { descriptiveHint: inputBinding.placeholder } : {}),
-          constraintBasis,
-          evidence: [...constraintBasis, ...(inputBinding.placeholder !== undefined ? ["jsx.TextInput.placeholder"] : [])],
-        },
-      ];
-    })
-    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const rnStateActionRelations: ReactNativePrimitiveStateActionRelationSignal[] = rnActionBindingList
-    .flatMap((actionBinding) => {
-      if (actionBinding.primitive !== "Pressable") return [];
-      const directInputMatches = rnInputBindingList.flatMap((inputBinding) => {
-        if (!inputBinding.valueExpr) return [];
-        const read = handlerReadsValue(actionBinding.onPressExpr, inputBinding.valueExpr, actionBinding.loc);
-        if (!read) return [];
-        return [{ inputBinding, read }];
-      });
-      if (directInputMatches.length !== 1) return [];
-      const { inputBinding, read } = directInputMatches[0];
-      return [
-        {
-          relationKind: "actionReadsInputValue" as const,
-          inputPrimitive: "TextInput" as const,
-          actionPrimitive: "Pressable" as const,
-          valueExpr: inputBinding.valueExpr!,
-          ...(inputBinding.onChangeTextExpr ? { onChangeTextExpr: inputBinding.onChangeTextExpr } : {}),
-          onPressExpr: actionBinding.onPressExpr,
-          ...(actionBinding.label ? { label: actionBinding.label } : {}),
-          relationBasis: read.basis,
-          loc: sourceRangeSpan([inputBinding.loc, actionBinding.loc]),
-          evidence: [
-            "rn.stateActionRelation.actionReadsInputValue",
-            ...inputBinding.evidence,
-            ...actionBinding.evidence,
-            ...read.basis,
-          ],
-        },
-      ];
-    })
-    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
-  const rnConstraintActionReadiness: ReactNativePrimitiveConstraintActionReadinessSignal[] = rnActionBindingList
-    .flatMap((actionBinding) => {
-      if (actionBinding.primitive !== "Pressable" || !actionBinding.disabled) return [];
-      const relationMatches = rnStateActionRelations.filter((relation) => relation.onPressExpr === actionBinding.onPressExpr);
-      if (relationMatches.length !== 1) return [];
-      const relation = relationMatches[0];
-      const inputConstraintMatches = rnInputConstraints.filter((constraint) => constraint.valueExpr === relation.valueExpr);
-      if (inputConstraintMatches.length !== 1) return [];
-      const inputConstraint = inputConstraintMatches[0];
-      return [
-        {
-          relationKind: "constraintActionReadiness" as const,
-          inputPrimitive: "TextInput" as const,
-          actionPrimitive: "Pressable" as const,
-          valueExpr: relation.valueExpr,
-          onPressExpr: actionBinding.onPressExpr,
-          constraintKind: "textInputMetadataConstraints" as const,
-          readinessKind: "pressableDisabledReadiness" as const,
-          disabledExpr: actionBinding.disabled,
-          constraintBasis: inputConstraint.constraintBasis,
-          readinessBasis: ["jsx.Pressable.disabled"],
-          relationBasis: relation.relationBasis,
-          loc: sourceRangeSpan([inputConstraint.loc, actionBinding.loc]),
-          evidence: [
-            "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
-            ...inputConstraint.evidence,
-            ...actionBinding.evidence,
-            ...relation.relationBasis,
-          ],
-        },
-      ];
-    })
-    .slice(0, MAX_RN_PRIMITIVE_BINDINGS);
   const rnNavigationConcernList = dedupeBy(
     rnNavigationConcerns,
     (item) => {
@@ -1359,12 +1198,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
       }
     },
   ).slice(0, 16);
-  const hasRnPrimitiveInteractions =
-    rnInputBindingList.length > 0 ||
-    rnActionBindingList.length > 0 ||
-    rnInputConstraints.length > 0 ||
-    rnStateActionRelations.length > 0 ||
-    rnConstraintActionReadiness.length > 0;
+  const hasRnPrimitiveInteractions = rnInputBindingList.length > 0 || rnActionBindingList.length > 0;
   const hasRnStateActionConcerns = rnStateActionConcernList.length > 0;
   return {
     behavior: {
@@ -1390,9 +1224,6 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
             rnPrimitiveInteractions: {
               ...(rnInputBindingList.length ? { inputBindings: rnInputBindingList } : {}),
               ...(rnActionBindingList.length ? { actionBindings: rnActionBindingList } : {}),
-              ...(rnInputConstraints.length ? { inputConstraints: rnInputConstraints } : {}),
-              ...(rnStateActionRelations.length ? { stateActionRelations: rnStateActionRelations } : {}),
-              ...(rnConstraintActionReadiness.length ? { constraintActionReadiness: rnConstraintActionReadiness } : {}),
             },
           }
         : {}),

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -313,25 +313,11 @@ function compactReactNativePrimitiveInteractions(
   if (!interactions) return undefined;
   const inputBindings = interactions.inputBindings?.slice(0, 8);
   const actionBindings = interactions.actionBindings?.slice(0, 8);
-  const inputConstraints = interactions.inputConstraints?.slice(0, 8);
-  const stateActionRelations = interactions.stateActionRelations?.slice(0, 8);
-  const constraintActionReadiness = interactions.constraintActionReadiness?.slice(0, 8);
 
-  if (
-    !inputBindings?.length &&
-    !actionBindings?.length &&
-    !inputConstraints?.length &&
-    !stateActionRelations?.length &&
-    !constraintActionReadiness?.length
-  ) {
-    return undefined;
-  }
+  if (!inputBindings?.length && !actionBindings?.length) return undefined;
   return {
     ...(inputBindings?.length ? { inputBindings } : {}),
     ...(actionBindings?.length ? { actionBindings } : {}),
-    ...(inputConstraints?.length ? { inputConstraints } : {}),
-    ...(stateActionRelations?.length ? { stateActionRelations } : {}),
-    ...(constraintActionReadiness?.length ? { constraintActionReadiness } : {}),
   };
 }
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -114,55 +114,9 @@ export type ReactNativePrimitiveActionBindingSignal = {
   evidence: string[];
 };
 
-export type ReactNativePrimitiveInputConstraintSignal = {
-  primitive: "TextInput";
-  loc?: SourceRange;
-  valueExpr?: string;
-  constraintKind: "textInputMetadataConstraints";
-  maxLength?: string;
-  secureTextEntry?: string;
-  keyboardType?: string;
-  autoCapitalize?: string;
-  descriptiveHint?: string;
-  constraintBasis: string[];
-  evidence: string[];
-};
-
-export type ReactNativePrimitiveStateActionRelationSignal = {
-  relationKind: "actionReadsInputValue";
-  inputPrimitive: "TextInput";
-  actionPrimitive: "Pressable";
-  valueExpr: string;
-  onChangeTextExpr?: string;
-  onPressExpr: string;
-  label?: string;
-  relationBasis: string[];
-  loc?: SourceRange;
-  evidence: string[];
-};
-
-export type ReactNativePrimitiveConstraintActionReadinessSignal = {
-  relationKind: "constraintActionReadiness";
-  inputPrimitive: "TextInput";
-  actionPrimitive: "Pressable";
-  valueExpr: string;
-  onPressExpr: string;
-  constraintKind: "textInputMetadataConstraints";
-  readinessKind: "pressableDisabledReadiness";
-  disabledExpr: string;
-  constraintBasis: string[];
-  readinessBasis: string[];
-  relationBasis: string[];
-  loc?: SourceRange;
-  evidence: string[];
-};
-
 export type ReactNativePrimitiveInteractionSignal = {
   inputBindings?: ReactNativePrimitiveInputBindingSignal[];
   actionBindings?: ReactNativePrimitiveActionBindingSignal[];
-  inputConstraints?: ReactNativePrimitiveInputConstraintSignal[];
-  stateActionRelations?: ReactNativePrimitiveStateActionRelationSignal[];
-  constraintActionReadiness?: ReactNativePrimitiveConstraintActionReadinessSignal[];
 };
 
 export type ReactNativeAccessibilityTestAnchorSignal = {

--- a/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
+++ b/test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx
@@ -8,7 +8,6 @@ type InlineActionRowProps = {
 
 export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionRowProps) {
   const submitCurrentValue = () => onSubmit(value.trim());
-  const isSubmitDisabled = value.trim().length === 0;
 
   return (
     <View accessibilityLabel="inline action row">
@@ -22,7 +21,7 @@ export function InlineActionRow({ value, onChangeText, onSubmit }: InlineActionR
         accessibilityLabel="Inline filter"
         testID="inline-filter-input"
       />
-      <Pressable onPress={submitCurrentValue} disabled={isSubmitDisabled} accessibilityLabel="Submit filter" testID="submit-filter-button">
+      <Pressable onPress={submitCurrentValue} accessibilityLabel="Submit filter" testID="submit-filter-button">
         <Text>Submit</Text>
       </Pressable>
     </View>

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -124,7 +124,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",
-      loc: { startLine: 16, endLine: 24 },
+      loc: { startLine: 15, endLine: 23 },
       valueExpr: "value",
       onChangeTextExpr: "onChangeText",
       onChangeTextKind: "identifier",
@@ -148,85 +148,14 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.deepEqual(payload?.facts.primitiveInteractions?.actionBindings, [
     {
       primitive: "Pressable",
-      loc: { startLine: 25, endLine: 25 },
+      loc: { startLine: 24, endLine: 24 },
       onPressExpr: "submitCurrentValue",
       onPressKind: "identifier",
       onPressSource: "same-file-local",
       label: "Submit",
-      disabled: "isSubmitDisabled",
       accessibilityLabel: "Submit filter",
       testID: "submit-filter-button",
-      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.disabled", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
-    },
-  ]);
-  assert.deepEqual(payload?.facts.primitiveInteractions?.inputConstraints, [
-    {
-      primitive: "TextInput",
-      loc: { startLine: 16, endLine: 24 },
-      valueExpr: "value",
-      constraintKind: "textInputMetadataConstraints",
-      keyboardType: "web-search",
-      autoCapitalize: "sentences",
-      descriptiveHint: "Type filter",
-      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
-      evidence: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize", "jsx.TextInput.placeholder"],
-    },
-  ]);
-  assert.deepEqual(payload?.facts.primitiveInteractions?.stateActionRelations, [
-    {
-      relationKind: "actionReadsInputValue",
-      inputPrimitive: "TextInput",
-      actionPrimitive: "Pressable",
-      valueExpr: "value",
-      onChangeTextExpr: "onChangeText",
-      onPressExpr: "submitCurrentValue",
-      label: "Submit",
-      relationBasis: ["handler.submitCurrentValue.reads.value"],
-      loc: { startLine: 16, endLine: 25 },
-      evidence: [
-        "rn.stateActionRelation.actionReadsInputValue",
-        "jsx.TextInput.value",
-        "jsx.TextInput.onChangeText",
-        "jsx.TextInput.placeholder",
-        "jsx.TextInput.keyboardType",
-        "jsx.TextInput.autoCapitalize",
-        "jsx.TextInput.accessibilityLabel",
-        "jsx.TextInput.testID",
-        "jsx.Pressable.onPress",
-        "jsx.Pressable.Text.label",
-        "jsx.Pressable.disabled",
-        "jsx.Pressable.accessibilityLabel",
-        "jsx.Pressable.testID",
-        "handler.submitCurrentValue.reads.value",
-      ],
-    },
-  ]);
-  assert.deepEqual(payload?.facts.primitiveInteractions?.constraintActionReadiness, [
-    {
-      relationKind: "constraintActionReadiness",
-      inputPrimitive: "TextInput",
-      actionPrimitive: "Pressable",
-      valueExpr: "value",
-      onPressExpr: "submitCurrentValue",
-      constraintKind: "textInputMetadataConstraints",
-      readinessKind: "pressableDisabledReadiness",
-      disabledExpr: "isSubmitDisabled",
-      constraintBasis: ["jsx.TextInput.keyboardType", "jsx.TextInput.autoCapitalize"],
-      readinessBasis: ["jsx.Pressable.disabled"],
-      relationBasis: ["handler.submitCurrentValue.reads.value"],
-      loc: { startLine: 16, endLine: 25 },
-      evidence: [
-        "rn.constraintActionReadiness.pressableDisabledReadsConstrainedInput",
-        "jsx.TextInput.keyboardType",
-        "jsx.TextInput.autoCapitalize",
-        "jsx.TextInput.placeholder",
-        "jsx.Pressable.onPress",
-        "jsx.Pressable.Text.label",
-        "jsx.Pressable.disabled",
-        "jsx.Pressable.accessibilityLabel",
-        "jsx.Pressable.testID",
-        "handler.submitCurrentValue.reads.value",
-      ],
+      evidence: ["jsx.Pressable.onPress", "jsx.Pressable.Text.label", "jsx.Pressable.accessibilityLabel", "jsx.Pressable.testID"],
     },
   ]);
   assert.equal("formControls" in payload.facts, false);
@@ -243,8 +172,6 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].onPressSource, "same-file-local");
   assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.actionBindings[0].label, "Submit");
-  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.constraintActionReadiness[0].disabledExpr, "isSubmitDisabled");
-  assert.equal(preReadDecision.payload.domainPayload.facts.primitiveInteractions.constraintActionReadiness[0].relationKind, "constraintActionReadiness");
   assert.equal(preReadDecision.debug.domainDetection.classification, "react-native");
   assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
 });

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -10,7 +10,7 @@ import {
 test("React Native payload evidence exposes primitiveInteractions without widening RN scope", async () => {
   const evidence = await buildReactNativePayloadEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
 
-  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v3");
+  assert.equal(evidence.schemaVersion, "react-native-payload-evidence.v2");
   assert.equal(evidence.measurement, "local-fixture-pre-read-and-model-facing-domain-payload-evidence");
   assert.match(evidence.claimBoundary, /Local fixture payload evidence only/);
   assert.match(evidence.claimBoundary, /not broad React Native support/);
@@ -25,12 +25,6 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.boundaryFallbacksPreserved.blocker, null);
   assert.equal(evidence.summary.metadataAnchorsVisible.claimable, true);
   assert.equal(evidence.summary.metadataAnchorsVisible.blocker, null);
-  assert.equal(evidence.summary.inputConstraintsVisible.claimable, true);
-  assert.equal(evidence.summary.inputConstraintsVisible.scope, "rn-primitive-input-narrow-payload-only");
-  assert.equal(evidence.summary.stateActionRelationsVisible.claimable, true);
-  assert.equal(evidence.summary.stateActionRelationsVisible.relationKind, "actionReadsInputValue");
-  assert.equal(evidence.summary.constraintActionReadinessVisible.claimable, true);
-  assert.equal(evidence.summary.constraintActionReadinessVisible.relationKind, "constraintActionReadiness");
   assert.deepEqual(
     evidence.summary.metadataAnchorsVisible.textInputFields.map((row) => row.field),
     RN_TEXT_INPUT_METADATA_FIELDS,
@@ -102,15 +96,8 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressExpr, "submitCurrentValue");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].onPressSource, "same-file-local");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].label, "Submit");
-  assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].disabled, "isSubmitDisabled");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
-  assert.deepEqual(inline.preRead.primitiveInteractions.stateActionRelations, inline.modelFacing.primitiveInteractions.stateActionRelations);
-  assert.equal(inline.preRead.primitiveInteractions.stateActionRelations[0].relationKind, "actionReadsInputValue");
-  assert.equal(inline.preRead.primitiveInteractions.stateActionRelations[0].onPressExpr, "submitCurrentValue");
-  assert.deepEqual(inline.preRead.primitiveInteractions.constraintActionReadiness, inline.modelFacing.primitiveInteractions.constraintActionReadiness);
-  assert.equal(inline.preRead.primitiveInteractions.constraintActionReadiness[0].relationKind, "constraintActionReadiness");
-  assert.equal(inline.preRead.primitiveInteractions.constraintActionReadiness[0].disabledExpr, "isSubmitDisabled");
 });
 
 test("React Native payload evidence keeps richer RN WebView and TUI boundaries fallback-only", async () => {
@@ -136,9 +123,6 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /RN primitive interaction facts visible: yes/);
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
   assert.match(markdown, /RN metadata anchors visible: yes/);
-  assert.match(markdown, /Measured RN narrow constraint\/action readiness visible: yes/);
-  assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
-  assert.match(markdown, /constraintActionReadiness:submitCurrentValue->value,disabled=isSubmitDisabled/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| secureTextEntry \| yes \| yes \| yes \|/);
   assert.match(markdown, /\| TextInput \| maxLength \| yes \| yes \| yes \|/);


### PR DESCRIPTION
Reverts #540 as requested so the RN constraint action readiness update can be re-landed from an upstream-owned branch instead of the fork-authored replacement PR.

## Summary
- revert merge commit `aea15c3923427f7209b7ba8ebdbf5b81d1838913` from #540
- remove the fork-authored RN constraint action readiness additions from `main`
- restore the repo to the pre-#540 state before reapplying the change through a minislively-owned branch

## Verification
- npm run typecheck -- --pretty false
- node --test test/payload-policy-react-native.test.mjs test/react-native-payload-evidence.test.mjs

## Notes
- this revert is intentional housekeeping so the feature can be reapplied through the required upstream-owned update path