### PR TITLE
Add a unified React Web profile surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "evidence:react-web-stability": "npm run build && node scripts/react-web-stability-evidence.mjs",
     "evidence:react-web-mixed-routing": "npm run build && node scripts/react-web-mixed-routing-evidence.mjs",
     "evidence:react-web-knowledge-context": "npm run build && node scripts/react-web-knowledge-context-evidence.mjs",
+    "evidence:react-web-profile": "npm run build && node scripts/react-web-profile-surface.mjs",
     "evidence:release-benchmark": "npm run build && node scripts/release-benchmark-evidence.mjs",
     "clean": "rm -rf dist",
     "bench": "npm run build && node benchmarks/scripts/run-all.mjs",

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebContextEvidence } from "./react-web-context-evidence.mjs";
+import { buildReactWebReuseEvidence } from "./react-web-reuse-evidence.mjs";
+import { buildReactWebOverCachingAuditEvidence } from "./react-web-over-caching-audit.mjs";
+import { buildReactWebStabilityEvidence } from "./react-web-stability-evidence.mjs";
+import { buildReactWebMixedRoutingEvidence } from "./react-web-mixed-routing-evidence.mjs";
+import { buildReactWebKnowledgeContextEvidence } from "./react-web-knowledge-context-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_PROFILE_ARTIFACT_KEYS = [
+  "context",
+  "reuse",
+  "overCachingAudit",
+  "stability",
+  "mixedRouting",
+  "knowledgeContext",
+];
+
+function prefixedWarnings(prefix, warnings = []) {
+  return warnings.map((warning) => `${prefix}: ${warning}`);
+}
+
+export async function buildReactWebProfileSurface({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const context = await buildReactWebContextEvidence({ repoRoot, runId: `${runId}-context` });
+  const reuse = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
+  const overCachingAudit = await buildReactWebOverCachingAuditEvidence({ repoRoot, runId: `${runId}-over-caching-audit` });
+  const stability = await buildReactWebStabilityEvidence({ repoRoot, runId: `${runId}-stability` });
+  const mixedRouting = await buildReactWebMixedRoutingEvidence({ repoRoot, runId: `${runId}-mixed-routing` });
+  const knowledgeContext = await buildReactWebKnowledgeContextEvidence({ repoRoot, runId: `${runId}-knowledge-context` });
+
+  const artifacts = {
+    context,
+    reuse,
+    overCachingAudit,
+    stability,
+    mixedRouting,
+    knowledgeContext,
+  };
+
+  return {
+    schemaVersion: "react-web-profile-surface.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    profile: "react-web",
+    measurement: "aggregated-react-web-evidence-lane",
+    claimBoundary:
+      "Aggregated local React Web evidence lane only: composes six existing bounded React Web evidence artifacts into one execution/reporting surface. This top-level surface does not widen context-reduction, performance, runtime-token, provider-cost, billing, invoice, or charged-cost claims beyond the child artifacts.",
+    claimability: {
+      contextReduction: false,
+      cachePerformance: false,
+      providerBillingSavings: false,
+    },
+    artifacts,
+    summary: {
+      artifactCount: REACT_WEB_PROFILE_ARTIFACT_KEYS.length,
+      artifactKeys: REACT_WEB_PROFILE_ARTIFACT_KEYS,
+      reactWebOnly: true,
+      contextReductionWidened: false,
+      cachePerformanceWidened: false,
+      providerBillingSavingsWidened: false,
+      childSignals: {
+        contextActualInjectedContextReductionClaimable: context.summary.actualInjectedContextReduction.claimable,
+        reuseCorrectnessClaimable: reuse.summary.reuseCorrectnessClaimable,
+        overCachingAuditVerdictName: overCachingAudit.summary.verdictName,
+        overCachingAuditBugReproduced: overCachingAudit.summary.bugReproduced,
+        stabilityWarningOnly: stability.summary.primaryMetric.warningOnly,
+        mixedRoutingBoundaryIsolationClaimable: mixedRouting.summary.boundaryIsolationClaimable,
+        knowledgeContextBoundaryEvidenceClaimable: knowledgeContext.summary.boundaryEvidenceOnlyClaimable,
+      },
+      warnings: [
+        ...(overCachingAudit.summary.bugReproduced
+          ? [`overCachingAudit: ${overCachingAudit.summary.verdictName}`]
+          : []),
+        ...prefixedWarnings("stability", stability.summary.warnings),
+        ...prefixedWarnings("mixedRouting", mixedRouting.summary.warnings),
+        ...prefixedWarnings("knowledgeContext", knowledgeContext.summary.warnings),
+      ],
+    },
+  };
+}
+
+export function renderReactWebProfileSurfaceMarkdown(evidence) {
+  const warnings = evidence.summary.warnings.length > 0 ? evidence.summary.warnings.map((warning) => `- ${warning}`).join("\n") : "- none";
+  return `# React Web profile surface
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Profile: ${evidence.profile}
+- Artifact count: ${evidence.summary.artifactCount}
+- Artifact keys: ${evidence.summary.artifactKeys.join(", ")}
+- React Web only: ${evidence.summary.reactWebOnly ? "yes" : "no"}
+- Top-level context reduction claim widened: ${evidence.summary.contextReductionWidened ? "yes" : "no"}
+- Top-level cache performance claim widened: ${evidence.summary.cachePerformanceWidened ? "yes" : "no"}
+- Top-level provider billing savings claim widened: ${evidence.summary.providerBillingSavingsWidened ? "yes" : "no"}
+
+## Child evidence snapshot
+
+- Context actual injected context reduction claimable: ${evidence.summary.childSignals.contextActualInjectedContextReductionClaimable ? "yes" : "no"}
+- Reuse correctness claimable: ${evidence.summary.childSignals.reuseCorrectnessClaimable ? "yes" : "no"}
+- Over-caching audit verdict: ${evidence.summary.childSignals.overCachingAuditVerdictName}
+- Over-caching audit bug reproduced: ${evidence.summary.childSignals.overCachingAuditBugReproduced ? "yes" : "no"}
+- Stability warning-only: ${evidence.summary.childSignals.stabilityWarningOnly ? "yes" : "no"}
+- Mixed-routing boundary isolation claimable: ${evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable ? "yes" : "no"}
+- Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
+
+## Top-level non-claims
+
+- Context reduction claimable at top level: ${evidence.claimability.contextReduction ? "yes" : "no"}
+- Cache performance claimable at top level: ${evidence.claimability.cachePerformance ? "yes" : "no"}
+- Provider billing savings claimable at top level: ${evidence.claimability.providerBillingSavings ? "yes" : "no"}
+
+## Warnings
+
+${warnings}
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebProfileSurface({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebProfileSurfaceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildReactWebProfileSurface,
+  REACT_WEB_PROFILE_ARTIFACT_KEYS,
+  renderReactWebProfileSurfaceMarkdown,
+} from "../scripts/react-web-profile-surface.mjs";
+
+const repoRoot = process.cwd();
+let evidencePromise;
+
+function getEvidence() {
+  evidencePromise ??= buildReactWebProfileSurface({ runId: `test-${Date.now()}-${Math.random()}` });
+  return evidencePromise;
+}
+
+test("React Web profile surface aggregates exactly the approved six evidence artifacts", async () => {
+  const evidence = await getEvidence();
+
+  assert.equal(evidence.schemaVersion, "react-web-profile-surface.v1");
+  assert.equal(evidence.profile, "react-web");
+  assert.equal(evidence.measurement, "aggregated-react-web-evidence-lane");
+  assert.match(evidence.claimBoundary, /Aggregated local React Web evidence lane only/);
+  assert.match(evidence.claimBoundary, /does not widen context-reduction, performance, runtime-token, provider-cost, billing, invoice, or charged-cost claims/);
+
+  assert.deepEqual(Object.keys(evidence.artifacts), REACT_WEB_PROFILE_ARTIFACT_KEYS);
+  assert.deepEqual(evidence.summary.artifactKeys, REACT_WEB_PROFILE_ARTIFACT_KEYS);
+  assert.equal(evidence.summary.artifactCount, 6);
+  assert.equal(evidence.summary.reactWebOnly, true);
+
+  assert.equal("rn" in evidence, false);
+  assert.equal("reactNative" in evidence, false);
+  assert.equal("webview" in evidence, false);
+  assert.equal("tui" in evidence, false);
+
+  assert.deepEqual(evidence.claimability, {
+    contextReduction: false,
+    cachePerformance: false,
+    providerBillingSavings: false,
+  });
+  assert.equal(evidence.summary.contextReductionWidened, false);
+  assert.equal(evidence.summary.cachePerformanceWidened, false);
+  assert.equal(evidence.summary.providerBillingSavingsWidened, false);
+
+  assert.equal(evidence.summary.childSignals.contextActualInjectedContextReductionClaimable, true);
+  assert.equal(evidence.summary.childSignals.reuseCorrectnessClaimable, true);
+  assert.equal(evidence.summary.childSignals.overCachingAuditVerdictName, "react-web-small-edit-refresh-no-repro");
+  assert.equal(evidence.summary.childSignals.overCachingAuditBugReproduced, false);
+  assert.equal(typeof evidence.summary.childSignals.stabilityWarningOnly, "boolean");
+  assert.equal(evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable, true);
+  assert.equal(evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable, true);
+});
+
+test("React Web profile surface markdown keeps the top-level non-claims explicit", async () => {
+  const evidence = await getEvidence();
+  const markdown = renderReactWebProfileSurfaceMarkdown(evidence);
+
+  assert.match(markdown, /# React Web profile surface/);
+  assert.match(markdown, /Profile: react-web/);
+  assert.match(markdown, /Artifact count: 6/);
+  assert.match(markdown, /Artifact keys: context, reuse, overCachingAudit, stability, mixedRouting, knowledgeContext/);
+  assert.match(markdown, /React Web only: yes/);
+  assert.match(markdown, /Top-level context reduction claim widened: no/);
+  assert.match(markdown, /Top-level cache performance claim widened: no/);
+  assert.match(markdown, /Top-level provider billing savings claim widened: no/);
+  assert.match(markdown, /Over-caching audit verdict: react-web-small-edit-refresh-no-repro/);
+  assert.match(markdown, /Over-caching audit bug reproduced: no/);
+  assert.match(markdown, /Context reduction claimable at top level: no/);
+  assert.match(markdown, /Cache performance claimable at top level: no/);
+  assert.match(markdown, /Provider billing savings claimable at top level: no/);
+  assert.doesNotMatch(markdown, /Context reduction claimable at top level: yes/i);
+});
+
+test("React Web profile surface command writes bounded JSON and Markdown reports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-profile-surface-"));
+  const outputPath = path.join(tempDir, "react-web-profile-surface.json");
+  const markdownPath = path.join(tempDir, "react-web-profile-surface.md");
+
+  const cli = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts", "react-web-profile-surface.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+
+  const stdoutEvidence = JSON.parse(cli.stdout);
+  const fileEvidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+
+  assert.equal(stdoutEvidence.runId, "cli-test");
+  assert.equal(stdoutEvidence.profile, "react-web");
+  assert.deepEqual(Object.keys(stdoutEvidence.artifacts), REACT_WEB_PROFILE_ARTIFACT_KEYS);
+  assert.deepEqual(fileEvidence, stdoutEvidence);
+  assert.match(markdown, /# React Web profile surface/);
+  assert.match(markdown, /Top-level context reduction claim widened: no/);
+});


### PR DESCRIPTION
## Summary
- add a React Web-only unified profile surface that aggregates the six approved evidence artifacts
- keep top-level claimability fail-closed while exposing child evidence signals in one bounded schema
- lock the exact inclusion list and React Web-only boundary with focused tests

## Testing
- git diff --check
- npm run build
- node --test test/react-web-profile-surface.test.mjs
- npm run evidence:react-web-profile -- --run-id=verify
- npm run lint
- npm test

Closes #590