### PR TITLE
Harden RN sourceAnchorBeta located proof anchors

### DIFF
--- a/scripts/react-native-payload-evidence.mjs
+++ b/scripts/react-native-payload-evidence.mjs
@@ -188,6 +188,16 @@ function interactionSummary(domainPayload) {
   };
 }
 
+function locatedAnchorSummary(domainPayload) {
+  const locatedAnchors = domainPayload?.sourceAnchorBeta?.anchors?.locatedAnchors ?? [];
+  return {
+    count: locatedAnchors.length,
+    kinds: uniqueSorted(locatedAnchors.map((item) => item.kind).filter(Boolean)),
+    labels: uniqueSorted(locatedAnchors.map((item) => item.label).filter(Boolean)),
+    allLocated: locatedAnchors.length > 0 && locatedAnchors.every((item) => item.loc && Number.isInteger(item.loc.startLine) && Number.isInteger(item.loc.endLine)),
+  };
+}
+
 function measureRnFixture({ repoRoot, relativeFile, dist }) {
   const filePath = path.join(repoRoot, relativeFile);
   const preReadDecision = dist.preRead.decidePreRead(filePath, repoRoot, "codex", { includeEditGuidance: false });
@@ -216,12 +226,14 @@ function measureRnFixture({ repoRoot, relativeFile, dist }) {
       reuseFreshnessSource: preReadDomainPayload?.reuseContract?.freshnessSource ?? null,
       strictContractsPresent: hasStrictRnContracts(preReadDomainPayload),
       primitiveInteractions: preReadInteractions,
+      locatedAnchors: locatedAnchorSummary(preReadDomainPayload),
     },
     modelFacing: {
       domain: modelDomainPayload?.domain ?? null,
       claimBoundary: modelDomainPayload?.claimBoundary ?? null,
       strictContractsPresent: hasStrictRnContracts(modelDomainPayload),
       primitiveInteractions: modelInteractions,
+      locatedAnchors: locatedAnchorSummary(modelDomainPayload),
       concernProfileIds: toConcernProfileIds(modelPayload),
       visibleBehaviorConcernKinds: toVisibleBehaviorConcernKinds(modelPayload.behavior),
     },
@@ -231,6 +243,8 @@ function measureRnFixture({ repoRoot, relativeFile, dist }) {
       preReadInteractions.hasPressableAction &&
       modelInteractions.hasTextInputBinding &&
       modelInteractions.hasPressableAction &&
+      locatedAnchorSummary(preReadDomainPayload).allLocated &&
+      locatedAnchorSummary(modelDomainPayload).allLocated &&
       hasStrictRnContracts(preReadDomainPayload) &&
       hasStrictRnContracts(modelDomainPayload),
   };
@@ -290,6 +304,9 @@ export async function buildReactNativePayloadEvidence({
   );
   const readinessRows = rnFixtures.filter(
     (row) => row.preRead.primitiveInteractions.hasConstraintActionReadiness && row.modelFacing.primitiveInteractions.hasConstraintActionReadiness,
+  );
+  const locatedAnchorRows = rnFixtures.filter(
+    (row) => row.preRead.locatedAnchors.allLocated && row.modelFacing.locatedAnchors.allLocated,
   );
   const measuredByFile = new Map(rnFixtures.map((row) => [row.file, row]));
   const boundaryByFile = new Map(boundaries.map((row) => [row.file, row]));
@@ -387,6 +404,14 @@ export async function buildReactNativePayloadEvidence({
         directReadinessFixtures: readinessRows.map((row) => row.file),
         blocker: readinessRows.length > 0 ? null : "no measured RN fixture exposed constraintActionReadiness in both pre-read and model-facing payloads",
       },
+      locatedAnchorsVisible: {
+        claimable: locatedAnchorRows.length === rnFixtures.length,
+        fixtureCoverage: locatedAnchorRows.map((row) => row.file),
+        blocker:
+          locatedAnchorRows.length === rnFixtures.length
+            ? null
+            : "one or more measured RN fixtures did not expose fully located sourceAnchorBeta anchors in both pre-read and model-facing payloads",
+      },
       stagedRnSurfaceInventory: {
         claimable: true,
         stagedSlots: stagedRnSurfaceInventory,
@@ -466,6 +491,7 @@ ${evidence.claimBoundary}
 - Measured RN narrow input constraints visible: ${evidence.summary.inputConstraintsVisible.claimable ? "yes" : "no"}
 - RN direct state/action relation visible: ${evidence.summary.stateActionRelationsVisible.claimable ? "yes" : "no"}
 - Measured RN narrow constraint/action readiness visible: ${evidence.summary.constraintActionReadinessVisible.claimable ? "yes" : "no"}
+- RN sourceAnchorBeta located anchors visible: ${evidence.summary.locatedAnchorsVisible.claimable ? "yes" : "no"}
 - RN staged surface inventory visible: ${evidence.summary.stagedRnSurfaceInventory.claimable ? "yes" : "no"}
 - Broad React Native support claimable: no
 - Runtime reuse promotion claimable: no

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -37,6 +37,23 @@ function arraysContainValues(left: string[] | readonly string[] | undefined, rig
   return right.every((value) => left.includes(value));
 }
 
+function isSourceRange(value: unknown): boolean {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as { startLine?: unknown }).startLine === "number" &&
+    typeof (value as { endLine?: unknown }).endLine === "number"
+  );
+}
+
+function hasLocatedAnchor(
+  anchors: ReactNativeSourceAnchorBetaPayload["anchors"] | Partial<ReactNativeSourceAnchorBetaPayload["anchors"]> | undefined,
+  predicate: (item: { kind?: string; label?: string; loc?: unknown }) => boolean,
+): boolean {
+  if (!anchors || !Array.isArray(anchors.locatedAnchors)) return false;
+  return anchors.locatedAnchors.some((item) => predicate(item) && isSourceRange(item.loc));
+}
+
 function isReactNativeSourceAnchorBetaPayload(value: unknown): value is ReactNativeSourceAnchorBetaPayload {
   if (!value || typeof value !== "object") return false;
   const payload = value as Partial<ReactNativeSourceAnchorBetaPayload>;
@@ -72,7 +89,13 @@ function isReactNativeSourceAnchorBetaPayload(value: unknown): value is ReactNat
     Boolean(anchors) &&
     anchors?.sourceFingerprintRequired === true &&
     arraysContainValues(anchors?.primitives, ["Pressable", "Text", "TextInput", "View"]) &&
-    arraysContainValues(anchors?.jsxProps, ["onChangeText", "onPress"])
+    arraysContainValues(anchors?.jsxProps, ["onChangeText", "onPress"]) &&
+    hasLocatedAnchor(anchors, (item) => item.kind === "component-name" && item.label === anchors.componentName) &&
+    (!anchors.propsName || hasLocatedAnchor(anchors, (item) => item.kind === "props-interface" && item.label === anchors.propsName)) &&
+    hasLocatedAnchor(anchors, (item) => item.kind === "event-handlers" && Boolean(item.label?.startsWith("onChangeText:"))) &&
+    hasLocatedAnchor(anchors, (item) => item.kind === "event-handlers" && Boolean(item.label?.startsWith("onPress:"))) &&
+    hasLocatedAnchor(anchors, (item) => item.kind === "rn-primitive-outline" && item.label === "TextInput") &&
+    hasLocatedAnchor(anchors, (item) => item.kind === "rn-primitive-outline" && item.label === "Pressable")
   );
 }
 

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -95,7 +95,7 @@ export type ReactNativeSourceAnchorBetaPayload = {
     primitives: string[];
     jsxProps: string[];
     sourceFingerprintRequired: true;
-    locatedAnchors?: ReactNativeSourceAnchorBetaLocatedAnchor[];
+    locatedAnchors: ReactNativeSourceAnchorBetaLocatedAnchor[];
   };
 };
 
