### PR TITLE
Refresh TUI docs for the landed dry-run boundary

### DIFF
--- a/docs/tui-fixture-candidates.md
+++ b/docs/tui-fixture-candidates.md
@@ -120,7 +120,7 @@ The evidence matrix above is sufficient to discuss a future payload-design PRD, 
 
 ### Minimal payload candidate vocabulary
 
-The first safe TUI payload design target is a source-only metadata vocabulary. These names are allowed to appear in docs and future dry-run tests, but they are not model-facing payload fields yet:
+The first safe TUI payload design target is the source-only metadata vocabulary already exercised by the landed debug/test-owned dry-run appendix. These names may appear in docs and debug/test evidence, but they are not model-facing payload fields:
 
 | Candidate metadata field | Representative fixture evidence | Required boundary |
 | --- | --- | --- |
@@ -133,17 +133,19 @@ The first safe TUI payload design target is a source-only metadata vocabulary. T
 
 The vocabulary is deliberately fixture-backed. A later field should not be added until a fixture proves the source shape and a negative or mixed case keeps fallback/no-payload behavior safe.
 
-### Source-only dry-run implementation handoff
+### Landed source-only dry-run boundary
 
-A future dry-run PR may implement a non-emitting metadata projection for the vocabulary above, but only if it keeps the current denied lane intact:
+A landed debug/test-owned `inspect-domain --json` appendix may expose a non-emitting `tuiSourceMetadata` summary for files with actual TUI evidence. That landed step does not change the survey's role: this page remains a candidate/evidence-only survey, not a support contract, not payload approval, and not runtime/pre-read promotion.
 
-1. read source and produce debug/test evidence for candidate metadata fields;
-2. keep `assessTuiInkPayloadPolicy` denied with `allowed: false`;
-3. keep every current TUI fixture fallback/no-payload;
-4. keep mixed and non-Ink cases outside TUI payload authorization;
-5. avoid model-facing payload builders, runtime/pre-read injection, manifest changes, detector/registry promotion, and token/performance/support claims.
+The landed dry-run boundary must continue to keep:
 
-If any of those constraints is too narrow, the next artifact should be a new PRD/test-spec pair rather than an opportunistic source edit.
+1. `assessTuiInkPayloadPolicy` denied with `allowed: false`;
+2. every current TUI fixture fallback/no-payload;
+3. mixed and non-Ink cases outside TUI payload authorization;
+4. `tuiSourceMetadata` limited to debug/test-owned `inspect-domain --json` visibility rather than model-facing payload builders;
+5. detector, registry, manifest, pre-read, runtime, and cross-lane promotion work out of scope.
+
+The next approved artifact is a separate **PRD + test-spec pair** for serialized shared-policy planning. If a future step wants broader payload/schema/runtime support than the current `inspect-domain --json` appendix, it must stop here and plan before implementation.
 
 ## Candidate source notes
 

--- a/docs/tui-operational-readiness.md
+++ b/docs/tui-operational-readiness.md
@@ -95,7 +95,7 @@ The disqualifier list is intentionally strict. Stop the current lane and write a
 
 ## Minimal payload candidate schema contract
 
-This contract names the first metadata vocabulary a future **source-only dry-run** may prototype. It is a schema target, not permission to emit a payload. Every field below must stay source-derived, fixture-backed, and denied by the current TUI payload policy until a later plan explicitly promotes it.
+This contract names the first metadata vocabulary the landed **source-only dry-run** may surface in debug/test-owned evidence. It is a schema target, not permission to emit a payload. Every field below must stay source-derived, fixture-backed, and denied by the current TUI payload policy until a later plan explicitly promotes it.
 
 | Candidate metadata field | What current fixtures can prove | Full-source / non-claim boundary |
 | --- | --- | --- |
@@ -108,17 +108,20 @@ This contract names the first metadata vocabulary a future **source-only dry-run
 
 The schema vocabulary above is intentionally smaller than terminal behavior. It may guide a future metadata projection, but it must not be described as compact context support, token reduction, runtime correctness, provider-cost improvement, or default TUI extraction.
 
-## Source-only dry-run handoff
+## Landed source-only dry-run boundary
 
-The next implementation PR may build only a **source-only dry-run** that reports the candidate metadata fields above in debug or test-owned evidence. That PR must continue to keep:
+The first source-only dry-run step is already landed as a debug/test-owned `tuiSourceMetadata` appendix on `fooks inspect-domain <file> --json` when actual TUI evidence is present. That landed surface must continue to keep:
 
 - `tui-ink-evidence-only-payload` denied with `allowed: false`;
-- pre-read fallback/no-payload behavior for every current TUI fixture;
-- mixed and non-Ink cases outside TUI payload authorization;
+- `domainDetection` and `fallbackFirst` as the primary inspect contract, with `tuiSourceMetadata` additive and non-promotional;
 - model-facing payload emission out of scope;
