### PR TITLE
Add explicit JSON flag for artifact audit status

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -651,7 +651,7 @@ Everyday commands:
   ${displayCliName} status claude
   ${displayCliName} status cache
   ${displayCliName} status worktree
-  ${displayCliName} status artifacts
+  ${displayCliName} status artifacts [--json]
   ${displayCliName} status activity [--include-remote-counts]
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
@@ -740,6 +740,21 @@ function buildInspectDomainResult(options: {
       ? { applies: true, reason: "unsupported-react-native-webview-boundary" }
       : { applies: false },
   };
+}
+
+
+function parseStatusArtifactsArgs(args: string[]): { json: boolean } {
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    throw new Error(`Unexpected status artifacts argument: ${arg}`);
+  }
+
+  return { json };
 }
 
 function parseDoctorArgs(args: string[]): { target: "all" | "codex" | "claude"; json: boolean; help: boolean } {
@@ -1122,6 +1137,7 @@ async function run(): Promise<void> {
         return;
       }
       if (arg1 === "artifacts") {
+        parseStatusArtifactsArgs(rest.slice(1));
         const { auditArtifacts } = await import("../core/artifact-audit.js");
         print(auditArtifacts(process.cwd()));
         return;

--- a/test/artifact-audit.test.mjs
+++ b/test/artifact-audit.test.mjs
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 
 const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
@@ -241,5 +241,20 @@ test("status artifacts emits JSON and remains read-only when git and tmux are un
   assert.equal(result.command, "status artifacts");
   assert.match(result.claimBoundary, /never deletes/);
   assert.ok(Array.isArray(result.blockers));
+  assert.deepEqual(fs.readdirSync(tempDir), before);
+});
+
+test("status artifacts accepts explicit --json and rejects unknown extra args", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-artifact-audit-json-"));
+  const before = fs.readdirSync(tempDir);
+  const result = JSON.parse(execFileSync(process.execPath, [cli, "status", "artifacts", "--json"], { cwd: tempDir, encoding: "utf8" }));
+
+  assert.equal(result.command, "status artifacts");
+  assert.equal(result.claimBoundary, ARTIFACT_AUDIT_CLAIM_BOUNDARY);
+  assert.deepEqual(fs.readdirSync(tempDir), before);
+
+  const rejected = spawnSync(process.execPath, [cli, "status", "artifacts", "--cleanup"], { cwd: tempDir, encoding: "utf8" });
+  assert.notEqual(rejected.status, 0);
+  assert.match(`${rejected.stdout}${rejected.stderr}`, /Unexpected status artifacts argument: --cleanup/);
   assert.deepEqual(fs.readdirSync(tempDir), before);
 });


### PR DESCRIPTION
Closes #577

## Summary
- Document and accept the explicit `fooks status artifacts --json` path while preserving the existing default JSON output for `fooks status artifacts`.
- Reject unknown extra arguments after `status artifacts` with a clear `Unexpected status artifacts argument: ...` error.
- Keep the artifact audit read-only and preserve the existing claim boundary wording.

## Verification
- `npm run build && node --test test/artifact-audit.test.mjs`