### PR TITLE
Add React Web evidence artifact schema and inspect surface

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -20,6 +20,7 @@ import {
   recordFooksSessionMetricEventSafe,
 } from "../core/session-metrics";
 import { finalizeWorktreeEvidenceSafe, initializeWorktreeEvidenceSafe } from "../core/worktree-evidence";
+import { emitReactWebEvidenceArtifact } from "../core/react-web-evidence-artifact";
 
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
@@ -331,6 +332,35 @@ function fallbackDecision(
   };
 }
 
+function attachReactWebEvidenceArtifact(
+  cwd: string,
+  runtimeDecision: CodexRuntimeHookDecision,
+): CodexRuntimeHookDecision {
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  try {
+    const artifact = emitReactWebEvidenceArtifact(cwd, runtimeDecision);
+    if (artifact) {
+      runtimeDecision.debug = {
+        ...debug,
+        reactWebEvidenceArtifact: artifact,
+      };
+    }
+  } catch (error) {
+    runtimeDecision.debug = {
+      ...debug,
+      reactWebEvidenceArtifact: {
+        emitted: false,
+        reason: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+  return runtimeDecision;
+}
+
 export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = process.cwd()): CodexRuntimeHookDecision {
   const hookEventName = input.hookEventName;
   const sessionKey = resolveCodexRuntimeSessionKey(input.sessionId, input.threadId);
@@ -568,7 +598,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       actualEstimatedBytes: estimateTextBytes(additionalContext),
       comparableForSavings: editGuidanceIncluded ? false : originalEstimatedBytes !== undefined,
     });
-    return runtimeDecision;
+    return attachReactWebEvidenceArtifact(cwd, runtimeDecision);
   }
 
   markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
@@ -589,5 +619,5 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     actualEstimatedBytes: originalEstimatedBytes,
     comparableForSavings: originalEstimatedBytes !== undefined,
   });
-  return runtimeDecision;
+  return attachReactWebEvidenceArtifact(cwd, runtimeDecision);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -625,7 +625,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|run|scan|extract|compare|decide|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|run|scan|extract|compare|decide|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -641,6 +641,7 @@ Everyday commands:
   ${displayCliName} run <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
