### PR TITLE
Expose staged and unstaged worktree path summaries

### DIFF
--- a/src/core/worktree-evidence.ts
+++ b/src/core/worktree-evidence.ts
@@ -30,6 +30,9 @@ export type WorktreeSnapshot = {
   clean: boolean;
   changedPaths: string[];
   trackedPaths: string[];
+  stagedPaths: string[];
+  unstagedPaths: string[];
+  partiallyStagedPaths: string[];
   untrackedPaths: string[];
   ignoredPaths: string[];
   conflictedPaths: string[];
@@ -228,6 +231,9 @@ export function captureWorktreeSnapshot(cwd = process.cwd(), options: WorktreeEv
         clean: summary.clean,
         changedPaths: uniqueSorted(summary.changedPaths),
         trackedPaths: uniqueSorted(summary.trackedPaths),
+        stagedPaths: uniqueSorted(summary.stagedPaths),
+        unstagedPaths: uniqueSorted(summary.unstagedPaths),
+        partiallyStagedPaths: uniqueSorted(summary.partiallyStagedPaths),
         untrackedPaths: uniqueSorted(summary.untrackedPaths),
         ignoredPaths: uniqueSorted(summary.ignoredPaths),
         conflictedPaths: uniqueSorted(summary.conflictedPaths),

--- a/src/core/worktree-status.ts
+++ b/src/core/worktree-status.ts
@@ -38,6 +38,9 @@ export type WorktreeStatusSummary = {
   entries: WorktreeStatusEntry[];
   changedPaths: string[];
   trackedPaths: string[];
+  stagedPaths: string[];
+  unstagedPaths: string[];
+  partiallyStagedPaths: string[];
   untrackedPaths: string[];
   ignoredPaths: string[];
   conflictedPaths: string[];
@@ -120,6 +123,14 @@ function countChangeKinds(entries: WorktreeStatusEntry[]): Partial<Record<Worktr
   }, {});
 }
 
