### PR TITLE
Allow docs/test-only merge-gate exceptions

### DIFF
--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -74,13 +74,16 @@ export function pullRequestHasLinkedClosingIssue(pullRequest) {
 export function evaluatePullRequestMergeGate({
   pullRequest,
   reviews = [],
+  changedFiles = [],
   requireLinkedIssue = true,
   requireApproval = true,
   allowedReviewerLogins = DEFAULT_ALLOWED_REVIEWERS,
 }) {
   const blockers = [];
+  const docsTestsOnlyChange = classifyDocsTestsOnlyChange(changedFiles);
+  const linkedIssueRequired = requireLinkedIssue && !docsTestsOnlyChange.docsTestsOnly;
 
-  if (requireLinkedIssue && !pullRequestHasLinkedClosingIssue(pullRequest)) {
+  if (linkedIssueRequired && !pullRequestHasLinkedClosingIssue(pullRequest)) {
     blockers.push("PR body or title must link a closing issue with Fixes/Closes/Resolves #123.");
   }
 
@@ -106,6 +109,7 @@ export function evaluatePullRequestMergeGate({
     ok: blockers.length === 0,
     blockers,
     approvingReviewers: qualifyingReviewers,
+    docsTestsOnly: docsTestsOnlyChange.docsTestsOnly,
   };
 }
 
@@ -123,6 +127,33 @@ async function fetchPullRequestReviews({ repository, pullNumber, token }) {
     throw new Error(`Failed to fetch PR reviews: ${response.status} ${response.statusText}`);
   }
   return response.json();
+}
+
+async function fetchPullRequestFiles({ repository, pullNumber, token }) {
+  const files = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${repository}/pulls/${pullNumber}/files?per_page=100&page=${page}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "fooks-merge-gate",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch PR files: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = await response.json();
+    files.push(...payload.map((item) => item?.filename).filter(Boolean));
+    if (payload.length < 100) break;
+    page += 1;
+  }
+
+  return files;
 }
 
 async function main() {
@@ -143,15 +174,23 @@ async function main() {
   }
 
   const requireApproval = process.env.MERGE_GATE_REQUIRE_APPROVAL !== "false";
-  const reviews = await fetchPullRequestReviews({
+  const changedFiles = await fetchPullRequestFiles({
     repository,
     pullNumber: pullRequest.number,
     token,
   });
+  const reviews = requireApproval
+    ? await fetchPullRequestReviews({
+      repository,
+      pullNumber: pullRequest.number,
+      token,
+    })
+    : [];
 
   const result = evaluatePullRequestMergeGate({
     pullRequest,
     reviews,
+    changedFiles,
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
     requireApproval,
     allowedReviewerLogins: [...parseAllowedReviewers(process.env.MERGE_GATE_ALLOWED_REVIEWERS)],
@@ -164,10 +203,16 @@ async function main() {
     return;
   }
 
+  const docsTestsOnlySummary = result.docsTestsOnly
+    ? " Docs/test-only change detected; linked issue requirement skipped."
+    : "";
   const approvalSummary = result.approvingReviewers.length > 0
     ? ` Qualifying reviewer(s): ${result.approvingReviewers.join(", ")}`
     : "";
-  console.log(`Merge gate passed. Linked issue detected.${approvalSummary}`);
+  const linkedIssueSummary = result.docsTestsOnly
+    ? ""
+    : " Linked issue detected.";
+  console.log(`Merge gate passed.${linkedIssueSummary}${docsTestsOnlySummary}${approvalSummary}`);
 }
 
 function isMainModule() {

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -125,6 +125,28 @@ test("merge gate can disable linked issue enforcement explicitly", () => {
   assert.equal(result.ok, true);
 });
 
+test("merge gate skips linked issue requirement for docs/test-only changes when approval is otherwise disabled", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: { title: "Tighten docs wording", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
+    changedFiles: ["docs/development-principles.md", "test/merge-gate-workflow.test.mjs"],
+    requireApproval: false,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.docsTestsOnly, true);
+});
+
+test("merge gate still requires linked issue when docs/test-only allowlist is exceeded", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: { title: "Touch docs and source", body: "Refs #42", head: { sha: "head-sha" }, user: { login: "contributor" } },
+    changedFiles: ["docs/development-principles.md", "src/core/domain-detector.ts"],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.docsTestsOnly, false);
+  assert.match(result.blockers.join("\n"), /closing issue/);
+});
+
 test("merge gate can disable approval enforcement explicitly", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: { title: "Improve cache", body: "Fixes #42", head: { sha: "head-sha" }, user: { login: "contributor" } },


### PR DESCRIPTION
## Linked issue

Fixes #566

## Summary

- use PR changed-file data in merge-gate evaluation
- skip the linked-issue requirement for docs/test-only changes
- add regression coverage for allowlisted and mixed-file cases

## Verification

- `node --test test/pr-merge-gate.test.mjs test/merge-gate-workflow.test.mjs`
- `npm run typecheck`
