### PR TITLE
Expand React Web fixture coverage with pass-2 context cases

### DIFF
--- a/scripts/react-web-context-evidence.mjs
+++ b/scripts/react-web-context-evidence.mjs
@@ -16,6 +16,9 @@ export const DEFAULT_REACT_WEB_EVIDENCE_FIXTURES = [
   "test/fixtures/react-web-context-expansion/route-page-account-settings.tsx",
   "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
   "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+  "test/fixtures/react-web-context-expansion/table-list-filter-results.tsx",
+  "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+  "test/fixtures/react-web-context-expansion/wrapper-heavy-ops-overview.tsx",
 ];
 
 function byteLength(value) {

--- a/test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.hooks.ts
+++ b/test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.hooks.ts
@@ -1,0 +1,34 @@
+import { useMemo, useState } from "react";
+
+export interface ReviewInboxItem {
+  id: string;
+  title: string;
+  owner: string;
+  status: "open" | "blocked" | "done";
+}
+
+export function useReviewSearchState(initialQuery: string) {
+  const [query, setQuery] = useState(initialQuery);
+  const hasActiveQuery = useMemo(() => query.trim().length > 0, [query]);
+  return { query, setQuery, hasActiveQuery };
+}
+
+export function useReviewSegments(items: ReviewInboxItem[], query: string) {
+  return useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const visibleItems =
+      normalizedQuery.length === 0
+        ? items
+        : items.filter((item) => `${item.title} ${item.owner}`.toLowerCase().includes(normalizedQuery));
+
+    return {
+      visibleItems,
+      summaryLabel: `${visibleItems.length} reviews`,
+    };
+  }, [items, query]);
+}
+
+export function useSelectedReviewId(items: ReviewInboxItem[]) {
+  const [selectedReviewId, setSelectedReviewId] = useState<string | null>(items[0]?.id ?? null);
+  return { selectedReviewId, setSelectedReviewId };
+}

