### PR TITLE
Close out stale RN next-step wording after located-anchor hardening

### DIFF
--- a/docs/react-native-source-only-guidance-report.md
+++ b/docs/react-native-source-only-guidance-report.md
@@ -10,6 +10,7 @@ Use this report when reviewing or writing RN-facing docs/tests so the current me
 - That narrow payload evidence is limited to the existing `rn-primitive-input-narrow-payload` policy.
 - `F16`, `F2`, `F9`, and `F10` remain fallback/readiness lanes with source-only concern or boundary metadata.
 - No current RN surface is a broad React Native support claim.
+- Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout/frozen until a new `extract` / `compare` / `inspect-domain` visibility plan is explicitly approved.
 
 ## Slot-by-slot guidance
 

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -85,7 +85,7 @@ function isReactNativeSourceAnchorBetaPayload(value: unknown): value is ReactNat
       "tui-ink",
     ]) &&
     contract.nextImplementationStep ===
-      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates" &&
+      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved" &&
     Boolean(anchors) &&
     anchors?.sourceFingerprintRequired === true &&
     arraysContainValues(anchors?.primitives, ["Pressable", "Text", "TextInput", "View"]) &&

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -71,7 +71,7 @@ export type ReactNativeSourceAnchorBetaContract = {
   sourceDerivedOnly: true;
   anchorKinds: readonly (typeof RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS)[number][];
   fallbackFirstBoundaries: readonly (typeof RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES)[number][];
-  nextImplementationStep: "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates";
+  nextImplementationStep: "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved";
 };
 
 export type ReactNativeSourceAnchorBetaLocatedAnchor = {
@@ -283,7 +283,7 @@ function buildReactNativeSourceAnchorBetaContract(): ReactNativeSourceAnchorBeta
     anchorKinds: [...RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS],
     fallbackFirstBoundaries: [...RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES],
     nextImplementationStep:
-      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
   };
 }
 

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -182,7 +182,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   ]);
   assert.equal(
     payload?.sourceAnchorBeta.contract.nextImplementationStep,
-    "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+    "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
   );
   assert.equal(payload?.sourceAnchorBeta.anchors.componentName, "InlineActionRow");
   assert.equal(payload?.sourceAnchorBeta.anchors.propsName, "InlineActionRowProps");
@@ -945,7 +945,7 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
       "tui-ink",
     ],
     nextImplementationStep:
-      "emit located RN sourceAnchorBeta anchors from existing component/props/hook/handler/primitive evidence before widening detector gates",
+      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
   });
   assert.deepEqual(payload?.sourceAnchorBeta.anchors, {
     componentName: "NativeInput",

--- a/test/react-native-source-only-guidance-report.test.mjs
+++ b/test/react-native-source-only-guidance-report.test.mjs
@@ -14,6 +14,7 @@ test("RN source-only guidance report locks the slot taxonomy boundary", () => {
 
   assert.match(report, /`F1`, `F13`, `F14`, and `F15` are the only RN slots that may emit narrow payload evidence\./);
   assert.match(report, /`F16`, `F2`, `F9`, and `F10` remain fallback\/readiness lanes with source-only concern or boundary metadata\./);
+  assert.match(report, /Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout\/frozen until a new `extract` \/ `compare` \/ `inspect-domain` visibility plan is explicitly approved\./);
   assert.match(report, /`F1` \/ `F13` \/ `F14` \/ `F15` primitive\/input[\s\S]*`rn-primitive-input-narrow-payload`/);
   assert.match(report, /`F16` adjacent inline-callback boundary[\s\S]*alternate action primitives such as `TouchableOpacity` or `Button`/);
   assert.match(report, /`F2` style\/platform\/navigation[\s\S]*Must not claim route existence, navigation success/);


### PR DESCRIPTION
## Why
`main` already absorbed RN located-anchor hardening, but the RN `sourceAnchorBeta` contract still described that completed work as the next implementation step. This PR closes that stale wording gap without opening a new RN capability lane.

## What changed
- updated the RN `sourceAnchorBeta.contract.nextImplementationStep` wording to a post-closeout/freeze message
- aligned the RN profile-gate exact-match contract check
- added a bounded RN guidance note that located-anchor hardening is complete and future visibility work needs an explicit new lane
- aligned exact-match RN tests with the closeout wording

## Scope boundary
- closeout / hardening only
- no `extract` / `compare` / `inspect-domain` visibility expansion
- no new fixture lane
- no detector widening
- no payload-policy widening
- no broad React Native support claim

## Verification
- `npm run build`
- `node --test test/payload-policy-react-native.test.mjs test/react-native-source-only-guidance-report.test.mjs test/react-native-payload-evidence.test.mjs`
- `npm run lint`
- `npm test`
- `git diff --check`

Closes #627
