### PR TITLE
Reinforce TUI evidence-only review guardrails

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -97,6 +97,15 @@ This matrix is the current review contract for TUI-related fixtures. It is inten
 
 If a future PR changes any row from fallback/no-payload to payload emission, it is no longer a TUI evidence matrix update and must go through a serialized shared-policy plan.
 
+## Evidence-only review checklist
+
+Before merging a docs/tests-only TUI fixture PR, reviewers should confirm:
+
+1. every positive Ink row still ends in `evidence-only`, denied policy, and fallback/no-payload;
+2. at least one non-Ink or mixed fallback row remains visible whenever positive Ink evidence expands, so over-match risk stays explicit;
+3. fixture-lane wording stays local to fixture docs/tests and must not be reused as README, roadmap, release-note, or package support wording;
+4. any request for `allowed: true`, payload emission, manifest edits, or shared detector/pre-read/runtime seams is redirected into a serialized shared-policy plan.
+
 ## Payload design readiness handoff
 
 The evidence matrix above is sufficient to discuss a future payload-design PRD, but it is not itself a payload contract. A payload-design handoff must first prove that the current evidence-only lane stays denied:

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -54,6 +54,15 @@ Choose the smallest lane that matches the intended change:
 
 If a change does not fit one of these lanes, stop and write a new plan before editing.
 
+## Evidence reinforcement review checklist
+
+When the current lane is docs/tests-only evidence reinforcement, reviewers should verify:
+
+- the change only clarifies source evidence, denied policy, fallback reason, or stop rules;
+- positive Ink evidence remains paired with non-Ink or mixed fallback visibility so over-match risk stays visible;
+- README, roadmap, release, package, and runtime-facing wording stay candidate/evidence-only and are not widened from fixture-lane language;
+- any `allowed: true`, payload emission, manifest, detector, policy, pre-read, or runtime request stops the lane and returns to a serialized shared-policy plan.
+
 ## Promotion criteria before payload-design planning
 
 Before a TUI payload-design plan is useful, the repo should already have:

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4783,6 +4783,8 @@ test("docs describe TUI/Ink fixture survey as future candidate evidence only", (
   assert.match(survey, /No extractor, pre-read, setup, doctor, or runtime behavior change/);
   assert.match(survey, /No provider-token, billing, runtime-token, performance, or terminal correctness claim/);
   assert.match(survey, /No default TUI compact extraction or profile promotion/);
+  assert.match(survey, /Evidence-only review checklist/);
+  assert.match(survey, /must not be reused as README, roadmap, release-note, or package support wording/);
   assert.equal(pkg.files.includes("docs/tui-fixture-candidates.md"), false);
 
   assert.doesNotMatch(combined, /TUI support is available/i);

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -193,6 +193,23 @@ const tuiMinimalPayloadFixtureMap = [
   ["terminalNegativeBoundaryEvidence", "tui-non-ink-cli-renderer.tsx"],
 ];
 
+const surveyReviewChecklistTerms = [
+  "Evidence-only review checklist",
+  "every positive Ink row still ends in `evidence-only`, denied policy, and fallback/no-payload",
+  "at least one non-Ink or mixed fallback row remains visible whenever positive Ink evidence expands",
+  "must not be reused as README, roadmap, release-note, or package support wording",
+  "shared detector/pre-read/runtime seams",
+];
+
+const operationalReviewChecklistTerms = [
+  "Evidence reinforcement review checklist",
+  "docs/tests-only evidence reinforcement",
+  "denied policy, fallback reason, or stop rules",
+  "positive Ink evidence remains paired with non-Ink or mixed fallback visibility",
+  "README, roadmap, release, package, and runtime-facing wording stay candidate/evidence-only",
+  "manifest, detector, policy, pre-read, or runtime request stops the lane",
+];
+
 function tuiFixturePath(fileName) {
   return path.join("test", "fixtures", "frontend-domain-expectations", fileName);
 }
@@ -507,6 +524,9 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /tui-ink-rn-narrow-mixed\.tsx/);
   assert.match(survey, /Negative\/fallback reinforcement/);
   assert.match(survey, /Current TUI evidence matrix/);
+  for (const term of surveyReviewChecklistTerms) {
+    assert.ok(survey.includes(term), term);
+  }
   assert.match(survey, /Payload design readiness handoff/);
   assert.match(survey, /not itself a payload contract/);
   assert.match(survey, /TUI-safe metadata projection contract/);
@@ -539,6 +559,9 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /Concern category/);
   assert.match(guide, /concern evidence is not payload permission/);
   assert.match(guide, /## Allowed next work/);
+  for (const term of operationalReviewChecklistTerms) {
+    assert.ok(guide.includes(term), term);
+  }
   assert.match(guide, /## Promotion criteria before payload-design planning/);
   assert.match(guide, /## Payload design readiness gate/);
   assert.match(guide, /## Minimal payload candidate schema contract/);


### PR DESCRIPTION
## Summary
- add compact TUI evidence-only review checklists to the fixture survey and operational readiness docs
- harden tests so fixture-lane wording cannot drift into support-style wording
- keep mixed/non-Ink fallback visibility explicit alongside positive Ink evidence

## Boundaries
- TUI remains candidate / evidence-only / fallback-only
- no `src/`, detector, payload-policy, pre-read, runtime, or manifest schema changes
- no `allowed: true`, compact payload, support, correctness, token, billing, or performance claims

## Verification
- `git diff --check`
- `npm run build`
- `npm run lint`
- `node --test test/payload-policy-tui-ink.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm test`

Fixes #610