--- a/test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx
+++ b/test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from "react";
+import {
+  type ReviewInboxItem,
+  useReviewSearchState,
+  useReviewSegments,
+  useSelectedReviewId,
+} from "./custom-hook-heavy-review-inbox.hooks";
+
+export interface ReviewInboxPanelProps {
+  initialItems: ReviewInboxItem[];
+  title: string;
+}
+
+export function ReviewInboxPanel({ initialItems, title }: ReviewInboxPanelProps) {
+  const { query, setQuery, hasActiveQuery } = useReviewSearchState("");
+  const { visibleItems, summaryLabel } = useReviewSegments(initialItems, query);
+  const { selectedReviewId, setSelectedReviewId } = useSelectedReviewId(visibleItems);
+
+  const selectedItemTitle = useMemo(() => {
+    return visibleItems.find((item) => item.id === selectedReviewId)?.title ?? "Pick a review";
+  }, [selectedReviewId, visibleItems]);
+
+  return (
+    <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="grid gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Review inbox</span>
+          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        </div>
+        <span className="text-sm text-slate-600">{summaryLabel}</span>
+      </div>
+
+      <label className="grid gap-2 text-sm text-slate-700" htmlFor="review-inbox-search">
+        <span className="font-medium text-slate-900">Search reviews</span>
+        <input
+          id="review-inbox-search"
+          className="rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+        />
+      </label>
+
+      <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600">
+        {hasActiveQuery ? `Showing filtered reviews · ${selectedItemTitle}` : `Showing all reviews · ${selectedItemTitle}`}
+      </div>
+
+      <ul className="grid gap-2">
+        {visibleItems.map((item) => (
+          <li key={item.id}>
+            <button
+              className="flex w-full items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 text-left"
+              type="button"
+              onClick={() => setSelectedReviewId(item.id)}
+            >
+              <span className="grid gap-1">
+                <span className="text-sm font-medium text-slate-900">{item.title}</span>
+                <span className="text-sm text-slate-600">{item.owner}</span>
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{item.status}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/test/fixtures/react-web-context-expansion/table-list-filter-results.tsx
+++ b/test/fixtures/react-web-context-expansion/table-list-filter-results.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState } from "react";
+
+export interface FilterableResultRow {
+  id: string;
+  name: string;
+  owner: string;
+  status: "ready" | "blocked" | "draft";
+}
+
+export interface FilterableResultsTableProps {
+  initialRows: FilterableResultRow[];
+  onExport: () => void;
+  title: string;
+}
+
+export function FilterableResultsTable({ initialRows, onExport, title }: FilterableResultsTableProps) {
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | FilterableResultRow["status"]>("all");
+
+  const filteredRows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return initialRows.filter((row) => {
+      const matchesQuery =
+        normalizedQuery.length === 0 || `${row.name} ${row.owner}`.toLowerCase().includes(normalizedQuery);
+      const matchesStatus = statusFilter === "all" || row.status === statusFilter;
+      return matchesQuery && matchesStatus;
+    });
+  }, [initialRows, query, statusFilter]);
+
+  return (
+    <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Release watch</span>
+          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        </div>
+        <button className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700" type="button" onClick={onExport}>
+          Export rows
+        </button>
+      </div>
+
+      <form className="grid gap-3 rounded-xl border border-slate-100 bg-slate-50 p-4 md:grid-cols-[minmax(0,1fr)_220px]">
+        <label className="grid gap-2 text-sm text-slate-700" htmlFor="results-table-query">
+          <span className="font-medium text-slate-900">Search rows</span>
+          <input
+            id="results-table-query"
+            className="rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+        </label>
+
+        <label className="grid gap-2 text-sm text-slate-700" htmlFor="results-table-status">
+          <span className="font-medium text-slate-900">Status</span>
+          <select
+            id="results-table-status"
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.currentTarget.value as "all" | FilterableResultRow["status"])}
+          >
+            <option value="all">All statuses</option>
+            <option value="ready">Ready</option>
+            <option value="blocked">Blocked</option>
+            <option value="draft">Draft</option>
+          </select>
+        </label>
+      </form>
+
+      <div className="overflow-hidden rounded-xl border border-slate-100">
+        <table className="min-w-full divide-y divide-slate-200 text-sm text-slate-700">
+          <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Owner</th>
+              <th className="px-4 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 bg-white">
+            {filteredRows.map((row) => (
+              <tr key={row.id}>
+                <td className="px-4 py-3 font-medium text-slate-900">{row.name}</td>
+                <td className="px-4 py-3">{row.owner}</td>
+                <td className="px-4 py-3">
+                  <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
+                    {row.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/test/fixtures/react-web-context-expansion/wrapper-heavy-ops-overview.tsx
+++ b/test/fixtures/react-web-context-expansion/wrapper-heavy-ops-overview.tsx
@@ -1,0 +1,54 @@
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, MetricTile, SectionHeading, Stack, Toolbar } from "@/components/ui";
+
+export interface OperationsOverviewShellProps {
+  hasBlockingSyncs?: boolean;
+  onAcknowledgeRisk: () => void;
+  onOpenRunbook: () => void;
+  onRetrySync: () => void;
+}
+
+export function OperationsOverviewShell({
+  hasBlockingSyncs = false,
+  onAcknowledgeRisk,
+  onOpenRunbook,
+  onRetrySync,
+}: OperationsOverviewShellProps) {
+  return (
+    <Card className={hasBlockingSyncs ? "rounded-3xl border-amber-300 bg-amber-50 shadow-sm" : "rounded-3xl border-slate-200 bg-white shadow-sm"}>
+      <CardHeader className="space-y-3">
+        <SectionHeading className="text-xs font-semibold uppercase tracking-wide text-sky-600">Operations readiness</SectionHeading>
+        <Stack className="gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-xl font-semibold text-slate-900">Daily control room</CardTitle>
+            <Badge className="rounded-full px-2 py-1 text-xs font-medium" variant={hasBlockingSyncs ? "warning" : "success"}>
+              {hasBlockingSyncs ? "Needs attention" : "Healthy"}
+            </Badge>
+          </div>
+          <CardDescription className="text-sm text-slate-600">
+            Keep queue health, release messaging, and incident-response ownership visible in one wrapper-heavy shell.
+          </CardDescription>
+        </Stack>
+      </CardHeader>
+
+      <CardContent className="space-y-5">
+        <Toolbar className="grid gap-3 md:grid-cols-3">
+          <MetricTile className="rounded-2xl border px-4 py-3" label="Escalations" value="3" tone={hasBlockingSyncs ? "warning" : "neutral"} />
+          <MetricTile className="rounded-2xl border px-4 py-3" label="Queued releases" value="5" tone="neutral" />
+          <MetricTile className="rounded-2xl border px-4 py-3" label="Owner coverage" value="92%" tone="success" />
+        </Toolbar>
+
+        <Stack className="gap-3 rounded-2xl border border-slate-100 bg-slate-50 p-4">
+          <Button className="justify-start" variant="ghost" onClick={onOpenRunbook}>
+            Open runbook
+          </Button>
+          <Button className="justify-start" variant="outline" onClick={onRetrySync}>
+            Retry sync
+          </Button>
+          <Button className="justify-start" variant="secondary" onClick={onAcknowledgeRisk}>
+            Acknowledge risk
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/test/react-web-context-evidence.test.mjs
+++ b/test/react-web-context-evidence.test.mjs
@@ -15,6 +15,9 @@ const EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES = [
   "test/fixtures/react-web-context-expansion/route-page-account-settings.tsx",
   "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
   "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+  "test/fixtures/react-web-context-expansion/table-list-filter-results.tsx",
+  "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+  "test/fixtures/react-web-context-expansion/wrapper-heavy-ops-overview.tsx",
 ];
 
 test("React Web context evidence measures actual injected additionalContext without broad savings claims", async () => {

--- a/test/react-web-domain-payload-expansion.test.mjs
+++ b/test/react-web-domain-payload-expansion.test.mjs
@@ -323,3 +323,132 @@ test("React Web runtime payload stays exact for the first-pass context-expansion
   });
   assertNoNonWhitelistedDetails(dataFetchingPayload.facts);
 });
+
+
+test("React Web runtime payload stays exact for the second-pass context-expansion fixtures", () => {
+  const tableFilterPayload = repeatedPayloadFor(
+    "test/fixtures/react-web-context-expansion/table-list-filter-results.tsx",
+    "table-list-filter-results",
+  );
+
+  assertExactPayload(tableFilterPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:dom-tag:button",
+      "react-web:dom-tag:div",
+      "react-web:dom-tag:form",
+      "react-web:dom-tag:input",
+      "react-web:dom-tag:label",
+      "react-web:dom-tag:select",
+      "react-web:dom-tag:span",
+      "react-web:jsx-attribute:className",
+      "react-web:jsx-attribute:htmlFor",
+    ],
+    facts: {
+      componentName: "FilterableResultsTable",
+      exports: [{ name: "FilterableResultsTable", kind: "named", type: "function" }],
+      hooks: ["useMemo", "useState"],
+      jsxDepth: 7,
+      hasSideEffects: false,
+      hasStyleBranching: false,
+      domTags: ["button", "div", "form", "input", "label", "select", "span"],
+      jsxAttributes: ["className", "htmlFor"],
+      formControls: [
+        { tag: "input", handlers: ["onChange"] },
+        { tag: "select", handlers: ["onChange"] },
+      ],
+      eventHandlers: ["onChange", "onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(tableFilterPayload.facts);
+
+  const customHookPayload = repeatedPayloadFor(
+    "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+    "custom-hook-heavy-review-inbox",
+  );
+
+  assertExactPayload(customHookPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:dom-tag:button",
+      "react-web:dom-tag:div",
+      "react-web:dom-tag:input",
+      "react-web:dom-tag:label",
+      "react-web:dom-tag:span",
+      "react-web:jsx-attribute:className",
+      "react-web:jsx-attribute:htmlFor",
+    ],
+    facts: {
+      componentName: "ReviewInboxPanel",
+      exports: [{ name: "ReviewInboxPanel", kind: "named", type: "function" }],
+      hooks: ["useMemo", "useReviewSearchState", "useReviewSegments", "useSelectedReviewId"],
+      jsxDepth: 6,
+      hasSideEffects: false,
+      hasStyleBranching: false,
+      domTags: ["button", "div", "input", "label", "span"],
+      jsxAttributes: ["className", "htmlFor"],
+      formControls: [{ tag: "input", handlers: ["onChange"] }],
+      eventHandlers: ["onChange", "onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(customHookPayload.facts);
+
+  const wrapperHeavyPayload = repeatedPayloadFor(
+    "test/fixtures/react-web-context-expansion/wrapper-heavy-ops-overview.tsx",
+    "wrapper-heavy-ops-overview",
+  );
+
+  assertExactPayload(wrapperHeavyPayload, {
+    schemaVersion: "domain-payload.v1",
+    domain: "react-web",
+    policy: "react-web-current-supported-lane",
+    plannerDecision: "compact-safe",
+    claimStatus: "current-supported-lane",
+    claimBoundary: "react-web-measured-extraction",
+    evidence: [
+      "react-web:dom-tag:div",
+      "react-web:jsx-attribute:className",
+    ],
+    facts: {
+      componentName: "OperationsOverviewShell",
+      exports: [{ name: "OperationsOverviewShell", kind: "named", type: "function" }],
+      jsxDepth: 5,
+      hasSideEffects: false,
+      hasStyleBranching: true,
+      domTags: ["div"],
+      jsxAttributes: ["className"],
+      jsxComponentCount: 11,
+      jsxComponents: [
+        "Badge",
+        "Button",
+        "Card",
+        "CardContent",
+        "CardDescription",
+        "CardHeader",
+        "CardTitle",
+        "MetricTile",
+        "SectionHeading",
+        "Stack",
+        "Toolbar",
+      ],
+      eventHandlers: ["onClick"],
+      styleSystem: "tailwind",
+    },
+    warnings: reactWebWarnings,
+  });
+  assertNoNonWhitelistedDetails(wrapperHeavyPayload.facts);
+});


### PR DESCRIPTION
Closes #622

## Summary
- add three new React Web context fixtures for table/list filtering, custom-hook-heavy, and wrapper-heavy large components
- extend the default React Web evidence fixture suite so context/stability and downstream profile surfaces inherit the new coverage automatically
- lock the new fixtures with exact default-suite membership and domain-payload contract tests

## Verification
- git diff --check
- npm run build
- node --test test/react-web-context-evidence.test.mjs test/react-web-domain-payload-expansion.test.mjs test/react-web-stability-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-advisory-workflow.test.mjs test/react-web-pr-gate-surface.test.mjs test/react-web-pr-gate-workflow.test.mjs
- npm run evidence:react-web-context -- --run-id=verify-pass2
- npm run evidence:react-web-stability -- --repeat=2 --run-id=verify-pass2
- npm run evidence:react-web-profile -- --run-id=verify-pass2
- npm run evidence:react-web-pr-advisory -- --run-id=verify-pass2
- npm run evidence:react-web-pr-gate -- --run-id=verify-pass2
- npm run lint
- npm test
- npm run build
- node --test test/react-web-context-evidence.test.mjs test/react-web-domain-payload-expansion.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs
- npm run evidence:react-web-pr-gate -- --run-id=post-rebase