### PR TITLE
Expose bounded RN located-anchor visibility on compare and inspect-domain

### DIFF
--- a/docs/react-native-source-only-guidance-report.md
+++ b/docs/react-native-source-only-guidance-report.md
@@ -10,7 +10,7 @@ Use this report when reviewing or writing RN-facing docs/tests so the current me
 - That narrow payload evidence is limited to the existing `rn-primitive-input-narrow-payload` policy.
 - `F16`, `F2`, `F9`, and `F10` remain fallback/readiness lanes with source-only concern or boundary metadata.
 - No current RN surface is a broad React Native support claim.
-- Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout/frozen until a new `extract` / `compare` / `inspect-domain` visibility plan is explicitly approved.
+- Located-anchor hardening is already complete, and `extract` / `compare` / `inspect-domain` may expose additive local-proof-only RN `sourceAnchorBeta` visibility. Any further runtime-reuse or support widening still requires a new explicit plan.
 
 ## Slot-by-slot guidance
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ExtractionResult } from "../core/schema";
+import type { InspectDomainReactNativeSourceAnchorBeta } from "../core/react-native-proof-surface";
 
 function print(value: unknown): void {
   console.log(JSON.stringify(value));
@@ -730,6 +731,7 @@ type InspectDomainCliResult = {
     terminalMixedBoundaryEvidence: string[];
     omittedRuntimeSemantics: string[];
   };
+  reactNativeSourceAnchorBeta?: InspectDomainReactNativeSourceAnchorBeta;
 };
 
 function hasWebViewEvidence(evidence: Array<{ domain: string }>): boolean {
@@ -776,6 +778,7 @@ function buildInspectDomainResult(options: {
   detection: { classification: string; evidence: Array<{ domain: string; signal: string; detail: string }> };
   json: boolean;
   tuiSourceMetadata?: NonNullable<InspectDomainCliResult["tuiSourceMetadata"]>;
+  reactNativeSourceAnchorBeta?: InspectDomainCliResult["reactNativeSourceAnchorBeta"];
 }): InspectDomainCliResult {
   const relative = path.relative(options.cwd, options.filePath) || path.basename(options.filePath);
   const webViewFallbackFirst = hasWebViewEvidence(options.detection.evidence);
@@ -793,6 +796,9 @@ function buildInspectDomainResult(options: {
   };
   if (options.json && options.tuiSourceMetadata) {
     result.tuiSourceMetadata = options.tuiSourceMetadata;
+  }
+  if (options.json && options.reactNativeSourceAnchorBeta) {
+    result.reactNativeSourceAnchorBeta = options.reactNativeSourceAnchorBeta;
   }
   return result;
 }
@@ -1115,9 +1121,20 @@ async function run(): Promise<void> {
     }
 
     case "inspect-domain": {
-      const [{ detectDomainFromSource }, { projectTuiSourceMetadataDryRun }] = await Promise.all([
+      const [
+        { detectDomainFromSource },
+        { projectTuiSourceMetadataDryRun },
+        { extractFile },
+        { toModelFacingPayload },
+        { assessFrontendPayloadPolicy },
+        { inspectDomainReactNativeSourceAnchorBetaFor },
+      ] = await Promise.all([
         import("../core/domain-detector.js"),
         import("../core/tui-source-metadata.js"),
+        import("../core/extract.js"),
+        import("../core/payload/model-facing.js"),
+        import("../core/payload-policy/registry.js"),
+        import("../core/react-native-proof-surface.js"),
       ]);
       const { filePath: file, json } = parseCompareArgs(rest);
       const sourceText = fs.readFileSync(file, "utf8");
@@ -1132,7 +1149,29 @@ async function run(): Promise<void> {
               }),
             )
           : undefined;
-      print(buildInspectDomainResult({ filePath: file, cwd: process.cwd(), detection, json, tuiSourceMetadata }));
+      const reactNativeSourceAnchorBeta =
+        json && detection.classification === "react-native"
+          ? (() => {
+              const extracted = extractFile(file);
+              const frontendPayloadPolicy = extracted.domainDetection
+                ? assessFrontendPayloadPolicy(extracted.domainDetection)
+                : undefined;
+              return inspectDomainReactNativeSourceAnchorBetaFor(
+                toModelFacingPayload(extracted, process.cwd(), {
+                  includeDomainPayload: true,
+                  ...(frontendPayloadPolicy ? { domainPayloadPolicy: frontendPayloadPolicy.name } : {}),
+                }),
+              );
+            })()
+          : undefined;
+      print(buildInspectDomainResult({
+        filePath: file,
+        cwd: process.cwd(),
+        detection,
+        json,
+        tuiSourceMetadata,
+        reactNativeSourceAnchorBeta,
+      }));
       return;
     }
     case "attach": {

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,5 +1,6 @@
 import { extractFile } from "./extract";
 import { toModelFacingPayload } from "./payload/model-facing";
+import { assessFrontendPayloadPolicy } from "./payload-policy/registry";
 import {
   FOOKS_METRIC_CLAIM_BOUNDARY,
   FOOKS_SESSION_METRIC_TIER,
@@ -12,6 +13,11 @@ import {
   reactWebContextSummaryFor,
   type ReactWebContextSummary,
 } from "./react-web-context-summary";
+import {
+  formatReactNativeSourceAnchorBetaSummary,
+  reactNativeSourceAnchorBetaSummaryFor,
+  type ReactNativeSourceAnchorBetaSummary,
+} from "./react-native-proof-surface";
 
 export const FOOKS_COMPARE_CLAIM_BOUNDARY = `${FOOKS_METRIC_CLAIM_BOUNDARY} Compare values are local model-facing payload estimates, not provider tokenizer output, not runtime hook envelope overhead, and not provider invoice/dashboard/charged-cost proof.`;
 
@@ -22,6 +28,7 @@ export type FooksCompareUserSummary = {
 };
 
 export type FooksCompareReactWebContextSummary = ReactWebContextSummary;
+export type FooksCompareReactNativeSourceAnchorBetaSummary = ReactNativeSourceAnchorBetaSummary;
 
 export type FooksCompareResult = {
   filePath: string;
@@ -38,6 +45,7 @@ export type FooksCompareResult = {
   payloadLarger: boolean;
   nonSavingReason?: "original-source-preserved-for-small-raw-file" | "model-facing-payload-not-smaller";
   reactWebContextSummary?: FooksCompareReactWebContextSummary;
+  reactNativeSourceAnchorBetaSummary?: FooksCompareReactNativeSourceAnchorBetaSummary;
   metricTier: typeof FOOKS_SESSION_METRIC_TIER;
   measurement: "local-model-facing-payload";
   excludes: string[];
@@ -92,6 +100,9 @@ export function formatCompare(result: FooksCompareResult): string {
   const reactWebContextLine = result.reactWebContextSummary
     ? formatReactWebContextSummary(result.reactWebContextSummary)
     : undefined;
+  const reactNativeVisibilityLine = result.reactNativeSourceAnchorBetaSummary
+    ? formatReactNativeSourceAnchorBetaSummary(result.reactNativeSourceAnchorBetaSummary)
+    : undefined;
   const lines = [
     `fooks compare ${result.filePath}`,
     "",
@@ -100,6 +111,7 @@ export function formatCompare(result: FooksCompareResult): string {
     `Mode: ${result.mode}${result.useOriginal ? " (original source preserved)" : ""}`,
     proofLine,
     ...(reactWebContextLine ? [reactWebContextLine] : []),
+    ...(reactNativeVisibilityLine ? [reactNativeVisibilityLine] : []),
     `Next action: ${result.userSummary.nextAction}`,
     "",
     "Boundary: Local model-facing payload estimate only; not provider tokenizer output, billing tokens, invoices, dashboards, or charged costs.",
@@ -112,11 +124,18 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
   const extracted = extractFile(filePath);
   const payload = toModelFacingPayload(extracted, cwd);
   const useOriginal = extracted.useOriginal === true;
+  const frontendPayloadPolicy = extracted.domainDetection
+    ? assessFrontendPayloadPolicy(extracted.domainDetection)
+    : undefined;
   const contextPayload = toModelFacingPayload(extracted, cwd, {
     includeDomainPayload: true,
     includeReactWebContextMetadata: true,
+    ...(frontendPayloadPolicy ? { domainPayloadPolicy: frontendPayloadPolicy.name } : {}),
   });
-  const reactWebContextSummary = reactWebContextSummaryFor(contextPayload, useOriginal);
+  const reactWebContextSummary = contextPayload.domainPayload?.domain === "react-web"
+    ? reactWebContextSummaryFor(contextPayload, useOriginal)
+    : undefined;
+  const reactNativeSourceAnchorBetaSummary = reactNativeSourceAnchorBetaSummaryFor(contextPayload);
   const sourceBytes = extracted.meta.rawSizeBytes;
   const modelFacingBytes = estimateTextBytes(JSON.stringify(payload));
   const estimatedSourceTokens = estimateTokensFromBytes(sourceBytes);
@@ -141,6 +160,7 @@ export function compareModelFacingPayload(filePath: string, cwd = process.cwd())
     payloadLarger,
     ...(payloadLarger || useOriginal ? { nonSavingReason: nonSavingReason(useOriginal, payloadLarger) } : {}),
     ...(reactWebContextSummary ? { reactWebContextSummary } : {}),
+    ...(reactNativeSourceAnchorBetaSummary ? { reactNativeSourceAnchorBetaSummary } : {}),
     metricTier: FOOKS_SESSION_METRIC_TIER,
     measurement: "local-model-facing-payload",
     excludes: [

--- a/src/core/payload-policy/profile-gate.ts
+++ b/src/core/payload-policy/profile-gate.ts
@@ -85,7 +85,7 @@ function isReactNativeSourceAnchorBetaPayload(value: unknown): value is ReactNat
       "tui-ink",
     ]) &&
     contract.nextImplementationStep ===
-      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved" &&
+      "keep RN sourceAnchorBeta visibility additive and local-proof-only across extract/compare/inspect-domain; require a new explicit plan before any further runtime-reuse or support widening" &&
     Boolean(anchors) &&
     anchors?.sourceFingerprintRequired === true &&
     arraysContainValues(anchors?.primitives, ["Pressable", "Text", "TextInput", "View"]) &&

--- a/src/core/payload/domain-payload.ts
+++ b/src/core/payload/domain-payload.ts
@@ -71,7 +71,7 @@ export type ReactNativeSourceAnchorBetaContract = {
   sourceDerivedOnly: true;
   anchorKinds: readonly (typeof RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS)[number][];
   fallbackFirstBoundaries: readonly (typeof RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES)[number][];
-  nextImplementationStep: "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved";
+  nextImplementationStep: "keep RN sourceAnchorBeta visibility additive and local-proof-only across extract/compare/inspect-domain; require a new explicit plan before any further runtime-reuse or support widening";
 };
 
 export type ReactNativeSourceAnchorBetaLocatedAnchor = {
@@ -283,7 +283,7 @@ function buildReactNativeSourceAnchorBetaContract(): ReactNativeSourceAnchorBeta
     anchorKinds: [...RN_SOURCE_ANCHOR_BETA_ANCHOR_KINDS],
     fallbackFirstBoundaries: [...RN_SOURCE_ANCHOR_BETA_FALLBACK_FIRST_BOUNDARIES],
     nextImplementationStep:
-      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
+      "keep RN sourceAnchorBeta visibility additive and local-proof-only across extract/compare/inspect-domain; require a new explicit plan before any further runtime-reuse or support widening",
   };
 }
 

--- a/src/core/react-native-proof-surface.ts
+++ b/src/core/react-native-proof-surface.ts
@@ -1,0 +1,93 @@
+import type { ReactNativeSourceAnchorBetaPayload } from "./payload/domain-payload";
+import type { ModelFacingPayload } from "./schema";
+
+export const RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY = "source-backed-rn-located-anchor-visibility-only" as const;
+
+export type ReactNativeSourceAnchorBetaSummary = {
+  present: true;
+  schemaVersion: typeof RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY;
+  proofSurface: "compare";
+  contractVersion: ReactNativeSourceAnchorBetaPayload["contract"]["contractVersion"];
+  scope: ReactNativeSourceAnchorBetaPayload["contract"]["scope"];
+  runtimeReusePromotion: ReactNativeSourceAnchorBetaPayload["contract"]["runtimeReusePromotion"];
+  allowedProofSurfaces: string[];
+  componentName?: string;
+  propsName?: string;
+  hookCount: number;
+  eventHandlerCount: number;
+  primitiveCount: number;
+  jsxPropCount: number;
+  locatedAnchorCount: number;
+  locatedAnchorPreview: Array<{
+    kind: ReactNativeSourceAnchorBetaPayload["anchors"]["locatedAnchors"][number]["kind"];
+    label: string;
+  }>;
+  claimBoundary: typeof RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY;
+};
+
+export type InspectDomainReactNativeSourceAnchorBeta = {
+  schemaVersion: 1;
+  proofSurface: "inspect-domain";
+  contractVersion: ReactNativeSourceAnchorBetaPayload["contract"]["contractVersion"];
+  scope: ReactNativeSourceAnchorBetaPayload["contract"]["scope"];
+  runtimeReusePromotion: ReactNativeSourceAnchorBetaPayload["contract"]["runtimeReusePromotion"];
+  sourceDerivedOnly: true;
+  allowedProofSurfaces: string[];
+  claimBoundary: typeof RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY;
+  anchors: ReactNativeSourceAnchorBetaPayload["anchors"];
+};
+
+function sourceAnchorBetaFrom(payload: ModelFacingPayload): ReactNativeSourceAnchorBetaPayload | undefined {
+  if (payload.domainPayload?.domain !== "react-native") return undefined;
+  return payload.domainPayload.sourceAnchorBeta;
+}
+
+export function reactNativeSourceAnchorBetaSummaryFor(payload: ModelFacingPayload): ReactNativeSourceAnchorBetaSummary | undefined {
+  const sourceAnchorBeta = sourceAnchorBetaFrom(payload);
+  if (!sourceAnchorBeta || !sourceAnchorBeta.contract.allowedProofSurfaces.includes("compare")) return undefined;
+
+  return {
+    present: true,
+    schemaVersion: RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY,
+    proofSurface: "compare",
+    contractVersion: sourceAnchorBeta.contract.contractVersion,
+    scope: sourceAnchorBeta.contract.scope,
+    runtimeReusePromotion: sourceAnchorBeta.contract.runtimeReusePromotion,
+    allowedProofSurfaces: [...sourceAnchorBeta.contract.allowedProofSurfaces],
+    ...(sourceAnchorBeta.anchors.componentName ? { componentName: sourceAnchorBeta.anchors.componentName } : {}),
+    ...(sourceAnchorBeta.anchors.propsName ? { propsName: sourceAnchorBeta.anchors.propsName } : {}),
+    hookCount: sourceAnchorBeta.anchors.hooks?.length ?? 0,
+    eventHandlerCount: sourceAnchorBeta.anchors.eventHandlers?.length ?? 0,
+    primitiveCount: sourceAnchorBeta.anchors.primitives.length,
+    jsxPropCount: sourceAnchorBeta.anchors.jsxProps.length,
+    locatedAnchorCount: sourceAnchorBeta.anchors.locatedAnchors.length,
+    locatedAnchorPreview: sourceAnchorBeta.anchors.locatedAnchors.slice(0, 5).map((anchor) => ({
+      kind: anchor.kind,
+      label: anchor.label,
+    })),
+    claimBoundary: RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY,
+  };
+}
+
+export function formatReactNativeSourceAnchorBetaSummary(summary: ReactNativeSourceAnchorBetaSummary): string {
+  return `RN visibility: ${summary.locatedAnchorCount} local-proof-only located anchors across ${summary.primitiveCount} primitives / ${summary.jsxPropCount} JSX props; additive compare summary only, not runtime or support proof (see --json).`;
+}
+
+export function inspectDomainReactNativeSourceAnchorBetaFor(
+  payload: ModelFacingPayload,
+): InspectDomainReactNativeSourceAnchorBeta | undefined {
+  const sourceAnchorBeta = sourceAnchorBetaFrom(payload);
+  if (!sourceAnchorBeta || !sourceAnchorBeta.contract.allowedProofSurfaces.includes("inspect-domain")) return undefined;
+
+  return {
+    schemaVersion: 1,
+    proofSurface: "inspect-domain",
+    contractVersion: sourceAnchorBeta.contract.contractVersion,
+    scope: sourceAnchorBeta.contract.scope,
+    runtimeReusePromotion: sourceAnchorBeta.contract.runtimeReusePromotion,
+    sourceDerivedOnly: true,
+    allowedProofSurfaces: [...sourceAnchorBeta.contract.allowedProofSurfaces],
+    claimBoundary: RN_SOURCE_ANCHOR_VISIBILITY_CLAIM_BOUNDARY,
+    anchors: sourceAnchorBeta.anchors,
+  };
+}

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -354,23 +354,59 @@ test("CLI inspect-domain exposes top-level TUI source metadata only on JSON TUI 
   assert.doesNotMatch(JSON.stringify(result), forbiddenSupportClaims);
 });
 
-test("CLI inspect-domain keeps TUI source metadata out of unflagged and non-TUI paths", () => {
+test("CLI inspect-domain exposes bounded RN sourceAnchorBeta visibility only on JSON RN paths", () => {
+  const fixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
+  const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(cli.status, 0, cli.stderr);
+  const result = JSON.parse(cli.stdout);
+
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "inspect-domain");
+  assert.equal(result.filePath, path.relative(repoRoot, fixture));
+  assert.deepEqual(Object.keys(result.domainDetection).sort(), ["classification", "evidence"]);
+  assert.equal(result.domainDetection.classification, "react-native");
+  assert.deepEqual(result.fallbackFirst, { applies: false });
+  assert.ok(result.reactNativeSourceAnchorBeta);
+  assert.equal(result.reactNativeSourceAnchorBeta.schemaVersion, 1);
+  assert.equal(result.reactNativeSourceAnchorBeta.proofSurface, "inspect-domain");
+  assert.equal(result.reactNativeSourceAnchorBeta.contractVersion, "rn-source-anchor-beta.v0");
+  assert.equal(result.reactNativeSourceAnchorBeta.scope, "local-proof-only");
+  assert.equal(result.reactNativeSourceAnchorBeta.runtimeReusePromotion, "not-promoted");
+  assert.equal(result.reactNativeSourceAnchorBeta.sourceDerivedOnly, true);
+  assert.deepEqual(result.reactNativeSourceAnchorBeta.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(result.reactNativeSourceAnchorBeta.claimBoundary, "source-backed-rn-located-anchor-visibility-only");
+  assert.equal(result.reactNativeSourceAnchorBeta.anchors.componentName, "SearchRow");
+  assert.equal(result.reactNativeSourceAnchorBeta.anchors.propsName, "SearchRowProps");
+  assert.ok(result.reactNativeSourceAnchorBeta.anchors.locatedAnchors.some((item) => item.kind === "rn-primitive-outline" && item.label === "TextInput"));
+  assert.equal("reactNativeSourceAnchorBeta" in result.domainDetection, false);
+  assert.doesNotMatch(JSON.stringify(result.reactNativeSourceAnchorBeta), forbiddenSupportClaims);
+});
+
+test("CLI inspect-domain keeps TUI metadata out of unflagged and non-TUI paths while allowing RN appendix on JSON RN paths", () => {
   const tuiFixture = path.join(fixtureRoot, "tui-ink-basic.tsx");
-  const nonTuiFixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
+  const rnFixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
 
-  for (const args of [
-    ["inspect-domain", tuiFixture],
-    ["inspect-domain", nonTuiFixture, "--json"],
-  ]) {
-    const cli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), ...args], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    });
+  const tuiCli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", tuiFixture], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(tuiCli.status, 0, tuiCli.stderr);
+  const tuiResult = JSON.parse(tuiCli.stdout);
+  assert.equal("tuiSourceMetadata" in tuiResult, false);
+  assert.equal("reactNativeSourceAnchorBeta" in tuiResult, false);
 
-    assert.equal(cli.status, 0, cli.stderr);
-    const result = JSON.parse(cli.stdout);
-    assert.equal("tuiSourceMetadata" in result, false);
-  }
+  const rnCli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", rnFixture, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(rnCli.status, 0, rnCli.stderr);
+  const rnResult = JSON.parse(rnCli.stdout);
+  assert.equal("tuiSourceMetadata" in rnResult, false);
+  assert.ok(rnResult.reactNativeSourceAnchorBeta);
 });
 
 test("CLI inspect-domain keeps mixed TUI evidence top-level while preserving domainDetection shape", () => {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -639,6 +639,29 @@ test("compare keeps tiny raw fallback from reporting false positive savings", ()
   assert.match(result.claimBoundary, /not provider usage\/billing tokens/);
 });
 
+test("compare exposes bounded RN located-anchor visibility only on RN JSON surfaces", () => {
+  const rn = run(["compare", "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx", "--json"]);
+  const web = run(["compare", "fixtures/compressed/FormSection.tsx", "--json"]);
+
+  assert.ok(rn.reactNativeSourceAnchorBetaSummary);
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.proofSurface, "compare");
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.schemaVersion, "source-backed-rn-located-anchor-visibility-only");
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.contractVersion, "rn-source-anchor-beta.v0");
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.scope, "local-proof-only");
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.runtimeReusePromotion, "not-promoted");
+  assert.deepEqual(rn.reactNativeSourceAnchorBetaSummary.allowedProofSurfaces, ["extract", "compare", "inspect-domain"]);
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.componentName, "SearchRow");
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.propsName, "SearchRowProps");
+  assert.ok(rn.reactNativeSourceAnchorBetaSummary.primitiveCount >= 4);
+  assert.ok(rn.reactNativeSourceAnchorBetaSummary.jsxPropCount >= 2);
+  assert.ok(rn.reactNativeSourceAnchorBetaSummary.locatedAnchorCount > 0);
+  assert.ok(rn.reactNativeSourceAnchorBetaSummary.locatedAnchorPreview.some((item) => item.kind === "rn-primitive-outline"));
+  assert.equal(rn.reactNativeSourceAnchorBetaSummary.claimBoundary, "source-backed-rn-located-anchor-visibility-only");
+  assert.equal("reactWebContextSummary" in rn, false);
+  assert.equal("reactNativeSourceAnchorBetaSummary" in web, false);
+  assert.doesNotMatch(JSON.stringify(rn.reactNativeSourceAnchorBetaSummary), /broad React Native support|runtime correctness|billing/i);
+});
+
 test("compare default output is a concise human verdict with json details opt-in", () => {
   const output = runText(["compare", "fixtures/compressed/FormSection.tsx"]);
   assert.match(output, /^fooks compare fixtures\/compressed\/FormSection\.tsx/m);
@@ -652,6 +675,14 @@ test("compare default output is a concise human verdict with json details opt-in
   assert.match(output, /Boundary: Local model-facing payload estimate only/);
   assert.match(output, /fooks compare <file> --json/);
   assert.doesNotMatch(output.trim(), /^\{/);
+});
+
+test("compare default output can mention bounded RN visibility without widening claims", () => {
+  const output = runText(["compare", "test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx"]);
+  assert.match(output, /RN visibility: \d+ local-proof-only located anchors across \d+ primitives \/ \d+ JSX props/);
+  assert.match(output, /additive compare summary only, not runtime or support proof/);
+  assert.doesNotMatch(output, /React Web context:/);
+  assert.doesNotMatch(output, /broad React Native support|runtime correctness|billing savings/i);
 });
 
 test("compare default output avoids reduction claims for no-savings files", () => {

--- a/test/payload-policy-react-native.test.mjs
+++ b/test/payload-policy-react-native.test.mjs
@@ -182,7 +182,7 @@ test("React Native F13 inline action fixture remains inside the narrow payload l
   ]);
   assert.equal(
     payload?.sourceAnchorBeta.contract.nextImplementationStep,
-    "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
+    "keep RN sourceAnchorBeta visibility additive and local-proof-only across extract/compare/inspect-domain; require a new explicit plan before any further runtime-reuse or support widening",
   );
   assert.equal(payload?.sourceAnchorBeta.anchors.componentName, "InlineActionRow");
   assert.equal(payload?.sourceAnchorBeta.anchors.propsName, "InlineActionRowProps");
@@ -945,7 +945,7 @@ test("React Native F1 signal gate is the shared source of truth for policy and p
       "tui-ink",
     ],
     nextImplementationStep:
-      "treat RN sourceAnchorBeta as closeout/frozen after located-anchor hardening until a new extract/compare/inspect-domain visibility plan is explicitly approved",
+      "keep RN sourceAnchorBeta visibility additive and local-proof-only across extract/compare/inspect-domain; require a new explicit plan before any further runtime-reuse or support widening",
   });
   assert.deepEqual(payload?.sourceAnchorBeta.anchors, {
     componentName: "NativeInput",

--- a/test/react-native-source-only-guidance-report.test.mjs
+++ b/test/react-native-source-only-guidance-report.test.mjs
@@ -14,7 +14,8 @@ test("RN source-only guidance report locks the slot taxonomy boundary", () => {
 
   assert.match(report, /`F1`, `F13`, `F14`, and `F15` are the only RN slots that may emit narrow payload evidence\./);
   assert.match(report, /`F16`, `F2`, `F9`, and `F10` remain fallback\/readiness lanes with source-only concern or boundary metadata\./);
-  assert.match(report, /Located-anchor hardening is already complete; RN `sourceAnchorBeta` should now be treated as closeout\/frozen until a new `extract` \/ `compare` \/ `inspect-domain` visibility plan is explicitly approved\./);
+  assert.match(report, /Located-anchor hardening is already complete, and `extract` \/ `compare` \/ `inspect-domain` may expose additive local-proof-only RN `sourceAnchorBeta` visibility\./);
+  assert.match(report, /Any further runtime-reuse or support widening still requires a new explicit plan\./);
   assert.match(report, /`F1` \/ `F13` \/ `F14` \/ `F15` primitive\/input[\s\S]*`rn-primitive-input-narrow-payload`/);
   assert.match(report, /`F16` adjacent inline-callback boundary[\s\S]*alternate action primitives such as `TouchableOpacity` or `Button`/);
   assert.match(report, /`F2` style\/platform\/navigation[\s\S]*Must not claim route existence, navigation success/);


### PR DESCRIPTION
## Why

`extract --model-payload --json` already exposed RN `sourceAnchorBeta` / located-anchor proof, but `compare` and `inspect-domain` still lagged behind that visibility. This PR makes those weaker surfaces explicit without generating new proof or widening RN support claims.

Closes #631.

## What changed

- added a small RN proof-surface projector for additive local-proof-only visibility
- surfaced bounded RN located-anchor summary data on `fooks compare`
- surfaced bounded RN `sourceAnchorBeta` appendix data on `fooks inspect-domain --json`
- updated RN closeout/guidance wording to reflect that compare/inspect visibility is now implemented while broader widening still requires a new plan
- added focused regression coverage for compare, inspect-domain, and RN contract wording

## Scope boundary

- reuse existing RN proof only
- no `extract` expansion
- no new RN fixtures
- no detector widening
- no payload-policy widening
- no broad React Native support/runtime-correctness claim

## Verification

- `npm run build`
- `node --test test/fooks.test.mjs test/domain-detector.test.mjs test/payload-policy-react-native.test.mjs test/react-native-source-only-guidance-report.test.mjs`
- `node dist/cli/index.js compare test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx --json`
- `node dist/cli/index.js inspect-domain test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx --json`
- `npm run lint`
- `npm test`
- `git diff --check`