+- runtime and pre-read integration out of scope;
+- mixed and non-Ink cases outside TUI payload authorization;
 - runtime hooks, detector registries, fixture manifest entries, and cross-lane RN/React Web/WebView files unchanged unless a new serialized plan names owners and fallback regressions first.
 
-If the dry-run needs a payload builder, `allowed: true`, runtime injection, token/performance claims, or shared-seam edits, stop and create a new PRD/test-spec pair before implementation.
+The next approved artifact is a separate **PRD + test-spec pair** for serialized shared-policy planning. It is not another opportunistic implementation-promotion PR from this readiness guide.
+
+If a follow-up wants to widen beyond the current `inspect-domain --json` appendix, add a payload builder, turn `allowed: true`, integrate runtime/pre-read, or make token/performance/support claims, stop and create a new PRD/test-spec pair before implementation.
 
 ## Stop rules
 

--- a/test/payload-policy-tui-ink.test.mjs
+++ b/test/payload-policy-tui-ink.test.mjs
@@ -532,7 +532,7 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
   assert.match(survey, /TUI-safe metadata projection contract/);
   assert.match(survey, /forbidden React Web-only projections/);
   assert.match(survey, /Minimal payload candidate vocabulary/);
-  assert.match(survey, /Source-only dry-run implementation handoff/);
+  assert.match(survey, /Landed source-only dry-run boundary/);
   assert.match(survey, /pre-read emits no model-facing TUI payload/);
   assert.match(survey, /separate serialized plan/);
   assert.match(survey, /tui-ink-evidence-only-payload/);
@@ -544,9 +544,14 @@ test("TUI/Ink fixture survey documents evidence-only reinforcement without suppo
     assert.ok(survey.includes(field), field);
     assert.ok(survey.includes(fixture), fixture);
   }
-  assert.match(survey, /not model-facing payload fields yet/);
-  assert.match(survey, /non-emitting metadata projection/);
-  assert.match(survey, /keep `assessTuiInkPayloadPolicy` denied with `allowed: false`/);
+  assert.match(survey, /not model-facing payload fields/);
+  assert.match(survey, /non-emitting `tuiSourceMetadata` summary/);
+  assert.match(survey, /`assessTuiInkPayloadPolicy` denied with `allowed: false`/);
+  assert.match(survey, /inspect-domain --json/);
+  assert.match(survey, /candidate\/evidence-only survey/);
+  assert.match(survey, /not a support contract/);
+  assert.match(survey, /PRD \+ test-spec pair/);
+  assert.doesNotMatch(survey, /A future dry-run PR may implement/);
   assert.doesNotMatch(survey, forbiddenSupportClaims);
 });
 
@@ -565,7 +570,7 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /## Promotion criteria before payload-design planning/);
   assert.match(guide, /## Payload design readiness gate/);
   assert.match(guide, /## Minimal payload candidate schema contract/);
-  assert.match(guide, /## Source-only dry-run handoff/);
+  assert.match(guide, /## Landed source-only dry-run boundary/);
   assert.match(guide, /## Stop rules/);
   assert.match(guide, /tui-ink-evidence-only-payload/);
   assert.match(guide, /fallback\/no-payload/);
@@ -573,6 +578,11 @@ test("TUI operational readiness guide keeps payload planning separate", () => {
   assert.match(guide, /\*\*not\*\* compact extraction permission/);
   assert.match(guide, /\*\*not\*\* model-facing output/);
   assert.match(guide, /serialized shared-policy plan/);
+  assert.match(guide, /debug\/test-owned `tuiSourceMetadata` appendix/);
+  assert.match(guide, /fooks inspect-domain <file> --json/);
+  assert.match(guide, /`domainDetection` and `fallbackFirst` as the primary inspect contract/);
+  assert.match(guide, /The next approved artifact is a separate \*\*PRD \+ test-spec pair\*\*/);
+  assert.doesNotMatch(guide, /The next implementation PR may build only a \*\*source-only dry-run\*\*/);
   for (const category of metadataProjectionCategories) {
     assert.ok(guide.includes(category), category);
   }


### PR DESCRIPTION
Closes #624

## Summary
- refresh the TUI readiness/survey docs so they describe the landed debug/test-owned dry-run boundary instead of a future dry-run handoff
- keep the TUI lane candidate/evidence-only while pointing the next step to a PRD + test-spec pair for serialized shared-policy planning
- update the TUI doc guard to lock the new landed-boundary wording and reject the old future-dry-run phrasing

## Contract-doc owner
- Owner: `minislively`

## Merge-order note
- Merge this docs/tests contract refresh first.
- Any future TUI payload/design promotion must start in a separate PRD + test-spec pair after this wording lands.

## Verification
- `git diff --check`
- `npm run lint`
- `node --test test/payload-policy-tui-ink.test.mjs`
- `node --test test/tui-source-metadata.test.mjs`
- `node --test test/fooks.test.mjs`
- `npm test`
