### PR TITLE
Publish the bounded RN source-only guidance report

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -97,6 +97,7 @@ The current forbidden claim shapes are:
 - Do not claim that RN primitives are equivalent to DOM controls or React Web form semantics.
 
 These boundaries apply to docs, tests, fixture explanations, and payload-policy wording until a later approved PR widens the measured scope.
+For a reviewer-oriented summary of the current merged RN wording boundary, see [React Native source-only guidance report](./react-native-source-only-guidance-report.md).
 
 ## Runtime debug evidence boundary
 

--- a/docs/react-native-source-only-guidance-report.md
+++ b/docs/react-native-source-only-guidance-report.md
@@ -1,0 +1,72 @@
+# React Native source-only guidance report
+
+This report consolidates the current React Native wording boundary across the merged docs, fixtures, and tests. It is a **guidance artifact only**: it does not change runtime behavior, detector behavior, payload policy, setup eligibility, or support status.
+
+Use this report when reviewing or writing RN-facing docs/tests so the current merged claim boundary stays stable.
+
+## Current RN lane status
+
+- `F1` and `F13` are the only RN slots that may emit narrow payload evidence.
+- That narrow payload evidence is limited to the existing `rn-primitive-input-narrow-payload` policy.
+- `F2`, `F9`, and `F10` remain fallback/readiness lanes with source-only concern metadata.
+- No current RN surface is a broad React Native support claim.
+
+## Slot-by-slot guidance
+
+| Slot group | Current allowed wording | Current forbidden leap |
+| --- | --- | --- |
+| `F1` / `F13` primitive/input | Source-only RN primitive/input evidence, same-file named handler evidence, same-file inline callback evidence, measured narrow payload through `rn-primitive-input-narrow-payload` | Must not claim broad RN support, DOM/form equivalence, runtime/mobile correctness, imported callback promotion, or cross-file behavior understanding |
+| `F2` style/platform/navigation | Source-only RN style/platform concern metadata and navigation concern metadata | Must not claim route existence, navigation success, stack/back/focus correctness, style correctness, or platform behavior correctness |
+| `F9` interaction/list | Source-only RN interaction, gesture, and list concern metadata | Must not claim gesture correctness, runtime safety, list virtualization success, rendered-order correctness, or performance claims |
+| `F10` media/layout | Source-only RN media/layout concern metadata | Must not claim image loading correctness, layout correctness, paging correctness, or broad RN support |
+
+## Safe wording inventory
+
+The following wording shapes remain inside the current merged boundary:
+
+- This source contains React Native primitive/input evidence.
+- This source contains source-only RN interaction hints inside the measured `F1` / `F13` narrow gate.
+- This source contains same-file named-handler or inline-callback evidence observed in the same source file.
+- This source contains RN accessibility/test anchor evidence.
+- This source contains RN navigation concern evidence.
+- This source contains RN list/rendering pattern evidence.
+- This source contains RN media/layout concern evidence.
+- This source contains RN state/action concern evidence.
+- This source contains RN style/platform concern evidence.
+- This fixture or policy record is limited to `rn-primitive-input-narrow-payload` measured evidence with no RN support promotion.
+- `F2`, `F9`, and `F10` remain source-only readiness/fallback lanes.
+
+## Forbidden claims
+
+The following claims remain out of bounds for current RN docs/tests/reporting:
+
+- Do not claim broad React Native support.
+- Do not claim runtime correctness or mobile UI success.
+- Do not claim that a gesture works correctly or is runtime-safe.
+- Do not claim that list virtualization works correctly, rendered order is correct, or performance is good.
+- Do not claim that an image loads correctly, layout is correct, or paging works correctly.
+- Do not claim that style correctness or platform-specific behavior is verified.
+- Do not claim that a route exists, navigation succeeds, or stack/back/focus behavior is verified.
+- Do not claim that the app was run on a device or simulator.
+- Do not claim that screen reader behavior is verified or that accessibility correctness is proven.
+- Do not claim that cross-file navigation, route, or global-state behavior is understood.
+- Do not claim that a state transition, reducer, or setter behavior is correct.
+- Do not claim that RN primitives are equivalent to DOM controls or React Web form semantics.
+- Do not claim WebView support, TUI support, or React Web equivalence from RN evidence.
+
+## Reviewer checklist
+
+Before merging RN docs/tests wording, confirm all of the following:
+
+1. `F1` / `F13` are still the only narrow payload-capable RN slots.
+2. `F2` / `F9` / `F10` are still described as fallback/readiness lanes with source-only concern metadata.
+3. The wording stays at source-observed evidence or exact measured policy names.
+4. No sentence implies runtime correctness, device execution, DOM/form equivalence, or cross-file understanding.
+5. No sentence widens RN evidence into WebView support, TUI support, or React Web support.
+
+## Pointers
+
+- Normative contract: [frontend-domain-contract](./frontend-domain-contract.md)
+- Fixture baseline: [frontend-domain-fixture-expectations](./frontend-domain-fixture-expectations.md)
+- Slot regression map: [frontend-fixture-boundary-regression-map](./frontend-fixture-boundary-regression-map.md)
+- Architecture boundary: [domain-payload-architecture](./domain-payload-architecture.md)

