### PR TITLE
Add a React Web status surface backed by evidence artifacts

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -653,6 +653,7 @@ Everyday commands:
   ${displayCliName} status claude
   ${displayCliName} status cache
   ${displayCliName} status worktree
+  ${displayCliName} status react-web [--json]
   ${displayCliName} status artifacts [--json]
   ${displayCliName} status activity [--include-remote-counts]
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -837,6 +838,20 @@ function parseStatusArtifactsArgs(args: string[]): { json: boolean } {
       continue;
     }
     throw new Error(`Unexpected status artifacts argument: ${arg}`);
+  }
+
+  return { json };
+}
+
+function parseStatusReactWebArgs(args: string[]): { json: boolean } {
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    throw new Error(`Unexpected status react-web argument: ${arg}`);
   }
 
   return { json };
@@ -1282,6 +1297,17 @@ async function run(): Promise<void> {
         print(currentWorktreeEvidenceStatus(process.cwd()));
         return;
       }
+      if (arg1 === "react-web") {
+        const { json } = parseStatusReactWebArgs(rest.slice(1));
+        const { readReactWebStatus, renderReactWebStatusText } = await import("../core/react-web-status.js");
+        const status = readReactWebStatus(process.cwd());
+        if (json) {
+          print(status);
+        } else {
+          process.stdout.write(renderReactWebStatusText(status));
+        }
+        return;
+      }
       if (arg1 === "artifacts") {
         parseStatusArtifactsArgs(rest.slice(1));
         const { auditArtifacts } = await import("../core/artifact-audit.js");
@@ -1299,7 +1325,7 @@ async function run(): Promise<void> {
         print(readOperatorActivitySnapshot(process.cwd(), { includeRemoteCounts: rest.includes("--include-remote-counts") }));
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'artifacts', or 'activity'");
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'react-web', 'artifacts', or 'activity'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs";
+import path from "node:path";
+import { hashText } from "./hash";
+import {
+  REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+  type ReactWebEvidenceArtifact,
+  readReactWebEvidenceArtifact,
+  reactWebEvidenceArtifactsDir,
+} from "./react-web-evidence-artifact";
+import type { SourceFingerprint } from "./schema";
+
+export const REACT_WEB_STATUS_SCHEMA_VERSION = 1;
+export const REACT_WEB_STATUS_COMMAND = "status react-web";
+export const REACT_WEB_STATUS_CLAIM_BOUNDARY =
+  "Local React Web source-context decision status only: summarizes existing bounded evidence artifacts without emitting new artifacts, changing runtime behavior, or broadening support or performance claims.";
+
+export type ReactWebProfileStatus = "ready" | "partial" | "blocked";
+export type ReactWebBoundaryState = "bounded" | "blocked" | "advisory-only";
+export type ReactWebFreshnessState = "current" | "stale" | "missing-source-file" | "unavailable";
+
+export type ReactWebStatusResult = {
+  schemaVersion: typeof REACT_WEB_STATUS_SCHEMA_VERSION;
+  command: typeof REACT_WEB_STATUS_COMMAND;
+  profile: "react-web";
+  generatedAt: string;
+  claimBoundary: typeof REACT_WEB_STATUS_CLAIM_BOUNDARY;
+  profileStatus: ReactWebProfileStatus;
+  latestEvidenceId: string | null;
+  latestEvidenceGeneratedAt: string | null;
+  latestDecision: ReactWebEvidenceArtifact["decision"] | null;
+  evidenceStrength: ReactWebEvidenceArtifact["evidenceStrength"] | null;
+  latestFilePath: string | null;
+  repeatedSameFileReady: boolean;
+  fallbackReasons: string[];
+  boundaryStatus: {
+    mixedRouting: {
+      status: ReactWebBoundaryState;
+      reasons: string[];
+    };
+    projectKnowledge: {
+      status: ReactWebBoundaryState;
+      reasons: string[];
+    };
+  };
+  freshness: {
+    status: ReactWebFreshnessState;
+    sourceFingerprint: SourceFingerprint | null;
+    currentSourceFingerprint: SourceFingerprint | null;
+    staleWhen: string[];
+  };
+  risks: string[];
+};
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function latestArtifactIndexPath(cwd: string): string {
+  return path.join(reactWebEvidenceArtifactsDir(cwd), "latest.json");
+}
+
+function currentSourceFingerprint(filePath: string): SourceFingerprint | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const source = fs.readFileSync(filePath, "utf8");
+  return {
+    fileHash: hashText(source),
+    lineCount: source.split(/\r?\n/u).length,
+  };
+}
+
+function sourceFingerprintsEqual(left: SourceFingerprint | undefined, right: SourceFingerprint | null): boolean {
+  if (!left || !right) return false;
+  return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
+}
+
+function buildBlockedNoEvidenceStatus(cwd: string, generatedAt: string): ReactWebStatusResult {
+  return {
+    schemaVersion: REACT_WEB_STATUS_SCHEMA_VERSION,
+    command: REACT_WEB_STATUS_COMMAND,
+    profile: "react-web",
+    generatedAt,
+    claimBoundary: REACT_WEB_STATUS_CLAIM_BOUNDARY,
+    profileStatus: "blocked",
+    latestEvidenceId: null,
+    latestEvidenceGeneratedAt: null,
+    latestDecision: null,
+    evidenceStrength: null,
+    latestFilePath: null,
+    repeatedSameFileReady: false,
+    fallbackReasons: [],
+    boundaryStatus: {
+      mixedRouting: {
+        status: "bounded",
+        reasons: ["no latest React Web evidence artifact recorded yet"],
+      },
+      projectKnowledge: {
+        status: "advisory-only",
+        reasons: ["project knowledge remains an advisory-only boundary and is not promoted to runtime execution authority"],
+      },
+    },
+    freshness: {
+      status: "unavailable",
+      sourceFingerprint: null,
+      currentSourceFingerprint: null,
+      staleWhen: [],
+    },
+    risks: [
+      `no React Web evidence artifact found at ${path.relative(cwd, latestArtifactIndexPath(cwd)) || ".fooks/artifacts/react-web-evidence/latest.json"}`,
+    ],
+  };
+}
+
+function buildMixedRoutingBoundary(artifact: ReactWebEvidenceArtifact): ReactWebStatusResult["boundaryStatus"]["mixedRouting"] {
+  const boundaryReasons = artifact.whyDenied.filter(
+    (reason) => reason === "unsupported-react-native-webview-boundary" || reason.startsWith("unsupported-classification:"),
+  );
+  if (boundaryReasons.length > 0) {
+    return {
+      status: "blocked",
+      reasons: uniqueSorted(boundaryReasons),
+    };
+  }
+  return {
+    status: "bounded",
+    reasons: ["latest evidence stays within the React Web source-context boundary"],
+  };
+}
+
+function buildProjectKnowledgeBoundary(artifact: ReactWebEvidenceArtifact): ReactWebStatusResult["boundaryStatus"]["projectKnowledge"] {
+  return {
+    status: "advisory-only",
+    reasons: uniqueSorted([
+      "project knowledge remains advisory-only and is not execution authority",
+      artifact.contextModeReason ? `latest context mode reason: ${artifact.contextModeReason}` : "latest context mode reason: none",
+    ]),
+  };
+}
+
+function buildFreshness(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebStatusResult["freshness"] {
+  const sourceFingerprint = artifact.sourceFingerprint ?? null;
+  if (!sourceFingerprint) {
+    return {
+      status: "unavailable",
+      sourceFingerprint: null,
+      currentSourceFingerprint: null,
+      staleWhen: artifact.freshness.staleWhen,
+    };
+  }
+
+  const resolvedPath = path.resolve(cwd, artifact.filePath);
+  const current = currentSourceFingerprint(resolvedPath);
+  if (!current) {
+    return {
+      status: "missing-source-file",
+      sourceFingerprint,
+      currentSourceFingerprint: null,
+      staleWhen: artifact.freshness.staleWhen,
+    };
+  }
+
+  return {
+    status: sourceFingerprintsEqual(sourceFingerprint, current) ? "current" : "stale",
+    sourceFingerprint,
+    currentSourceFingerprint: current,
+    staleWhen: artifact.freshness.staleWhen,
+  };
+}
+
+function buildRisks(
+  artifact: ReactWebEvidenceArtifact,
+  freshness: ReactWebStatusResult["freshness"],
+  repeatedSameFileReady: boolean,
+): string[] {
+  const risks: string[] = [];
+
+  if (artifact.decision === "fallback") {
+    risks.push(
+      `latest React Web decision is fallback${artifact.whyDenied.length > 0 ? `: ${artifact.whyDenied.join(", ")}` : ""}`,
+    );
+  }
+  if (artifact.decision === "deny") {
+    risks.push(
+      `latest React Web decision is deny${artifact.whyDenied.length > 0 ? `: ${artifact.whyDenied.join(", ")}` : ""}`,
+    );
+  }
+  if (!artifact.sourceFingerprint) {
+    risks.push("latest evidence artifact is missing sourceFingerprint freshness data");
+  }
+  if (!artifact.editGuidance?.patchTargets?.length) {
+    risks.push("latest evidence artifact is missing patchTargets for repeated same-file reuse");
+  }
+  if (artifact.domainPayload?.domain !== "react-web") {
+    risks.push("latest evidence artifact is missing a React Web domain payload");
+  }
+  if (freshness.status === "stale") {
+    risks.push("latest evidence artifact is stale against the current source file");
+  }
+  if (freshness.status === "missing-source-file") {
+    risks.push("latest evidence source file is missing from the working tree");
+  }
+  if (!repeatedSameFileReady && artifact.decision === "use") {
+    risks.push("latest evidence artifact is not yet strong enough to report repeated same-file ready");
+  }
+
+  return uniqueSorted(risks);
+}
+
+function deriveProfileStatus(
+  artifact: ReactWebEvidenceArtifact,
+  mixedRoutingStatus: ReactWebStatusResult["boundaryStatus"]["mixedRouting"]["status"],
+  freshness: ReactWebStatusResult["freshness"]["status"],
+  repeatedSameFileReady: boolean,
+  risks: string[],
+): ReactWebProfileStatus {
+  if (artifact.decision === "deny" || mixedRoutingStatus === "blocked") {
+    return "blocked";
+  }
+  if (artifact.decision === "fallback") {
+    return "partial";
+  }
+  if (freshness !== "current" || !repeatedSameFileReady || risks.length > 0) {
+    return "partial";
+  }
+  return "ready";
+}
+
+export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
+  const generatedAt = new Date().toISOString();
+  if (!fs.existsSync(latestArtifactIndexPath(cwd))) {
+    return buildBlockedNoEvidenceStatus(cwd, generatedAt);
+  }
+
+  const artifact = readReactWebEvidenceArtifact(cwd, "latest");
+  const freshness = buildFreshness(cwd, artifact);
+  const repeatedSameFileReady =
+    artifact.decision === "use" &&
+    artifact.domainPayload?.domain === "react-web" &&
+    Boolean(artifact.sourceFingerprint) &&
+    freshness.status === "current" &&
+    Boolean(artifact.editGuidance?.patchTargets?.length);
+  const mixedRouting = buildMixedRoutingBoundary(artifact);
+  const projectKnowledge = buildProjectKnowledgeBoundary(artifact);
+  const fallbackReasons = artifact.decision === "use" ? [] : uniqueSorted(artifact.whyDenied);
+  const risks = buildRisks(artifact, freshness, repeatedSameFileReady);
+
+  return {
+    schemaVersion: REACT_WEB_STATUS_SCHEMA_VERSION,
+    command: REACT_WEB_STATUS_COMMAND,
+    profile: "react-web",
+    generatedAt,
+    claimBoundary: REACT_WEB_STATUS_CLAIM_BOUNDARY,
+    profileStatus: deriveProfileStatus(artifact, mixedRouting.status, freshness.status, repeatedSameFileReady, risks),
+    latestEvidenceId: artifact.id,
+    latestEvidenceGeneratedAt: artifact.generatedAt,
+    latestDecision: artifact.decision,
+    evidenceStrength: artifact.evidenceStrength,
+    latestFilePath: artifact.filePath,
+    repeatedSameFileReady,
+    fallbackReasons,
+    boundaryStatus: {
+      mixedRouting,
+      projectKnowledge,
+    },
+    freshness,
+    risks,
+  };
+}
+
+export function renderReactWebStatusText(status: ReactWebStatusResult): string {
+  const risks = status.risks.length > 0 ? status.risks.map((risk) => `- ${risk}`).join("\n") : "- none";
+  const fallbackReasons = status.fallbackReasons.length > 0 ? status.fallbackReasons.join(", ") : "none";
+  return [
+    "# React Web status",
+    "",
+    status.claimBoundary,
+    "",
+    "## Summary",
+    `- profile status: ${status.profileStatus}`,
+    `- latest evidence id: ${status.latestEvidenceId ?? "none"}`,
+    `- latest decision: ${status.latestDecision ?? "none"}`,
+    `- evidence strength: ${status.evidenceStrength ?? "none"}`,
+    `- repeated same-file ready: ${status.repeatedSameFileReady ? "yes" : "no"}`,
+    `- fallback reasons: ${fallbackReasons}`,
+    `- mixed-routing boundary: ${status.boundaryStatus.mixedRouting.status}`,
+    `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
+    `- freshness: ${status.freshness.status}`,
+    "",
+    "## Risks",
+    risks,
+    "",
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,16 @@ export type {
   ArtifactAuditStatus,
   ArtifactAuditWorktree,
 } from "./core/artifact-audit";
+export {
+  REACT_WEB_STATUS_CLAIM_BOUNDARY,
+  REACT_WEB_STATUS_COMMAND,
+  REACT_WEB_STATUS_SCHEMA_VERSION,
+  readReactWebStatus,
+  renderReactWebStatusText,
+} from "./core/react-web-status";
+export type {
+  ReactWebBoundaryState,
+  ReactWebFreshnessState,
+  ReactWebProfileStatus,
+  ReactWebStatusResult,
+} from "./core/react-web-status";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3522,6 +3522,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect evidence <id> \[--json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
+  assert.match(help, /fooks status react-web \[--json\]/);
   assert.match(help, /fooks status artifacts/);
   assert.match(help, /Codex: automatic repeated-file runtime hook path/);
   assert.match(help, /Claude: project-local context hooks/);

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -1,0 +1,126 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  REACT_WEB_STATUS_COMMAND,
+  REACT_WEB_STATUS_CLAIM_BOUNDARY,
+  readReactWebStatus,
+} = require(path.join(repoRoot, "dist", "core", "react-web-status.js"));
+const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function writeFixture(tempDir, fixturePath, fileName) {
+  fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
+}
+
+function runRepeatedDecision(tempDir, fileName, secondPrompt) {
+  const sessionId = `react-web-status-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Please inspect ${fileName}` }, tempDir);
+  const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  return second;
+}
+
+test("status react-web reports blocked without failing when no latest evidence exists", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-status-empty-"));
+
+  const status = readReactWebStatus(tempDir);
+  assert.equal(status.command, REACT_WEB_STATUS_COMMAND);
+  assert.equal(status.profileStatus, "blocked");
+  assert.equal(status.latestEvidenceId, null);
+  assert.equal(status.repeatedSameFileReady, false);
+  assert.match(status.claimBoundary, /source-context decision status only/);
+  assert.ok(status.risks.some((risk) => /no React Web evidence artifact found/.test(risk)));
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "status", "react-web", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.profileStatus, "blocked");
+});
+
+test("status react-web reports ready from a current repeated same-file use artifact", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-status-ready-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+  assert.equal(second.action, "inject");
+
+  const status = readReactWebStatus(tempDir);
+  assert.equal(status.profileStatus, "ready");
+  assert.equal(status.latestDecision, "use");
+  assert.equal(status.repeatedSameFileReady, true);
+  assert.equal(status.boundaryStatus.mixedRouting.status, "bounded");
+  assert.equal(status.boundaryStatus.projectKnowledge.status, "advisory-only");
+  assert.deepEqual(status.risks, []);
+  assert.equal(status.claimBoundary, REACT_WEB_STATUS_CLAIM_BOUNDARY);
+
+  const cliText = spawnSync(process.execPath, [cliPath, "status", "react-web"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliText.status, 0, cliText.stderr);
+  assert.match(cliText.stdout, /React Web status/);
+  assert.match(cliText.stdout, /profile status: ready/);
+});
+
+test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-status-deny-"));
+  writeFixture(tempDir, "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx", "Boundary.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "Boundary.tsx",
+    "Please inspect Boundary.tsx again and keep the same-file context compact if safe",
+  );
+  assert.equal(second.action, "fallback");
+
+  const status = readReactWebStatus(tempDir);
+  assert.equal(status.profileStatus, "blocked");
+  assert.equal(status.latestDecision, "deny");
+  assert.equal(status.boundaryStatus.mixedRouting.status, "blocked");
+  assert.match(status.fallbackReasons.join("\n"), /unsupported-react-native-webview-boundary/);
+  assert.ok(status.risks.some((risk) => /latest React Web decision is deny/.test(risk)));
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "status", "react-web", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.profileStatus, "blocked");
+  assert.equal(parsed.boundaryStatus.mixedRouting.status, "blocked");
+});
+
+test("status react-web fails non-zero when the latest artifact index is corrupt", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-status-corrupt-"));
+  const artifactsDir = reactWebEvidenceArtifactsDir(tempDir);
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.writeFileSync(path.join(artifactsDir, "latest.json"), "{not-valid-json\n");
+
+  const cli = spawnSync(process.execPath, [cliPath, "status", "react-web", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.notEqual(cli.status, 0);
+  assert.match(`${cli.stdout}${cli.stderr}`, /Unexpected token|Expected property name|JSON/);
+});


### PR DESCRIPTION
## Summary
- add a React Web-only `fooks status react-web` surface backed by the existing evidence artifacts
- treat missing evidence and fallback/deny as diagnostic payload state (`partial|blocked` + `risks[]`) rather than CLI failure
- add targeted status-surface tests and update CLI help/export wiring

## Validation
- npm install
- npm run build
- node --test test/react-web-status-surface.test.mjs
- node --test --test-name-pattern "cli help advertises setup and package install has no auto hook side effects|status artifacts route reports read-only audit JSON" test/fooks.test.mjs
- npm run lint
- npm test

Closes #638