### PR TITLE
Expose RN located-anchor proof on weak CLI surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ No. opencode support is a project-local `fooks_extract` tool and `/fooks-extract
 
 The strongest path today is repeated same-file React `.tsx` / `.jsx` work in Codex. Unsupported or unsafe cases fall back to normal full-source behavior.
 
-React Native and embedded WebView files are not supported today. Treat `.tsx` parsing as syntax-level eligibility only; it is not evidence that fooks understands RN primitives, native platform semantics, bridge behavior, or WebView boundaries.
+React Native and embedded WebView files are not supported today. Treat `.tsx` parsing as syntax-level eligibility only; it is not evidence that fooks understands RN primitives, native platform semantics, bridge behavior, or WebView boundaries. For the measured RN primitive/input narrow lane only, `fooks compare <file> --json` and `fooks inspect-domain <file> --json` may expose the existing `sourceAnchorBeta` located-anchor proof as local evidence; that appendix is not extract expansion, runtime reuse promotion, edit routing, or broad RN support.
 
 ## Everyday commands
 

--- a/docs/react-native-source-only-guidance-report.md
+++ b/docs/react-native-source-only-guidance-report.md
@@ -10,7 +10,7 @@ Use this report when reviewing or writing RN-facing docs/tests so the current me
 - That narrow payload evidence is limited to the existing `rn-primitive-input-narrow-payload` policy.
 - `F16`, `F2`, `F9`, and `F10` remain fallback/readiness lanes with source-only concern or boundary metadata.
 - No current RN surface is a broad React Native support claim.
-- Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout/frozen until a new `extract` / `compare` / `inspect-domain` visibility plan is explicitly approved.
+- Located-anchor hardening is already complete; RN `sourceAnchorBeta` remains closeout/frozen. The weak proof surfaces `compare --json` and `inspect-domain --json` may show that existing located-anchor proof for the measured narrow lane only; this does not change extraction, detector breadth, payload policy, runtime reuse, or the `sourceAnchorBeta` contract meaning.
 
 ## Slot-by-slot guidance
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ExtractionResult } from "../core/schema";
+import type { ReactNativeSourceAnchorBetaPayload } from "../core/payload/domain-payload";
 
 function print(value: unknown): void {
   console.log(JSON.stringify(value));
@@ -715,6 +716,16 @@ type InspectDomainCliResult = {
     applies: boolean;
     reason?: string;
   };
+  reactNativeSourceAnchorBeta?: {
+    schemaVersion: "rn-source-anchor-beta-visibility.v1";
+    proofSurface: "inspect-domain";
+    claimBoundary: "rn-primitive-input-narrow-payload-only";
+    nonEmitting: true;
+    modelFacingPayload: false;
+    runtimeOrPreRead: false;
+    sourceAnchorBeta: ReactNativeSourceAnchorBetaPayload;
+    warnings: string[];
+  };
   tuiSourceMetadata?: {
     schemaVersion: 1;
     mode: "source-only-dry-run";
@@ -775,6 +786,7 @@ function buildInspectDomainResult(options: {
   cwd: string;
   detection: { classification: string; evidence: Array<{ domain: string; signal: string; detail: string }> };
   json: boolean;
+  reactNativeSourceAnchorBeta?: NonNullable<InspectDomainCliResult["reactNativeSourceAnchorBeta"]>;
   tuiSourceMetadata?: NonNullable<InspectDomainCliResult["tuiSourceMetadata"]>;
 }): InspectDomainCliResult {
   const relative = path.relative(options.cwd, options.filePath) || path.basename(options.filePath);
@@ -791,6 +803,9 @@ function buildInspectDomainResult(options: {
       ? { applies: true, reason: "unsupported-react-native-webview-boundary" }
       : { applies: false },
   };
+  if (options.json && options.reactNativeSourceAnchorBeta) {
+    result.reactNativeSourceAnchorBeta = options.reactNativeSourceAnchorBeta;
+  }
   if (options.json && options.tuiSourceMetadata) {
     result.tuiSourceMetadata = options.tuiSourceMetadata;
   }
@@ -1115,13 +1130,43 @@ async function run(): Promise<void> {
     }
 
     case "inspect-domain": {
-      const [{ detectDomainFromSource }, { projectTuiSourceMetadataDryRun }] = await Promise.all([
+      const [
+        { detectDomainFromSource },
+        { projectTuiSourceMetadataDryRun },
+        { extractFile },
+        { toModelFacingPayload },
+        { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions },
+      ] = await Promise.all([
         import("../core/domain-detector.js"),
         import("../core/tui-source-metadata.js"),
+        import("../core/extract.js"),
+        import("../core/payload/model-facing.js"),
+        import("../core/payload-policy/registry.js"),
       ]);
       const { filePath: file, json } = parseCompareArgs(rest);
       const sourceText = fs.readFileSync(file, "utf8");
       const detection = detectDomainFromSource(sourceText, file);
+      const extracted = json ? extractFile(file) : undefined;
+      const frontendPayloadPolicy = extracted?.domainDetection ? assessFrontendPayloadPolicy(extracted.domainDetection) : undefined;
+      const domainPayload = extracted
+        ? toModelFacingPayload(extracted, process.cwd(), {
+            includeEditGuidance: false,
+            ...toFrontendPayloadBuildOptions(frontendPayloadPolicy),
+          }).domainPayload
+        : undefined;
+      const reactNativeSourceAnchorBeta =
+        domainPayload?.domain === "react-native"
+          ? {
+              schemaVersion: "rn-source-anchor-beta-visibility.v1" as const,
+              proofSurface: "inspect-domain" as const,
+              claimBoundary: domainPayload.claimBoundary,
+              nonEmitting: true as const,
+              modelFacingPayload: false as const,
+              runtimeOrPreRead: false as const,
+              sourceAnchorBeta: domainPayload.sourceAnchorBeta,
+              warnings: domainPayload.warnings,
+            }
+          : undefined;
       const tuiSourceMetadata =
         json && hasTuiInkEvidence(detection.evidence)
           ? toInspectDomainTuiSourceMetadata(
@@ -1132,7 +1177,7 @@ async function run(): Promise<void> {
               }),
             )
           : undefined;
-      print(buildInspectDomainResult({ filePath: file, cwd: process.cwd(), detection, json, tuiSourceMetadata }));
+      print(buildInspectDomainResult({ filePath: file, cwd: process.cwd(), detection, json, reactNativeSourceAnchorBeta, tuiSourceMetadata }));
       return;
     }
     case "attach": {

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,5 +1,7 @@
 import { extractFile } from "./extract";
 import { toModelFacingPayload } from "./payload/model-facing";
+import type { ReactNativeSourceAnchorBetaPayload } from "./payload/domain-payload";
+import { assessFrontendPayloadPolicy, toFrontendPayloadBuildOptions } from "./payload-policy/registry";
 import {
   FOOKS_METRIC_CLAIM_BOUNDARY,
   FOOKS_SESSION_METRIC_TIER,
@@ -23,6 +25,14 @@ export type FooksCompareUserSummary = {
 
 export type FooksCompareReactWebContextSummary = ReactWebContextSummary;
 
+export type FooksCompareReactNativeSourceAnchorBetaVisibility = {
+  schemaVersion: "rn-source-anchor-beta-visibility.v1";
+  proofSurface: "compare";
+  claimBoundary: "rn-primitive-input-narrow-payload-only";
+  sourceAnchorBeta: ReactNativeSourceAnchorBetaPayload;
+  warnings: string[];
+};
+
 export type FooksCompareResult = {
   filePath: string;
   mode: OutputMode;
@@ -38,6 +48,7 @@ export type FooksCompareResult = {
   payloadLarger: boolean;
   nonSavingReason?: "original-source-preserved-for-small-raw-file" | "model-facing-payload-not-smaller";
   reactWebContextSummary?: FooksCompareReactWebContextSummary;
+  reactNativeSourceAnchorBeta?: FooksCompareReactNativeSourceAnchorBetaVisibility;
   metricTier: typeof FOOKS_SESSION_METRIC_TIER;
   measurement: "local-model-facing-payload";
   excludes: string[];
@@ -112,11 +123,19 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
   const extracted = extractFile(filePath);
   const payload = toModelFacingPayload(extracted, cwd);
   const useOriginal = extracted.useOriginal === true;
-  const contextPayload = toModelFacingPayload(extracted, cwd, {
-    includeDomainPayload: true,
-    includeReactWebContextMetadata: true,
-  });
+  const frontendPayloadPolicy = extracted.domainDetection ? assessFrontendPayloadPolicy(extracted.domainDetection) : undefined;
+  const contextPayload = toModelFacingPayload(extracted, cwd, toFrontendPayloadBuildOptions(frontendPayloadPolicy));
   const reactWebContextSummary = reactWebContextSummaryFor(contextPayload, useOriginal);
+  const reactNativeSourceAnchorBeta =
+    contextPayload.domainPayload?.domain === "react-native"
+      ? {
+          schemaVersion: "rn-source-anchor-beta-visibility.v1" as const,
+          proofSurface: "compare" as const,
+          claimBoundary: contextPayload.domainPayload.claimBoundary,
+          sourceAnchorBeta: contextPayload.domainPayload.sourceAnchorBeta,
+          warnings: contextPayload.domainPayload.warnings,
+        }
+      : undefined;
   const sourceBytes = extracted.meta.rawSizeBytes;
   const modelFacingBytes = estimateTextBytes(JSON.stringify(payload));
   const estimatedSourceTokens = estimateTokensFromBytes(sourceBytes);
@@ -141,6 +160,7 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
     payloadLarger,
     ...(payloadLarger || useOriginal ? { nonSavingReason: nonSavingReason(useOriginal, payloadLarger) } : {}),
     ...(reactWebContextSummary ? { reactWebContextSummary } : {}),
+    ...(reactNativeSourceAnchorBeta ? { reactNativeSourceAnchorBeta } : {}),
     metricTier: FOOKS_SESSION_METRIC_TIER,
     measurement: "local-model-facing-payload",
     excludes: [

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -392,6 +392,42 @@ test("CLI inspect-domain keeps mixed TUI evidence top-level while preserving dom
   assert.equal("tuiSourceMetadata" in result.domainDetection, false);
 });
 
+
+test("CLI inspect-domain JSON exposes bounded RN sourceAnchorBeta located-anchor proof", () => {
+  const fixture = path.join(fixtureRoot, "rn-primitive-inline-action.tsx");
+  const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(cli.status, 0, cli.stderr);
+  const result = JSON.parse(cli.stdout);
+
+  assert.equal(result.command, "inspect-domain");
+  assert.equal(result.domainDetection.classification, "react-native");
+  assert.deepEqual(result.fallbackFirst, { applies: false });
+  assert.equal(result.reactNativeSourceAnchorBeta.schemaVersion, "rn-source-anchor-beta-visibility.v1");
+  assert.equal(result.reactNativeSourceAnchorBeta.proofSurface, "inspect-domain");
+  assert.equal(result.reactNativeSourceAnchorBeta.nonEmitting, true);
+  assert.equal(result.reactNativeSourceAnchorBeta.modelFacingPayload, false);
+  assert.equal(result.reactNativeSourceAnchorBeta.runtimeOrPreRead, false);
+  assert.equal(result.reactNativeSourceAnchorBeta.claimBoundary, "rn-primitive-input-narrow-payload-only");
+  assert.equal(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.contractVersion, "rn-source-anchor-beta.v0");
+  assert.deepEqual(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.runtimeReusePromotion, "not-promoted");
+  assert.deepEqual(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.anchors.locatedAnchors, [
+    { kind: "component-name", label: "InlineActionRow", loc: { startLine: 9, endLine: 30 } },
+    { kind: "props-interface", label: "InlineActionRowProps", loc: { startLine: 3, endLine: 7 } },
+    { kind: "event-handlers", label: "onChangeText:onChangeText", loc: { startLine: 19, endLine: 19 } },
+    { kind: "event-handlers", label: "onPress:submitCurrentValue", loc: { startLine: 25, endLine: 25 } },
+    { kind: "rn-primitive-outline", label: "TextInput", loc: { startLine: 16, endLine: 24 } },
+    { kind: "rn-primitive-outline", label: "Pressable", loc: { startLine: 25, endLine: 25 } },
+  ]);
+  assert.equal("domainPayload" in result, false);
+  assert.equal("tuiSourceMetadata" in result, false);
+  assert.doesNotMatch(JSON.stringify(result.reactNativeSourceAnchorBeta), forbiddenSupportClaims);
+});
+
 test("CLI inspect-domain keeps non-WebView fixture output as evidence-only non-fallback inspection", () => {
   const fixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
   const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture], {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -622,6 +622,31 @@ test("compare reports local estimated model-facing payload reduction", () => {
   assert.ok(result.excludes.includes("optional-edit-guidance-overhead"));
 });
 
+
+test("compare JSON exposes bounded RN sourceAnchorBeta located-anchor proof", () => {
+  const result = run(["compare", "test/fixtures/frontend-domain-expectations/rn-primitive-inline-action.tsx", "--json"]);
+
+  assert.equal(result.filePath, path.join("test", "fixtures", "frontend-domain-expectations", "rn-primitive-inline-action.tsx"));
+  assert.equal(result.reactNativeSourceAnchorBeta.schemaVersion, "rn-source-anchor-beta-visibility.v1");
+  assert.equal(result.reactNativeSourceAnchorBeta.proofSurface, "compare");
+  assert.equal(result.reactNativeSourceAnchorBeta.claimBoundary, "rn-primitive-input-narrow-payload-only");
+  assert.equal(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.contractVersion, "rn-source-anchor-beta.v0");
+  assert.deepEqual(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.contract.runtimeReusePromotion, "not-promoted");
+  assert.deepEqual(result.reactNativeSourceAnchorBeta.sourceAnchorBeta.anchors.locatedAnchors, [
+    { kind: "component-name", label: "InlineActionRow", loc: { startLine: 9, endLine: 30 } },
+    { kind: "props-interface", label: "InlineActionRowProps", loc: { startLine: 3, endLine: 7 } },
+    { kind: "event-handlers", label: "onChangeText:onChangeText", loc: { startLine: 19, endLine: 19 } },
+    { kind: "event-handlers", label: "onPress:submitCurrentValue", loc: { startLine: 25, endLine: 25 } },
+    { kind: "rn-primitive-outline", label: "TextInput", loc: { startLine: 16, endLine: 24 } },
+    { kind: "rn-primitive-outline", label: "Pressable", loc: { startLine: 25, endLine: 25 } },
+  ]);
+  assert.match(JSON.stringify(result.reactNativeSourceAnchorBeta.warnings), /local-proof beta contract only/);
+  assert.equal("domainPayload" in result, false);
+  assert.equal("reactWebContextSummary" in result, false);
+  assert.doesNotMatch(JSON.stringify(result.reactNativeSourceAnchorBeta), /runtimeReusePromotion":"promoted|React Native support is available|editTargetRouting/i);
+});
+
 test("compare keeps tiny raw fallback from reporting false positive savings", () => {
   const result = run(["compare", "fixtures/raw/SimpleButton.tsx", "--json"]);
   assert.equal(result.filePath, path.join("fixtures", "raw", "SimpleButton.tsx"));

--- a/test/react-native-source-only-guidance-report.test.mjs
+++ b/test/react-native-source-only-guidance-report.test.mjs
@@ -14,7 +14,9 @@ test("RN source-only guidance report locks the slot taxonomy boundary", () => {
 
   assert.match(report, /`F1`, `F13`, `F14`, and `F15` are the only RN slots that may emit narrow payload evidence\./);
   assert.match(report, /`F16`, `F2`, `F9`, and `F10` remain fallback\/readiness lanes with source-only concern or boundary metadata\./);
-  assert.match(report, /Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout\/frozen until a new `extract` \/ `compare` \/ `inspect-domain` visibility plan is explicitly approved\./);
+  assert.match(report, /Located-anchor hardening is already complete; RN `sourceAnchorBeta` remains closeout\/frozen\./);
+  assert.match(report, /`compare --json` and `inspect-domain --json` may show that existing located-anchor proof for the measured narrow lane only/);
+  assert.match(report, /does not change extraction, detector breadth, payload policy, runtime reuse, or the `sourceAnchorBeta` contract meaning/);
   assert.match(report, /`F1` \/ `F13` \/ `F14` \/ `F15` primitive\/input[\s\S]*`rn-primitive-input-narrow-payload`/);
   assert.match(report, /`F16` adjacent inline-callback boundary[\s\S]*alternate action primitives such as `TouchableOpacity` or `Button`/);
   assert.match(report, /`F2` style\/platform\/navigation[\s\S]*Must not claim route existence, navigation success/);


### PR DESCRIPTION
## Linked issue

Fixes #631

## Summary

- Add bounded `reactNativeSourceAnchorBeta` JSON visibility to `fooks compare` for the existing measured RN primitive/input narrow lane.
- Add matching `inspect-domain --json` visibility that reuses the existing `sourceAnchorBeta` located anchors while marking it non-emitting and not runtime/pre-read.
- Keep docs/tests explicit that this is local located-anchor proof only, not extract expansion, detector widening, payload-policy widening, runtime reuse, edit routing, or broad RN support.

## Verification

- `npm test`
- Targeted before full suite: `npm run build && node --test test/fooks.test.mjs test/domain-detector.test.mjs test/react-native-payload-evidence.test.mjs test/payload-policy-react-native.test.mjs test/payload-policy-profile-gate.test.mjs`

## Review gate

- [ ] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.
