### PR TITLE
Harden React Web release-facing summary consumption

### DIFF
--- a/.github/workflows/react-web-release-report.yml
+++ b/.github/workflows/react-web-release-report.yml
@@ -1,0 +1,43 @@
+name: React Web Release Report
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-web-release-report:
+    name: Publish React Web release report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate React Web release report
+        run: >-
+          npm run evidence:react-web-release-report -- --run-id=release-${{ github.sha }}
+          --output=$RUNNER_TEMP/react-web-release-report.json
+          --markdown-output=$RUNNER_TEMP/react-web-release-report.md
+
+      - name: Publish step summary
+        run: cat "$RUNNER_TEMP/react-web-release-report.md" >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs",
     "evidence:react-native-readiness": "npm run build && node scripts/react-native-readiness-evidence.mjs",
     "evidence:react-web-pr-advisory": "npm run build && node scripts/react-web-pr-advisory-surface.mjs",
-    "evidence:react-web-pr-gate": "npm run build && node scripts/react-web-pr-gate-surface.mjs"
+    "evidence:react-web-pr-gate": "npm run build && node scripts/react-web-pr-gate-surface.mjs",
+    "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-release-report-surface.mjs
+++ b/scripts/react-web-release-report-surface.mjs
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertReactWebProfileSurfaceContract,
+  buildReactWebProfileSurface,
+  REACT_WEB_PROFILE_ARTIFACT_KEYS,
+} from "./react-web-profile-surface.mjs";
+import {
+  buildReleaseBenchmarkEvidence,
+  buildReleaseBenchmarkSmokeSummary,
+} from "./release-benchmark-evidence.mjs";
+import { assertPublicSurfaceClaimBoundaries } from "./release-claim-guards.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+function assertFalseNonClaim(value, label) {
+  if (value !== false) {
+    throw new Error(`React Web release report contract broken: ${label} widened`);
+  }
+}
+
+export function assertReactWebReleaseReportContract(evidence) {
+  if (evidence?.schemaVersion !== "react-web-release-report-surface.v1") {
+    throw new Error("React Web release report contract broken: schemaVersion is missing or unsupported");
+  }
+  if (evidence?.advisory !== true) {
+    throw new Error("React Web release report contract broken: advisory must stay true");
+  }
+  if (evidence?.status !== "advisory") {
+    throw new Error("React Web release report contract broken: status must stay advisory");
+  }
+  if (evidence?.consumer !== "release") {
+    throw new Error("React Web release report contract broken: consumer must stay on release");
+  }
+  if (evidence?.profile !== "react-web") {
+    throw new Error("React Web release report contract broken: profile must stay on react-web");
+  }
+  if (evidence?.checkName !== "React Web release report") {
+    throw new Error("React Web release report contract broken: checkName changed");
+  }
+  assertReactWebProfileSurfaceContract(evidence?.profileSurface);
+  if (evidence?.releaseBenchmarkEvidence?.schemaVersion !== "release-benchmark-evidence.v1") {
+    throw new Error("React Web release report contract broken: release benchmark schema changed");
+  }
+  if (JSON.stringify(evidence?.summary?.artifactKeys ?? []) !== JSON.stringify(REACT_WEB_PROFILE_ARTIFACT_KEYS)) {
+    throw new Error("React Web release report contract broken: profile surface artifact keys changed");
+  }
+  if (evidence?.summary?.profileArtifactCount !== REACT_WEB_PROFILE_ARTIFACT_KEYS.length) {
+    throw new Error("React Web release report contract broken: profile artifact count changed");
+  }
+  assertFalseNonClaim(evidence?.profileSurface?.claimability?.contextReduction, "profile top-level context reduction");
+  assertFalseNonClaim(evidence?.profileSurface?.claimability?.cachePerformance, "profile cache performance");
+  assertFalseNonClaim(evidence?.profileSurface?.claimability?.providerBillingSavings, "profile provider billing savings");
+  assertFalseNonClaim(
+    evidence?.releaseBenchmarkEvidence?.nonClaims?.cachePerformanceImprovement?.claimable,
+    "release benchmark cache performance non-claims",
+  );
+  assertFalseNonClaim(
+    evidence?.releaseBenchmarkEvidence?.nonClaims?.runtimeTokenSavings?.claimable,
+    "release benchmark runtime-token non-claims",
+  );
+  assertFalseNonClaim(
+    evidence?.releaseBenchmarkEvidence?.nonClaims?.providerBillingSavings?.claimable,
+    "release benchmark provider billing non-claims",
+  );
+  assertFalseNonClaim(evidence?.summary?.nonClaims?.profileTopLevelContextReduction, "summary profile top-level context reduction");
+  assertFalseNonClaim(evidence?.summary?.nonClaims?.cachePerformance, "summary cache performance");
+  assertFalseNonClaim(evidence?.summary?.nonClaims?.runtimeTokenSavings, "summary runtime-token savings");
+  assertFalseNonClaim(evidence?.summary?.nonClaims?.providerBillingSavings, "summary provider billing savings");
+  assertFalseNonClaim(evidence?.summary?.nonClaims?.broadSupport, "summary broad support");
+  if (typeof evidence?.summary?.releaseSafeHeadline !== "string" || evidence.summary.releaseSafeHeadline.trim().length === 0) {
+    throw new Error("React Web release report contract broken: release-safe headline is required");
+  }
+  assertPublicSurfaceClaimBoundaries({
+    "react-web-release-report headline": evidence.summary.releaseSafeHeadline,
+    "react-web-release-report claimBoundary": evidence.claimBoundary,
+    "react-web-release-report markdown": renderReactWebReleaseReportMarkdown(evidence),
+  });
+}
+
+export async function buildReactWebReleaseReportSurface({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const profileSurface = await buildReactWebProfileSurface({ repoRoot, runId: `${runId}-profile` });
+  const releaseBenchmarkEvidence = await buildReleaseBenchmarkEvidence({ repoRoot, runId: `${runId}-release-benchmark` });
+  const releaseBenchmarkSummary = buildReleaseBenchmarkSmokeSummary(releaseBenchmarkEvidence);
+
+  const evidence = {
+    schemaVersion: "react-web-release-report-surface.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    advisory: true,
+    status: "advisory",
+    consumer: "release",
+    profile: "react-web",
+    checkName: "React Web release report",
+    measurement: "release-facing-react-web-consumption-surface",
+    claimBoundary:
+      "Release-facing presentation adapter over the existing bounded React Web profile surface and release-benchmark evidence only. This surface does not create a new evidence lane, does not change merge or release gate policy, and does not prove cache performance, runtime-token savings, provider cost, billing, invoice, charged-cost, or broad frontend support.",
+    profileSurface,
+    releaseBenchmarkEvidence,
+    releaseBenchmarkSummary,
+    summary: {
+      advisoryOnly: true,
+      profileArtifactCount: profileSurface.summary.artifactCount,
+      artifactKeys: profileSurface.summary.artifactKeys,
+      releaseSafeHeadline: releaseBenchmarkSummary.headline,
+      npmUpdateClaimable: releaseBenchmarkSummary.npmUpdateClaimable,
+      releaseProvenanceClaimable: releaseBenchmarkSummary.releaseProvenance.claimable,
+      reactWebOnly: profileSurface.summary.reactWebOnly,
+      profileWarnings: profileSurface.summary.warnings,
+      nonClaims: {
+        profileTopLevelContextReduction: profileSurface.claimability.contextReduction,
+        cachePerformance: releaseBenchmarkEvidence.nonClaims.cachePerformanceImprovement.claimable,
+        runtimeTokenSavings: releaseBenchmarkEvidence.nonClaims.runtimeTokenSavings.claimable,
+        providerBillingSavings: releaseBenchmarkEvidence.nonClaims.providerBillingSavings.claimable,
+        broadSupport: false,
+      },
+    },
+  };
+
+  assertReactWebReleaseReportContract(evidence);
+  return evidence;
+}
+
+export function renderReactWebReleaseReportMarkdown(evidence) {
+  const warnings = evidence.summary.profileWarnings.length > 0 ? evidence.summary.profileWarnings.map((warning) => `- ${warning}`).join("\n") : "- none";
+  return `# React Web release report
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Advisory only: ${evidence.advisory ? "yes" : "no"}
+- Consumer: ${evidence.consumer}
+- Profile: ${evidence.profile}
+- Release-safe headline: ${evidence.summary.releaseSafeHeadline}
+- npm update wording claimable: ${evidence.summary.npmUpdateClaimable ? "yes" : "no"}
+- Release provenance claimable: ${evidence.summary.releaseProvenanceClaimable ? "yes" : "no"}
+- React Web artifact count: ${evidence.summary.profileArtifactCount}
+- Artifact keys: ${evidence.summary.artifactKeys.join(", ")}
+- React Web only: ${evidence.summary.reactWebOnly ? "yes" : "no"}
+
+## Non-claims
+
+- Profile top-level context reduction proof: ${evidence.summary.nonClaims.profileTopLevelContextReduction ? "yes" : "no"}
+- Cache performance proof: ${evidence.summary.nonClaims.cachePerformance ? "yes" : "no"}
+- Runtime-token savings proof: ${evidence.summary.nonClaims.runtimeTokenSavings ? "yes" : "no"}
+- Provider billing/cost savings proof: ${evidence.summary.nonClaims.providerBillingSavings ? "yes" : "no"}
+- Broad React/RN/WebView/TUI support proof: ${evidence.summary.nonClaims.broadSupport ? "yes" : "no"}
+
+## Profile warnings
+
+${warnings}
+
+## Release provenance snapshot
+
+- Status: ${evidence.releaseBenchmarkSummary.releaseProvenance.status}
+- Package: ${evidence.releaseBenchmarkSummary.releaseProvenance.package.name}@${evidence.releaseBenchmarkSummary.releaseProvenance.package.version}
+- Expected tag: ${evidence.releaseBenchmarkSummary.releaseProvenance.package.expectedVersionTag}
+
+This report stays read-only in pass 1. It does not block merge or release, and it does not widen React Web evidence into performance, runtime-token, provider-cost, billing, invoice, charged-cost, or broad-support claims.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebReleaseReportSurface({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebReleaseReportMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-release-report-surface.test.mjs
+++ b/test/react-web-release-report-surface.test.mjs
@@ -1,0 +1,228 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  assertReactWebReleaseReportContract,
+  buildReactWebReleaseReportSurface,
+  renderReactWebReleaseReportMarkdown,
+} from "../scripts/react-web-release-report-surface.mjs";
+
+const repoRoot = process.cwd();
+let evidencePromise;
+
+function getEvidence() {
+  evidencePromise ??= buildReactWebReleaseReportSurface({ runId: `test-${Date.now()}-${Math.random()}` });
+  return evidencePromise;
+}
+
+test("React Web release report surface stays advisory-only over existing bounded release inputs", async () => {
+  const evidence = await getEvidence();
+
+  assert.equal(evidence.schemaVersion, "react-web-release-report-surface.v1");
+  assert.equal(evidence.advisory, true);
+  assert.equal(evidence.status, "advisory");
+  assert.equal(evidence.consumer, "release");
+  assert.equal(evidence.profile, "react-web");
+  assert.equal(evidence.checkName, "React Web release report");
+  assert.match(evidence.claimBoundary, /presentation adapter over the existing bounded React Web profile surface and release-benchmark evidence only/i);
+  assert.match(evidence.claimBoundary, /does not create a new evidence lane/i);
+  assert.match(evidence.claimBoundary, /does not change merge or release gate policy/i);
+  assert.match(evidence.claimBoundary, /does not prove cache performance, runtime-token savings, provider cost, billing/i);
+
+  assert.equal(evidence.profileSurface.schemaVersion, "react-web-profile-surface.v1");
+  assert.deepEqual(Object.keys(evidence.profileSurface.artifacts), [
+    "context",
+    "reuse",
+    "overCachingAudit",
+    "stability",
+    "mixedRouting",
+    "knowledgeContext",
+  ]);
+  assert.deepEqual(evidence.profileSurface.claimability, {
+    contextReduction: false,
+    cachePerformance: false,
+    providerBillingSavings: false,
+  });
+
+  assert.equal(evidence.releaseBenchmarkEvidence.schemaVersion, "release-benchmark-evidence.v1");
+  assert.equal(evidence.releaseBenchmarkSummary.npmUpdateClaimable, true);
+  assert.match(evidence.summary.releaseSafeHeadline, /React Web same-file reuse is routed correctly/);
+  assert.equal(evidence.summary.profileArtifactCount, 6);
+  assert.deepEqual(evidence.summary.artifactKeys, [
+    "context",
+    "reuse",
+    "overCachingAudit",
+    "stability",
+    "mixedRouting",
+    "knowledgeContext",
+  ]);
+  assert.equal(evidence.summary.nonClaims.profileTopLevelContextReduction, false);
+  assert.equal(evidence.summary.nonClaims.cachePerformance, false);
+  assert.equal(evidence.summary.nonClaims.runtimeTokenSavings, false);
+  assert.equal(evidence.summary.nonClaims.providerBillingSavings, false);
+  assert.equal(evidence.summary.nonClaims.broadSupport, false);
+});
+
+test("React Web release report markdown keeps release-facing wording and explicit non-claims", async () => {
+  const evidence = await getEvidence();
+  const markdown = renderReactWebReleaseReportMarkdown(evidence);
+
+  assert.match(markdown, /# React Web release report/);
+  assert.match(markdown, /Advisory only: yes/);
+  assert.match(markdown, /Consumer: release/);
+  assert.match(markdown, /Release-safe headline:/);
+  assert.match(markdown, /Cache performance proof: no/);
+  assert.match(markdown, /Runtime-token savings proof: no/);
+  assert.match(markdown, /Provider billing\/cost savings proof: no/);
+  assert.match(markdown, /Broad React\/RN\/WebView\/TUI support proof: no/);
+  assert.match(markdown, /does not block merge or release/i);
+  assert.doesNotMatch(markdown, /Cache performance proof: yes/i);
+});
+
+test("React Web release report contract fails closed on malformed upstream inputs", () => {
+  assert.throws(
+    () =>
+      assertReactWebReleaseReportContract({
+        schemaVersion: "react-web-release-report-surface.v1",
+        advisory: true,
+        status: "advisory",
+        consumer: "release",
+        profile: "react-web",
+        checkName: "React Web release report",
+        claimBoundary: "boundary",
+        profileSurface: {
+          schemaVersion: "react-web-profile-surface.v1",
+          profile: "react-web",
+          artifacts: { context: {} },
+          summary: { artifactCount: 1, artifactKeys: ["context"] },
+          claimability: {
+            contextReduction: false,
+            cachePerformance: false,
+            providerBillingSavings: false,
+          },
+        },
+        releaseBenchmarkEvidence: {
+          schemaVersion: "release-benchmark-evidence.v1",
+          nonClaims: {
+            cachePerformanceImprovement: { claimable: false },
+            runtimeTokenSavings: { claimable: false },
+            providerBillingSavings: { claimable: false },
+          },
+        },
+        summary: {
+          artifactKeys: ["context"],
+          profileArtifactCount: 1,
+          releaseSafeHeadline: "headline",
+          nonClaims: {
+            profileTopLevelContextReduction: false,
+            cachePerformance: false,
+            runtimeTokenSavings: false,
+            providerBillingSavings: false,
+            broadSupport: false,
+          },
+        },
+      }),
+    /artifact keys changed/,
+  );
+
+  assert.throws(
+    () =>
+      assertReactWebReleaseReportContract({
+        schemaVersion: "react-web-release-report-surface.v1",
+        advisory: true,
+        status: "advisory",
+        consumer: "release",
+        profile: "react-web",
+        checkName: "React Web release report",
+        claimBoundary: "boundary",
+        profileSurface: {
+          schemaVersion: "react-web-profile-surface.v1",
+          profile: "react-web",
+          artifacts: {
+            context: {},
+            reuse: {},
+            overCachingAudit: {},
+            stability: {},
+            mixedRouting: {},
+            knowledgeContext: {},
+          },
+          summary: {
+            artifactCount: 6,
+            artifactKeys: ["context", "reuse", "overCachingAudit", "stability", "mixedRouting", "knowledgeContext"],
+          },
+          claimability: {
+            contextReduction: false,
+            cachePerformance: false,
+            providerBillingSavings: false,
+          },
+        },
+        releaseBenchmarkEvidence: {
+          schemaVersion: "release-benchmark-evidence.v1",
+          nonClaims: {
+            cachePerformanceImprovement: { claimable: true },
+            runtimeTokenSavings: { claimable: false },
+            providerBillingSavings: { claimable: false },
+          },
+        },
+        summary: {
+          artifactKeys: ["context", "reuse", "overCachingAudit", "stability", "mixedRouting", "knowledgeContext"],
+          profileArtifactCount: 6,
+          releaseSafeHeadline: "headline",
+          nonClaims: {
+            profileTopLevelContextReduction: false,
+            cachePerformance: false,
+            runtimeTokenSavings: false,
+            providerBillingSavings: false,
+            broadSupport: false,
+          },
+        },
+      }),
+    /release benchmark cache performance non-claims widened/,
+  );
+});
+
+test("React Web release report CLI writes bounded JSON and Markdown reports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-release-report-"));
+  const outputPath = path.join(tempDir, "react-web-release-report.json");
+  const markdownPath = path.join(tempDir, "react-web-release-report.md");
+
+  const cli = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts", "react-web-release-report-surface.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+
+  const stdoutEvidence = JSON.parse(cli.stdout);
+  const fileEvidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+
+  assert.equal(stdoutEvidence.runId, "cli-test");
+  assert.equal(stdoutEvidence.status, "advisory");
+  assert.equal(stdoutEvidence.consumer, "release");
+  assert.deepEqual(stdoutEvidence.summary.artifactKeys, [
+    "context",
+    "reuse",
+    "overCachingAudit",
+    "stability",
+    "mixedRouting",
+    "knowledgeContext",
+  ]);
+  assert.deepEqual(fileEvidence, stdoutEvidence);
+  assert.match(markdown, /# React Web release report/);
+  assert.match(markdown, /does not block merge or release/i);
+});

--- a/test/react-web-release-report-workflow.test.mjs
+++ b/test/react-web-release-report-workflow.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "react-web-release-report.yml");
+const packageJsonPath = path.join(repoRoot, "package.json");
+
+test("React Web release report workflow is release-facing and invokes the package script", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  assert.match(workflow, /^name: React Web Release Report/m);
+  assert.match(workflow, /push:\s+[\s\S]*branches:\s+[\s\S]*- main/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /pull_request_target:/);
+  assert.match(workflow, /contents: read/);
+  assert.match(workflow, /npm ci/);
+  assert.match(workflow, /npm run evidence:react-web-release-report -- --run-id=release-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+  assert.doesNotMatch(workflow, /assertReleaseBenchmarkSmokeGate/);
+  assert.doesNotMatch(workflow, /validate-pr-merge-gate/);
+
+  assert.equal(
+    pkg.scripts["evidence:react-web-release-report"],
+    "npm run build && node scripts/react-web-release-report-surface.mjs",
+  );
+});


### PR DESCRIPTION
## Summary
- add a bounded React Web release-report surface over the existing profile + release-benchmark artifacts
- add a release-facing advisory workflow that publishes the safe summary without changing gate semantics
- lock the new consumer with contract, CLI, and workflow tests

## Verification
- git diff --check
- npm run build
- node --test test/react-web-release-report-surface.test.mjs test/react-web-release-report-workflow.test.mjs
- npm run evidence:react-web-release-report -- --run-id=verify
- npm run lint
- npm test

Closes #628