### PR TITLE
Expose worktree change-kind counts in local evidence

### DIFF
--- a/src/core/worktree-evidence.ts
+++ b/src/core/worktree-evidence.ts
@@ -33,6 +33,7 @@ export type WorktreeSnapshot = {
   untrackedPaths: string[];
   ignoredPaths: string[];
   conflictedPaths: string[];
+  changeKindCounts: Partial<Record<import("./worktree-status").WorktreeChangeKind, number>>;
   branchDivergence?: BranchDivergence;
 };
 
@@ -230,6 +231,7 @@ export function captureWorktreeSnapshot(cwd = process.cwd(), options: WorktreeEv
         untrackedPaths: uniqueSorted(summary.untrackedPaths),
         ignoredPaths: uniqueSorted(summary.ignoredPaths),
         conflictedPaths: uniqueSorted(summary.conflictedPaths),
+        changeKindCounts: summary.changeKindCounts,
         branchDivergence,
       },
       blockers: [],

--- a/src/core/worktree-status.ts
+++ b/src/core/worktree-status.ts
@@ -41,6 +41,7 @@ export type WorktreeStatusSummary = {
   untrackedPaths: string[];
   ignoredPaths: string[];
   conflictedPaths: string[];
+  changeKindCounts: Partial<Record<WorktreeChangeKind, number>>;
 };
 
 export type ParseWorktreeStatusOptions = {
@@ -112,6 +113,13 @@ function parsePorcelainLine(line: string): WorktreeStatusEntry | undefined {
   };
 }
 
+function countChangeKinds(entries: WorktreeStatusEntry[]): Partial<Record<WorktreeChangeKind, number>> {
+  return entries.reduce<Partial<Record<WorktreeChangeKind, number>>>((counts, entry) => {
+    counts[entry.kind] = (counts[entry.kind] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
 function parseNulTerminatedPorcelain(output: string): WorktreeStatusEntry[] {
   const fields = output.split("\0").filter((field) => field.length > 0);
   const entries: WorktreeStatusEntry[] = [];
@@ -154,6 +162,7 @@ export function summarizeWorktreeStatus(entries: WorktreeStatusEntry[]): Worktre
     untrackedPaths: entries.filter((entry) => entry.kind === "untracked").map((entry) => entry.path),
     ignoredPaths: entries.filter((entry) => entry.kind === "ignored").map((entry) => entry.path),
     conflictedPaths: entries.filter((entry) => entry.conflicted).map((entry) => entry.path),
+    changeKindCounts: countChangeKinds(changedEntries),
   };
 }
 

--- a/test/worktree-evidence.test.mjs
+++ b/test/worktree-evidence.test.mjs
@@ -53,6 +53,7 @@ test("captureWorktreeSnapshot parses clean, untracked, conflicted, and rename ev
   assert.deepEqual(clean.blockers, []);
   assert.equal(clean.snapshot.clean, true);
   assert.deepEqual(clean.snapshot.changedPaths, []);
+  assert.deepEqual(clean.snapshot.changeKindCounts, {});
 
   const dirty = captureWorktreeSnapshot("/tmp/project", {
     runner: outputRunner(" M src/App.tsx\0?? scratch.log\0UU conflict.ts\0R  src/NewName.tsx\0src/OldName.tsx\0"),
@@ -64,6 +65,12 @@ test("captureWorktreeSnapshot parses clean, untracked, conflicted, and rename ev
   assert.deepEqual(dirty.snapshot.trackedPaths, ["conflict.ts", "src/App.tsx", "src/NewName.tsx"]);
   assert.deepEqual(dirty.snapshot.untrackedPaths, ["scratch.log"]);
   assert.deepEqual(dirty.snapshot.conflictedPaths, ["conflict.ts"]);
+  assert.deepEqual(dirty.snapshot.changeKindCounts, {
+    modified: 1,
+    untracked: 1,
+    unmerged: 1,
+    renamed: 1,
+  });
 });
 
 test("session evidence records baseline/latest and computes dirty deltas with a fake runner", () => {
@@ -358,6 +365,7 @@ test("dirty worktrees keep dirty verdict primary even with local tracking diverg
   assert.equal(dirty.worktreeVerdict.severity, "warning");
   assert.equal(dirty.worktreeVerdict.primary, "dirty");
   assert.equal(dirty.worktreeVerdict.summary, "dirty worktree");
+  assert.deepEqual(dirty.snapshot.changeKindCounts, { untracked: 1 });
 });
 
 test("doctor warns for clean local tracking divergence but suppresses dirty divergence", () => {

--- a/test/worktree-status.test.mjs
+++ b/test/worktree-status.test.mjs
@@ -65,9 +65,27 @@ test("summarizeWorktreeStatus separates tracked, untracked, ignored, and conflic
   assert.deepEqual(summary.untrackedPaths, ["scratch.log"]);
   assert.deepEqual(summary.ignoredPaths, ["dist/index.js"]);
   assert.deepEqual(summary.conflictedPaths, ["src/conflict.ts"]);
+  assert.deepEqual(summary.changeKindCounts, {
+    modified: 1,
+    untracked: 1,
+    unmerged: 1,
+  });
 });
 
 test("parseAndSummarizeWorktreeStatus treats empty or ignored-only output as clean", () => {
   assert.equal(parseAndSummarizeWorktreeStatus("\n").clean, true);
   assert.equal(parseAndSummarizeWorktreeStatus("!! dist/index.js\n").clean, true);
+});
+
+test("summarizeWorktreeStatus counts additive change kinds for downstream worktree evidence", () => {
+  const summary = parseAndSummarizeWorktreeStatus(
+    "R  src/old.ts -> src/new.ts\n?? scratch.log\n D docs/old.md\nT  scripts/run.sh\n",
+  );
+
+  assert.deepEqual(summary.changeKindCounts, {
+    renamed: 1,
+    untracked: 1,
+    deleted: 1,
+    "type-changed": 1,
+  });
 });


### PR DESCRIPTION
## Why
The repo already had a worktree parser on `main`, so this first pass should add a real parser-backed improvement instead of replaying stale branch history or widening into runtime/cache integration.

Closes #582

## What changed
- added `changeKindCounts` to `WorktreeStatusSummary`
- threaded `changeKindCounts` into worktree snapshots / `status worktree`
- added focused parser and worktree-evidence coverage for the new additive signal

## Scope boundary
- local/read-only git worktree evidence only
- no parser rewrite
- no runtime-hook integration
- no cache integration
- no performance/billing/runtime claims

## Verification
- `node --test test/worktree-status.test.mjs test/worktree-evidence.test.mjs`
- `npm run lint`

## Base
- refreshed `main` to `aab1d4ee7315d3c139f1f9bb2e005d2ac72db511`
- created fresh worktree/branch: `feat/worktree-parser-first-pass`
