### PR TITLE
Productize the React Web evidence lane as one fail-closed profile surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "branch:audit": "node scripts/audit-remote-branches.mjs",
     "ci:alerts": "node scripts/triage-ci-alerts.mjs",
     "pr:alerts": "node scripts/guard-pr-alerts.mjs",
-    "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs"
+    "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs",
+    "bench:profile": "npm run build && node scripts/bench-profile.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/bench-profile.mjs
+++ b/scripts/bench-profile.mjs
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebProfileRunnerEvidence, renderReactWebProfileRunnerMarkdown } from "./react-web-profile-runner.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+const SUPPORTED_PROFILES = Object.freeze(["react-web"]);
+
+function parseProfile(argv) {
+  const profile = argv.find((arg) => !arg.startsWith("-"));
+  if (!profile) {
+    throw new Error(`profile name required; supported profiles: ${SUPPORTED_PROFILES.join(", ")}`);
+  }
+  if (!SUPPORTED_PROFILES.includes(profile)) {
+    throw new Error(`unsupported profile '${profile}'; supported profiles: ${SUPPORTED_PROFILES.join(", ")}`);
+  }
+  return profile;
+}
+
+function parseRepeat(argv) {
+  const raw = argv.find((arg) => arg.startsWith("--repeat="))?.slice("--repeat=".length);
+  if (raw == null) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--repeat must be a positive integer; received ${raw}`);
+  }
+  return parsed;
+}
+
+export async function runBenchProfile({
+  repoRoot = defaultRepoRoot,
+  argv = process.argv.slice(2),
+} = {}) {
+  const profile = parseProfile(argv);
+  const runId = argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const repeat = parseRepeat(argv);
+
+  if (profile !== "react-web") {
+    throw new Error(`unsupported profile '${profile}'; supported profiles: ${SUPPORTED_PROFILES.join(", ")}`);
+  }
+
+  const evidence = await buildReactWebProfileRunnerEvidence({
+    repoRoot,
+    runId,
+    ...(repeat ? { repeat } : {}),
+  });
+
+  if (outputArg) {
+    const outputPath = path.resolve(repoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(repoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebProfileRunnerMarkdown(evidence));
+  }
+
+  return evidence;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const evidence = await runBenchProfile();
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/scripts/react-web-profile-runner.mjs
+++ b/scripts/react-web-profile-runner.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebContextEvidence } from "./react-web-context-evidence.mjs";
+import { buildReactWebReuseEvidence } from "./react-web-reuse-evidence.mjs";
+import { buildReactWebOverCachingAuditEvidence } from "./react-web-over-caching-audit.mjs";
+import { buildReactWebStabilityEvidence } from "./react-web-stability-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+const DEFAULT_REPEAT = 5;
+
+function parseRepeat(argv) {
+  const raw = argv.find((arg) => arg.startsWith("--repeat="))?.slice("--repeat=".length);
+  if (raw == null) return DEFAULT_REPEAT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--repeat must be a positive integer; received ${raw}`);
+  }
+  return parsed;
+}
+
+export async function buildReactWebProfileRunnerEvidence({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+  repeat = DEFAULT_REPEAT,
+} = {}) {
+  const context = await buildReactWebContextEvidence({ repoRoot, runId: `${runId}-context` });
+  const reuse = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
+  const overCachingAudit = await buildReactWebOverCachingAuditEvidence({ repoRoot, runId: `${runId}-audit` });
+  const stability = await buildReactWebStabilityEvidence({ repoRoot, runId: `${runId}-stability`, repeat });
+
+  return {
+    schemaVersion: "react-web-profile-runner.v1",
+    profile: "react-web",
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "react-web-evidence-profile-aggregation",
+    claimBoundary:
+      "Local React Web evidence aggregation only: this bench:profile surface aggregates bounded React Web evidence artifacts. It is not benchmark/profiler semantics, not cache-hit-rate proof, not wall-clock performance proof, not runtime-token savings proof, and not provider cost, billing, invoice, or charged-cost evidence.",
+    claimability: {
+      contextReduction: true,
+      cachePerformance: false,
+      providerBillingSavings: false,
+    },
+    artifacts: {
+      context,
+      reuse,
+      overCachingAudit,
+      stability,
+    },
+    summary: {
+      contextReductionClaimable: context.summary.actualInjectedContextReduction.claimable,
+      reuseCorrectnessClaimable: reuse.summary.reuseCorrectnessClaimable,
+      overCachingNoRepro: overCachingAudit.summary.verdict === "no-repro",
+      stabilityStable: stability.summary.primaryMetric.stable,
+      primaryMetric: {
+        ...stability.summary.primaryMetric,
+      },
+      warnings: [...stability.summary.warnings],
+    },
+  };
+}
+
+export function renderReactWebProfileRunnerMarkdown(evidence) {
+  const warnings = evidence.summary.warnings.length > 0 ? evidence.summary.warnings.map((warning) => `- ${warning}`).join("\n") : "- none";
+
+  return `# React Web profile runner\n\n${evidence.claimBoundary}\n\n## Summary\n\n- Profile: ${evidence.profile}\n- Context reduction claimable: ${evidence.claimability.contextReduction ? "yes" : "no"}\n- Cache performance claimable: no\n- Provider billing savings claimable: no\n- Reuse correctness claimable: ${evidence.summary.reuseCorrectnessClaimable ? "yes" : "no"}\n- Over-caching no-repro: ${evidence.summary.overCachingNoRepro ? "yes" : "no"}\n- Stability stable: ${evidence.summary.stabilityStable ? "yes" : "no"}\n- Primary metric: ${evidence.summary.primaryMetric.metric}\n- Primary metric observed range: ${evidence.summary.primaryMetric.minObservedPct}% to ${evidence.summary.primaryMetric.maxObservedPct}%\n\n## Nested artifacts\n\n- context: ${evidence.artifacts.context.schemaVersion}\n- reuse: ${evidence.artifacts.reuse.schemaVersion}\n- overCachingAudit: ${evidence.artifacts.overCachingAudit.schemaVersion}\n- stability: ${evidence.artifacts.stability.schemaVersion}\n\n## Warnings\n\n${warnings}\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const repeat = parseRepeat(process.argv.slice(2));
+  const evidence = await buildReactWebProfileRunnerEvidence({ repoRoot: defaultRepoRoot, runId, repeat });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebProfileRunnerMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-profile-runner.test.mjs
+++ b/test/react-web-profile-runner.test.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReactWebProfileRunnerEvidence,
+  renderReactWebProfileRunnerMarkdown,
+} from "../scripts/react-web-profile-runner.mjs";
+import { runBenchProfile } from "../scripts/bench-profile.mjs";
+
+test("React Web profile runner aggregates exactly four approved artifacts with locked claimability", async () => {
+  const evidence = await buildReactWebProfileRunnerEvidence({
+    repeat: 2,
+    runId: `profile-test-${Date.now()}-${Math.random()}`,
+  });
+
+  assert.equal(evidence.schemaVersion, "react-web-profile-runner.v1");
+  assert.equal(evidence.profile, "react-web");
+  assert.equal(evidence.measurement, "react-web-evidence-profile-aggregation");
+  assert.match(evidence.claimBoundary, /Local React Web evidence aggregation only/);
+  assert.match(evidence.claimBoundary, /not benchmark\/profiler semantics/);
+  assert.match(evidence.claimBoundary, /not wall-clock performance proof/);
+  assert.match(evidence.claimBoundary, /not runtime-token savings proof/);
+  assert.match(evidence.claimBoundary, /not provider cost, billing, invoice, or charged-cost evidence/);
+
+  assert.deepEqual(evidence.claimability, {
+    contextReduction: true,
+    cachePerformance: false,
+    providerBillingSavings: false,
+  });
+
+  assert.deepEqual(Object.keys(evidence.artifacts), ["context", "reuse", "overCachingAudit", "stability"]);
+  assert.equal(evidence.artifacts.context.schemaVersion, "react-web-context-evidence.v2");
+  assert.equal(evidence.artifacts.reuse.schemaVersion, "react-web-reuse-evidence.v1");
+  assert.equal(evidence.artifacts.overCachingAudit.schemaVersion, "react-web-over-caching-audit.v1");
+  assert.equal(evidence.artifacts.stability.schemaVersion, "react-web-stability-evidence.v1");
+
+  assert.equal(evidence.summary.contextReductionClaimable, true);
+  assert.equal(evidence.summary.reuseCorrectnessClaimable, true);
+  assert.equal(evidence.summary.overCachingNoRepro, true);
+  assert.equal(typeof evidence.summary.stabilityStable, "boolean");
+  assert.equal(evidence.summary.primaryMetric.metric, "repeatRunActualInjectedContextReductionMinPct");
+  assert.deepEqual(evidence.summary.warnings, evidence.artifacts.stability.summary.warnings);
+
+  assert.ok(evidence.artifacts.reuse.checks.unsupportedDomainFallbacks.webview);
+  assert.ok(evidence.artifacts.reuse.checks.unsupportedDomainFallbacks.reactNative);
+  assert.equal("rn" in evidence.artifacts, false);
+  assert.equal("tui" in evidence.artifacts, false);
+  assert.equal("mixedRouting" in evidence.artifacts, false);
+  assert.equal("knowledgeContext" in evidence.artifacts, false);
+  assert.equal("fixturesExpanded" in evidence.artifacts, false);
+});
+
+test("React Web profile runner markdown keeps evidence-only boundary language", async () => {
+  const evidence = await buildReactWebProfileRunnerEvidence({
+    repeat: 2,
+    runId: `profile-markdown-${Date.now()}-${Math.random()}`,
+  });
+  const markdown = renderReactWebProfileRunnerMarkdown(evidence);
+
+  assert.match(markdown, /React Web profile runner/);
+  assert.match(markdown, /Local React Web evidence aggregation only/);
+  assert.match(markdown, /not benchmark\/profiler semantics/);
+  assert.match(markdown, /Cache performance claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /context: react-web-context-evidence\.v2/);
+  assert.match(markdown, /reuse: react-web-reuse-evidence\.v1/);
+  assert.match(markdown, /overCachingAudit: react-web-over-caching-audit\.v1/);
+  assert.match(markdown, /stability: react-web-stability-evidence\.v1/);
+});
+
+test("Bench profile dispatch is fail-closed and profile runner composes builders directly", async () => {
+  const benchSource = fs.readFileSync(new URL("../scripts/bench-profile.mjs", import.meta.url), "utf8");
+  const runnerSource = fs.readFileSync(new URL("../scripts/react-web-profile-runner.mjs", import.meta.url), "utf8");
+
+  assert.match(benchSource, /SUPPORTED_PROFILES = Object\.freeze\(\["react-web"\]\)/);
+  assert.doesNotMatch(benchSource, /benchmarks\/scripts\/profiler\.mjs/);
+  assert.doesNotMatch(benchSource, /execFileSync|spawn|npm run/);
+
+  assert.match(runnerSource, /buildReactWebContextEvidence/);
+  assert.match(runnerSource, /buildReactWebReuseEvidence/);
+  assert.match(runnerSource, /buildReactWebOverCachingAuditEvidence/);
+  assert.match(runnerSource, /buildReactWebStabilityEvidence/);
+  assert.doesNotMatch(runnerSource, /execFileSync|spawn|npm run/);
+
+  await assert.rejects(
+    () => runBenchProfile({ argv: ["rn"] }),
+    /unsupported profile 'rn'; supported profiles: react-web/,
+  );
+  await assert.rejects(
+    () => runBenchProfile({ argv: ["mixed-routing"] }),
+    /unsupported profile 'mixed-routing'; supported profiles: react-web/,
+  );
+});


### PR DESCRIPTION
## Linked issue

Fixes #575

## Summary
- add a fail-closed `bench:profile` entrypoint for React Web evidence aggregation
- compose the React Web context/reuse/over-caching/stability evidence into one bounded profile artifact
- keep claimability conservative: context reduction only, with no cache-performance or billing-savings claim

## Validation
- `npm run build`
- `node --test test/react-web-profile-runner.test.mjs test/react-web-context-evidence.test.mjs test/react-web-reuse-evidence.test.mjs test/react-web-over-caching-audit.test.mjs test/react-web-stability-evidence.test.mjs`
- `npm run bench:profile -- react-web --repeat=2`
- `npm run lint`
- `npm test`