### PR TITLE
Add a standalone RN readiness evidence surface

### DIFF
--- a/docs/react-native-source-only-guidance-report.md
+++ b/docs/react-native-source-only-guidance-report.md
@@ -54,6 +54,10 @@ The following claims remain out of bounds for current RN docs/tests/reporting:
 - Do not claim that RN primitives are equivalent to DOM controls or React Web form semantics.
 - Do not claim WebView support, TUI support, or React Web equivalence from RN evidence.
 
+## Readiness evidence surface
+
+Use `npm run evidence:react-native-readiness` when you want the current merged RN slot boundary in one dedicated report surface. The readiness report must keep `F1` / `F13` as narrow measured evidence only, keep `F2` / `F9` / `F10` as readiness/fallback-only, and keep broad RN support plus runtime correctness non-claimable.
+
 ## Reviewer checklist
 
 Before merging RN docs/tests wording, confirm all of the following:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "branch:audit": "node scripts/audit-remote-branches.mjs",
     "ci:alerts": "node scripts/triage-ci-alerts.mjs",
     "pr:alerts": "node scripts/guard-pr-alerts.mjs",
-    "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs"
+    "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs",
+    "evidence:react-native-readiness": "npm run build && node scripts/react-native-readiness-evidence.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-native-readiness-evidence.mjs
+++ b/scripts/react-native-readiness-evidence.mjs
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildReactNativePayloadEvidence,
+  RN_STAGED_SLOT_FIXTURES,
+} from "./react-native-payload-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const RN_READINESS_SLOT_ORDER = ["F1", "F13", "F2", "F9", "F10"];
+
+function readSelectedManifestRows(repoRoot) {
+  const manifestPath = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  return new Map(manifest.selected.map((row) => [row.slot, row]));
+}
+
+function blockersForReadinessSlot(slot) {
+  switch (slot) {
+    case "F2":
+      return [
+        "no runtime navigation correctness evidence",
+        "must not imply broad RN support",
+      ];
+    case "F9":
+      return [
+        "no gesture or list virtualization correctness evidence",
+        "must not imply broad RN support",
+      ];
+    case "F10":
+      return [
+        "no image or layout correctness evidence",
+        "must not imply broad RN support",
+      ];
+    default:
+      return [];
+  }
+}
+
+export async function buildReactNativeReadinessEvidence({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const payloadEvidence = await buildReactNativePayloadEvidence({ repoRoot, runId: `${runId}-payload-evidence` });
+  const manifestBySlot = readSelectedManifestRows(repoRoot);
+  const stagedBySlot = new Map(payloadEvidence.summary.stagedRnSurfaceInventory.stagedSlots.map((row) => [row.slot, row]));
+  const slotSurfaceBySlot = new Map(RN_STAGED_SLOT_FIXTURES.map((row) => [row.slot, row.lane]));
+
+  const slots = RN_READINESS_SLOT_ORDER.map((slot) => {
+    const manifest = manifestBySlot.get(slot);
+    const staged = stagedBySlot.get(slot);
+    const surface = slotSurfaceBySlot.get(slot);
+    const payloadCapable = manifest?.preReadExpectedOutcome === "payload";
+
+    if (payloadCapable) {
+      return {
+        slot,
+        id: manifest.id,
+        surface,
+        outcome: "payload",
+        policy: manifest.payloadPolicy,
+        claim: "narrow measured evidence only",
+        supportClaim: manifest.supportClaim,
+        evidenceScope: manifest.evidenceScope,
+        fixture: manifest.path,
+      };
+    }
+
+    return {
+      slot,
+      id: manifest?.id ?? null,
+      surface,
+      outcome: "fallback",
+      policy: "source-only-readiness",
+      supportClaim: manifest?.supportClaim ?? "none",
+      evidenceScope: manifest?.evidenceScope ?? "rn-component-semantics-readiness-only",
+      fixture: manifest?.path ?? staged?.file ?? null,
+      fallbackReason: staged?.preReadExpectation ?? manifest?.preReadExpectedReason ?? null,
+      blockers: blockersForReadinessSlot(slot),
+    };
+  });
+
+  return {
+    schemaVersion: "react-native-readiness-evidence.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    profile: "react-native",
+    measurement: "aggregated-react-native-readiness-evidence-lane",
+    claimBoundary:
+      "Aggregated local React Native readiness evidence only: summarizes the current merged RN slot contract without widening payload policy, runtime behavior, or support claims. This is not broad React Native support, not runtime correctness, not device execution proof, and not provider billing or cost evidence.",
+    slots,
+    summary: {
+      slotCount: slots.length,
+      payloadCapableSlots: slots.filter((row) => row.outcome === "payload").map((row) => row.slot),
+      readinessOnlySlots: slots.filter((row) => row.outcome !== "payload").map((row) => row.slot),
+      childArtifact: {
+        schemaVersion: payloadEvidence.schemaVersion,
+        stagedSlotCount: payloadEvidence.summary.stagedRnSurfaceInventory.stagedSlots.length,
+      },
+    },
+    claimability: {
+      broadReactNativeSupport: false,
+      runtimeCorrectness: false,
+      providerBillingSavings: false,
+    },
+  };
+}
+
+export function renderReactNativeReadinessEvidenceMarkdown(evidence) {
+  const slotRows = evidence.slots
+    .map((row) => {
+      const blockerText = Array.isArray(row.blockers) && row.blockers.length > 0 ? row.blockers.join("; ") : row.claim;
+      const fallbackReason = row.fallbackReason ?? row.policy;
+      return `| ${row.slot} | ${row.id} | ${row.surface} | ${row.outcome} | ${row.policy} | ${fallbackReason} | ${blockerText} |`;
+    })
+    .join("\n");
+
+  return `# React Native readiness evidence\n\n${evidence.claimBoundary}\n\n## Summary\n\n- Profile: ${evidence.profile}\n- Slot count: ${evidence.summary.slotCount}\n- Payload-capable slots: ${evidence.summary.payloadCapableSlots.join(", ")}\n- Readiness-only slots: ${evidence.summary.readinessOnlySlots.join(", ")}\n- Broad React Native support claimable: ${evidence.claimability.broadReactNativeSupport ? "yes" : "no"}\n- Runtime correctness claimable: ${evidence.claimability.runtimeCorrectness ? "yes" : "no"}\n- Provider billing savings claimable: ${evidence.claimability.providerBillingSavings ? "yes" : "no"}\n\n## Slot readiness map\n\n| Slot | ID | Surface | Outcome | Policy | Fallback / claim anchor | Boundary note |\n| --- | --- | --- | --- | --- | --- | --- |\n${slotRows}\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactNativeReadinessEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactNativeReadinessEvidenceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-native-readiness-evidence.test.mjs
+++ b/test/react-native-readiness-evidence.test.mjs
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildReactNativeReadinessEvidence,
+  RN_READINESS_SLOT_ORDER,
+  renderReactNativeReadinessEvidenceMarkdown,
+} from "../scripts/react-native-readiness-evidence.mjs";
+
+const repoRoot = process.cwd();
+let evidencePromise;
+
+function getEvidence() {
+  evidencePromise ??= buildReactNativeReadinessEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
+  return evidencePromise;
+}
+
+test("React Native readiness evidence emits the approved slot map without widening RN claims", async () => {
+  const evidence = await getEvidence();
+
+  assert.equal(evidence.schemaVersion, "react-native-readiness-evidence.v1");
+  assert.equal(evidence.profile, "react-native");
+  assert.equal(evidence.measurement, "aggregated-react-native-readiness-evidence-lane");
+  assert.match(evidence.claimBoundary, /Aggregated local React Native readiness evidence only/);
+  assert.match(evidence.claimBoundary, /not broad React Native support/);
+  assert.match(evidence.claimBoundary, /not runtime correctness/);
+
+  assert.equal(evidence.summary.slotCount, 5);
+  assert.deepEqual(evidence.slots.map((row) => row.slot), RN_READINESS_SLOT_ORDER);
+  assert.deepEqual(evidence.summary.payloadCapableSlots, ["F1", "F13"]);
+  assert.deepEqual(evidence.summary.readinessOnlySlots, ["F2", "F9", "F10"]);
+  assert.deepEqual(evidence.claimability, {
+    broadReactNativeSupport: false,
+    runtimeCorrectness: false,
+    providerBillingSavings: false,
+  });
+  assert.equal(evidence.summary.childArtifact.schemaVersion, "react-native-payload-evidence.v4");
+  assert.equal(evidence.summary.childArtifact.stagedSlotCount, 5);
+
+  const bySlot = new Map(evidence.slots.map((row) => [row.slot, row]));
+  assert.deepEqual(bySlot.get("F1"), {
+    slot: "F1",
+    id: "rn-primitive-basic",
+    surface: "RN primitive/input",
+    outcome: "payload",
+    policy: "rn-primitive-input-narrow-payload",
+    claim: "narrow measured evidence only",
+    supportClaim: "none",
+    evidenceScope: "rn-primitive-input-narrow-payload-only",
+    fixture: "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx",
+  });
+  assert.deepEqual(bySlot.get("F13"), {
+    slot: "F13",
+    id: "rn-primitive-inline-action",
+    surface: "RN primitive/input adjacent",
+    outcome: "payload",
+    policy: "rn-primitive-input-narrow-payload",
+    claim: "narrow measured evidence only",
+    supportClaim: "none",
+    evidenceScope: "rn-primitive-input-narrow-payload-only",
+    fixture: "test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx",
+  });
+  assert.equal(bySlot.get("F2").outcome, "fallback");
+  assert.equal(bySlot.get("F2").policy, "source-only-readiness");
+  assert.equal(bySlot.get("F2").fallbackReason, "unsupported-frontend-domain-profile");
+  assert.deepEqual(bySlot.get("F2").blockers, [
+    "no runtime navigation correctness evidence",
+    "must not imply broad RN support",
+  ]);
+  assert.equal(bySlot.get("F9").fallbackReason, "unsupported-frontend-domain-profile");
+  assert.deepEqual(bySlot.get("F9").blockers, [
+    "no gesture or list virtualization correctness evidence",
+    "must not imply broad RN support",
+  ]);
+  assert.equal(bySlot.get("F10").fallbackReason, "unsupported-frontend-domain-profile");
+  assert.deepEqual(bySlot.get("F10").blockers, [
+    "no image or layout correctness evidence",
+    "must not imply broad RN support",
+  ]);
+});
+
+test("React Native readiness evidence markdown keeps non-claims explicit", async () => {
+  const evidence = await getEvidence();
+  const markdown = renderReactNativeReadinessEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /# React Native readiness evidence/);
+  assert.match(markdown, /Profile: react-native/);
+  assert.match(markdown, /Slot count: 5/);
+  assert.match(markdown, /Payload-capable slots: F1, F13/);
+  assert.match(markdown, /Readiness-only slots: F2, F9, F10/);
+  assert.match(markdown, /Broad React Native support claimable: no/);
+  assert.match(markdown, /Runtime correctness claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /\| F2 \| rn-style-platform-navigation \| RN style\/platform\/navigation \| fallback \| source-only-readiness \| unsupported-frontend-domain-profile \| no runtime navigation correctness evidence; must not imply broad RN support \|/);
+  assert.doesNotMatch(markdown, /Broad React Native support claimable: yes/i);
+  assert.doesNotMatch(markdown, /Runtime correctness claimable: yes/i);
+});
+
+test("React Native readiness evidence command writes bounded JSON and Markdown reports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-native-readiness-evidence-"));
+  const outputPath = path.join(tempDir, "react-native-readiness-evidence.json");
+  const markdownPath = path.join(tempDir, "react-native-readiness-evidence.md");
+
+  const cli = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts", "react-native-readiness-evidence.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+
+  const stdoutEvidence = JSON.parse(cli.stdout);
+  const fileEvidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+
+  assert.equal(stdoutEvidence.runId, "cli-test");
+  assert.equal(stdoutEvidence.profile, "react-native");
+  assert.deepEqual(fileEvidence, stdoutEvidence);
+  assert.match(markdown, /# React Native readiness evidence/);
+  assert.match(markdown, /Payload-capable slots: F1, F13/);
+});


### PR DESCRIPTION
## Why
The current merged RN lane already has leakage guards, slot taxonomy, and guidance wording. The next missing bounded artifact is a dedicated readiness evidence surface that summarizes the RN slot contract in one operator-facing report without changing runtime behavior.

Closes #597

## What changed
- added `scripts/react-native-readiness-evidence.mjs`
- added `test/react-native-readiness-evidence.test.mjs`
- added npm script `evidence:react-native-readiness`
- updated `docs/react-native-source-only-guidance-report.md` with the readiness report pointer

## Scope boundary
- scripts/tests/minimal-docs only
- no `src/` behavior changes
- no payload-policy changes
- no broad React Native support or runtime-correctness claims
- no promotion of `F2` / `F9` / `F10` into payload-capable lanes

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/react-native-readiness-evidence.test.mjs test/react-native-payload-evidence.test.mjs test/payload-policy-react-native.test.mjs test/react-native-source-only-guidance-report.test.mjs`
- `npm run evidence:react-native-readiness`
- `npm run lint`
- `npm test`

## Notes
- The readiness surface is intentionally anchored to the RN evidence already merged on `main`.
- `F1` / `F13` remain narrow measured evidence only; `F2` / `F9` / `F10` remain readiness/fallback-only.