--- a/test/react-native-source-only-guidance-report.test.mjs
+++ b/test/react-native-source-only-guidance-report.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const reportPath = path.join(process.cwd(), "docs", "react-native-source-only-guidance-report.md");
+
+function readReport() {
+  return fs.readFileSync(reportPath, "utf8");
+}
+
+test("RN source-only guidance report locks the slot taxonomy boundary", () => {
+  const report = readReport();
+
+  assert.match(report, /`F1` and `F13` are the only RN slots that may emit narrow payload evidence\./);
+  assert.match(report, /`F2`, `F9`, and `F10` remain fallback\/readiness lanes with source-only concern metadata\./);
+  assert.match(report, /`F1` \/ `F13` primitive\/input[\s\S]*`rn-primitive-input-narrow-payload`/);
+  assert.match(report, /`F2` style\/platform\/navigation[\s\S]*Must not claim route existence, navigation success/);
+  assert.match(report, /`F9` interaction\/list[\s\S]*Must not claim gesture correctness, runtime safety, list virtualization success/);
+  assert.match(report, /`F10` media\/layout[\s\S]*Must not claim image loading correctness, layout correctness/);
+});
+
+test("RN source-only guidance report enumerates current forbidden claims", () => {
+  const report = readReport();
+
+  assert.match(report, /Do not claim broad React Native support\./);
+  assert.match(report, /Do not claim runtime correctness or mobile UI success\./);
+  assert.match(report, /Do not claim that a route exists, navigation succeeds, or stack\/back\/focus behavior is verified\./);
+  assert.match(report, /Do not claim that the app was run on a device or simulator\./);
+  assert.match(report, /Do not claim that RN primitives are equivalent to DOM controls or React Web form semantics\./);
+  assert.match(report, /Do not claim WebView support, TUI support, or React Web equivalence from RN evidence\./);
+});
+
+test("RN source-only guidance report includes the reviewer checklist and contract pointers", () => {
+  const report = readReport();
+
+  assert.match(report, /1\. `F1` \/ `F13` are still the only narrow payload-capable RN slots\./);
+  assert.match(report, /2\. `F2` \/ `F9` \/ `F10` are still described as fallback\/readiness lanes with source-only concern metadata\./);
+  assert.match(report, /frontend-domain-contract/);
+  assert.match(report, /frontend-domain-fixture-expectations/);
+  assert.match(report, /frontend-fixture-boundary-regression-map/);
+  assert.match(report, /domain-payload-architecture/);
+});


### PR DESCRIPTION
## Why
After the RN readiness, leakage, and slot-taxonomy follow-ups, the next safe increment is a reviewer-facing guidance artifact that keeps current RN wording inside the merged claim boundary without changing runtime behavior.

Closes #594

## What changed
- added `docs/react-native-source-only-guidance-report.md`
- linked the report from `docs/frontend-domain-contract.md`
- added `test/react-native-source-only-guidance-report.test.mjs`

## Scope boundary
- docs/tests-only
- no `src/` behavior changes
- no new RN payload policies
- no broad React Native support or runtime-correctness claims

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/react-native-source-only-guidance-report.test.mjs test/claim-boundary-doc-audit.test.mjs test/react-native-slot-taxonomy-audit.test.mjs test/react-native-payload-evidence.test.mjs test/payload-policy-react-native.test.mjs`
- `npm run lint`
- `npm test`

## Notes
- The report is intentionally anchored to the RN evidence surfaces currently merged on `main`.
- `F1` / `F13` remain the only narrow payload-capable RN slots; `F2` / `F9` / `F10` remain source-only readiness/fallback lanes.
