### PR TITLE
Restore merge-gate review approval requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@ Fixes #
 ## Verification
 
 -
+
+## Review gate
+
+- [ ] Current head has a GitHub PR review approval from a non-author reviewer. Issue comments and regular PR comments do not count.

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -8,6 +8,9 @@ on:
       - synchronize
       - edited
       - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: read
@@ -20,7 +23,7 @@ concurrency:
 
 jobs:
   merge-gate:
-    name: Validate linked issue
+    name: Validate approval review and linked issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -33,4 +36,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
+          MERGE_GATE_REQUIRE_APPROVAL: "true"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -64,7 +64,7 @@ export function evaluatePullRequestMergeGate({
   pullRequest,
   reviews = [],
   requireLinkedIssue = true,
-  requireApproval = false,
+  requireApproval = true,
 }) {
   const blockers = [];
 
@@ -126,14 +126,12 @@ async function main() {
     throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required in GitHub Actions.");
   }
 
-  const requireApproval = process.env.MERGE_GATE_REQUIRE_APPROVAL === "true";
-  const reviews = requireApproval
-    ? await fetchPullRequestReviews({
-      repository,
-      pullNumber: pullRequest.number,
-      token,
-    })
-    : [];
+  const requireApproval = process.env.MERGE_GATE_REQUIRE_APPROVAL !== "false";
+  const reviews = await fetchPullRequestReviews({
+    repository,
+    pullNumber: pullRequest.number,
+    token,
+  });
 
   const result = evaluatePullRequestMergeGate({
     pullRequest,

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -8,21 +8,19 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
 const pullRequestTemplatePath = path.join(repoRoot, ".github", "PULL_REQUEST_TEMPLATE.md");
 
-test("merge gate workflow validates linked issues in CI without review approval events", () => {
+test("merge gate workflow validates linked issues and current-head review approval", () => {
   const workflow = fs.readFileSync(workflowPath, "utf8");
   assert.match(workflow, /pull_request_target:/);
-  assert.doesNotMatch(workflow, /pull_request_review:/);
-  assert.doesNotMatch(workflow, /MERGE_GATE_ALLOWED_MAINTAINERS/);
-  assert.doesNotMatch(workflow, /MERGE_GATE_APPROVAL_MODE/);
-  assert.doesNotMatch(workflow, /MERGE_GATE_REQUIRE_APPROVAL:/);
-  assert.match(workflow, /Validate linked issue/);
+  assert.match(workflow, /pull_request_review:/);
+  assert.match(workflow, /MERGE_GATE_REQUIRE_APPROVAL: "true"/);
+  assert.match(workflow, /Validate approval review and linked issue/);
 });
 
-test("pull request template keeps linked issue prompt and drops approval checklist", () => {
+test("pull request template keeps linked issue prompt and approval checklist", () => {
   const template = fs.readFileSync(pullRequestTemplatePath, "utf8");
   assert.match(template, /Linked issue/i);
   assert.match(template, /Fixes #/);
-  assert.doesNotMatch(template, /non-author reviewer/i);
-  assert.doesNotMatch(template, /current head commit/i);
-  assert.doesNotMatch(template, /issue comment or regular PR comment/i);
+  assert.match(template, /non-author reviewer/i);
+  assert.match(template, /Current head/i);
+  assert.match(template, /Issue comments and regular PR comments do not count/i);
 });

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -11,12 +11,13 @@ import {
 
 const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } };
 
-test("merge gate passes by default when PR links a closing issue", () => {
+test("merge gate requires non-author approval by default even when PR links a closing issue", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
   });
 
-  assert.equal(result.ok, true);
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /GitHub PR review approval/);
   assert.deepEqual(result.approvingReviewers, []);
 });
 
@@ -68,6 +69,27 @@ test("merge gate can require approval on the current head commit when enabled", 
   assert.match(result.blockers.join("\n"), /requires re-approval/i);
 });
 
+
+test("merge gate passes by default with linked issue and current-head non-author approval", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: pr,
+    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.approvingReviewers, ["reviewer"]);
+});
+
+test("issue comments do not satisfy the approval gate", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: pr,
+    reviews: [],
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /comments do not count/i);
+});
+
 test("merge gate ignores PR author self-approval", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "reviewer" } },
@@ -84,6 +106,7 @@ test("merge gate can disable linked issue enforcement explicitly", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
     requireLinkedIssue: false,
+    requireApproval: false,
   });
 
   assert.equal(result.ok, true);


### PR DESCRIPTION
Closes #556

## Summary
- Restore the merge gate's current-head non-author GitHub PR review approval requirement.
- Keep linked issue enforcement intact.
- Re-add the PR template checklist so issue comments are not mistaken for review approvals.

## Verification
- npm ci
- node --check scripts/validate-pr-merge-gate.mjs
- node --test test/pr-merge-gate.test.mjs test/merge-gate-workflow.test.mjs
- npm run typecheck -- --pretty false
- git diff --check
