### PR TITLE
Harden RN sourceAnchorBeta with located proof anchors

### DIFF
--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -6,7 +6,13 @@ import {
   RN_PRIMITIVE_INPUT_REQUIRED_SIGNALS,
   RN_PRIMITIVE_INPUT_SUPPORT_BOUNDARY,
 } from "../payload-policy/react-native";
-import type { ExtractionResult, FormControlSignal, ReactNativePrimitiveInteractionSignal, StyleSystem } from "../schema";
+import type {
+  ExtractionResult,
+  FormControlSignal,
+  ReactNativePrimitiveInteractionSignal,
+  SourceRange,
+  StyleSystem,
+} from "../schema";
 
 export const DOMAIN_PAYLOAD_SCHEMA_VERSION = "domain-payload.v1";
 export const REACT_WEB_DOMAIN_PAYLOAD_POLICY = "react-web-current-supported-lane";
@@ -68,6 +74,17 @@ export type ReactNativeSourceAnchorBetaContract = {
   nextImplementationStep: "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates";
 };
 
+export type ReactNativeSourceAnchorBetaLocatedAnchor = {
+  kind:
+    | "component-name"
+    | "props-interface"
+    | "hooks-effects"
+    | "event-handlers"
+    | "rn-primitive-outline";
+  label: string;
+  loc: SourceRange;
+};
+
 export type ReactNativeSourceAnchorBetaPayload = {
   contract: ReactNativeSourceAnchorBetaContract;
   anchors: {
@@ -78,6 +95,7 @@ export type ReactNativeSourceAnchorBetaPayload = {
     primitives: string[];
     jsxProps: string[];
     sourceFingerprintRequired: true;
+    locatedAnchors?: ReactNativeSourceAnchorBetaLocatedAnchor[];
   };
 };
 
@@ -269,12 +287,92 @@ function buildReactNativeSourceAnchorBetaContract(): ReactNativeSourceAnchorBeta
   };
 }
 
+function uniqueLocatedByKey<T>(items: T[], key: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    const itemKey = key(item);
+    if (seen.has(itemKey)) continue;
+    seen.add(itemKey);
+    result.push(item);
+  }
+  return result;
+}
+
+function buildReactNativeLocatedHookAnchors(result: ExtractionResult): ReactNativeSourceAnchorBetaLocatedAnchor[] | undefined {
+  const hooks = [
+    ...(result.behavior?.effectSignals ?? []).flatMap((item) =>
+      item.loc ? [{ kind: "hooks-effects" as const, label: item.hook, loc: item.loc }] : [],
+    ),
+    ...(result.behavior?.callbackSignals ?? []).flatMap((item) =>
+      item.loc ? [{ kind: "hooks-effects" as const, label: item.hook, loc: item.loc }] : [],
+    ),
+  ];
+  if (hooks.length === 0) return undefined;
+  return uniqueLocatedByKey(hooks, (item) => `${item.kind}:${item.label}:${item.loc.startLine}:${item.loc.endLine}`);
+}
+
+function buildReactNativeLocatedEventHandlerAnchors(
+  result: ExtractionResult,
+): ReactNativeSourceAnchorBetaLocatedAnchor[] | undefined {
+  const handlers =
+    result.behavior?.eventHandlerSignals?.flatMap((item) =>
+      item.loc
+        ? [
+            {
+              kind: "event-handlers" as const,
+              label: item.trigger ? `${item.trigger}:${item.name}` : item.name,
+              loc: item.loc,
+            },
+          ]
+        : [],
+    ) ?? [];
+  if (handlers.length === 0) return undefined;
+  return uniqueLocatedByKey(handlers, (item) => `${item.kind}:${item.label}:${item.loc.startLine}:${item.loc.endLine}`);
+}
+
+function buildReactNativeLocatedPrimitiveAnchors(
+  interactions: ReactNativePrimitiveInteractionSignal | undefined,
+): ReactNativeSourceAnchorBetaLocatedAnchor[] | undefined {
+  if (!interactions) return undefined;
+  const items = [
+    ...(interactions.inputBindings ?? []).flatMap((item) =>
+      item.loc ? [{ kind: "rn-primitive-outline" as const, label: item.primitive, loc: item.loc }] : [],
+    ),
+    ...(interactions.actionBindings ?? []).flatMap((item) =>
+      item.loc ? [{ kind: "rn-primitive-outline" as const, label: item.primitive, loc: item.loc }] : [],
+    ),
+    ...(interactions.inputConstraints ?? []).flatMap((item) =>
+      item.loc ? [{ kind: "rn-primitive-outline" as const, label: item.primitive, loc: item.loc }] : [],
+    ),
+  ];
+  if (items.length === 0) return undefined;
+  return uniqueLocatedByKey(items, (item) => `${item.kind}:${item.label}:${item.loc.startLine}:${item.loc.endLine}`);
+}
+
 function buildReactNativeSourceAnchorBetaPayload(
   result: ExtractionResult,
   evidenceFacts: ReactNativePayloadEvidenceFacts,
 ): ReactNativeSourceAnchorBetaPayload {
   const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
   const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+  const locatedHooks = buildReactNativeLocatedHookAnchors(result);
+  const locatedEventHandlers = buildReactNativeLocatedEventHandlerAnchors(result);
+  const locatedPrimitives = buildReactNativeLocatedPrimitiveAnchors(result.behavior?.rnPrimitiveInteractions);
+  const locatedAnchors = uniqueLocatedByKey(
+    [
+      ...(result.componentName && result.componentLoc
+        ? [{ kind: "component-name" as const, label: result.componentName, loc: result.componentLoc }]
+        : []),
+      ...(result.contract?.propsName && result.contract.propsLoc
+        ? [{ kind: "props-interface" as const, label: result.contract.propsName, loc: result.contract.propsLoc }]
+        : []),
+      ...(locatedHooks ?? []),
+      ...(locatedEventHandlers ?? []),
+      ...(locatedPrimitives ?? []),
+    ],
+    (item) => `${item.kind}:${item.label}:${item.loc.startLine}:${item.loc.endLine}`,
+  );
 
   return {
     contract: buildReactNativeSourceAnchorBetaContract(),
@@ -286,6 +384,7 @@ function buildReactNativeSourceAnchorBetaPayload(
       primitives: evidenceFacts.primitives,
       jsxProps: evidenceFacts.jsxProps,
       sourceFingerprintRequired: true,
+      ...(locatedAnchors.length > 0 ? { locatedAnchors } : {}),
     },
   };
 }

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -128,10 +128,30 @@ test("frontend profile gate allows narrow allowed non-web frontend policies", ()
   assert.deepEqual(payload.domainPayload.sourceAnchorBeta.anchors.primitives, ["Pressable", "Text", "TextInput", "View"]);
   assert.deepEqual(payload.domainPayload.sourceAnchorBeta.anchors.jsxProps, ["onChangeText", "onPress"]);
   assert.equal(payload.domainPayload.sourceAnchorBeta.anchors.sourceFingerprintRequired, true);
+  assert.ok(Array.isArray(payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors));
+  assert.ok(
+    payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "component-name" && item.label === "Native"),
+  );
+  assert.ok(
+    payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "event-handlers" && item.label === "onChangeText:() => null"),
+  );
+  assert.ok(
+    payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "event-handlers" && item.label === "onPress:() => null"),
+  );
+  assert.ok(
+    payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "rn-primitive-outline" && item.label === "TextInput"),
+  );
+  assert.ok(
+    payload.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "rn-primitive-outline" && item.label === "Pressable"),
+  );
   assert.equal(payload.domainPayload.reuseContract.sourceDerivedOnly, true);
   assert.equal(payload.domainPayload.reuseContract.policy, policy.name);
   assert.equal(payload.domainPayload.reuseContract.freshnessSource, "sourceFingerprint");
   assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), { allowed: true });
