### PR TITLE
Add React Web stability evidence and metric provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "evidence:react-native-payload": "npm run build && node scripts/react-native-payload-evidence.mjs",
     "evidence:react-web-reuse": "npm run build && node scripts/react-web-reuse-evidence.mjs",
     "evidence:react-web-over-caching-audit": "npm run build && node scripts/react-web-over-caching-audit.mjs",
+    "evidence:react-web-stability": "npm run build && node scripts/react-web-stability-evidence.mjs",
     "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",
     "bench": "npm run build && node benchmarks/scripts/run-all.mjs",

--- a/scripts/react-web-context-evidence.mjs
+++ b/scripts/react-web-context-evidence.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildReactWebMetricProvenance } from "./react-web-metric-provenance.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -114,6 +115,7 @@ export async function buildReactWebContextEvidence({
   const additionalContextReductionValues = rows.map((row) => row.additionalContextReductionPct);
   const allRuntimePayloadsSmaller = rows.every((row) => row.secondAction === "inject" && !row.runtimePayloadLargerThanSource);
   const allAdditionalContextsSmaller = rows.every((row) => row.secondAction === "inject" && !row.additionalContextLargerThanSource);
+  const metricProvenance = buildReactWebMetricProvenance();
 
   return {
     schemaVersion: "react-web-context-evidence.v2",
@@ -122,6 +124,9 @@ export async function buildReactWebContextEvidence({
     measurement: "local-source-bytes-vs-host-facing-additional-context-bytes",
     claimBoundary:
       "Local fixture byte-size evidence only: actual host-facing additionalContext compactness for React Web current-lane reuse; domainPayload is diagnostic-only. This is not provider tokenizer output, not runtime-token savings, not cache performance, not latency, and not provider billing or invoice savings.",
+    metricProvenance: {
+      actualInjectedContextReduction: metricProvenance.actualInjectedContextReduction,
+    },
     fixtures: rows,
     summary: {
       fixtureCount: rows.length,
@@ -185,6 +190,12 @@ ${evidence.claimBoundary}
 | Fixture | Source bytes | actual additionalContext bytes | actual additionalContext reduction | diagnostic domainPayload bytes | diagnostic domainPayload reduction | diagnostic runtime payload bytes | diagnostic runtime payload reduction |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${rows}
+
+## Metric provenance
+
+- \`actualInjectedContextReduction\`: ${evidence.metricProvenance.actualInjectedContextReduction.formula}
+- Claim boundary: ${evidence.metricProvenance.actualInjectedContextReduction.claimBoundary}
+- Not comparable to: ${evidence.metricProvenance.actualInjectedContextReduction.notComparableTo.join(", ")}
 
 ## Claim boundary
 

--- a/scripts/react-web-metric-provenance.mjs
+++ b/scripts/react-web-metric-provenance.mjs
@@ -1,0 +1,38 @@
+const NOT_COMPARABLE_TO = Object.freeze([
+  "wallClockSpeedup",
+  "cacheHitRate",
+  "runtimeTokenSavings",
+  "providerBillingSavings",
+]);
+
+export const ACTUAL_INJECTED_CONTEXT_REDUCTION_PROVENANCE = Object.freeze({
+  metric: "actualInjectedContextReduction",
+  unit: "percent",
+  numerator: "sourceBytes - additionalContextBytes",
+  denominator: "sourceBytes",
+  formula: "((sourceBytes - additionalContextBytes) / sourceBytes) * 100",
+  claimBoundary: "local React Web fixture byte reduction only",
+  notComparableTo: [...NOT_COMPARABLE_TO],
+});
+
+export const REPEATED_RUN_ACTUAL_INJECTED_CONTEXT_MIN_PROVENANCE = Object.freeze({
+  metric: "repeatRunActualInjectedContextReductionMinPct",
+  unit: "percent",
+  sourceMetric: "actualInjectedContextReduction.minPct",
+  aggregation: "per-run conservative suite minimum across measured fixtures, then repeated-run summary statistics",
+  formula: "perRunValue = min(fixtures[].additionalContextReductionPct); repeatedRunSummary = stats(perRunValue across runs)",
+  conservative: true,
+  claimBoundary: "local React Web fixture byte reduction only",
+  notComparableTo: [...NOT_COMPARABLE_TO],
+});
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function buildReactWebMetricProvenance() {
+  return {
+    actualInjectedContextReduction: clone(ACTUAL_INJECTED_CONTEXT_REDUCTION_PROVENANCE),
+    repeatRunActualInjectedContextReductionMinPct: clone(REPEATED_RUN_ACTUAL_INJECTED_CONTEXT_MIN_PROVENANCE),
+  };
+}

--- a/scripts/react-web-stability-evidence.mjs
+++ b/scripts/react-web-stability-evidence.mjs
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebContextEvidence } from "./react-web-context-evidence.mjs";
+import { buildReactWebReuseEvidence } from "./react-web-reuse-evidence.mjs";
+import { buildReactWebOverCachingAuditEvidence } from "./react-web-over-caching-audit.mjs";
+import { buildReactWebMetricProvenance } from "./react-web-metric-provenance.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+const DEFAULT_REPEAT = 5;
+const DEFAULT_STABLE_THRESHOLD_PCT = 5;
+
+function round(value) {
+  return Number.parseFloat(value.toFixed(3));
+}
+
+function mean(values) {
+  if (values.length === 0) return 0;
+  return round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function stddev(values) {
+  if (values.length <= 1) return 0;
+  const average = mean(values);
+  const variance = values.reduce((sum, value) => sum + (value - average) ** 2, 0) / values.length;
+  return round(Math.sqrt(variance));
+}
+
+function coefficientOfVariationPct(values) {
+  if (values.length === 0) return 0;
+  const average = mean(values);
+  if (average === 0) return 0;
+  return round((stddev(values) / Math.abs(average)) * 100);
+}
+
+function allSame(values) {
+  return values.every((value) => value === values[0]);
+}
+
+function parseRepeat(argv) {
+  const raw = argv.find((arg) => arg.startsWith("--repeat="))?.slice("--repeat=".length);
+  const parsed = raw ? Number.parseInt(raw, 10) : DEFAULT_REPEAT;
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--repeat must be a positive integer; received ${raw ?? "undefined"}`);
+  }
+  return parsed;
+}
+
+export async function buildReactWebStabilityEvidence({
+  repoRoot = defaultRepoRoot,
+  repeat = DEFAULT_REPEAT,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+  stableThresholdPct = DEFAULT_STABLE_THRESHOLD_PCT,
+} = {}) {
+  const metricProvenance = buildReactWebMetricProvenance();
+  const runs = [];
+
+  for (let index = 0; index < repeat; index += 1) {
+    const iteration = index + 1;
+    const iterationRunId = `${runId}-run-${String(iteration).padStart(2, "0")}`;
+    const contextEvidence = await buildReactWebContextEvidence({ repoRoot, runId: `${iterationRunId}-context` });
+    const reuseEvidence = await buildReactWebReuseEvidence({ repoRoot, runId: `${iterationRunId}-reuse` });
+    const overCachingAudit = await buildReactWebOverCachingAuditEvidence({ repoRoot, runId: `${iterationRunId}-audit` });
+
+    runs.push({
+      iteration,
+      runId: iterationRunId,
+      contextEvidence: {
+        actualInjectedContextReduction: contextEvidence.summary.actualInjectedContextReduction,
+        allReactWebInjects: contextEvidence.summary.allReactWebInjects,
+      },
+      reuseEvidence: {
+        reuseCorrectnessClaimable: reuseEvidence.summary.reuseCorrectnessClaimable,
+        sameFileReactWebReuse: reuseEvidence.checks.sameFileReactWebReuse.claimable,
+        sourceChangeRefresh: reuseEvidence.checks.sourceChangeRefresh.claimable,
+        unsupportedDomainFallbacks: reuseEvidence.checks.unsupportedDomainFallbacks.claimable,
+      },
+      overCachingAudit: {
+        verdict: overCachingAudit.summary.verdict,
+        verdictName: overCachingAudit.summary.verdictName,
+        bugReproduced: overCachingAudit.summary.bugReproduced,
+        suspiciousStepCount: overCachingAudit.checks.smallEditRefreshAudit.suspiciousStepCount,
+      },
+      primaryMetric: {
+        metric: "repeatRunActualInjectedContextReductionMinPct",
+        valuePct: contextEvidence.summary.actualInjectedContextReduction.minPct,
+      },
+    });
+  }
+
+  const primaryMetricValues = runs.map((run) => run.primaryMetric.valuePct);
+  const reuseValues = runs.map((run) => run.reuseEvidence.reuseCorrectnessClaimable);
+  const auditVerdictNames = runs.map((run) => run.overCachingAudit.verdictName);
+  const stable = repeat < 2 ? true : coefficientOfVariationPct(primaryMetricValues) <= stableThresholdPct;
+  const warnings = [];
+
+  if (!stable) {
+    warnings.push("repeat-run conservative context reduction metric is unstable; treat as warning evidence, not a stronger optimization claim");
+  }
+  if (!runs.every((run) => run.contextEvidence.actualInjectedContextReduction.claimable)) {
+    warnings.push("at least one run failed the actual injected context claimability gate");
+  }
+  if (!runs.every((run) => run.reuseEvidence.reuseCorrectnessClaimable)) {
+    warnings.push("at least one run regressed React Web reuse correctness");
+  }
+  if (!allSame(auditVerdictNames)) {
+    warnings.push("over-caching audit verdict name changed across repeated runs");
+  }
+  if (runs.some((run) => run.overCachingAudit.bugReproduced)) {
+    warnings.push("over-caching audit reproduced a stale-payload warning in at least one run");
+  }
+
+  return {
+    schemaVersion: "react-web-stability-evidence.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    repeat,
+    measurement: "repeat-run-react-web-evidence-stability",
+    claimBoundary:
+      "Repeat-run local React Web evidence only: summarizes repeated context-byte, reuse-routing, and over-caching audit results on current main. This is not wall-clock performance, not cache-hit-rate proof, not runtime-token savings, and not provider cost, billing, invoice, or charged-cost evidence. Unstable results remain warning evidence, not broadened claims.",
+    claimability: {
+      contextReduction: true,
+      cachePerformance: false,
+      providerBillingSavings: false,
+    },
+    metricProvenance: {
+      actualInjectedContextReduction: metricProvenance.actualInjectedContextReduction,
+      repeatRunActualInjectedContextReductionMinPct: metricProvenance.repeatRunActualInjectedContextReductionMinPct,
+    },
+    runs,
+    summary: {
+      primaryMetric: {
+        metric: "repeatRunActualInjectedContextReductionMinPct",
+        minObservedPct: round(Math.min(...primaryMetricValues)),
+        maxObservedPct: round(Math.max(...primaryMetricValues)),
+        meanPct: mean(primaryMetricValues),
+        stddevPct: stddev(primaryMetricValues),
+        coefficientOfVariationPct: coefficientOfVariationPct(primaryMetricValues),
+        stableThresholdPct,
+        stable,
+        warningOnly: !stable,
+      },
+      contextReductionEvidenceClaimableAcrossRuns: runs.every((run) => run.contextEvidence.actualInjectedContextReduction.claimable),
+      allReactWebInjectsAcrossRuns: runs.every((run) => run.contextEvidence.allReactWebInjects),
+      reuseCorrectness: {
+        consistent: allSame(reuseValues),
+        claimableAcrossRuns: runs.every((run) => run.reuseEvidence.reuseCorrectnessClaimable),
+        values: reuseValues,
+      },
+      overCachingAudit: {
+        stable: allSame(auditVerdictNames),
+        verdictNames: auditVerdictNames,
+        noReproAcrossRuns: runs.every((run) => run.overCachingAudit.verdict === "no-repro"),
+      },
+      warnings,
+    },
+  };
+}
+
+export function renderReactWebStabilityEvidenceMarkdown(evidence) {
+  const runRows = evidence.runs
+    .map(
+      (run) =>
+        `| ${run.iteration} | ${run.primaryMetric.valuePct}% | ${run.reuseEvidence.reuseCorrectnessClaimable ? "yes" : "no"} | ${run.overCachingAudit.verdictName} | ${run.overCachingAudit.bugReproduced ? "yes" : "no"} |`,
+    )
+    .join("\n");
+  const warnings = evidence.summary.warnings.length > 0 ? evidence.summary.warnings.map((warning) => `- ${warning}`).join("\n") : "- none";
+
+  return `# React Web stability evidence
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Repeat count: ${evidence.repeat}
+- Primary metric: ${evidence.summary.primaryMetric.metric}
+- Observed range: ${evidence.summary.primaryMetric.minObservedPct}% to ${evidence.summary.primaryMetric.maxObservedPct}%
+- Mean/stddev: ${evidence.summary.primaryMetric.meanPct}% / ${evidence.summary.primaryMetric.stddevPct}%
+- Coefficient of variation: ${evidence.summary.primaryMetric.coefficientOfVariationPct}%
+- Stable: ${evidence.summary.primaryMetric.stable ? "yes" : "no"}
+- Context reduction claimability boundary: ${evidence.claimability.contextReduction ? "yes" : "no"}
+- Cache performance claimability: no
+- Provider billing savings claimability: no
+
+## Run table
+
+| Run | conservative context reduction minPct | reuse correctness claimable | over-caching verdict | bug reproduced |
+| --- | ---: | --- | --- | --- |
+${runRows}
+
+## Metric provenance
+
+- \`actualInjectedContextReduction\`: ${evidence.metricProvenance.actualInjectedContextReduction.formula}
+- \`repeatRunActualInjectedContextReductionMinPct\`: ${evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.formula}
+- Conservative aggregation: ${evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.aggregation}
+- Not comparable to: ${evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.notComparableTo.join(", ")}
+
+## Warnings
+
+${warnings}
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const repeat = parseRepeat(process.argv.slice(2));
+  const evidence = await buildReactWebStabilityEvidence({ repoRoot: defaultRepoRoot, runId, repeat });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebStabilityEvidenceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-context-evidence.test.mjs
+++ b/test/react-web-context-evidence.test.mjs
@@ -14,6 +14,12 @@ test("React Web context evidence measures actual injected additionalContext with
   assert.match(evidence.claimBoundary, /not runtime-token savings/);
   assert.match(evidence.claimBoundary, /not cache performance/);
   assert.match(evidence.claimBoundary, /not provider billing or invoice savings/);
+  assert.equal(evidence.metricProvenance.actualInjectedContextReduction.metric, "actualInjectedContextReduction");
+  assert.equal(evidence.metricProvenance.actualInjectedContextReduction.unit, "percent");
+  assert.equal(evidence.metricProvenance.actualInjectedContextReduction.numerator, "sourceBytes - additionalContextBytes");
+  assert.equal(evidence.metricProvenance.actualInjectedContextReduction.denominator, "sourceBytes");
+  assert.ok(evidence.metricProvenance.actualInjectedContextReduction.notComparableTo.includes("cacheHitRate"));
+  assert.ok(evidence.metricProvenance.actualInjectedContextReduction.notComparableTo.includes("providerBillingSavings"));
 
   assert.equal(evidence.summary.fixtureCount, 5);
   assert.equal(evidence.summary.allReactWebInjects, true);
@@ -72,6 +78,9 @@ test("React Web context evidence Markdown keeps the public claim boundary explic
   assert.match(markdown, /Internal runtime payload reduction diagnostic-only: no/);
   assert.match(markdown, /Cache performance improvement claimable: no/);
   assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /Metric provenance/);
+  assert.match(markdown, /sourceBytes - additionalContextBytes/);
+  assert.match(markdown, /Not comparable to: wallClockSpeedup, cacheHitRate, runtimeTokenSavings, providerBillingSavings/);
   assert.match(markdown, /domainPayload metric is diagnostic-only/);
   assert.match(markdown, /does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims/);
   assert.doesNotMatch(markdown, /provider billing savings claimable: yes/i);

--- a/test/react-web-stability-evidence.test.mjs
+++ b/test/react-web-stability-evidence.test.mjs
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReactWebStabilityEvidence,
+  renderReactWebStabilityEvidenceMarkdown,
+} from "../scripts/react-web-stability-evidence.mjs";
+
+test("React Web stability evidence reports repeated-run conservative stats with locked claimability", async () => {
+  const evidence = await buildReactWebStabilityEvidence({
+    repeat: 2,
+    runId: `test-${Date.now()}-${Math.random()}`,
+  });
+
+  assert.equal(evidence.schemaVersion, "react-web-stability-evidence.v1");
+  assert.equal(evidence.measurement, "repeat-run-react-web-evidence-stability");
+  assert.equal(evidence.repeat, 2);
+  assert.match(evidence.claimBoundary, /Repeat-run local React Web evidence only/);
+  assert.match(evidence.claimBoundary, /not wall-clock performance/);
+  assert.match(evidence.claimBoundary, /not runtime-token savings/);
+  assert.match(evidence.claimBoundary, /not provider cost, billing, invoice, or charged-cost evidence/);
+
+  assert.deepEqual(evidence.claimability, {
+    contextReduction: true,
+    cachePerformance: false,
+    providerBillingSavings: false,
+  });
+
+  assert.equal(evidence.metricProvenance.actualInjectedContextReduction.metric, "actualInjectedContextReduction");
+  assert.equal(evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.metric, "repeatRunActualInjectedContextReductionMinPct");
+  assert.equal(evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.conservative, true);
+  assert.match(
+    evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.aggregation,
+    /conservative suite minimum/,
+  );
+  assert.ok(
+    evidence.metricProvenance.repeatRunActualInjectedContextReductionMinPct.notComparableTo.includes("runtimeTokenSavings"),
+  );
+
+  assert.equal(evidence.runs.length, 2);
+  for (const run of evidence.runs) {
+    assert.equal(run.primaryMetric.metric, "repeatRunActualInjectedContextReductionMinPct");
+    assert.equal(typeof run.primaryMetric.valuePct, "number");
+    assert.equal(run.contextEvidence.actualInjectedContextReduction.claimable, true);
+    assert.equal(run.reuseEvidence.reuseCorrectnessClaimable, true);
+    assert.equal(run.overCachingAudit.verdict, "no-repro");
+  }
+
+  assert.equal(evidence.summary.primaryMetric.metric, "repeatRunActualInjectedContextReductionMinPct");
+  assert.ok(evidence.summary.primaryMetric.minObservedPct > 0);
+  assert.ok(evidence.summary.primaryMetric.maxObservedPct >= evidence.summary.primaryMetric.minObservedPct);
+  assert.equal(typeof evidence.summary.primaryMetric.meanPct, "number");
+  assert.equal(typeof evidence.summary.primaryMetric.stddevPct, "number");
+  assert.equal(typeof evidence.summary.primaryMetric.coefficientOfVariationPct, "number");
+  assert.equal(typeof evidence.summary.primaryMetric.stable, "boolean");
+  assert.equal(evidence.summary.contextReductionEvidenceClaimableAcrossRuns, true);
+  assert.equal(evidence.summary.allReactWebInjectsAcrossRuns, true);
+  assert.equal(evidence.summary.reuseCorrectness.consistent, true);
+  assert.equal(evidence.summary.reuseCorrectness.claimableAcrossRuns, true);
+  assert.deepEqual(evidence.summary.reuseCorrectness.values, [true, true]);
+  assert.equal(evidence.summary.overCachingAudit.stable, true);
+  assert.deepEqual(
+    evidence.summary.overCachingAudit.verdictNames,
+    ["react-web-small-edit-refresh-no-repro", "react-web-small-edit-refresh-no-repro"],
+  );
+  assert.equal(evidence.summary.overCachingAudit.noReproAcrossRuns, true);
+});
+
+test("React Web stability evidence markdown keeps warning/report boundaries explicit", async () => {
+  const evidence = await buildReactWebStabilityEvidence({
+    repeat: 2,
+    runId: `markdown-test-${Date.now()}-${Math.random()}`,
+  });
+  const markdown = renderReactWebStabilityEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /Repeat count: 2/);
+  assert.match(markdown, /Primary metric: repeatRunActualInjectedContextReductionMinPct/);
+  assert.match(markdown, /Cache performance claimability: no/);
+  assert.match(markdown, /Provider billing savings claimability: no/);
+  assert.match(markdown, /Metric provenance/);
+  assert.match(markdown, /perRunValue = min\(fixtures\[\]\.additionalContextReductionPct\)/);
+  assert.match(markdown, /Conservative aggregation:/);
+  assert.match(markdown, /Warnings/);
+  assert.doesNotMatch(markdown, /Cache performance claimability: yes/i);
+  assert.doesNotMatch(markdown, /Provider billing savings claimability: yes/i);
+});


### PR DESCRIPTION
## Linked issue

Fixes #

## Summary

- add `evidence:react-web-stability` for repeated-run React Web context/reuse/audit stability reporting
- add shared metric provenance so context-reduction numbers stay explicitly bounded to local React Web fixture byte reduction
- keep claimability locked to `contextReduction=true`, `cachePerformance=false`, and `providerBillingSavings=false`

## Verification

- `git diff --check`
- `npm run build`
- `node --test test/react-web-context-evidence.test.mjs test/react-web-stability-evidence.test.mjs test/react-web-reuse-evidence.test.mjs test/react-web-over-caching-audit.test.mjs`
- `npm run evidence:react-web-stability -- --repeat=3`
- `npm run lint`
- `npm test`

## Review gate

- [ ] Current head has a GitHub PR review from `minislively` or `yeachan-heo`. Self-review by those accounts is allowed. Issue comments and regular PR comments do not count.
