### PR TITLE
Surface React Web evidence as a PR-visible advisory check

### DIFF
--- a/.github/workflows/react-web-pr-advisory.yml
+++ b/.github/workflows/react-web-pr-advisory.yml
@@ -1,0 +1,41 @@
+name: React Web PR Advisory
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-web-pr-advisory:
+    name: React Web PR advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run React Web PR advisory
+        run: npm run evidence:react-web-pr-advisory -- --run-id=pr-${{ github.event.pull_request.number }} --output=$RUNNER_TEMP/react-web-pr-advisory.json --markdown-output=$RUNNER_TEMP/react-web-pr-advisory.md
+
+      - name: Publish React Web advisory summary
+        run: cat "$RUNNER_TEMP/react-web-pr-advisory.md" >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ci:alerts": "node scripts/triage-ci-alerts.mjs",
     "pr:alerts": "node scripts/guard-pr-alerts.mjs",
     "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs",
-    "evidence:react-native-readiness": "npm run build && node scripts/react-native-readiness-evidence.mjs"
+    "evidence:react-native-readiness": "npm run build && node scripts/react-native-readiness-evidence.mjs",
+    "evidence:react-web-pr-advisory": "npm run build && node scripts/react-web-pr-advisory-surface.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildReactWebProfileSurface,
+  REACT_WEB_PROFILE_ARTIFACT_KEYS,
+} from "./react-web-profile-surface.mjs";
+import {
+  buildReleaseBenchmarkEvidence,
+  buildReleaseBenchmarkSmokeSummary,
+} from "./release-benchmark-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export function assertReactWebPrAdvisoryContract({ profileSurface, releaseBenchmarkEvidence }) {
+  if (profileSurface?.schemaVersion !== "react-web-profile-surface.v1") {
+    throw new Error("React Web PR advisory contract broken: profile surface schemaVersion is missing or unsupported");
+  }
+  if (profileSurface?.profile !== "react-web") {
+    throw new Error("React Web PR advisory contract broken: profile surface must stay on react-web");
+  }
+  if (JSON.stringify(Object.keys(profileSurface?.artifacts ?? {})) !== JSON.stringify(REACT_WEB_PROFILE_ARTIFACT_KEYS)) {
+    throw new Error("React Web PR advisory contract broken: profile surface artifact keys changed");
+  }
+  if (profileSurface?.claimability?.contextReduction !== false
+    || profileSurface?.claimability?.cachePerformance !== false
+    || profileSurface?.claimability?.providerBillingSavings !== false) {
+    throw new Error("React Web PR advisory contract broken: profile surface top-level claimability widened");
+  }
+
+  if (releaseBenchmarkEvidence?.schemaVersion !== "release-benchmark-evidence.v1") {
+    throw new Error("React Web PR advisory contract broken: release benchmark schemaVersion is missing or unsupported");
+  }
+  if (typeof releaseBenchmarkEvidence?.releaseClaims?.headline !== "string" || releaseBenchmarkEvidence.releaseClaims.headline.length === 0) {
+    throw new Error("React Web PR advisory contract broken: release benchmark headline is missing");
+  }
+  if (releaseBenchmarkEvidence?.nonClaims?.cachePerformanceImprovement?.claimable !== false
+    || releaseBenchmarkEvidence?.nonClaims?.runtimeTokenSavings?.claimable !== false
+    || releaseBenchmarkEvidence?.nonClaims?.providerBillingSavings?.claimable !== false) {
+    throw new Error("React Web PR advisory contract broken: release benchmark non-claims widened");
+  }
+}
+
+export async function buildReactWebPrAdvisorySurface({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+  profileSurfaceBuilder = buildReactWebProfileSurface,
+  releaseBenchmarkBuilder = buildReleaseBenchmarkEvidence,
+} = {}) {
+  const profileSurface = await profileSurfaceBuilder({ repoRoot, runId: `${runId}-profile` });
+  const releaseBenchmarkEvidence = await releaseBenchmarkBuilder({ repoRoot, runId: `${runId}-release-benchmark` });
+
+  assertReactWebPrAdvisoryContract({ profileSurface, releaseBenchmarkEvidence });
+
+  const releaseBenchmarkSummary = buildReleaseBenchmarkSmokeSummary(releaseBenchmarkEvidence);
+
+  return {
+    schemaVersion: "react-web-pr-advisory-surface.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    advisory: true,
+    consumer: "pull-request",
+    status: "advisory",
+    checkName: "React Web PR advisory",
+    profile: "react-web",
+    claimBoundary:
+      "PR-facing advisory summary only: presentation adapter over the existing bounded React Web profile surface. This check does not create a new evidence lane, does not change merge policy, and does not prove cache performance, runtime-token savings, provider cost, billing, invoice, charged-cost, or broad multi-domain support claims.",
+    profileSurface,
+    releaseBenchmarkSummary,
+    summary: {
+      advisoryOnly: true,
+      profileArtifactCount: profileSurface.summary.artifactCount,
+      artifactKeys: profileSurface.summary.artifactKeys,
+      childSignals: profileSurface.summary.childSignals,
+      warningCount: profileSurface.summary.warnings.length,
+      warnings: profileSurface.summary.warnings,
+      releaseSafeHeadline: releaseBenchmarkSummary.headline,
+      nonClaims: {
+        profileTopLevelContextReduction: profileSurface.claimability.contextReduction,
+        cachePerformance: releaseBenchmarkSummary.nonClaims.cachePerformanceImprovement,
+        runtimeTokenSavings: releaseBenchmarkSummary.nonClaims.runtimeTokenSavings,
+        providerBillingSavings: releaseBenchmarkSummary.nonClaims.providerBillingSavings,
+        broadSupport: false,
+      },
+    },
+  };
+}
+
+export function renderReactWebPrAdvisoryMarkdown(evidence) {
+  const warnings = evidence.summary.warnings.length > 0
+    ? evidence.summary.warnings.map((warning) => `- ${warning}`).join("\n")
+    : "- none";
+
+  return `# React Web PR advisory
+
+${evidence.claimBoundary}
+
+## Advisory status
+
+- Advisory only: ${evidence.summary.advisoryOnly ? "yes" : "no"}
+- Consumer: ${evidence.consumer}
+- Check name: ${evidence.checkName}
+- Profile: ${evidence.profile}
+- Artifact count: ${evidence.summary.profileArtifactCount}
+- Artifact keys: ${evidence.summary.artifactKeys.join(", ")}
+- Release-safe headline: ${evidence.summary.releaseSafeHeadline}
+
+## Child evidence snapshot
+
+- Context actual injected context reduction claimable inside child evidence: ${evidence.summary.childSignals.contextActualInjectedContextReductionClaimable ? "yes" : "no"}
+- Reuse correctness claimable inside child evidence: ${evidence.summary.childSignals.reuseCorrectnessClaimable ? "yes" : "no"}
+- Over-caching audit verdict: ${evidence.summary.childSignals.overCachingAuditVerdictName}
+- Stability warning-only: ${evidence.summary.childSignals.stabilityWarningOnly ? "yes" : "no"}
+- Mixed-routing boundary isolation claimable: ${evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable ? "yes" : "no"}
+- Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
+
+## Non-claims
+
+- This advisory does not block merge or release in pass 1.
+- Profile top-level context reduction claim widened: ${evidence.summary.nonClaims.profileTopLevelContextReduction ? "yes" : "no"}
+- Cache performance proof: ${evidence.summary.nonClaims.cachePerformance ? "yes" : "no"}
+- Runtime-token savings proof: ${evidence.summary.nonClaims.runtimeTokenSavings ? "yes" : "no"}
+- Provider billing/cost savings proof: ${evidence.summary.nonClaims.providerBillingSavings ? "yes" : "no"}
+- Broad React/RN/WebView/TUI support proof: ${evidence.summary.nonClaims.broadSupport ? "yes" : "no"}
+
+## Warnings
+
+${warnings}
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebPrAdvisorySurface({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebPrAdvisoryMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -1,0 +1,174 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  assertReactWebPrAdvisoryContract,
+  buildReactWebPrAdvisorySurface,
+  renderReactWebPrAdvisoryMarkdown,
+} from "../scripts/react-web-pr-advisory-surface.mjs";
+
+const repoRoot = process.cwd();
+let evidencePromise;
+
+function getEvidence() {
+  evidencePromise ??= buildReactWebPrAdvisorySurface({ runId: `test-${Date.now()}-${Math.random()}` });
+  return evidencePromise;
+}
+
+test("React Web PR advisory surface stays advisory-only over the existing full profile surface", async () => {
+  const evidence = await getEvidence();
+
+  assert.equal(evidence.schemaVersion, "react-web-pr-advisory-surface.v1");
+  assert.equal(evidence.advisory, true);
+  assert.equal(evidence.status, "advisory");
+  assert.equal(evidence.consumer, "pull-request");
+  assert.equal(evidence.profile, "react-web");
+  assert.equal(evidence.checkName, "React Web PR advisory");
+  assert.match(evidence.claimBoundary, /presentation adapter over the existing bounded React Web profile surface/);
+  assert.match(evidence.claimBoundary, /does not create a new evidence lane/);
+  assert.match(evidence.claimBoundary, /does not change merge policy/);
+  assert.match(evidence.claimBoundary, /does not prove cache performance, runtime-token savings, provider cost, billing/);
+
+  assert.equal(evidence.profileSurface.schemaVersion, "react-web-profile-surface.v1");
+  assert.deepEqual(Object.keys(evidence.profileSurface.artifacts), [
+    "context",
+    "reuse",
+    "overCachingAudit",
+    "stability",
+    "mixedRouting",
+    "knowledgeContext",
+  ]);
+  assert.deepEqual(evidence.profileSurface.claimability, {
+    contextReduction: false,
+    cachePerformance: false,
+    providerBillingSavings: false,
+  });
+
+  assert.equal(evidence.summary.advisoryOnly, true);
+  assert.equal(evidence.summary.profileArtifactCount, 6);
+  assert.equal(evidence.summary.nonClaims.profileTopLevelContextReduction, false);
+  assert.equal(evidence.summary.nonClaims.cachePerformance, false);
+  assert.equal(evidence.summary.nonClaims.runtimeTokenSavings, false);
+  assert.equal(evidence.summary.nonClaims.providerBillingSavings, false);
+  assert.equal(evidence.summary.nonClaims.broadSupport, false);
+  assert.match(evidence.summary.releaseSafeHeadline, /React Web same-file reuse is routed correctly/);
+});
+
+test("React Web PR advisory markdown keeps advisory wording and explicit non-claims", async () => {
+  const evidence = await getEvidence();
+  const markdown = renderReactWebPrAdvisoryMarkdown(evidence);
+
+  assert.match(markdown, /# React Web PR advisory/);
+  assert.match(markdown, /Advisory only: yes/);
+  assert.match(markdown, /Consumer: pull-request/);
+  assert.match(markdown, /This advisory does not block merge or release in pass 1/);
+  assert.match(markdown, /Cache performance proof: no/);
+  assert.match(markdown, /Runtime-token savings proof: no/);
+  assert.match(markdown, /Provider billing\/cost savings proof: no/);
+  assert.match(markdown, /Broad React\/RN\/WebView\/TUI support proof: no/);
+  assert.doesNotMatch(markdown, /Cache performance proof: yes/i);
+});
+
+test("React Web PR advisory contract fails closed on malformed upstream inputs", () => {
+  assert.throws(
+    () => assertReactWebPrAdvisoryContract({
+      profileSurface: {
+        schemaVersion: "react-web-profile-surface.v1",
+        profile: "react-web",
+        artifacts: { context: {} },
+        claimability: {
+          contextReduction: false,
+          cachePerformance: false,
+          providerBillingSavings: false,
+        },
+      },
+      releaseBenchmarkEvidence: {
+        schemaVersion: "release-benchmark-evidence.v1",
+        releaseClaims: { headline: "headline" },
+        nonClaims: {
+          cachePerformanceImprovement: { claimable: false },
+          runtimeTokenSavings: { claimable: false },
+          providerBillingSavings: { claimable: false },
+        },
+      },
+    }),
+    /profile surface artifact keys changed/,
+  );
+
+  assert.throws(
+    () => assertReactWebPrAdvisoryContract({
+      profileSurface: {
+        schemaVersion: "react-web-profile-surface.v1",
+        profile: "react-web",
+        artifacts: {
+          context: {},
+          reuse: {},
+          overCachingAudit: {},
+          stability: {},
+          mixedRouting: {},
+          knowledgeContext: {},
+        },
+        claimability: {
+          contextReduction: false,
+          cachePerformance: false,
+          providerBillingSavings: false,
+        },
+      },
+      releaseBenchmarkEvidence: {
+        schemaVersion: "release-benchmark-evidence.v1",
+        releaseClaims: { headline: "headline" },
+        nonClaims: {
+          cachePerformanceImprovement: { claimable: true },
+          runtimeTokenSavings: { claimable: false },
+          providerBillingSavings: { claimable: false },
+        },
+      },
+    }),
+    /release benchmark non-claims widened/,
+  );
+});
+
+test("React Web PR advisory CLI writes bounded JSON and Markdown reports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-pr-advisory-"));
+  const outputPath = path.join(tempDir, "react-web-pr-advisory.json");
+  const markdownPath = path.join(tempDir, "react-web-pr-advisory.md");
+
+  const cli = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts", "react-web-pr-advisory-surface.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+
+  const stdoutEvidence = JSON.parse(cli.stdout);
+  const fileEvidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+
+  assert.equal(stdoutEvidence.runId, "cli-test");
+  assert.equal(stdoutEvidence.status, "advisory");
+  assert.deepEqual(stdoutEvidence.summary.artifactKeys, [
+    "context",
+    "reuse",
+    "overCachingAudit",
+    "stability",
+    "mixedRouting",
+    "knowledgeContext",
+  ]);
+  assert.deepEqual(fileEvidence, stdoutEvidence);
+  assert.match(markdown, /# React Web PR advisory/);
+  assert.match(markdown, /This advisory does not block merge or release in pass 1/);
+});

--- a/test/react-web-pr-advisory-workflow.test.mjs
+++ b/test/react-web-pr-advisory-workflow.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "react-web-pr-advisory.yml");
+const packageJsonPath = path.join(repoRoot, "package.json");
+
+test("React Web PR advisory workflow is PR-scoped and invokes the package script", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  assert.match(workflow, /^name: React Web PR Advisory/m);
+  assert.match(workflow, /pull_request:/);
+  assert.doesNotMatch(workflow, /pull_request_target:/);
+  assert.match(workflow, /contents: read/);
+  assert.match(workflow, /npm ci/);
+  assert.match(workflow, /npm run evidence:react-web-pr-advisory -- --run-id=pr-\$\{\{ github\.event\.pull_request\.number \}\}/);
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+  assert.doesNotMatch(workflow, /assertReleaseBenchmarkSmokeGate/);
+  assert.doesNotMatch(workflow, /validate-pr-merge-gate/);
+
+  assert.equal(
+    pkg.scripts["evidence:react-web-pr-advisory"],
+    "npm run build && node scripts/react-web-pr-advisory-surface.mjs",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #608

## Summary

- add a dedicated `pull_request` React Web advisory workflow/check
- add a presentation-only PR advisory wrapper over the existing full React Web profile surface
- keep warnings and non-claim states advisory-only while locking the workflow/script contract with focused tests

## Verification

- [x] `git diff --check`
- [x] `npm run build`
- [x] `node --test test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-advisory-workflow.test.mjs`
- [x] `npm run evidence:react-web-pr-advisory -- --run-id=post-rebase`
- [x] `npm run lint`
- [x] `npm test`

## Review gate

- [ ] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.