+function isTrackedStagedEntry(entry: WorktreeStatusEntry): boolean {
+  return entry.tracked && !entry.conflicted && entry.indexStatus !== " ";
+}
+
+function isTrackedUnstagedEntry(entry: WorktreeStatusEntry): boolean {
+  return entry.tracked && !entry.conflicted && entry.worktreeStatus !== " ";
+}
+
 function parseNulTerminatedPorcelain(output: string): WorktreeStatusEntry[] {
   const fields = output.split("\0").filter((field) => field.length > 0);
   const entries: WorktreeStatusEntry[] = [];
@@ -154,11 +165,17 @@ export function parseWorktreeStatus(output: string, options: ParseWorktreeStatus
 
 export function summarizeWorktreeStatus(entries: WorktreeStatusEntry[]): WorktreeStatusSummary {
   const changedEntries = entries.filter((entry) => entry.kind !== "ignored");
+  const trackedChangedEntries = changedEntries.filter((entry) => entry.tracked);
+  const stagedEntries = trackedChangedEntries.filter((entry) => isTrackedStagedEntry(entry));
+  const unstagedEntries = trackedChangedEntries.filter((entry) => isTrackedUnstagedEntry(entry));
   return {
     clean: changedEntries.length === 0,
     entries,
     changedPaths: changedEntries.map((entry) => entry.path),
-    trackedPaths: changedEntries.filter((entry) => entry.tracked).map((entry) => entry.path),
+    trackedPaths: trackedChangedEntries.map((entry) => entry.path),
+    stagedPaths: stagedEntries.map((entry) => entry.path),
+    unstagedPaths: unstagedEntries.map((entry) => entry.path),
+    partiallyStagedPaths: stagedEntries.filter((entry) => isTrackedUnstagedEntry(entry)).map((entry) => entry.path),
     untrackedPaths: entries.filter((entry) => entry.kind === "untracked").map((entry) => entry.path),
     ignoredPaths: entries.filter((entry) => entry.kind === "ignored").map((entry) => entry.path),
     conflictedPaths: entries.filter((entry) => entry.conflicted).map((entry) => entry.path),

--- a/test/worktree-evidence.test.mjs
+++ b/test/worktree-evidence.test.mjs
@@ -53,24 +53,65 @@ test("captureWorktreeSnapshot parses clean, untracked, conflicted, and rename ev
   assert.deepEqual(clean.blockers, []);
   assert.equal(clean.snapshot.clean, true);
   assert.deepEqual(clean.snapshot.changedPaths, []);
+  assert.deepEqual(clean.snapshot.stagedPaths, []);
+  assert.deepEqual(clean.snapshot.unstagedPaths, []);
+  assert.deepEqual(clean.snapshot.partiallyStagedPaths, []);
   assert.deepEqual(clean.snapshot.changeKindCounts, {});
 
   const dirty = captureWorktreeSnapshot("/tmp/project", {
-    runner: outputRunner(" M src/App.tsx\0?? scratch.log\0UU conflict.ts\0R  src/NewName.tsx\0src/OldName.tsx\0"),
+    runner: outputRunner(
+      "A  src/Staged.tsx\0 M src/App.tsx\0MM src/PartiallyStaged.tsx\0?? scratch.log\0UU conflict.ts\0R  src/NewName.tsx\0src/OldName.tsx\0",
+    ),
     now: () => "2026-04-23T00:00:01.000Z",
   });
   assert.deepEqual(dirty.blockers, []);
   assert.equal(dirty.snapshot.clean, false);
-  assert.deepEqual(dirty.snapshot.changedPaths, ["conflict.ts", "scratch.log", "src/App.tsx", "src/NewName.tsx"]);
-  assert.deepEqual(dirty.snapshot.trackedPaths, ["conflict.ts", "src/App.tsx", "src/NewName.tsx"]);
+  assert.deepEqual(dirty.snapshot.changedPaths, [
+    "conflict.ts",
+    "scratch.log",
+    "src/App.tsx",
+    "src/NewName.tsx",
+    "src/PartiallyStaged.tsx",
+    "src/Staged.tsx",
+  ]);
+  assert.deepEqual(dirty.snapshot.trackedPaths, [
+    "conflict.ts",
+    "src/App.tsx",
+    "src/NewName.tsx",
+    "src/PartiallyStaged.tsx",
+    "src/Staged.tsx",
+  ]);
+  assert.deepEqual(dirty.snapshot.stagedPaths, ["src/NewName.tsx", "src/PartiallyStaged.tsx", "src/Staged.tsx"]);
+  assert.deepEqual(dirty.snapshot.unstagedPaths, ["src/App.tsx", "src/PartiallyStaged.tsx"]);
+  assert.deepEqual(dirty.snapshot.partiallyStagedPaths, ["src/PartiallyStaged.tsx"]);
   assert.deepEqual(dirty.snapshot.untrackedPaths, ["scratch.log"]);
   assert.deepEqual(dirty.snapshot.conflictedPaths, ["conflict.ts"]);
   assert.deepEqual(dirty.snapshot.changeKindCounts, {
-    modified: 1,
+    added: 1,
+    modified: 2,
     untracked: 1,
     unmerged: 1,
     renamed: 1,
   });
+});
+
+test("currentWorktreeEvidenceStatus exposes parser-backed staged path summaries", () => {
+  const current = currentWorktreeEvidenceStatus("/tmp/project", {
+    runner: outputRunner("A  src/Staged.ts\0 M src/Unstaged.ts\0MM src/Partial.ts\0"),
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected ${args.join(" ")}`);
+    },
+    now: () => "2026-04-23T00:00:02.000Z",
+  });
+
+  assert.equal(current.snapshot.clean, false);
+  assert.deepEqual(current.snapshot.stagedPaths, ["src/Partial.ts", "src/Staged.ts"]);
+  assert.deepEqual(current.snapshot.unstagedPaths, ["src/Partial.ts", "src/Unstaged.ts"]);
+  assert.deepEqual(current.snapshot.partiallyStagedPaths, ["src/Partial.ts"]);
+  assert.equal(current.worktreeVerdict.kind, "dirty");
 });
 
 test("session evidence records baseline/latest and computes dirty deltas with a fake runner", () => {

--- a/test/worktree-status.test.mjs
+++ b/test/worktree-status.test.mjs
@@ -72,6 +72,23 @@ test("summarizeWorktreeStatus separates tracked, untracked, ignored, and conflic
   });
 });
 
+test("summarizeWorktreeStatus exposes staged, unstaged, and partially staged tracked paths", () => {
+  const summary = summarizeWorktreeStatus(
+    parseWorktreeStatus("A  src/staged.ts\n M src/unstaged.ts\nMM src/partially-staged.ts\nUU src/conflict.ts\n?? scratch.log\n"),
+  );
+
+  assert.deepEqual(summary.trackedPaths, [
+    "src/staged.ts",
+    "src/unstaged.ts",
+    "src/partially-staged.ts",
+    "src/conflict.ts",
+  ]);
+  assert.deepEqual(summary.stagedPaths, ["src/staged.ts", "src/partially-staged.ts"]);
+  assert.deepEqual(summary.unstagedPaths, ["src/unstaged.ts", "src/partially-staged.ts"]);
+  assert.deepEqual(summary.partiallyStagedPaths, ["src/partially-staged.ts"]);
+  assert.deepEqual(summary.conflictedPaths, ["src/conflict.ts"]);
+});
+
 test("parseAndSummarizeWorktreeStatus treats empty or ignored-only output as clean", () => {
   assert.equal(parseAndSummarizeWorktreeStatus("\n").clean, true);
   assert.equal(parseAndSummarizeWorktreeStatus("!! dist/index.js\n").clean, true);


### PR DESCRIPTION
## Why
The merged first-pass parser PR exposed `changeKindCounts`, but local worktree evidence still grouped all tracked dirty files together. This follow-up adds one more parser-backed signal so `status worktree` can distinguish what is staged, unstaged, and partially staged without reopening the broader integration plan.

Closes #599

## What changed
- added `stagedPaths`, `unstagedPaths`, and `partiallyStagedPaths` to `WorktreeStatusSummary`
- threaded those additive fields into worktree snapshots / `status worktree`
- added focused parser and worktree-evidence coverage for the new summaries

## Scope boundary
- local/read-only git worktree evidence only
- no parser rewrite
- no runtime-hook integration
- no cache integration
- no TUI work mixed into this lane
- no provider/runtime/billing/performance claims

## Verification
- `npm run build`
- `node --test test/worktree-status.test.mjs`
- `node --test test/worktree-evidence.test.mjs`
- `npm run lint`
- `node dist/cli/index.js status worktree`
- `npm test`