@@ -356,9 +356,10 @@ function buildReactNativeSourceAnchorBetaPayload(
 ): ReactNativeSourceAnchorBetaPayload {
   const eventHandlers = uniqueSorted(result.behavior?.eventHandlers ?? []);
   const hooks = uniqueSorted(result.behavior?.hooks ?? []);
+  const primitiveInteractions = result.behavior?.rnPrimitiveInteractions;
   const locatedHooks = buildReactNativeLocatedHookAnchors(result);
   const locatedEventHandlers = buildReactNativeLocatedEventHandlerAnchors(result);
-  const locatedPrimitives = buildReactNativeLocatedPrimitiveAnchors(result.behavior?.rnPrimitiveInteractions);
+  const locatedPrimitives = buildReactNativeLocatedPrimitiveAnchors(primitiveInteractions);
   const locatedAnchors = uniqueLocatedByKey(
     [
       ...(result.componentName && result.componentLoc
@@ -384,7 +385,7 @@ function buildReactNativeSourceAnchorBetaPayload(
       primitives: evidenceFacts.primitives,
       jsxProps: evidenceFacts.jsxProps,
       sourceFingerprintRequired: true,
-      ...(locatedAnchors.length > 0 ? { locatedAnchors } : {}),
+      locatedAnchors,
     },
   };
 }

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -151,7 +151,10 @@ test("frontend profile gate allows narrow allowed non-web frontend policies", ()
 
   const withoutLocatedAnchors = clonePayload(payload);
   delete withoutLocatedAnchors.domainPayload.sourceAnchorBeta.anchors.locatedAnchors;
-  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutLocatedAnchors, policy), { allowed: true });
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, withoutLocatedAnchors, policy), {
+    allowed: false,
+    reason: MISSING_REACT_NATIVE_DOMAIN_PAYLOAD_REASON,
+  });
 });
 
 test("frontend profile gate requires RN domain payload for the measured narrow RN policy", () => {
@@ -228,6 +231,23 @@ test("frontend profile gate rejects adversarial RN narrow payload contract and f
     ["missing source-anchor fingerprint requirement", () => {
       const stale = clonePayload(payload);
       stale.domainPayload.sourceAnchorBeta.anchors.sourceFingerprintRequired = false;
+      return stale;
+    }],
+    ["missing located anchors", () => {
+      const stale = clonePayload(payload);
+      delete stale.domainPayload.sourceAnchorBeta.anchors.locatedAnchors;
+      return stale;
+    }],
+    ["missing located component anchor", () => {
+      const stale = clonePayload(payload);
+      stale.domainPayload.sourceAnchorBeta.anchors.locatedAnchors = stale.domainPayload.sourceAnchorBeta.anchors.locatedAnchors.filter(
+        (item) => !(item.kind === "component-name" && item.label === "Native"),
+      );
+      return stale;
+    }],
+    ["missing located anchor loc", () => {
+      const stale = clonePayload(payload);
+      delete stale.domainPayload.sourceAnchorBeta.anchors.locatedAnchors[0].loc;
       return stale;
     }],
     ["missing reuse contract", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -952,6 +952,7 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
     primitives: ["Pressable", "Text", "TextInput", "View"],
     jsxProps: ["onChangeText", "onPress"],
     sourceFingerprintRequired: true,
+    locatedAnchors: [],
   });
 
   assert.deepEqual(payload?.reuseContract, {

--- a/test/react-native-payload-evidence.test.mjs
+++ b/test/react-native-payload-evidence.test.mjs
@@ -37,6 +37,8 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(evidence.summary.stateActionRelationsVisible.relationKind, "actionReadsInputValue");
   assert.equal(evidence.summary.constraintActionReadinessVisible.claimable, true);
   assert.equal(evidence.summary.constraintActionReadinessVisible.relationKind, "constraintActionReadiness");
+  assert.equal(evidence.summary.locatedAnchorsVisible.claimable, true);
+  assert.equal(evidence.summary.locatedAnchorsVisible.fixtureCoverage.length, evidence.fixtures.length);
   assert.equal(evidence.summary.stagedRnSurfaceInventory.claimable, true);
   assert.equal(evidence.summary.stagedRnSurfaceInventory.stagedSlots.length, 8);
   assert.deepEqual(
@@ -102,11 +104,16 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
     assert.equal(row.preRead.strictContractsPresent, true);
     assert.equal(row.preRead.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.preRead.primitiveInteractions.hasPressableAction, true);
+    assert.equal(row.preRead.locatedAnchors.allLocated, true);
+    assert.ok(row.preRead.locatedAnchors.kinds.includes("component-name"), row.file);
+    assert.ok(row.preRead.locatedAnchors.kinds.includes("event-handlers"), row.file);
+    assert.ok(row.preRead.locatedAnchors.kinds.includes("rn-primitive-outline"), row.file);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.preRead.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
     assert.equal(row.modelFacing.strictContractsPresent, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasTextInputBinding, true);
     assert.equal(row.modelFacing.primitiveInteractions.hasPressableAction, true);
+    assert.equal(row.modelFacing.locatedAnchors.allLocated, true);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.textInputFields.length > 0, row.file);
     assert.ok(row.modelFacing.primitiveInteractions.metadataCoverage.pressableFields.length > 0, row.file);
     assert.equal(row.claimable, true);
@@ -143,6 +150,14 @@ test("React Native payload evidence exposes primitiveInteractions without wideni
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].disabled, "isSubmitDisabled");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].accessibilityLabel, "Submit filter");
   assert.equal(inline.preRead.primitiveInteractions.actionBindings[0].testID, "submit-filter-button");
+  assert.deepEqual(inline.preRead.locatedAnchors.labels, [
+    "InlineActionRow",
+    "InlineActionRowProps",
+    "Pressable",
+    "TextInput",
+    "onChangeText:onChangeText",
+    "onPress:submitCurrentValue",
+  ]);
   assert.deepEqual(inline.preRead.primitiveInteractions.stateActionRelations, inline.modelFacing.primitiveInteractions.stateActionRelations);
   assert.equal(inline.preRead.primitiveInteractions.stateActionRelations[0].relationKind, "actionReadsInputValue");
   assert.equal(inline.preRead.primitiveInteractions.stateActionRelations[0].onPressExpr, "submitCurrentValue");
@@ -195,6 +210,7 @@ test("React Native payload evidence Markdown keeps claim boundaries explicit", a
   assert.match(markdown, /Richer RN\/WebView\/TUI boundaries preserved: yes/);
   assert.match(markdown, /RN metadata anchors visible: yes/);
   assert.match(markdown, /Measured RN narrow constraint\/action readiness visible: yes/);
+  assert.match(markdown, /RN sourceAnchorBeta located anchors visible: yes/);
   assert.match(markdown, /actionReadsInputValue:submitCurrentValue->value/);
   assert.match(markdown, /constraintActionReadiness:submitCurrentValue->value,disabled=isSubmitDisabled/);
   assert.match(markdown, /\| TextInput \| keyboardType \| yes \| yes \| yes \|/);


### PR DESCRIPTION
## Why
The RN lane already has bounded primitive/input evidence, taxonomy, and readiness surfaces on `main`. The next safe increment is to harden `sourceAnchorBeta` located proof anchors so extract/compare/inspect-domain can rely on explicit source locations before any broader detector or runtime work is considered.

## What changed
- made RN `sourceAnchorBeta.anchors.locatedAnchors` an additive required proof field
- tightened the RN profile gate so narrow payload reuse requires valid located anchors for component, props, event handlers, and primitive outlines
- surfaced located-anchor visibility in RN payload evidence and aligned RN proof tests

## Scope boundary
- additive RN proof-surface hardening only
- no detector widening
- no new fixture lane
- no contract version bump
- no `runtimeReusePromotion` change
- no payload-policy widening
- no broad React Native/runtime correctness claim

## Verification
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs test/react-native-payload-evidence.test.mjs`
- `npm run evidence:react-native-payload`
- `npm run lint`
- `npm test`
- `git diff --check`

Closes #621
