### PR TITLE
Allow designated maintainers to satisfy the merge gate review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Fixes #
 
 ## Review gate
 
-- [ ] Current head has a GitHub PR review approval from a non-author reviewer. Issue comments and regular PR comments do not count.
+- [ ] Current head has a GitHub PR review from `minislively` or `yeachan-heo`. Self-review by those accounts is allowed. Issue comments and regular PR comments do not count.

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -37,4 +37,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_GATE_REQUIRE_LINKED_ISSUE: "true"
           MERGE_GATE_REQUIRE_APPROVAL: "true"
+          MERGE_GATE_ALLOWED_REVIEWERS: "minislively,yeachan-heo"
         run: node scripts/validate-pr-merge-gate.mjs

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const CLOSING_ISSUE_PATTERN = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
+const DEFAULT_ALLOWED_REVIEWERS = ["minislively", "yeachan-heo"];
 
 function normalizeLogin(value) {
   return String(value || "").trim().toLowerCase();
@@ -13,6 +14,16 @@ function normalizeLogin(value) {
 
 function normalizePath(value) {
   return String(value || "").replace(/^\/+/, "");
+}
+
+function parseAllowedReviewers(value) {
+  if (!value) return new Set(DEFAULT_ALLOWED_REVIEWERS);
+  return new Set(
+    String(value)
+      .split(",")
+      .map((item) => normalizeLogin(item))
+      .filter(Boolean),
+  );
 }
 
 const DOCS_TESTS_ONLY_ALLOWED_PREFIXES = ["docs/", "test/"];
@@ -65,6 +76,7 @@ export function evaluatePullRequestMergeGate({
   reviews = [],
   requireLinkedIssue = true,
   requireApproval = true,
+  allowedReviewerLogins = DEFAULT_ALLOWED_REVIEWERS,
 }) {
   const blockers = [];
 
@@ -74,22 +86,26 @@ export function evaluatePullRequestMergeGate({
 
   const latestByUser = latestReviewStateByUser(reviews);
   const headSha = pullRequest?.head?.sha;
-  const author = normalizeLogin(pullRequest?.user?.login);
-  const approvingReviewers = [...latestByUser.entries()]
-    .filter(([login, latest]) => login !== author && latest?.state === "APPROVED" && (!headSha || latest.commitId === headSha))
+  const allowedReviewers = new Set((allowedReviewerLogins || []).map((login) => normalizeLogin(login)).filter(Boolean));
+  const qualifyingReviewers = [...latestByUser.entries()]
+    .filter(([login, latest]) => {
+      if (!allowedReviewers.has(login)) return false;
+      if (!latest?.state || latest.state === "DISMISSED") return false;
+      return !headSha || latest.commitId === headSha;
+    })
     .map(([login]) => login)
     .sort();
 
-  if (requireApproval && approvingReviewers.length === 0) {
+  if (requireApproval && qualifyingReviewers.length === 0) {
     blockers.push(
-      "PR must have an active GitHub PR review approval on the current head commit from a reviewer other than the PR author. Issue comments and regular PR comments do not count, and any new push/amend/rebase/force-push after approval requires re-approval.",
+      `PR must have an active GitHub PR review on the current head commit from at least one allowed reviewer (${[...allowedReviewers].join(", ")}). Self-review by those accounts is allowed. Issue comments and regular PR comments do not count, and any new push/amend/rebase/force-push after review requires re-review.`,
     );
   }
 
   return {
     ok: blockers.length === 0,
     blockers,
-    approvingReviewers,
+    approvingReviewers: qualifyingReviewers,
   };
 }
 
@@ -138,6 +154,7 @@ async function main() {
     reviews,
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
     requireApproval,
+    allowedReviewerLogins: [...parseAllowedReviewers(process.env.MERGE_GATE_ALLOWED_REVIEWERS)],
   });
 
   if (!result.ok) {
@@ -148,7 +165,7 @@ async function main() {
   }
 
   const approvalSummary = result.approvingReviewers.length > 0
-    ? ` Approving reviewer(s): ${result.approvingReviewers.join(", ")}`
+    ? ` Qualifying reviewer(s): ${result.approvingReviewers.join(", ")}`
     : "";
   console.log(`Merge gate passed. Linked issue detected.${approvalSummary}`);
 }

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -8,11 +8,12 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
 const pullRequestTemplatePath = path.join(repoRoot, ".github", "PULL_REQUEST_TEMPLATE.md");
 
-test("merge gate workflow validates linked issues and current-head review approval", () => {
+test("merge gate workflow validates linked issues and current-head allowed-reviewer review", () => {
   const workflow = fs.readFileSync(workflowPath, "utf8");
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /pull_request_review:/);
   assert.match(workflow, /MERGE_GATE_REQUIRE_APPROVAL: "true"/);
+  assert.match(workflow, /MERGE_GATE_ALLOWED_REVIEWERS: "minislively,yeachan-heo"/);
   assert.match(workflow, /Validate approval review and linked issue/);
 });
 
@@ -20,7 +21,9 @@ test("pull request template keeps linked issue prompt and approval checklist", (
   const template = fs.readFileSync(pullRequestTemplatePath, "utf8");
   assert.match(template, /Linked issue/i);
   assert.match(template, /Fixes #/);
-  assert.match(template, /non-author reviewer/i);
+  assert.match(template, /minislively/i);
+  assert.match(template, /yeachan-heo/i);
+  assert.match(template, /self-review.*allowed/i);
   assert.match(template, /Current head/i);
   assert.match(template, /Issue comments and regular PR comments do not count/i);
 });

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -11,13 +11,15 @@ import {
 
 const pr = { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } };
 
-test("merge gate requires non-author approval by default even when PR links a closing issue", () => {
+test("merge gate requires an allowed reviewer by default even when PR links a closing issue", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /GitHub PR review approval/);
+  assert.match(result.blockers.join("\n"), /GitHub PR review/);
+  assert.match(result.blockers.join("\n"), /minislively/i);
+  assert.match(result.blockers.join("\n"), /yeachan-heo/i);
   assert.deepEqual(result.approvingReviewers, []);
 });
 
@@ -41,43 +43,43 @@ test("merge gate rejects PRs without a closing issue reference", () => {
   assert.match(result.blockers.join("\n"), /closing issue/);
 });
 
-test("merge gate can still enforce latest reviewer state when approval checks are enabled", () => {
+test("merge gate ignores dismissed allowed reviews when review checks are enabled", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
     reviews: [
-      { user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
-      { user: { login: "reviewer" }, state: "CHANGES_REQUESTED", submitted_at: "2026-05-01T00:02:00Z" },
+      { user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" },
+      { user: { login: "minislively" }, state: "DISMISSED", submitted_at: "2026-05-01T00:02:00Z", commit_id: "head-sha" },
     ],
     requireApproval: true,
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /GitHub PR review approval/);
-  assert.match(result.blockers.join("\n"), /requires re-approval/i);
+  assert.match(result.blockers.join("\n"), /GitHub PR review/);
+  assert.match(result.blockers.join("\n"), /requires re-review/i);
 });
 
 test("merge gate can require approval on the current head commit when enabled", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
-    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "old-sha" }],
+    reviews: [{ user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "old-sha" }],
     requireApproval: true,
   });
 
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /current head commit/);
   assert.match(result.blockers.join("\n"), /comments do not count/i);
-  assert.match(result.blockers.join("\n"), /requires re-approval/i);
+  assert.match(result.blockers.join("\n"), /requires re-review/i);
 });
 
 
-test("merge gate passes by default with linked issue and current-head non-author approval", () => {
+test("merge gate passes by default with linked issue and current-head allowed review", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
-    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
+    reviews: [{ user: { login: "minislively" }, state: "COMMENTED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
   });
 
   assert.equal(result.ok, true);
-  assert.deepEqual(result.approvingReviewers, ["reviewer"]);
+  assert.deepEqual(result.approvingReviewers, ["minislively"]);
 });
 
 test("issue comments do not satisfy the approval gate", () => {
@@ -90,15 +92,26 @@ test("issue comments do not satisfy the approval gate", () => {
   assert.match(result.blockers.join("\n"), /comments do not count/i);
 });
 
-test("merge gate ignores PR author self-approval", () => {
+test("merge gate allows self-review when the author is an allowed reviewer", () => {
   const result = evaluatePullRequestMergeGate({
-    pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "reviewer" } },
-    reviews: [{ user: { login: "reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
+    pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "minislively" } },
+    reviews: [{ user: { login: "minislively" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
+    requireApproval: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.approvingReviewers, ["minislively"]);
+});
+
+test("merge gate rejects reviews from users outside the allowed reviewer set", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: pr,
+    reviews: [{ user: { login: "outside-reviewer" }, state: "APPROVED", submitted_at: "2026-05-01T00:01:00Z", commit_id: "head-sha" }],
     requireApproval: true,
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /reviewer other than the PR author/);
+  assert.match(result.blockers.join("\n"), /allowed reviewer/i);
   assert.deepEqual(result.approvingReviewers, []);
 });
 


### PR DESCRIPTION
## Linked issue

Fixes #564

## Summary

- allow current-head GitHub PR reviews from `minislively` or `yeachan-heo` to satisfy the merge gate
- permit self-review by those designated maintainer accounts
- keep the workflow env, validator, PR template, and merge-gate tests aligned with the same policy

## Verification

- node --test test/pr-merge-gate.test.mjs test/merge-gate-workflow.test.mjs
- npm run typecheck
- npm test
