### PR TITLE
Accept maintainer comments as merge-gate participation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Fixes #
 
 ## Review gate
 
-- [ ] Current head has a GitHub PR review from `minislively` or `yeachan-heo`. Self-review by those accounts is allowed. Issue comments and regular PR comments do not count.
+- [ ] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.

--- a/scripts/validate-pr-merge-gate.mjs
+++ b/scripts/validate-pr-merge-gate.mjs
@@ -65,6 +65,14 @@ function latestReviewStateByUser(reviews) {
   return latest;
 }
 
+function collectCommentAuthors(comments = []) {
+  return new Set(
+    (comments || [])
+      .map((comment) => normalizeLogin(comment?.user?.login))
+      .filter(Boolean),
+  );
+}
+
 export function pullRequestHasLinkedClosingIssue(pullRequest) {
   const title = pullRequest?.title || "";
   const body = pullRequest?.body || "";
@@ -74,6 +82,8 @@ export function pullRequestHasLinkedClosingIssue(pullRequest) {
 export function evaluatePullRequestMergeGate({
   pullRequest,
   reviews = [],
+  issueComments = [],
+  reviewComments = [],
   changedFiles = [],
   requireLinkedIssue = true,
   requireApproval = true,
@@ -98,10 +108,21 @@ export function evaluatePullRequestMergeGate({
     })
     .map(([login]) => login)
     .sort();
+  const qualifyingIssueCommenters = [...collectCommentAuthors(issueComments)]
+    .filter((login) => allowedReviewers.has(login))
+    .sort();
+  const qualifyingReviewCommenters = [...collectCommentAuthors(reviewComments)]
+    .filter((login) => allowedReviewers.has(login))
+    .sort();
+  const qualifyingParticipants = [...new Set([
+    ...qualifyingReviewers,
+    ...qualifyingIssueCommenters,
+    ...qualifyingReviewCommenters,
+  ])].sort();
 
-  if (requireApproval && qualifyingReviewers.length === 0) {
+  if (requireApproval && qualifyingParticipants.length === 0) {
     blockers.push(
-      `PR must have an active GitHub PR review on the current head commit from at least one allowed reviewer (${[...allowedReviewers].join(", ")}). Self-review by those accounts is allowed. Issue comments and regular PR comments do not count, and any new push/amend/rebase/force-push after review requires re-review.`,
+      `PR must have at least one GitHub PR review, review comment, or PR/issue comment from an allowed reviewer (${[...allowedReviewers].join(", ")}). Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit, and any new push/amend/rebase/force-push after review requires re-review unless a qualifying comment remains present.`,
     );
   }
 
@@ -109,6 +130,7 @@ export function evaluatePullRequestMergeGate({
     ok: blockers.length === 0,
     blockers,
     approvingReviewers: qualifyingReviewers,
+    qualifyingParticipants,
     docsTestsOnly: docsTestsOnlyChange.docsTestsOnly,
   };
 }
@@ -127,6 +149,33 @@ async function fetchPullRequestReviews({ repository, pullNumber, token }) {
     throw new Error(`Failed to fetch PR reviews: ${response.status} ${response.statusText}`);
   }
   return response.json();
+}
+
+async function fetchAllPages({ repository, pullNumber, token, resourcePath, errorLabel }) {
+  const items = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${repository}/${resourcePath}/${pullNumber}/comments?per_page=100&page=${page}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "fooks-merge-gate",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${errorLabel}: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = await response.json();
+    items.push(...payload);
+    if (payload.length < 100) break;
+    page += 1;
+  }
+
+  return items;
 }
 
 async function fetchPullRequestFiles({ repository, pullNumber, token }) {
@@ -154,6 +203,26 @@ async function fetchPullRequestFiles({ repository, pullNumber, token }) {
   }
 
   return files;
+}
+
+async function fetchPullRequestIssueComments({ repository, pullNumber, token }) {
+  return fetchAllPages({
+    repository,
+    pullNumber,
+    token,
+    resourcePath: "issues",
+    errorLabel: "PR issue comments",
+  });
+}
+
+async function fetchPullRequestReviewComments({ repository, pullNumber, token }) {
+  return fetchAllPages({
+    repository,
+    pullNumber,
+    token,
+    resourcePath: "pulls",
+    errorLabel: "PR review comments",
+  });
 }
 
 async function main() {
@@ -186,10 +255,26 @@ async function main() {
       token,
     })
     : [];
+  const issueComments = requireApproval
+    ? await fetchPullRequestIssueComments({
+      repository,
+      pullNumber: pullRequest.number,
+      token,
+    })
+    : [];
+  const reviewComments = requireApproval
+    ? await fetchPullRequestReviewComments({
+      repository,
+      pullNumber: pullRequest.number,
+      token,
+    })
+    : [];
 
   const result = evaluatePullRequestMergeGate({
     pullRequest,
     reviews,
+    issueComments,
+    reviewComments,
     changedFiles,
     requireLinkedIssue: process.env.MERGE_GATE_REQUIRE_LINKED_ISSUE !== "false",
     requireApproval,
@@ -206,8 +291,8 @@ async function main() {
   const docsTestsOnlySummary = result.docsTestsOnly
     ? " Docs/test-only change detected; linked issue requirement skipped."
     : "";
-  const approvalSummary = result.approvingReviewers.length > 0
-    ? ` Qualifying reviewer(s): ${result.approvingReviewers.join(", ")}`
+  const approvalSummary = result.qualifyingParticipants.length > 0
+    ? ` Qualifying participant(s): ${result.qualifyingParticipants.join(", ")}`
     : "";
   const linkedIssueSummary = result.docsTestsOnly
     ? ""

--- a/test/merge-gate-workflow.test.mjs
+++ b/test/merge-gate-workflow.test.mjs
@@ -8,7 +8,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const workflowPath = path.join(repoRoot, ".github", "workflows", "merge-gate.yml");
 const pullRequestTemplatePath = path.join(repoRoot, ".github", "PULL_REQUEST_TEMPLATE.md");
 
-test("merge gate workflow validates linked issues and current-head allowed-reviewer review", () => {
+test("merge gate workflow validates linked issues and allowed-reviewer participation", () => {
   const workflow = fs.readFileSync(workflowPath, "utf8");
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /pull_request_review:/);
@@ -24,6 +24,6 @@ test("pull request template keeps linked issue prompt and approval checklist", (
   assert.match(template, /minislively/i);
   assert.match(template, /yeachan-heo/i);
   assert.match(template, /self-review.*allowed/i);
-  assert.match(template, /Current head/i);
-  assert.match(template, /Issue comments and regular PR comments do not count/i);
+  assert.match(template, /review, review comment, or PR\/issue comment/i);
+  assert.match(template, /current head commit/i);
 });

--- a/test/pr-merge-gate.test.mjs
+++ b/test/pr-merge-gate.test.mjs
@@ -17,10 +17,11 @@ test("merge gate requires an allowed reviewer by default even when PR links a cl
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /GitHub PR review/);
+  assert.match(result.blockers.join("\n"), /review, review comment, or PR\/issue comment/);
   assert.match(result.blockers.join("\n"), /minislively/i);
   assert.match(result.blockers.join("\n"), /yeachan-heo/i);
   assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, []);
 });
 
 test("merge gate still requires linked issue when approval checks are disabled", () => {
@@ -32,6 +33,7 @@ test("merge gate still requires linked issue when approval checks are disabled",
   assert.match(result.blockers.join("\n"), /closing issue/);
   assert.doesNotMatch(result.blockers.join("\n"), /active approval/);
   assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, []);
 });
 
 test("merge gate rejects PRs without a closing issue reference", () => {
@@ -54,7 +56,7 @@ test("merge gate ignores dismissed allowed reviews when review checks are enable
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /GitHub PR review/);
+  assert.match(result.blockers.join("\n"), /review, review comment, or PR\/issue comment/);
   assert.match(result.blockers.join("\n"), /requires re-review/i);
 });
 
@@ -66,8 +68,7 @@ test("merge gate can require approval on the current head commit when enabled", 
   });
 
   assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /current head commit/);
-  assert.match(result.blockers.join("\n"), /comments do not count/i);
+  assert.match(result.blockers.join("\n"), /current head commit/i);
   assert.match(result.blockers.join("\n"), /requires re-review/i);
 });
 
@@ -80,16 +81,31 @@ test("merge gate passes by default with linked issue and current-head allowed re
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.approvingReviewers, ["minislively"]);
+  assert.deepEqual(result.qualifyingParticipants, ["minislively"]);
 });
 