+  ${displayCliName} inspect evidence <id> [--json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
@@ -701,6 +702,29 @@ function parseCompareArgs(args: string[]): { filePath: string; json: boolean } {
   }
 
   return { filePath: requireFilePath(filePath), json };
+}
+
+function parseInspectEvidenceArgs(args: string[]): { id: string; json: boolean } {
+  let id: string | undefined;
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!id) {
+      id = arg;
+      continue;
+    }
+    throw new Error(`Unexpected inspect evidence argument: ${arg}`);
+  }
+
+  if (!id) {
+    throw new Error("inspect evidence requires an artifact id");
+  }
+
+  return { id, json };
 }
 
 type InspectDomainCliResult = {
@@ -1133,6 +1157,20 @@ async function run(): Promise<void> {
             )
           : undefined;
       print(buildInspectDomainResult({ filePath: file, cwd: process.cwd(), detection, json, tuiSourceMetadata }));
+      return;
+    }
+    case "inspect": {
+      if (arg1 !== "evidence") {
+        throw new Error("inspect expects 'evidence'");
+      }
+      const { id, json } = parseInspectEvidenceArgs(rest.slice(1));
+      const { readReactWebEvidenceArtifact, renderReactWebEvidenceArtifactMarkdown } = await import("../core/react-web-evidence-artifact.js");
+      const artifact = readReactWebEvidenceArtifact(process.cwd(), id);
+      if (json) {
+        print(artifact);
+      } else {
+        process.stdout.write(renderReactWebEvidenceArtifactMarkdown(artifact));
+      }
       return;
     }
     case "attach": {

--- a/src/core/react-web-evidence-artifact.ts
+++ b/src/core/react-web-evidence-artifact.ts
@@ -1,0 +1,331 @@
+import fs from "node:fs";
+import path from "node:path";
+import { hashText } from "./hash";
+import { canonicalProjectDataDir, sanitizeDataKey } from "./paths";
+import type { CodexRuntimeHookDecision, ContextMode, ModelFacingPayload, SourceRange, SourceFingerprint } from "./schema";
+
+export const REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION = "react-web-evidence-artifact.v1";
+export const REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER = "fooks";
+export const REACT_WEB_EVIDENCE_ARTIFACT_PROFILE = "react-web";
+export const REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND = "frontend-source-evidence";
+export const REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY = "do-not-summarize";
+export const REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY =
+  "Local React Web repeated same-file source-context evidence only: captures why fooks used, fell back, or denied a bounded React Web source payload. This artifact is not a generic context-manager memory surface, not RN/TUI/WebView support promotion, and not runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost proof.";
+
+export type ReactWebEvidenceArtifactDecision = "use" | "fallback" | "deny";
+export type ReactWebEvidenceArtifactStrength = "direct" | "adjacent" | "weak" | "denied";
+
+export type ReactWebEvidenceArtifactFile = {
+  path: string;
+  symbols: string[];
+  lineRanges: string[];
+  whySelected: string[];
+};
+
+export type ReactWebEvidenceArtifact = {
+  schemaVersion: typeof REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION;
+  id: string;
+  generatedAt: string;
+  producer: typeof REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER;
+  profile: typeof REACT_WEB_EVIDENCE_ARTIFACT_PROFILE;
+  payloadKind: typeof REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND;
+  runtime: "codex";
+  hookEventName: "UserPromptSubmit";
+  decision: ReactWebEvidenceArtifactDecision;
+  evidenceStrength: ReactWebEvidenceArtifactStrength;
+  filePath: string;
+  reasons: string[];
+  whyDenied: string[];
+  claimBoundary: typeof REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY;
+  compressionPolicy: typeof REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY;
+  contextMode?: ContextMode;
+  contextModeReason?: string;
+  sourceFingerprint?: SourceFingerprint;
+  freshness: {
+    sourceFingerprint?: SourceFingerprint;
+    staleWhen: string[];
+  };
+  files: ReactWebEvidenceArtifactFile[];
+  editGuidance?: ModelFacingPayload["editGuidance"];
+  concernProfiles?: ModelFacingPayload["concernProfiles"];
+  domainPayload?: ModelFacingPayload["domainPayload"];
+};
+
+export type ReactWebEvidenceArtifactRef = {
+  emitted: true;
+  id: string;
+  path: string;
+};
+
+type ReactWebEvidenceArtifactIndex = {
+  schemaVersion: 1;
+  latest: {
+    id: string;
+    path: string;
+    generatedAt: string;
+    filePath: string;
+    decision: ReactWebEvidenceArtifactDecision;
+    evidenceStrength: ReactWebEvidenceArtifactStrength;
+  };
+};
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function toLineRange(loc: SourceRange | undefined): string | undefined {
+  if (!loc) return undefined;
+  return `${loc.startLine}-${loc.endLine}`;
+}
+
+function addRange(target: string[], loc: SourceRange | undefined): void {
+  const range = toLineRange(loc);
+  if (range) target.push(range);
+}
+
+function hasDeniedBoundary(reason: string | undefined, classification: string | undefined): boolean {
+  return reason === "unsupported-react-native-webview-boundary" || (classification !== undefined && classification !== "react-web");
+}
+
+function artifactDecision(runtimeDecision: CodexRuntimeHookDecision, classification: string | undefined): ReactWebEvidenceArtifactDecision {
+  if (runtimeDecision.action === "inject") {
+    return "use";
+  }
+  return hasDeniedBoundary(runtimeDecision.fallback?.reason, classification) ? "deny" : "fallback";
+}
+
+function evidenceStrength(decision: ReactWebEvidenceArtifactDecision, classification: string | undefined): ReactWebEvidenceArtifactStrength {
+  if (decision === "use") return "direct";
+  if (decision === "deny") return "denied";
+  return classification === "react-web" ? "adjacent" : "weak";
+}
+
+function buildWhySelected(runtimeDecision: CodexRuntimeHookDecision, payload: ModelFacingPayload | undefined): string[] {
+  const reasons = [...runtimeDecision.reasons];
+  if (runtimeDecision.debug?.repeatedFile) {
+    reasons.push("repeated-same-file-runtime-decision");
+  }
+  if (runtimeDecision.promptSpecificity === "exact-file") {
+    reasons.push("exact-file-prompt-target");
+  }
+  if (runtimeDecision.contextModeReason) {
+    reasons.push(runtimeDecision.contextModeReason);
+  }
+  if (payload?.domainPayload?.domain === "react-web") {
+    reasons.push(`react-web-domain-payload:${payload.domainPayload.policy}`);
+  }
+  if (payload?.editGuidance?.patchTargets?.length) {
+    reasons.push("sourceFingerprint-matched-editGuidance");
+  }
+  return uniqueSorted(reasons);
+}
+
+function buildWhyDenied(runtimeDecision: CodexRuntimeHookDecision, classification: string | undefined): string[] {
+  const whyDenied = [
+    runtimeDecision.fallback?.reason,
+    ...runtimeDecision.reasons,
+    classification && classification !== "react-web" ? `unsupported-classification:${classification}` : undefined,
+  ];
+  return uniqueSorted(whyDenied.filter(Boolean) as string[]);
+}
+
+function buildFileEntry(filePath: string, payload: ModelFacingPayload | undefined, whySelected: string[]): ReactWebEvidenceArtifactFile {
+  const symbols = uniqueSorted([
+    payload?.componentName,
+    payload?.contract?.propsName,
+    ...(payload?.exports ?? []).map((item) => item.name),
+  ].filter(Boolean) as string[]);
+
+  const lineRanges: string[] = [];
+  addRange(lineRanges, payload?.componentLoc);
+  addRange(lineRanges, payload?.contract?.propsLoc);
+  for (const target of payload?.editGuidance?.patchTargets ?? []) {
+    addRange(lineRanges, target.loc);
+  }
+
+  return {
+    path: filePath,
+    symbols,
+    lineRanges: uniqueSorted(lineRanges),
+    whySelected,
+  };
+}
+
+function staleWhen(payload: ModelFacingPayload | undefined): string[] {
+  const warnings = [
+    "sourceFingerprint.fileHash changes",
+    "sourceFingerprint.lineCount changes",
+    ...(payload?.domainPayload?.domain === "react-native" ? payload.domainPayload.reuseContract.staleWhen : []),
+  ];
+  return uniqueSorted(warnings);
+}
+
+function evidenceArtifactId(seed: {
+  filePath: string;
+  sourceFingerprint?: SourceFingerprint;
+  decision: ReactWebEvidenceArtifactDecision;
+  reasons: string[];
+  fallbackReason?: string;
+}): string {
+  const hash = hashText(JSON.stringify(seed)).slice(0, 16);
+  return sanitizeDataKey(`react-web-evidence-${hash}`);
+}
+
+export function reactWebEvidenceArtifactsDir(cwd = process.cwd()): string {
+  return path.join(canonicalProjectDataDir(cwd), "artifacts", "react-web-evidence");
+}
+
+export function reactWebEvidenceArtifactPath(cwd: string, id: string): string {
+  return path.join(reactWebEvidenceArtifactsDir(cwd), `${sanitizeDataKey(id)}.json`);
+}
+
+function reactWebEvidenceLatestPath(cwd: string): string {
+  return path.join(reactWebEvidenceArtifactsDir(cwd), "latest.json");
+}
+
+function assertValidArtifact(artifact: unknown): asserts artifact is ReactWebEvidenceArtifact {
+  if (!artifact || typeof artifact !== "object") {
+    throw new Error("React Web evidence artifact is missing or invalid");
+  }
+  const candidate = artifact as Partial<ReactWebEvidenceArtifact>;
+  if (candidate.schemaVersion !== REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION) {
+    throw new Error("React Web evidence artifact schemaVersion is missing or unsupported");
+  }
+  if (candidate.producer !== REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER) {
+    throw new Error("React Web evidence artifact producer changed");
+  }
+  if (candidate.profile !== REACT_WEB_EVIDENCE_ARTIFACT_PROFILE) {
+    throw new Error("React Web evidence artifact profile changed");
+  }
+  if (candidate.payloadKind !== REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND) {
+    throw new Error("React Web evidence artifact payloadKind changed");
+  }
+  if (candidate.compressionPolicy !== REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY) {
+    throw new Error("React Web evidence artifact compressionPolicy changed");
+  }
+}
+
+export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookDecision): ReactWebEvidenceArtifact | null {
+  if (runtimeDecision.runtime !== "codex") return null;
+  if (runtimeDecision.hookEventName !== "UserPromptSubmit") return null;
+  if (runtimeDecision.action !== "inject" && runtimeDecision.action !== "fallback") return null;
+  if (!runtimeDecision.debug?.repeatedFile) return null;
+  if (runtimeDecision.promptSpecificity !== "exact-file") return null;
+
+  const payload = runtimeDecision.debug.decision?.payload;
+  const classification = runtimeDecision.debug.decision?.debug?.domainDetection?.classification ?? payload?.domainPayload?.domain;
+  const filePath = runtimeDecision.filePath ?? payload?.filePath;
+  if (!filePath) return null;
+
+  const decision = artifactDecision(runtimeDecision, classification);
+  const whySelected = buildWhySelected(runtimeDecision, payload);
+  const generatedAt = new Date().toISOString();
+  const id = evidenceArtifactId({
+    filePath,
+    sourceFingerprint: payload?.sourceFingerprint,
+    decision,
+    reasons: runtimeDecision.reasons,
+    fallbackReason: runtimeDecision.fallback?.reason,
+  });
+
+  return {
+    schemaVersion: REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+    id,
+    generatedAt,
+    producer: REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
+    profile: REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
+    payloadKind: REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND,
+    runtime: "codex",
+    hookEventName: "UserPromptSubmit",
+    decision,
+    evidenceStrength: evidenceStrength(decision, classification),
+    filePath,
+    reasons: [...runtimeDecision.reasons],
+    whyDenied: decision === "use" ? [] : buildWhyDenied(runtimeDecision, classification),
+    claimBoundary: REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+    compressionPolicy: REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+    ...(runtimeDecision.contextMode ? { contextMode: runtimeDecision.contextMode } : {}),
+    ...(runtimeDecision.contextModeReason ? { contextModeReason: runtimeDecision.contextModeReason } : {}),
+    ...(payload?.sourceFingerprint ? { sourceFingerprint: payload.sourceFingerprint } : {}),
+    freshness: {
+      ...(payload?.sourceFingerprint ? { sourceFingerprint: payload.sourceFingerprint } : {}),
+      staleWhen: staleWhen(payload),
+    },
+    files: [buildFileEntry(filePath, payload, whySelected)],
+    ...(payload?.editGuidance ? { editGuidance: payload.editGuidance } : {}),
+    ...(payload?.concernProfiles ? { concernProfiles: payload.concernProfiles } : {}),
+    ...(payload?.domainPayload ? { domainPayload: payload.domainPayload } : {}),
+  };
+}
+
+export function writeReactWebEvidenceArtifact(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebEvidenceArtifactRef {
+  assertValidArtifact(artifact);
+  const root = reactWebEvidenceArtifactsDir(cwd);
+  fs.mkdirSync(root, { recursive: true });
+  const artifactPath = reactWebEvidenceArtifactPath(cwd, artifact.id);
+  fs.writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+
+  const latest: ReactWebEvidenceArtifactIndex = {
+    schemaVersion: 1,
+    latest: {
+      id: artifact.id,
+      path: artifactPath,
+      generatedAt: artifact.generatedAt,
+      filePath: artifact.filePath,
+      decision: artifact.decision,
+      evidenceStrength: artifact.evidenceStrength,
+    },
+  };
+  fs.writeFileSync(reactWebEvidenceLatestPath(cwd), `${JSON.stringify(latest, null, 2)}\n`);
+  return { emitted: true, id: artifact.id, path: artifactPath };
+}
+
+export function emitReactWebEvidenceArtifact(cwd: string, runtimeDecision: CodexRuntimeHookDecision): ReactWebEvidenceArtifactRef | null {
+  const artifact = buildReactWebEvidenceArtifact(runtimeDecision);
+  if (!artifact) return null;
+  return writeReactWebEvidenceArtifact(cwd, artifact);
+}
+
+function resolveArtifactPath(cwd: string, id: string): string {
+  if (id === "latest") {
+    const latestPath = reactWebEvidenceLatestPath(cwd);
+    if (!fs.existsSync(latestPath)) {
+      throw new Error("React Web evidence artifact not found: latest");
+    }
+    const parsed = JSON.parse(fs.readFileSync(latestPath, "utf8")) as ReactWebEvidenceArtifactIndex;
+    return parsed.latest?.path ?? reactWebEvidenceArtifactPath(cwd, id);
+  }
+  return reactWebEvidenceArtifactPath(cwd, id);
+}
+
+export function readReactWebEvidenceArtifact(cwd: string, id: string): ReactWebEvidenceArtifact {
+  const artifactPath = resolveArtifactPath(cwd, id);
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(`React Web evidence artifact not found: ${id}`);
+  }
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8")) as ReactWebEvidenceArtifact;
+  assertValidArtifact(artifact);
+  return artifact;
+}
+
+export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenceArtifact): string {
+  assertValidArtifact(artifact);
+  const fileLines = artifact.files
+    .map((file) => [
+      `### ${file.path}`,
+      `- Symbols: ${file.symbols.length > 0 ? file.symbols.join(", ") : "none"}`,
+      `- Line ranges: ${file.lineRanges.length > 0 ? file.lineRanges.join(", ") : "none"}`,
+      `- Why selected: ${file.whySelected.length > 0 ? file.whySelected.join(", ") : "none"}`,
+    ].join("\n"))
+    .join("\n\n");
+
+  const patchTargets = artifact.editGuidance?.patchTargets?.length
+    ? artifact.editGuidance.patchTargets.map((target) => `- ${target.kind}: ${target.label} (${target.loc.startLine}-${target.loc.endLine}) — ${target.reason}`).join("\n")
+    : "- none";
+  const concernProfiles = artifact.concernProfiles?.length
+    ? artifact.concernProfiles.map((profile) => `- ${profile.id}`).join("\n")
+    : "- none";
+  const whyDenied = artifact.whyDenied.length > 0 ? artifact.whyDenied.map((reason) => `- ${reason}`).join("\n") : "- none";
+
+  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -716,6 +716,12 @@ export type CodexRuntimeHookDecision = {
     eligible: boolean;
     escapeHatchUsed: boolean;
     decision?: PreReadDecision;
+    reactWebEvidenceArtifact?: {
+      emitted: boolean;
+      id?: string;
+      path?: string;
+      reason?: string;
+    };
     reactWebContextPacking?: {
       included: boolean;
       reason: "packed" | "not-emitted";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3488,6 +3488,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks setup/);
   assert.match(help, /fooks doctor \[codex\|claude\] \[--json\]/);
   assert.match(help, /fooks compare <file> \[--json\]/);
+  assert.match(help, /fooks inspect evidence <id> \[--json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status artifacts/);

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -1,0 +1,124 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+  readReactWebEvidenceArtifact,
+  renderReactWebEvidenceArtifactMarkdown,
+} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function writeFixture(tempDir, fixturePath, fileName) {
+  fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
+}
+
+function runRepeatedDecision(tempDir, fileName, secondPrompt) {
+  const sessionId = `react-web-evidence-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Please inspect ${fileName}` }, tempDir);
+  const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  return second;
+}
+
+test("repeated React Web inject emits a schema-first evidence artifact and inspect surfaces can read it", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-evidence-artifact-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+
+  assert.equal(second.action, "inject");
+  const ref = second.debug?.reactWebEvidenceArtifact;
+  assert.equal(ref?.emitted, true);
+  assert.ok(ref?.id);
+  assert.ok(fs.existsSync(ref.path));
+
+  const artifact = readReactWebEvidenceArtifact(tempDir, ref.id);
+  assert.equal(artifact.schemaVersion, REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION);
+  assert.equal(artifact.id, ref.id);
+  assert.equal(artifact.producer, "fooks");
+  assert.equal(artifact.profile, "react-web");
+  assert.equal(artifact.payloadKind, "frontend-source-evidence");
+  assert.equal(artifact.decision, "use");
+  assert.equal(artifact.evidenceStrength, "direct");
+  assert.equal(artifact.compressionPolicy, "do-not-summarize");
+  assert.equal(artifact.domainPayload?.domain, "react-web");
+  assert.ok(artifact.sourceFingerprint);
+  assert.ok(artifact.editGuidance?.patchTargets?.length > 0);
+  assert.ok(artifact.files[0].whySelected.includes("exact-file-prompt-target"));
+  assert.equal("confidence" in artifact, false);
+  assert.equal("confidenceScore" in artifact, false);
+
+  const latest = readReactWebEvidenceArtifact(tempDir, "latest");
+  assert.equal(latest.id, artifact.id);
+
+  const markdown = renderReactWebEvidenceArtifactMarkdown(artifact);
+  assert.match(markdown, /React Web evidence artifact/);
+  assert.match(markdown, /do-not-summarize/);
+  assert.match(markdown, /frontend-source-evidence/);
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id, "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.id, artifact.id);
+  assert.equal(parsed.decision, "use");
+
+  const cliText = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliText.status, 0, cliText.stderr);
+  assert.match(cliText.stdout, /React Web evidence artifact/);
+  assert.match(cliText.stdout, new RegExp(artifact.id));
+});
+
+test("repeated unsupported boundary emits a denied evidence artifact instead of widening support", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-evidence-deny-"));
+  writeFixture(tempDir, "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx", "Boundary.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "Boundary.tsx",
+    "Please inspect Boundary.tsx again and keep the same-file context compact if safe",
+  );
+
+  assert.equal(second.action, "fallback");
+  const ref = second.debug?.reactWebEvidenceArtifact;
+  assert.equal(ref?.emitted, true);
+
+  const artifact = readReactWebEvidenceArtifact(tempDir, ref.id);
+  assert.equal(artifact.decision, "deny");
+  assert.equal(artifact.evidenceStrength, "denied");
+  assert.match(artifact.whyDenied.join("\n"), /unsupported-react-native-webview-boundary/);
+  assert.equal("confidence" in artifact, false);
+  assert.equal("confidenceScore" in artifact, false);
+});
+
+test("inspect evidence fails clearly for missing ids", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-evidence-missing-"));
+  const cli = spawnSync(process.execPath, [cliPath, "inspect", "evidence", "missing-id", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.notEqual(cli.status, 0);
+  assert.match(`${cli.stdout}${cli.stderr}`, /React Web evidence artifact not found: missing-id/);
+});


### PR DESCRIPTION
## Summary
- add a schema-first React Web evidence artifact contract for repeated same-file codex runtime decisions
- persist bounded latest/id-addressable artifacts and surface them via `fooks inspect evidence <id>` in JSON and markdown
- attach emitted artifact references to runtime debug metadata and lock the behavior with artifact-focused tests

## Validation
- npm run build
- node --test test/react-web-evidence-artifact.test.mjs
- npm run lint
- npm test

Closes #633