### PR TITLE
Keep claim-boundary rules in AI coding context without widening no-op routing

### DIFF
--- a/docs/project-knowledge/claim-boundary-rules.json
+++ b/docs/project-knowledge/claim-boundary-rules.json
@@ -1,0 +1,28 @@
+{
+  "version": "project-knowledge.v1",
+  "rules": [
+    {
+      "id": "claim-boundary.rn-no-broad-support",
+      "family": "claim-boundary",
+      "summary": "Do not claim broad React Native support. Keep wording bounded to observed source-only evidence and the documented claim boundary.",
+      "appliesWhen": {
+        "keywords": [
+          "react native",
+          "rn",
+          "claim boundary",
+          "broad support",
+          "primitiveinteractions"
+        ],
+        "paths": [
+          "scripts/react-native-",
+          "test/react-web-release-smoke.test.mjs"
+        ]
+      },
+      "evidence": [
+        "docs/domain-payload-architecture.md#rn-claim-boundary-at-the-architecture-layer"
+      ],
+      "severity": "warning",
+      "authority": "tracked"
+    }
+  ]
+}

--- a/src/adapters/claude-runtime-hook.ts
+++ b/src/adapters/claude-runtime-hook.ts
@@ -11,6 +11,8 @@ import {
   CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS,
 } from "./claude-runtime-status";
 import type { ContextBudget, ContextMode, ModelFacingPayload, PromptSpecificity } from "../core/schema";