-test("issue comments do not satisfy the approval gate", () => {
+test("issue comments from allowed users satisfy the approval gate", () => {
   const result = evaluatePullRequestMergeGate({
     pullRequest: pr,
     reviews: [],
+    issueComments: [{ user: { login: "yeachan-heo" } }],
   });
 
-  assert.equal(result.ok, false);
-  assert.match(result.blockers.join("\n"), /comments do not count/i);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, ["yeachan-heo"]);
+});
+
+test("review comments from allowed users satisfy the approval gate", () => {
+  const result = evaluatePullRequestMergeGate({
+    pullRequest: pr,
+    reviews: [],
+    reviewComments: [{ user: { login: "Yeachan-Heo" } }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, ["yeachan-heo"]);
 });
 
 test("merge gate allows self-review when the author is an allowed reviewer", () => {
@@ -101,6 +117,7 @@ test("merge gate allows self-review when the author is an allowed reviewer", () 
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.approvingReviewers, ["minislively"]);
+  assert.deepEqual(result.qualifyingParticipants, ["minislively"]);
 });
 
 test("merge gate rejects reviews from users outside the allowed reviewer set", () => {
@@ -113,6 +130,7 @@ test("merge gate rejects reviews from users outside the allowed reviewer set", (
   assert.equal(result.ok, false);
   assert.match(result.blockers.join("\n"), /allowed reviewer/i);
   assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, []);
 });
 
 test("merge gate can disable linked issue enforcement explicitly", () => {
@@ -156,6 +174,7 @@ test("merge gate can disable approval enforcement explicitly", () => {
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.approvingReviewers, []);
+  assert.deepEqual(result.qualifyingParticipants, []);
 });
 
 test("docs/test-only classifier excludes manifest and non-doc non-test paths", () => {


### PR DESCRIPTION
## Linked issue

Fixes #572

## Summary

- allow merge gate participation through official PR reviews, review comments, or PR/issue comments from allowed maintainer accounts
- keep linked-issue enforcement unchanged
- update merge-gate template/tests to match the maintainer comment workflow

## Verification

- `node --test test/pr-merge-gate.test.mjs`
- `node --test test/merge-gate-workflow.test.mjs`
- `npm run lint`
