### PR TITLE
Add React Web knowledge-context evidence

### DIFF
--- a/docs/project-knowledge/claim-boundary-rules.json
+++ b/docs/project-knowledge/claim-boundary-rules.json
@@ -23,6 +23,26 @@
       ],
       "severity": "warning",
       "authority": "tracked"
+    },
+    {
+      "id": "claim-boundary.react-web-knowledge-boundary",
+      "family": "claim-boundary",
+      "summary": "Do not widen React Web repeated same-file context wording into actual context-reduction percentages, runtime-token savings, billing savings, or broad frontend support. Keep it advisory and bounded to the documented claim boundary.",
+      "appliesWhen": {
+        "keywords": [
+          "react web claim boundary",
+          "context reduction claim",
+          "actual injected context reduction",
+          "runtime token savings",
+          "billing savings"
+        ]
+      },
+      "evidence": [
+        "docs/react-web-context-retention.md",
+        "docs/release.md"
+      ],
+      "severity": "warning",
+      "authority": "tracked"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "evidence:react-web-over-caching-audit": "npm run build && node scripts/react-web-over-caching-audit.mjs",
     "evidence:react-web-stability": "npm run build && node scripts/react-web-stability-evidence.mjs",
     "evidence:react-web-mixed-routing": "npm run build && node scripts/react-web-mixed-routing-evidence.mjs",
+    "evidence:react-web-knowledge-context": "npm run build && node scripts/react-web-knowledge-context-evidence.mjs",
     "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",
     "bench": "npm run build && node benchmarks/scripts/run-all.mjs",

--- a/scripts/react-web-knowledge-context-evidence.mjs
+++ b/scripts/react-web-knowledge-context-evidence.mjs
@@ -1,0 +1,243 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+const REACT_WEB_RULE_ID = "claim-boundary.react-web-knowledge-boundary";
+
+function copyFixture(repoRoot, tempRoot, relativeFile) {
+  const target = path.join(tempRoot, relativeFile);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, relativeFile), target);
+}
+
+function cleanupRuntimeState(projectRoot, prefix) {
+  const runtimeRoot = path.join(projectRoot, ".fooks", "state", "codex-runtime");
+  if (!fs.existsSync(runtimeRoot)) return;
+  for (const entry of fs.readdirSync(runtimeRoot, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith(prefix)) {
+      fs.rmSync(path.join(runtimeRoot, entry.name), { force: true });
+    }
+  }
+}
+
+function hasProjectKnowledgeBlock(text) {
+  return typeof text === "string" && text.includes("PROJECT KNOWLEDGE CONTEXT");
+}
+
+function claimBoundaryWarnings(evidence) {
+  const warnings = [];
+  if (!evidence.summary.injectedOnRepeatedFile) warnings.push("repeated same-file React Web prompt did not inject tracked project knowledge");
+  if (evidence.summary.injectedOnFirstRun) warnings.push("first-run React Web prompt unexpectedly injected project knowledge");
+  if (evidence.summary.injectedOnNoTarget) warnings.push("no-target React Web prompt unexpectedly injected project knowledge");
+  if (!evidence.summary.advisoryOnly) warnings.push("project knowledge was not proven advisory-only");
+  if (evidence.summary.genericRepeatedPromptInjectedKnowledge) {
+    warnings.push("generic repeated same-file React Web prompt injected claim-boundary project knowledge without explicit boundary wording");
+  }
+  return warnings;
+}
+
+async function loadRuntimeHook(repoRoot) {
+  return import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+}
+
+export async function buildReactWebKnowledgeContextEvidence({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-knowledge-"));
+  const repeatedSessionId = `react-web-knowledge-context-${runId}`;
+  const genericSessionId = `react-web-knowledge-generic-${runId}`;
+  const noTargetSessionId = `react-web-knowledge-no-target-${runId}`;
+  const reactWebFile = "fixtures/compressed/HookEffectPanel.tsx";
+  const rulesFile = "docs/project-knowledge/claim-boundary-rules.json";
+
+  try {
+    fs.writeFileSync(
+      path.join(tempRoot, "package.json"),
+      JSON.stringify({ name: "react-web-knowledge-context-evidence-temp", private: true }, null, 2),
+    );
+    copyFixture(repoRoot, tempRoot, reactWebFile);
+    copyFixture(repoRoot, tempRoot, rulesFile);
+
+    const { handleCodexRuntimeHook } = await loadRuntimeHook(repoRoot);
+
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: repeatedSessionId }, tempRoot);
+    const firstClaimBoundaryPrompt = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: repeatedSessionId,
+        prompt: `Review ${reactWebFile} and keep the React Web context reduction claim narrow`,
+      },
+      tempRoot,
+    );
+    const repeatedClaimBoundaryPrompt = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: repeatedSessionId,
+        prompt: `Review ${reactWebFile} again and keep the React Web context reduction claim narrow`,
+      },
+      tempRoot,
+    );
+
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: genericSessionId }, tempRoot);
+    handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: genericSessionId,
+        prompt: `Review ${reactWebFile}`,
+      },
+      tempRoot,
+    );
+    const repeatedGenericPrompt = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: genericSessionId,
+        prompt: `Review ${reactWebFile} again`,
+      },
+      tempRoot,
+    );
+
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: noTargetSessionId }, tempRoot);
+    const noTargetPrompt = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId: noTargetSessionId,
+        prompt: "Tighten the React Web context reduction claim wording without widening support claims",
+      },
+      tempRoot,
+    );
+
+    const matchedRules = repeatedClaimBoundaryPrompt.projectKnowledge?.appliedRuleIds ?? [];
+    const evidence = {
+      schemaVersion: "react-web-knowledge-context-evidence.v1",
+      generatedAt: new Date().toISOString(),
+      runId,
+      measurement: "codex-runtime-hook-local-project-knowledge",
+      claimBoundary:
+        "Local runtime-hook/project-knowledge evidence only: proves React Web claim-boundary knowledge matching and advisory repeated same-file injection behavior; not actual context-reduction percentages, wall-clock performance, runtime-token savings, provider billing, or charged-cost evidence.",
+      summary: {
+        matchedRules,
+        injectedOnRepeatedFile:
+          repeatedClaimBoundaryPrompt.action === "inject" &&
+          hasProjectKnowledgeBlock(repeatedClaimBoundaryPrompt.additionalContext) &&
+          matchedRules.includes(REACT_WEB_RULE_ID),
+        injectedOnFirstRun:
+          hasProjectKnowledgeBlock(firstClaimBoundaryPrompt.additionalContext) || firstClaimBoundaryPrompt.projectKnowledge !== undefined,
+        injectedOnNoTarget: hasProjectKnowledgeBlock(noTargetPrompt.additionalContext) || noTargetPrompt.projectKnowledge !== undefined,
+        advisoryOnly:
+          repeatedClaimBoundaryPrompt.projectKnowledge?.mode === "advisory" &&
+          repeatedClaimBoundaryPrompt.projectKnowledge?.family === "claim-boundary" &&
+          hasProjectKnowledgeBlock(repeatedClaimBoundaryPrompt.additionalContext) &&
+          !/remembered|enforced|validated|guaranteed/i.test(repeatedClaimBoundaryPrompt.additionalContext),
+        genericRepeatedPromptInjectedKnowledge:
+          repeatedGenericPrompt.projectKnowledge !== undefined || hasProjectKnowledgeBlock(repeatedGenericPrompt.additionalContext),
+        boundaryEvidenceOnlyClaimable: false,
+        contextReduction: {
+          claimable: false,
+          blocker: "this artifact proves project-knowledge injection boundaries only; it does not measure actualInjectedContextReduction or any byte-reduction percentage",
+        },
+        cachePerformance: {
+          claimable: false,
+          blocker: "this artifact measures runtime-hook knowledge injection behavior, not wall-clock latency, cache hit rate, or end-to-end runtime performance",
+        },
+        providerBillingSavings: {
+          claimable: false,
+          blocker: "this artifact contains no provider usage, tokenizer, billing dashboard, invoice, or charged-cost data",
+        },
+        warnings: [],
+      },
+      checks: {
+        repeatedClaimBoundaryPrompt: {
+          firstAction: firstClaimBoundaryPrompt.action,
+          secondAction: repeatedClaimBoundaryPrompt.action,
+          secondReasons: repeatedClaimBoundaryPrompt.reasons,
+          matchedRules,
+          matchReasons: repeatedClaimBoundaryPrompt.projectKnowledge?.matchReasons ?? [],
+          authority: repeatedClaimBoundaryPrompt.projectKnowledge?.authority ?? null,
+          rulesPath: repeatedClaimBoundaryPrompt.projectKnowledge?.rulesPath ?? null,
+          mode: repeatedClaimBoundaryPrompt.projectKnowledge?.mode ?? null,
+        },
+        firstRunExclusion: {
+          action: firstClaimBoundaryPrompt.action,
+          projectKnowledgePresent: firstClaimBoundaryPrompt.projectKnowledge !== undefined,
+          hasProjectKnowledgeBlock: hasProjectKnowledgeBlock(firstClaimBoundaryPrompt.additionalContext),
+        },
+        noTargetExclusion: {
+          action: noTargetPrompt.action,
+          projectKnowledgePresent: noTargetPrompt.projectKnowledge !== undefined,
+          hasProjectKnowledgeBlock: hasProjectKnowledgeBlock(noTargetPrompt.additionalContext),
+        },
+        genericPromptNarrowness: {
+          action: repeatedGenericPrompt.action,
+          projectKnowledgePresent: repeatedGenericPrompt.projectKnowledge !== undefined,
+          hasProjectKnowledgeBlock: hasProjectKnowledgeBlock(repeatedGenericPrompt.additionalContext),
+        },
+      },
+    };
+
+    evidence.summary.warnings = claimBoundaryWarnings(evidence);
+    evidence.summary.boundaryEvidenceOnlyClaimable = evidence.summary.warnings.length === 0;
+    return evidence;
+  } finally {
+    cleanupRuntimeState(tempRoot, repeatedSessionId);
+    cleanupRuntimeState(tempRoot, genericSessionId);
+    cleanupRuntimeState(tempRoot, noTargetSessionId);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export function renderReactWebKnowledgeContextEvidenceMarkdown(evidence) {
+  return `# React Web knowledge-context evidence
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Matched rules: ${evidence.summary.matchedRules.join(", ") || "none"}
+- Injected on repeated file: ${evidence.summary.injectedOnRepeatedFile ? "yes" : "no"}
+- Injected on first run: ${evidence.summary.injectedOnFirstRun ? "yes" : "no"}
+- Injected on no-target prompt: ${evidence.summary.injectedOnNoTarget ? "yes" : "no"}
+- Advisory only: ${evidence.summary.advisoryOnly ? "yes" : "no"}
+- Generic repeated prompt injected knowledge: ${evidence.summary.genericRepeatedPromptInjectedKnowledge ? "yes" : "no"}
+- Boundary evidence claimable: ${evidence.summary.boundaryEvidenceOnlyClaimable ? "yes" : "no"}
+- Context reduction claimable: no
+- Cache performance claimable: no
+- Provider billing savings claimable: no
+
+## Decisions
+
+- React Web claim-boundary repeated prompt: ${evidence.checks.repeatedClaimBoundaryPrompt.firstAction} -> ${evidence.checks.repeatedClaimBoundaryPrompt.secondAction}
+- First-run exclusion: action=${evidence.checks.firstRunExclusion.action}; projectKnowledge=${evidence.checks.firstRunExclusion.projectKnowledgePresent ? "present" : "absent"}
+- No-target exclusion: action=${evidence.checks.noTargetExclusion.action}; projectKnowledge=${evidence.checks.noTargetExclusion.projectKnowledgePresent ? "present" : "absent"}
+- Generic repeated prompt narrowness: action=${evidence.checks.genericPromptNarrowness.action}; projectKnowledge=${evidence.checks.genericPromptNarrowness.projectKnowledgePresent ? "present" : "absent"}
+
+## Claim boundary
+
+This artifact supports bounded knowledge-injection wording for local Codex runtime-hook behavior only. It does not support actualInjectedContextReduction percentages, wall-clock performance, runtime-token, provider-cost, billing, invoice, or charged-cost claims.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebKnowledgeContextEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebKnowledgeContextEvidenceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-knowledge-context-evidence.test.mjs
+++ b/test/react-web-knowledge-context-evidence.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildReactWebKnowledgeContextEvidence,
+  renderReactWebKnowledgeContextEvidenceMarkdown,
+} from "../scripts/react-web-knowledge-context-evidence.mjs";
+
+const repoRoot = process.cwd();
+
+test("React Web knowledge-context evidence proves repeated-file injection and exclusion boundaries", async () => {
+  const evidence = await buildReactWebKnowledgeContextEvidence({ runId: `unit-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.schemaVersion, "react-web-knowledge-context-evidence.v1");
+  assert.equal(evidence.measurement, "codex-runtime-hook-local-project-knowledge");
+  assert.deepEqual(evidence.summary.matchedRules, ["claim-boundary.react-web-knowledge-boundary"]);
+  assert.equal(evidence.summary.injectedOnRepeatedFile, true);
+  assert.equal(evidence.summary.injectedOnFirstRun, false);
+  assert.equal(evidence.summary.injectedOnNoTarget, false);
+  assert.equal(evidence.summary.advisoryOnly, true);
+  assert.equal(evidence.summary.genericRepeatedPromptInjectedKnowledge, false);
+  assert.equal(evidence.summary.boundaryEvidenceOnlyClaimable, true);
+  assert.deepEqual(evidence.summary.warnings, []);
+
+  assert.equal(evidence.summary.contextReduction.claimable, false);
+  assert.equal(evidence.summary.cachePerformance.claimable, false);
+  assert.equal(evidence.summary.providerBillingSavings.claimable, false);
+
+  assert.equal(evidence.checks.repeatedClaimBoundaryPrompt.firstAction, "record");
+  assert.equal(evidence.checks.repeatedClaimBoundaryPrompt.secondAction, "inject");
+  assert.equal(evidence.checks.repeatedClaimBoundaryPrompt.mode, "advisory");
+  assert.ok(
+    evidence.checks.repeatedClaimBoundaryPrompt.matchReasons.some((reason) => reason.startsWith("prompt-keyword:context reduction claim")),
+  );
+  assert.equal(evidence.checks.firstRunExclusion.projectKnowledgePresent, false);
+  assert.equal(evidence.checks.noTargetExclusion.action, "noop");
+  assert.equal(evidence.checks.noTargetExclusion.projectKnowledgePresent, false);
+  assert.equal(evidence.checks.genericPromptNarrowness.projectKnowledgePresent, false);
+});
+
+test("React Web knowledge-context evidence markdown keeps the lane boundary-only", async () => {
+  const evidence = await buildReactWebKnowledgeContextEvidence({ runId: `markdown-${Date.now()}-${Math.random()}` });
+  const markdown = renderReactWebKnowledgeContextEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /React Web knowledge-context evidence/);
+  assert.match(markdown, /Injected on repeated file: yes/);
+  assert.match(markdown, /Injected on first run: no/);
+  assert.match(markdown, /Injected on no-target prompt: no/);
+  assert.match(markdown, /Generic repeated prompt injected knowledge: no/);
+  assert.match(markdown, /Boundary evidence claimable: yes/);
+  assert.match(markdown, /Context reduction claimable: no/);
+  assert.match(markdown, /Cache performance claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /does not support actualInjectedContextReduction percentages/);
+});
+
+test("React Web knowledge-context evidence command writes bounded JSON report", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-knowledge-context-"));
+  const outputPath = path.join(tempDir, "react-web-knowledge-context-evidence.json");
+
+  const cli = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "react-web-knowledge-context-evidence.mjs"), "--run-id=cli-test", `--output=${outputPath}`],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+
+  const stdoutEvidence = JSON.parse(cli.stdout);
+  const fileEvidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+
+  assert.deepEqual(fileEvidence, stdoutEvidence);
+  assert.equal(stdoutEvidence.runId, "cli-test");
+  assert.deepEqual(stdoutEvidence.summary.matchedRules, ["claim-boundary.react-web-knowledge-boundary"]);
+  assert.equal(stdoutEvidence.summary.injectedOnRepeatedFile, true);
+  assert.equal(stdoutEvidence.summary.genericRepeatedPromptInjectedKnowledge, false);
+});


### PR DESCRIPTION
Closes #587

## Summary
- add a standalone `evidence:react-web-knowledge-context` surface
- add a narrow tracked React Web project-knowledge rule for claim-boundary prompts
- lock repeated-file injection, first-run/no-target exclusion, and advisory-only behavior with tests

## Non-goals
- no `bench:profile` or `react-web-profile-runner` changes
- no new context-reduction, performance, or billing claim surface

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/react-web-knowledge-context-evidence.test.mjs`
- `npm run evidence:react-web-knowledge-context -- --run-id=verify`
- `npm run lint`
- `npm test`