+
+  const withoutLocatedAnchors = clonePayload(payload);
+  delete withoutLocatedAnchors.domainPayload.sourceAnchorBeta.anchors.locatedAnchors;
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutLocatedAnchors, policy), { allowed: true });
 });
 
 test("frontend profile gate requires RN domain payload for the measured narrow RN policy", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -183,9 +183,18 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
     "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
   );
   assert.equal(payload?.sourceAnchorBeta.anchors.componentName, "InlineActionRow");
+  assert.equal(payload?.sourceAnchorBeta.anchors.propsName, "InlineActionRowProps");
   assert.deepEqual(payload?.sourceAnchorBeta.anchors.primitives, ["Pressable", "Text", "TextInput", "View"]);
   assert.deepEqual(payload?.sourceAnchorBeta.anchors.jsxProps, ["onChangeText", "onPress"]);
   assert.equal(payload?.sourceAnchorBeta.anchors.sourceFingerprintRequired, true);
+  assert.deepEqual(payload?.sourceAnchorBeta.anchors.locatedAnchors, [
+    { kind: "component-name", label: "InlineActionRow", loc: { startLine: 9, endLine: 30 } },
+    { kind: "props-interface", label: "InlineActionRowProps", loc: { startLine: 3, endLine: 7 } },
+    { kind: "event-handlers", label: "onChangeText:onChangeText", loc: { startLine: 19, endLine: 19 } },
+    { kind: "event-handlers", label: "onPress:submitCurrentValue", loc: { startLine: 25, endLine: 25 } },
+    { kind: "rn-primitive-outline", label: "TextInput", loc: { startLine: 16, endLine: 24 } },
+    { kind: "rn-primitive-outline", label: "Pressable", loc: { startLine: 25, endLine: 25 } },
+  ]);
   assert.deepEqual(payload?.facts.primitiveInteractions?.inputBindings, [
     {
       primitive: "TextInput",


### PR DESCRIPTION
## Why
The current RN narrow payload lane already ships `sourceAnchorBeta` and explicitly names located anchors as the next bounded follow-up. This PR hardens that lane by emitting additive source-range proof anchors from existing primitive/input evidence without widening detector gates or payload policy.

Closes #607

## What changed
- added optional `sourceAnchorBeta.anchors.locatedAnchors` for RN narrow payloads
- derived located anchors from existing component, props, event-handler, and primitive interaction loc evidence
- kept the existing `rn-source-anchor-beta.v0` contract and current RN gate semantics unchanged
- added focused tests proving the located anchors exist while reuse authorization remains unchanged without them

## Scope boundary
- no detector widening
- no RN payload-policy broadening
- no contract version bump
- no F2/F9/F10 promotion
- no broad RN support or runtime correctness claim

## Verification
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs`
- `npm test`
- `git diff --check`
