### PR TITLE
Remove merge-gate review approval requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,6 @@
 
 Fixes #
 
-## Merge gate checklist
-
-- [ ] A non-author reviewer left a GitHub PR review approval on the current head commit.
-- [ ] If I push/amend/rebase/force-push after approval, I know the PR needs a fresh approval again.
-- [ ] I did not rely on an issue comment or regular PR comment as approval evidence.
-
 ## Summary
 
 -

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -8,11 +8,6 @@ on:
       - synchronize
       - edited
       - ready_for_review
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
 
 permissions:
   contents: read
@@ -25,7 +20,7 @@ concurrency:
 
 jobs:
   merge-gate:
-    name: Validate approval review and linked issue
+    name: Validate linked issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -37,6 +32,5 @@ jobs:
       - name: Validate merge policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MERGE_GATE_REQUIRE_APPROVAL: "true"
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -64,7 +64,7 @@ export function evaluatePullRequestMergeGate({
   pullRequest,
   reviews = [],
   requireLinkedIssue = true,
-  requireApproval = true,
+  requireApproval = false,
 }) {
   const blockers = [];
 
@@ -126,17 +126,20 @@ async function main() {
     throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required in GitHub Actions.");
   }
 
-  const reviews = await fetchPullRequestReviews({
-    repository,
-    pullNumber: pullRequest.number,
-    token,
-  });
+  const requireApproval = process.env.MERGE_GATE_REQUIRE_APPROVAL === "true";
+  const reviews = requireApproval
+    ? await fetchPullRequestReviews({
+      repository,
+      pullNumber: pullRequest.number,
+      token,
+    })
+    : [];
 
   const result = evaluatePullRequestMergeGate({
     pullRequest,
     reviews,
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
-    requireApproval: process.env.MERGE_GATE_REQUIRE_APPROVAL !== "false",
+    requireApproval,
   });
 
   if (!result.ok) {
@@ -147,9 +150,9 @@ async function main() {
   }
 
   const approvalSummary = result.approvingReviewers.length > 0
-    ? `Approving reviewer(s): ${result.approvingReviewers.join(", ")}`
-    : "Approval requirement disabled";
-  console.log(`Merge gate passed. Linked issue detected. ${approvalSummary}`);
+    ? ` Approving reviewer(s): ${result.approvingReviewers.join(", ")}`
+    : "";
+  console.log(`Merge gate passed. Linked issue detected.${approvalSummary}`);
 }
 
 function isMainModule() {

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -8,20 +8,21 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
 const pullRequestTemplatePath = path.join(repoRoot, ".github", "PULL_REQUEST_TEMPLATE.md");
 
-test("merge gate workflow validates approval reviews and linked issues in CI", () => {
+test("merge gate workflow validates linked issues in CI without review approval events", () => {
   const workflow = fs.readFileSync(workflowPath, "utf8");
   assert.match(workflow, /pull_request_target:/);
-  assert.match(workflow, /pull_request_review:/);
+  assert.doesNotMatch(workflow, /pull_request_review:/);
   assert.doesNotMatch(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS/);
   assert.doesNotMatch(workflow, /MERGE_GATE_APPROVAL_MODE/);
-  assert.match(workflow, /MERGE_GATE_REQUIRE_APPROVAL: "true"/);
-  assert.match(workflow, /Validate approval review and linked issue/);
+  assert.doesNotMatch(workflow, /MERGE_GATE_REQUIRE_APPROVAL:/);
+  assert.match(workflow, /Validate linked issue/);
 });
 
-test("pull request template warns about current-head non-author approval", () => {
+test("pull request template keeps linked issue prompt and drops approval checklist", () => {
   const template = fs.readFileSync(pullRequestTemplatePath, "utf8");
-  assert.match(template, /non-author reviewer/i);
-  assert.match(template, /current head commit/i);
-  assert.match(template, /issue comment or regular PR comment/i);
-  assert.match(template, /fresh approval again/i);
+  assert.match(template, /Linked issue/i);
+  assert.match(template, /Fixes #/);
+  assert.doesNotMatch(template, /non-author reviewer/i);
+  assert.doesNotMatch(template, /current head commit/i);
+  assert.doesNotMatch(template, /issue comment or regular PR comment/i);
 });

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -11,49 +11,43 @@ import {
 
 const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } };
 
-test("merge gate passes when PR links a closing issue and has current-head approval", () => {
+test("merge gate passes by default when PR links a closing issue", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
-    reviews: [
-      { user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
-    ],
   });
 
   assert.equal(result.ok, true);
-  assert.deepEqual(result.approvingReviewers, ["reviewer"]);
+  assert.deepEqual(result.approvingReviewers, []);
 });
 
-test("merge gate still requires linked issue when approval exists", () => {
+test("merge gate still requires linked issue when approval checks are disabled", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
-    reviews: [
-      { user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
-    ],
   });
 
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /closing issue/);
   assert.doesNotMatch(result.blockers.join("\n"), /active approval/);
-  assert.deepEqual(result.approvingReviewers, ["reviewer"]);
+  assert.deepEqual(result.approvingReviewers, []);
 });
 
 test("merge gate rejects PRs without a closing issue reference", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
-    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
   });
 
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /closing issue/);
 });
 
-test("merge gate requires latest reviewer state to stay approved", () => {
+test("merge gate can still enforce latest reviewer state when approval checks are enabled", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
     reviews: [
       { user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
       { user: { login: "reviewer" }, state: "CHANGES_REQUESTED", submitted_at: "2026-05-01T00:02:00Z" },
     ],
+    requireApproval: true,
   });
 
   assert.equal(result.ok, false);
@@ -61,10 +55,11 @@ test("merge gate requires latest reviewer state to stay approved", () => {
   assert.match(result.blockers.join("\n"), /requires re-approval/i);
 });
 
-test("merge gate requires approval on the current head commit", () => {
+test("merge gate can require approval on the current head commit when enabled", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
     reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "old-sha" }],
+    requireApproval: true,
   });
 
   assert.equal(result.ok, false);
@@ -77,6 +72,7 @@ test("merge gate ignores PR author self-approval", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "reviewer" } },
     reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
+    requireApproval: true,
   });
 
   assert.equal(result.ok, false);
@@ -87,7 +83,6 @@ test("merge gate ignores PR author self-approval", () => {
 test("merge gate can disable linked issue enforcement explicitly", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
-    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
     requireLinkedIssue: false,
   });
 


### PR DESCRIPTION
Closes #544

## Summary
- drop the current-head non-author approval requirement from the merge gate workflow
- keep linked-issue enforcement as the remaining merge gate
- remove the approval checklist from the PR template and align merge-gate tests

## Validation
- npm run build
- npm run typecheck -- --pretty false
- npm test