+import { appendProjectKnowledgeBlock, resolveProjectKnowledgeContext } from "../core/project-knowledge";
+import type { ProjectKnowledgeMetadata } from "../core/project-knowledge";
 import {
   estimateFileBytes,
   estimateTextBytes,
@@ -44,6 +46,7 @@ export type ClaudeRuntimeHookDecision = {
   contextBudget?: ContextBudget;
   promptSpecificity?: PromptSpecificity;
   contextPolicyVersion?: "context-policy.v1";
+  projectKnowledge?: ProjectKnowledgeMetadata;
   debug?: {
     repeatedFile: boolean;
     eligible: boolean;
@@ -183,6 +186,13 @@ function recordClaudeMetric(
     actualEstimatedBytes: options.actualEstimatedBytes,
     comparableForSavings: options.comparableForSavings,
     observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+    appliedRuleIds: decision.projectKnowledge?.appliedRuleIds,
+    family: decision.projectKnowledge?.family,
+    matchReasons: decision.projectKnowledge?.matchReasons,
+    evidencePaths: decision.projectKnowledge?.evidencePaths,
+    authority: decision.projectKnowledge?.authority,
+    rulesPath: decision.projectKnowledge?.rulesPath,
+    mode: decision.projectKnowledge?.mode,
   });
 }
 
@@ -451,7 +461,9 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
 
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
-    const { context: additionalContext, truncated, removedSections } = buildPayloadContext(target, decision.payload, contextMode);
+    const { context: payloadContext, truncated, removedSections } = buildPayloadContext(target, decision.payload, contextMode);
+    const projectKnowledge = resolveProjectKnowledgeContext(prompt, [target], cwd);
+    const additionalContext = clampAdditionalContext(appendProjectKnowledgeBlock(payloadContext, projectKnowledge?.block));
     const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
     const reasons = [
       "repeated-file",
@@ -474,6 +486,7 @@ export function handleClaudeRuntimeHook(input: ClaudeRuntimeHookInput, cwd = pro
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
+      ...(projectKnowledge ? { projectKnowledge: projectKnowledge.metadata } : {}),
       debug: {
         repeatedFile: true,
         eligible: true,

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { decidePreRead } from "./pre-read";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
+import { appendProjectKnowledgeBlock, resolveProjectKnowledgeContext } from "../core/project-knowledge";
 import { buildPreReadReuseStatus } from "./codex-runtime-status";
 import { clearCodexActiveFile, ensureFreshCodexContextForTarget, markCodexAttachPrepared, markCodexReady } from "./codex-runtime-trust";
 import {
@@ -283,6 +284,13 @@ function recordRuntimeDecisionMetric(
     actualEstimatedBytes: options.actualEstimatedBytes,
     comparableForSavings: options.comparableForSavings,
     observedOriginalEstimatedBytes: options.observedOriginalEstimatedBytes,
+    appliedRuleIds: decision.projectKnowledge?.appliedRuleIds,
+    family: decision.projectKnowledge?.family,
+    matchReasons: decision.projectKnowledge?.matchReasons,
+    evidencePaths: decision.projectKnowledge?.evidencePaths,
+    authority: decision.projectKnowledge?.authority,
+    rulesPath: decision.projectKnowledge?.rulesPath,
+    mode: decision.projectKnowledge?.mode,
   });
 }
 
@@ -524,7 +532,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   if (decision.decision === "payload" && decision.payload) {
     const contextMode = payloadContextMode(decision.payload);
     const runtimeContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
-    const { additionalContext, reactWebContextPacking } = runtimeContext;
+    const projectKnowledge = resolveProjectKnowledgeContext(prompt, [target], cwd);
+    const additionalContext = appendProjectKnowledgeBlock(runtimeContext.additionalContext, projectKnowledge?.block);
+    const { reactWebContextPacking } = runtimeContext;
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
     const runtimeDecision: CodexRuntimeHookDecision = {
@@ -544,6 +554,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
+      ...(projectKnowledge ? { projectKnowledge: projectKnowledge.metadata } : {}),
       debug: {
         repeatedFile: true,
         eligible: true,

--- a/src/core/discover.ts
+++ b/src/core/discover.ts
@@ -25,9 +25,27 @@ export type DiscoveryResult = {
   stats: DiscoveryStats;
 };
 
+function isMissingDuringDiscovery(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      ((error as NodeJS.ErrnoException).code === "ENOENT" || (error as NodeJS.ErrnoException).code === "ENOTDIR"),
+  );
+}
+
 function walk(dir: string, out: string[], stats: DiscoveryStats, root: string): void {
   stats.directoriesVisited += 1;
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingDuringDiscovery(error)) {
+      return;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
     if (IGNORE.has(entry.name)) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -40,8 +58,15 @@ function walk(dir: string, out: string[], stats: DiscoveryStats, root: string): 
   }
 }
 
-function readText(filePath: string): string {
-  return fs.readFileSync(filePath, "utf8");
+function readText(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if (isMissingDuringDiscovery(error)) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 function resolveRelativeImport(
@@ -88,6 +113,7 @@ function relativeImports(
   stats: DiscoveryStats,
 ): RelativeImport[] {
   const text = readText(filePath);
+  if (text === null) return [];
   const matches = text.matchAll(/import\s+(type\s+)?(?:[\s\S]*?)from\s+["'](\.[^"']+)["']|import\s+["'](\.[^"']+)["']/g);
   const imports = new Map<string, RelativeImport>();
   for (const match of matches) {

--- a/src/core/project-knowledge.ts
+++ b/src/core/project-knowledge.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const PROJECT_KNOWLEDGE_VERSION = "project-knowledge.v1" as const;
+export const DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH = path.join("docs", "project-knowledge", "claim-boundary-rules.json");
+
+export type ProjectKnowledgeAuthority = "tracked" | "local-opt-in";
+export type ProjectKnowledgeMode = "advisory";
+
+export type ProjectKnowledgeRule = {
+  id: string;
+  family: "claim-boundary";
+  summary: string;
+  appliesWhen?: {
+    keywords?: string[];
+    paths?: string[];
+  };
+  evidence: string[];
+  severity?: "info" | "warning";
+  authority?: ProjectKnowledgeAuthority;
+};
+
+export type ProjectKnowledgeRuleFile = {
+  version?: typeof PROJECT_KNOWLEDGE_VERSION;
+  rules: ProjectKnowledgeRule[];
+};
+
+export type ProjectKnowledgeMetadata = {
+  appliedRuleIds: string[];
+  family: "claim-boundary";
+  matchReasons: string[];
+  evidencePaths: string[];
+  authority: ProjectKnowledgeAuthority;
+  rulesPath: string;
+  mode: ProjectKnowledgeMode;
+};
+
+export type LoadedProjectKnowledgeRules = {
+  exists: boolean;
+  rulesPath: string;
+  authority: ProjectKnowledgeAuthority;
+  rules: ProjectKnowledgeRule[];
+  errors: string[];
+};
+
+export type ResolvedProjectKnowledgeContext = {
+  block: string;
+  metadata: ProjectKnowledgeMetadata;
+};
+
+type ProjectKnowledgeMatch = {
+  rule: ProjectKnowledgeRule;
+  matchReasons: string[];
+};
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function normalizeText(value: string): string {
+  return value.toLowerCase();
+}
+
+function normalizeKeywordText(value: string): string {
+  return normalizeText(value).replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function normalizePathHint(value: string): string {
+  return value.replaceAll("\\", "/").toLowerCase();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function promptContainsKeyword(prompt: string, keyword: string): boolean {
+  const normalizedPrompt = normalizeKeywordText(prompt);
+  const normalizedKeyword = normalizeKeywordText(keyword);
+  if (!normalizedPrompt || !normalizedKeyword) return false;
+  const pattern = new RegExp(`(?:^|\\s)${escapeRegExp(normalizedKeyword).replace(/\\ /g, "\\\\s+")}(?=\\s|$)`);
+  return pattern.test(normalizedPrompt);
+}
+
+function validateRule(candidate: unknown, index: number): { rule?: ProjectKnowledgeRule; errors: string[] } {
+  const errors: string[] = [];
+  if (!candidate || typeof candidate !== "object") {
+    return { errors: [`rule[${index}] must be an object`] };
+  }
+
+  const rule = candidate as Record<string, unknown>;
+  const id = typeof rule.id === "string" ? rule.id.trim() : "";
+  const family = rule.family;
+  const summary = typeof rule.summary === "string" ? rule.summary.trim() : "";
+  const evidence = Array.isArray(rule.evidence) ? rule.evidence.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0) : [];
+  const severity = rule.severity === "info" || rule.severity === "warning" ? rule.severity : undefined;
+  const authority = rule.authority === "tracked" || rule.authority === "local-opt-in" ? rule.authority : undefined;
+  const appliesWhen = rule.appliesWhen && typeof rule.appliesWhen === "object" ? (rule.appliesWhen as Record<string, unknown>) : undefined;
+  const keywords = Array.isArray(appliesWhen?.keywords)
+    ? appliesWhen?.keywords.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : [];
+  const paths = Array.isArray(appliesWhen?.paths)
+    ? appliesWhen?.paths.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : [];
+
+  if (!id) errors.push(`rule[${index}].id must be a non-empty string`);
+  if (family !== "claim-boundary") errors.push(`rule[${index}].family must be \"claim-boundary\"`);
+  if (!summary) errors.push(`rule[${index}].summary must be a non-empty string`);
+  if (evidence.length === 0) errors.push(`rule[${index}].evidence must contain at least one string`);
+  if (severity !== undefined && severity !== "info" && severity !== "warning") {
+    errors.push(`rule[${index}].severity must be \"info\" or \"warning\" when provided`);
+  }
+  if (authority !== undefined && authority !== "tracked" && authority !== "local-opt-in") {
+    errors.push(`rule[${index}].authority must be \"tracked\" or \"local-opt-in\" when provided`);
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  return {
+    rule: {
+      id,
+      family: "claim-boundary",
+      summary,
+      appliesWhen: keywords.length > 0 || paths.length > 0 ? { ...(keywords.length > 0 ? { keywords } : {}), ...(paths.length > 0 ? { paths } : {}) } : undefined,
+      evidence,
+      ...(severity ? { severity } : {}),
+      ...(authority ? { authority } : {}),
+    },
+    errors,
+  };
+}
+
+export function loadProjectKnowledgeRules(
+  cwd = process.cwd(),
+  options: { rulesPath?: string; authority?: ProjectKnowledgeAuthority } = {},
+): LoadedProjectKnowledgeRules {
+  const authority = options.authority ?? "tracked";
+  const rulesPath = options.rulesPath ?? DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH;
+  const resolvedRulesPath = path.isAbsolute(rulesPath) ? rulesPath : path.join(cwd, rulesPath);
+  if (!fs.existsSync(resolvedRulesPath)) {
+    return { exists: false, rulesPath, authority, rules: [], errors: [] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(resolvedRulesPath, "utf8"));
+  } catch (error) {
+    return {
+      exists: true,
+      rulesPath,
+      authority,
+      rules: [],
+      errors: [`project-knowledge parse failed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  if (!parsed || typeof parsed !== "object" || !Array.isArray((parsed as { rules?: unknown }).rules)) {
+    return {
+      exists: true,
+      rulesPath,
+      authority,
+      rules: [],
+      errors: ["project-knowledge file must be an object with a rules array"],
+    };
+  }
+
+  const file = parsed as ProjectKnowledgeRuleFile;
+  const errors: string[] = [];
+  const rules: ProjectKnowledgeRule[] = [];
+  for (const [index, candidate] of file.rules.entries()) {
+    const result = validateRule(candidate, index);
+    errors.push(...result.errors);
+    if (result.rule) rules.push(result.rule);
+  }
+
+  return {
+    exists: true,
+    rulesPath,
+    authority,
+    rules,
+    errors,
+  };
+}
+
+function matchProjectKnowledgeRule(rule: ProjectKnowledgeRule, prompt: string, filePaths: string[]): ProjectKnowledgeMatch | null {
+  const normalizedFilePaths = filePaths.map((filePath) => normalizePathHint(filePath));
+  const reasons: string[] = [];
+
+  for (const keyword of rule.appliesWhen?.keywords ?? []) {
+    if (promptContainsKeyword(prompt, keyword)) {
+      reasons.push(`prompt-keyword:${keyword}`);
+    }
+  }
+
+  for (const hint of rule.appliesWhen?.paths ?? []) {
+    const normalizedHint = normalizePathHint(hint);
+    if (normalizedFilePaths.some((filePath) => filePath.includes(normalizedHint))) {
+      reasons.push(`path:${hint}`);
+    }
+  }
+
+  if (reasons.length === 0) return null;
+  return {
+    rule,
+    matchReasons: uniqueStrings(reasons),
+  };
+}
+
+function formatProjectKnowledgeBlock(matches: ProjectKnowledgeMatch[], metadata: ProjectKnowledgeMetadata): string {
+  const commentMetadata = {
+    ...metadata,
+    version: PROJECT_KNOWLEDGE_VERSION,
+  };
+  const lines = [
+    "# PROJECT KNOWLEDGE CONTEXT",
+    "",
+    `<!-- fooks-project-knowledge ${JSON.stringify(commentMetadata)} -->`,
+    "",
+    `## ${metadata.family}`,
+  ];
+
+  for (const match of matches) {
+    lines.push(`- Rule \`${match.rule.id}\`: ${match.rule.summary}`);
+    lines.push(`  Match reasons: ${match.matchReasons.join(", ")}`);
+    lines.push(`  Evidence: ${match.rule.evidence.join(", ")}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function resolveProjectKnowledgeContext(
+  prompt: string,
+  filePaths: string[],
+  cwd = process.cwd(),
+  options: { rulesPath?: string; authority?: ProjectKnowledgeAuthority } = {},
+): ResolvedProjectKnowledgeContext | null {
+  const loaded = loadProjectKnowledgeRules(cwd, options);
+  if (loaded.errors.length > 0 || loaded.rules.length === 0) {
+    return null;
+  }
+
+  const matches = loaded.rules.map((rule) => matchProjectKnowledgeRule(rule, prompt, filePaths)).filter((match): match is ProjectKnowledgeMatch => Boolean(match));
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const metadata: ProjectKnowledgeMetadata = {
+    appliedRuleIds: matches.map((match) => match.rule.id),
+    family: matches[0].rule.family,
+    matchReasons: uniqueStrings(matches.flatMap((match) => match.matchReasons)),
+    evidencePaths: uniqueStrings(matches.flatMap((match) => match.rule.evidence)),
+    authority: loaded.authority,
+    rulesPath: loaded.rulesPath,
+    mode: "advisory",
+  };
+
+  return {
+    metadata,
+    block: formatProjectKnowledgeBlock(matches, metadata),
+  };
+}
+
+export function appendProjectKnowledgeBlock(base: string, block: string | undefined): string {
+  if (!block) return base;
+  const separator = base.endsWith("\n\n") ? "" : base.endsWith("\n") ? "\n" : "\n\n";
+  return `${base}${separator}${block}`;
+}

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -14,6 +14,15 @@ function getExtractSource(): typeof import("./extract")["extractSource"] {
   return extractSourceModule.extractSource;
 }
 
+function isMissingPathError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      ((error as NodeJS.ErrnoException).code === "ENOENT" || (error as NodeJS.ErrnoException).code === "ENOTDIR"),
+  );
+}
+
 export function scanProject(cwd = process.cwd()): ScanResult {
   const startedAt = performance.now();
   const discoveryStartedAt = performance.now();
@@ -54,7 +63,15 @@ export function scanProject(cwd = process.cwd()): ScanResult {
       continue;
     }
     const statStartedAt = performance.now();
-    const stat = fs.statSync(target.filePath);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(target.filePath);
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue;
+      }
+      throw error;
+    }
     statMs += performance.now() - statStartedAt;
     fileStatCount += 1;
 
@@ -80,7 +97,15 @@ export function scanProject(cwd = process.cwd()): ScanResult {
     }
 
     const readStartedAt = performance.now();
-    const text = fs.readFileSync(target.filePath, "utf8");
+    let text: string;
+    try {
+      text = fs.readFileSync(target.filePath, "utf8");
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue;
+      }
+      throw error;
+    }
     fileReadMs += performance.now() - readStartedAt;
     fileReadCount += 1;
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,6 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
 import type { DomainDetectionResult } from "./domain-detector";
+import type { ProjectKnowledgeMetadata } from "./project-knowledge";
 import type { DomainPayload } from "./payload/domain-payload";
 import type { FrontendConcernProfile } from "./concern-profiles/types";
 
@@ -709,6 +710,7 @@ export type CodexRuntimeHookDecision = {
   contextBudget?: ContextBudget;
   promptSpecificity?: PromptSpecificity;
   contextPolicyVersion?: "context-policy.v1";
+  projectKnowledge?: ProjectKnowledgeMetadata;
   debug?: {
     repeatedFile: boolean;
     eligible: boolean;

--- a/src/core/session-metrics.ts
+++ b/src/core/session-metrics.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { sessionEventsPath, sessionSummaryPath, sessionsSummaryPath, sanitizeDataKey } from "./paths";
 import type { ContextMode } from "./schema";
+import type { ProjectKnowledgeAuthority, ProjectKnowledgeMode } from "./project-knowledge";
 
 export const FOOKS_SESSION_METRICS_SCHEMA_VERSION = 1;
 export const FOOKS_SESSION_METRIC_TIER = "estimated" as const;
@@ -68,6 +69,13 @@ export type FooksSessionMetricEvent = {
   fallbackReason?: string;
   comparableForSavings: boolean;
   estimated: FooksEstimatedUsage;
+  appliedRuleIds?: string[];
+  family?: "claim-boundary";
+  matchReasons?: string[];
+  evidencePaths?: string[];
+  authority?: ProjectKnowledgeAuthority;
+  rulesPath?: string;
+  mode?: ProjectKnowledgeMode;
   observedOpportunity?: {
     originalEstimatedBytes: number;
     originalEstimatedTokens: number;
@@ -142,6 +150,13 @@ export type RecordFooksSessionMetricInput = {
   actualEstimatedBytes?: number;
   comparableForSavings?: boolean;
   observedOriginalEstimatedBytes?: number;
+  appliedRuleIds?: string[];
+  family?: "claim-boundary";
+  matchReasons?: string[];
+  evidencePaths?: string[];
+  authority?: ProjectKnowledgeAuthority;
+  rulesPath?: string;
+  mode?: ProjectKnowledgeMode;
 };
 
 type MetricIdentity = {
@@ -592,6 +607,13 @@ export function recordFooksSessionMetricEvent(cwd: string, sessionKey: string, i
     fallbackReason: input.fallbackReason ? truncateString(input.fallbackReason) : undefined,
     comparableForSavings,
     estimated: eventUsage,
+    appliedRuleIds: input.appliedRuleIds?.length ? input.appliedRuleIds : undefined,
+    family: input.family,
+    matchReasons: input.matchReasons?.length ? input.matchReasons.map((reason) => truncateString(reason)) : undefined,
+    evidencePaths: input.evidencePaths?.length ? input.evidencePaths.map((entry) => truncateString(entry)) : undefined,
+    authority: input.authority,
+    rulesPath: input.rulesPath ? truncateString(input.rulesPath) : undefined,
+    mode: input.mode,
     observedOpportunity: observedOpportunity
       ? {
           originalEstimatedBytes: observedOriginalEstimatedBytes,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -60,6 +60,11 @@ const {
   sessionsSummaryPath,
 } = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { classifyPromptContext, discoverRelevantFilesByPolicy } = require(path.join(repoRoot, "dist", "core", "context-policy.js"));
+const {
+  DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH,
+  loadProjectKnowledgeRules,
+  resolveProjectKnowledgeContext,
+} = require(path.join(repoRoot, "dist", "core", "project-knowledge.js"));
 const { prepareExecutionContext } = require(path.join(repoRoot, "dist", "adapters", "codex.js"));
 const { attachClaude } = require(path.join(repoRoot, "dist", "adapters", "claude.js"));
 const { handleCodexNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "codex-native-hook.js"));
@@ -69,6 +74,7 @@ const { readCodexTrustStatus } = require(path.join(repoRoot, "dist", "adapters",
 const { readClaudeTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
 const { handleClaudeNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "claude-native-hook.js"));
 const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
+const { discoverProjectFilesWithStats } = require(path.join(repoRoot, "dist", "core", "discover.js"));
 const ts = require("typescript");
 
 const repoMetricTestSessionPrefixes = ["hook-", "cli-hook-", "bridge-contract-"];
@@ -207,6 +213,44 @@ function makeTempProject(repositoryUrl = "https://github.com/minislively/temp-pr
   );
   fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify({ name: "temp-project", repository: { url: repositoryUrl } }, null, 2));
   return tempDir;
+}
+
+function writeProjectKnowledgeFixture(tempDir, overrides = {}) {
+  const docsDir = path.join(tempDir, "docs", "project-knowledge");
+  fs.mkdirSync(docsDir, { recursive: true });
+  fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "docs", "domain-payload-architecture.md"),
+    [
+      "## RN claim boundary at the architecture layer",
+      "",
+      "Do not claim broad React Native support.",
+      "Keep wording bounded to observed source-only evidence.",
+      "",
+    ].join("\n"),
+  );
+  const ruleFile = {
+    version: "project-knowledge.v1",
+    rules: [
+      {
+        id: "claim-boundary.rn-no-broad-support",
+        family: "claim-boundary",
+        summary: "Do not claim broad React Native support. Keep wording bounded to observed source-only evidence and the documented claim boundary.",
+        appliesWhen: {
+          keywords: ["react native", "support", "claim boundary", "payload"],
+          paths: ["src/core/"],
+        },
+        evidence: ["docs/domain-payload-architecture.md#rn-claim-boundary-at-the-architecture-layer"],
+        severity: "warning",
+        authority: "tracked",
+      },
+    ],
+  };
+  fs.writeFileSync(path.join(tempDir, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH), JSON.stringify(overrides.ruleFile ?? ruleFile, null, 2));
+  if (overrides.ignoredRuleFile) {
+    fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, ".fooks", "project-knowledge.json"), JSON.stringify(overrides.ignoredRuleFile, null, 2));
+  }
 }
 
 function makeTempTsJsBetaProject(repositoryUrl = "https://github.com/minislively/temp-ts-js-project.git") {
@@ -1700,6 +1744,106 @@ test("prepareExecutionContext writes context policy metadata and resolves files 
   assert.match(context, /## src\/components\/FormSection.tsx/);
 });
 
+test("project knowledge loader prefers tracked rules and ignores .fooks rules by default", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir, {
+    ignoredRuleFile: {
+      version: "project-knowledge.v1",
+      rules: [
+        {
+          id: "claim-boundary.local-override",
+          family: "claim-boundary",
+          summary: "local-only override that must not be loaded by default",
+          appliesWhen: { keywords: ["react native"] },
+          evidence: ["docs/local-only.md"],
+        },
+      ],
+    },
+  });
+
+  const loaded = loadProjectKnowledgeRules(tempDir);
+  assert.equal(loaded.rulesPath, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH);
+  assert.equal(loaded.authority, "tracked");
+  assert.equal(loaded.errors.length, 0);
+  assert.deepEqual(loaded.rules.map((rule) => rule.id), ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(loaded.rules[0].summary.includes("local-only override"), false);
+});
+
+test("project knowledge resolves matching rule metadata and block without persistence wording", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const resolved = resolveProjectKnowledgeContext(
+    "Tighten the React Native support claim boundary for src/components/FormSection.tsx",
+    [path.join("src", "components", "FormSection.tsx")],
+    tempDir,
+  );
+
+  assert.ok(resolved);
+  assert.deepEqual(resolved.metadata.appliedRuleIds, ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(resolved.metadata.family, "claim-boundary");
+  assert.equal(resolved.metadata.authority, "tracked");
+  assert.equal(resolved.metadata.rulesPath, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH);
+  assert.ok(resolved.metadata.matchReasons.some((reason) => reason.startsWith("prompt-keyword:react native")));
+  assert.match(resolved.block, /PROJECT KNOWLEDGE CONTEXT/);
+  assert.match(resolved.block, /claim-boundary\.rn-no-broad-support/);
+  assert.doesNotMatch(resolved.block, /remembered|enforced|validated|guaranteed/i);
+});
+
+test("prepareExecutionContext keeps project knowledge out of first-run temp context", async () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const prompt = "Update src/components/FormSection.tsx and keep the React Native support wording inside the documented claim boundary";
+  const policy = classifyPromptContext(prompt, tempDir);
+  const result = await prepareExecutionContext(prompt, [path.join("src", "components", "FormSection.tsx")], tempDir, policy);
+  const context = fs.readFileSync(result.contextPath, "utf8");
+
+  assert.equal(result.projectKnowledge, undefined);
+  assert.doesNotMatch(context, /PROJECT KNOWLEDGE CONTEXT/);
+  assert.doesNotMatch(context, /claim-boundary\.rn-no-broad-support/);
+});
+
+test("prepareExecutionContext leaves project knowledge absent for non-matching prompts", async () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const prompt = "Modify src/components/FormSection.tsx";
+  const policy = classifyPromptContext(prompt, tempDir);
+  const result = await prepareExecutionContext(prompt, [path.join("src", "components", "FormSection.tsx")], tempDir, policy);
+  const context = fs.readFileSync(result.contextPath, "utf8");
+
+  assert.equal(result.projectKnowledge, undefined);
+  assert.doesNotMatch(context, /PROJECT KNOWLEDGE CONTEXT/);
+});
+
+test("project knowledge matching does not treat embedded short tokens like 'rn' inside unrelated words as a match", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir, {
+    ruleFile: {
+      version: "project-knowledge.v1",
+      rules: [
+        {
+          id: "claim-boundary.rn-short-token",
+          family: "claim-boundary",
+          summary: "Short rn token should only match as a standalone token.",
+          appliesWhen: {
+            keywords: ["rn"],
+          },
+          evidence: ["docs/domain-payload-architecture.md#rn-claim-boundary-at-the-architecture-layer"],
+        },
+      ],
+    },
+  });
+
+  assert.equal(resolveProjectKnowledgeContext("Return src/components/FormSection.tsx unchanged", [], tempDir), null);
+  assert.equal(resolveProjectKnowledgeContext("Turn src/components/FormSection.tsx into cleaner code", [], tempDir), null);
+  assert.ok(resolveProjectKnowledgeContext("Keep the rn claim boundary narrow", [], tempDir));
+});
+
+test("default tracked project knowledge rules stay narrow for generic support/core/adapter tasks", () => {
+  assert.equal(resolveProjectKnowledgeContext("Add support for dark mode", [path.join("src", "components", "FormSection.tsx")], repoRoot), null);
+  assert.equal(resolveProjectKnowledgeContext("Refactor src/core/cache.ts for clarity", [path.join("src", "core", "cache.ts")], repoRoot), null);
+  assert.equal(resolveProjectKnowledgeContext("Fix typo in src/adapters/codex.ts", [path.join("src", "adapters", "codex.ts")], repoRoot), null);
+});
+
 test("cli run keeps exact-file prompts to one light context file", () => {
   const tempDir = makeTempProject();
   const output = runText(["run", "Please", "update", "src/components/FormSection.tsx"], tempDir);
@@ -1767,6 +1911,82 @@ test("cli run prefers direct Codex prompt guidance when setup is already ready o
   assert.match(output, /If you intentionally want another runtime, use your original prompt there instead of the metadata-only temp context\./);
   assert.doesNotMatch(output, /Reliable first success: run `fooks setup` in this repo first\./);
   assert.doesNotMatch(output, /Optional check: `fooks status codex`/);
+});
+
+test("codex runtime hook keeps matching no-target claim-boundary prompts as no-op without project knowledge", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const sessionId = `hook-knowledge-no-target-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  const decision = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Tighten the React Native support claim boundary wording",
+    },
+    tempDir,
+  );
+
+  assert.equal(decision.action, "noop");
+  assert.equal(decision.projectKnowledge, undefined);
+  const summary = readSessionMetricSummary(tempDir, sessionId);
+  const events = fs
+    .readFileSync(sessionEventsPath(tempDir, summary.metricSessionKey), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const lastEvent = events.at(-1);
+  assert.equal("appliedRuleIds" in lastEvent, false);
+  assert.equal("matchReasons" in lastEvent, false);
+});
+
+test("codex runtime hook records first matching exact-file prompt without project knowledge and injects it on repeated file", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const sessionId = `hook-knowledge-repeated-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Review ${target} and keep the React Native support claim boundary narrow`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+  assert.equal(first.projectKnowledge, undefined);
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, review ${target} and keep the React Native support claim boundary narrow`,
+    },
+    tempDir,
+  );
+  assert.equal(second.action, "inject");
+  assert.ok(second.additionalContext.length <= CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS);
+  assert.ok(second.additionalContext.includes("PROJECT KNOWLEDGE CONTEXT"));
+  assert.deepEqual(second.projectKnowledge.appliedRuleIds, ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(second.projectKnowledge.family, "claim-boundary");
+  assert.ok(second.projectKnowledge.matchReasons.some((reason) => reason.startsWith("prompt-keyword:react native")));
+
+  const summary = readSessionMetricSummary(tempDir, sessionId);
+  const events = fs
+    .readFileSync(sessionEventsPath(tempDir, summary.metricSessionKey), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const lastEvent = events.at(-1);
+  assert.deepEqual(lastEvent.appliedRuleIds, ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(lastEvent.family, "claim-boundary");
+  assert.ok(lastEvent.matchReasons.some((reason) => reason.startsWith("prompt-keyword:react native")));
+  assert.equal(lastEvent.authority, "tracked");
+  assert.equal(lastEvent.rulesPath, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH);
+  assert.equal(lastEvent.mode, "advisory");
 });
 
 test("runtime hook falls back when repeated-file payload build throws", () => {
@@ -2795,6 +3015,70 @@ test("scan excludes cross-folder linked ts even when directly imported", () => {
   assert.ok(!filePaths.includes(path.join("src", "date-utils.ts")));
 });
 
+test("discover tolerates files that disappear during linked-import inspection", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-discover-race-"));
+  const componentFile = path.join(tempDir, "src", "components", "Widget.tsx");
+  const linkedTypesFile = path.join(tempDir, "src", "components", "Widget.types.ts");
+  fs.mkdirSync(path.dirname(componentFile), { recursive: true });
+  fs.writeFileSync(
+    componentFile,
+    [
+      'import type { WidgetProps } from "./Widget.types";',
+      "",
+      "export function Widget(_props: WidgetProps) {",
+      "  return null;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(linkedTypesFile, "export type WidgetProps = { label: string };\n");
+
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = ((filePath, ...args) => {
+    if (String(filePath) === componentFile) {
+      fs.rmSync(componentFile, { force: true });
+      const error = new Error(`ENOENT: no such file or directory, open '${componentFile}'`);
+      error.code = "ENOENT";
+      throw error;
+    }
+    return originalReadFileSync.call(fs, filePath, ...args);
+  });
+
+  try {
+    const result = discoverProjectFilesWithStats(tempDir);
+    const filePaths = result.targets.map((item) => item.filePath);
+    assert.ok(filePaths.includes(componentFile));
+    assert.ok(!filePaths.includes(linkedTypesFile));
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+  }
+});
+
+test("discover tolerates directories that disappear during traversal", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-discover-dir-race-"));
+  const componentsDir = path.join(tempDir, "src", "components");
+  fs.mkdirSync(componentsDir, { recursive: true });
+  fs.writeFileSync(path.join(componentsDir, "Widget.tsx"), "export function Widget() { return null; }\n");
+  const originalReaddirSync = fs.readdirSync;
+
+  fs.readdirSync = ((dirPath, ...args) => {
+    if (String(dirPath) === componentsDir) {
+      const error = new Error(`ENOTDIR: not a directory, scandir '${componentsDir}'`);
+      error.code = "ENOTDIR";
+      throw error;
+    }
+    return originalReaddirSync.call(fs, dirPath, ...args);
+  });
+
+  try {
+    const result = discoverProjectFilesWithStats(tempDir);
+    assert.deepEqual(result.targets, []);
+  } finally {
+    fs.readdirSync = originalReaddirSync;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("scan regenerates when the persisted scan index is corrupt", () => {
   const tempDir = makeTempProject();
   fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
@@ -2826,6 +3110,34 @@ test("scan only refreshes changed files after cache warm-up", () => {
   const indexEntry = secondScan.files.find((item) => item.filePath === path.join("src", "components", "FormSection.tsx"));
   assert.ok(indexEntry);
   assert.notEqual(indexEntry.fileHash, firstScan.files.find((item) => item.filePath === indexEntry.filePath).fileHash);
+});
+
+test("scan skips files that disappear after discovery instead of crashing", () => {
+  const tempDir = makeTempProject();
+  const disappearingFile = path.join(tempDir, "src", "components", "FormSection.tsx");
+  const relativeDisappearingFile = path.join("src", "components", "FormSection.tsx");
+  const originalReadFileSync = fs.readFileSync;
+  let injectedMissingPath = false;
+
+  fs.readFileSync = ((filePath, ...args) => {
+    if (!injectedMissingPath && String(filePath) === disappearingFile) {
+      injectedMissingPath = true;
+      fs.rmSync(disappearingFile, { force: true });
+      const error = new Error(`ENOENT: no such file or directory, open '${disappearingFile}'`);
+      error.code = "ENOENT";
+      throw error;
+    }
+    return originalReadFileSync.call(fs, filePath, ...args);
+  });
+
+  try {
+    const result = scanProject(tempDir);
+    const filePaths = result.files.map((item) => item.filePath);
+    assert.ok(!filePaths.includes(relativeDisappearingFile));
+    assert.ok(filePaths.includes(path.join("src", "components", "SimpleButton.tsx")));
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+  }
 });
 
 test("scan writes benchmark-only command-path timings to a side channel without changing stdout", () => {
@@ -3704,6 +4016,53 @@ test("claude runtime hook records first eligible prompt, injects repeated same-f
   assert.equal(linkedTs.action, "noop");
   const missing = handleClaudeRuntimeHook({ hookEventName: "UserPromptSubmit", prompt: "Create src/components/NewPanel.tsx" }, tempDir);
   assert.equal(missing.action, "noop");
+});
+
+test("claude runtime hook keeps first-seen matching prompts free of project knowledge and adds it on repeated file", () => {
+  const tempDir = makeTempProject();
+  writeProjectKnowledgeFixture(tempDir);
+  const sessionId = `claude-knowledge-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+
+  handleClaudeRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Explain ${target} and keep the React Native support claim boundary narrow`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+  assert.equal(first.projectKnowledge, undefined);
+
+  const second = handleClaudeRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, explain ${target} and keep the React Native support claim boundary narrow`,
+    },
+    tempDir,
+  );
+  assert.equal(second.action, "inject");
+  assert.ok(second.additionalContext.includes("PROJECT KNOWLEDGE CONTEXT"));
+  assert.deepEqual(second.projectKnowledge.appliedRuleIds, ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(second.projectKnowledge.family, "claim-boundary");
+  assert.ok(second.projectKnowledge.matchReasons.some((reason) => reason.startsWith("prompt-keyword:react native")));
+
+  const summary = readSessionMetricSummary(tempDir, sessionId, { runtime: "claude", measurementSource: "project-local-context-hook" });
+  const events = fs
+    .readFileSync(sessionEventsPath(tempDir, summary.metricSessionKey), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const lastEvent = events.at(-1);
+  assert.deepEqual(lastEvent.appliedRuleIds, ["claim-boundary.rn-no-broad-support"]);
+  assert.equal(lastEvent.family, "claim-boundary");
+  assert.ok(lastEvent.matchReasons.some((reason) => reason.startsWith("prompt-keyword:react native")));
+  assert.equal(lastEvent.authority, "tracked");
+  assert.equal(lastEvent.rulesPath, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH);
+  assert.equal(lastEvent.mode, "advisory");
 });
 
 test("claude runtime hook refreshes stale target state and clears active file on stop", () => {


### PR DESCRIPTION
## Linked issue

Fixes #563

## Summary

- add tracked project-knowledge routing for claim-boundary guidance
- inject project knowledge only on repeated same-file Codex/Claude runtime paths
- record additive applied-knowledge metadata in session metrics/events
- add narrow default tracked rules and regression coverage for no-op boundary preservation

## Applied knowledge

- `claim-boundary.rn-no-broad-support`
- authority: `tracked`
- mode: `advisory`
- evidence:
  - `docs/domain-payload-architecture.md#rn-claim-boundary-at-the-architecture-layer`

## Verification

- `npm run typecheck`
- `npm test`
- architect final approve