### PR TITLE
Add a React Web interop marker to evidence and status surfaces

### DIFF
--- a/src/core/react-web-evidence-artifact.ts
+++ b/src/core/react-web-evidence-artifact.ts
@@ -9,6 +9,11 @@ export const REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER = "fooks";
 export const REACT_WEB_EVIDENCE_ARTIFACT_PROFILE = "react-web";
 export const REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND = "frontend-source-evidence";
 export const REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY = "do-not-summarize";
+export const REACT_WEB_EVIDENCE_ARTIFACT_INTEROP = Object.freeze({
+  mayBeStored: true,
+  mayBeSummarized: false,
+  mayOverrideDecision: false,
+});
 export const REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY =
   "Local React Web repeated same-file source-context evidence only: captures why fooks used, fell back, or denied a bounded React Web source payload. This artifact is not a generic context-manager memory surface, not RN/TUI/WebView support promotion, and not runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost proof.";
 
@@ -21,6 +26,8 @@ export type ReactWebEvidenceArtifactFile = {
   lineRanges: string[];
   whySelected: string[];
 };
+
+export type ReactWebEvidenceArtifactInterop = typeof REACT_WEB_EVIDENCE_ARTIFACT_INTEROP;
 
 export type ReactWebEvidenceArtifact = {
   schemaVersion: typeof REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION;
@@ -38,6 +45,7 @@ export type ReactWebEvidenceArtifact = {
   whyDenied: string[];
   claimBoundary: typeof REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY;
   compressionPolicy: typeof REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY;
+  interop: ReactWebEvidenceArtifactInterop;
   contextMode?: ContextMode;
   contextModeReason?: string;
   sourceFingerprint?: SourceFingerprint;
@@ -171,6 +179,23 @@ function evidenceArtifactId(seed: {
   return sanitizeDataKey(`react-web-evidence-${hash}`);
 }
 
+function defaultReactWebEvidenceArtifactInterop(): ReactWebEvidenceArtifactInterop {
+  return { ...REACT_WEB_EVIDENCE_ARTIFACT_INTEROP };
+}
+
+function isCanonicalReactWebInterop(
+  interop: Partial<ReactWebEvidenceArtifactInterop> | undefined,
+): interop is ReactWebEvidenceArtifactInterop {
+  return interop?.mayBeStored === true && interop?.mayBeSummarized === false && interop?.mayOverrideDecision === false;
+}
+
+function normalizeReactWebEvidenceArtifact(artifact: ReactWebEvidenceArtifact): ReactWebEvidenceArtifact {
+  return {
+    ...artifact,
+    interop: isCanonicalReactWebInterop(artifact.interop) ? artifact.interop : defaultReactWebEvidenceArtifactInterop(),
+  };
+}
+
 export function reactWebEvidenceArtifactsDir(cwd = process.cwd()): string {
   return path.join(canonicalProjectDataDir(cwd), "artifacts", "react-web-evidence");
 }
@@ -202,6 +227,9 @@ function assertValidArtifact(artifact: unknown): asserts artifact is ReactWebEvi
   }
   if (candidate.compressionPolicy !== REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY) {
     throw new Error("React Web evidence artifact compressionPolicy changed");
+  }
+  if (candidate.interop !== undefined && !isCanonicalReactWebInterop(candidate.interop)) {
+    throw new Error("React Web evidence artifact interop contract changed");
   }
 }
 
@@ -244,6 +272,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
     whyDenied: decision === "use" ? [] : buildWhyDenied(runtimeDecision, classification),
     claimBoundary: REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
     compressionPolicy: REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+    interop: defaultReactWebEvidenceArtifactInterop(),
     ...(runtimeDecision.contextMode ? { contextMode: runtimeDecision.contextMode } : {}),
     ...(runtimeDecision.contextModeReason ? { contextModeReason: runtimeDecision.contextModeReason } : {}),
     ...(payload?.sourceFingerprint ? { sourceFingerprint: payload.sourceFingerprint } : {}),
@@ -259,25 +288,26 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
 }
 
 export function writeReactWebEvidenceArtifact(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebEvidenceArtifactRef {
-  assertValidArtifact(artifact);
+  const normalizedArtifact = normalizeReactWebEvidenceArtifact(artifact);
+  assertValidArtifact(normalizedArtifact);
   const root = reactWebEvidenceArtifactsDir(cwd);
   fs.mkdirSync(root, { recursive: true });
-  const artifactPath = reactWebEvidenceArtifactPath(cwd, artifact.id);
-  fs.writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  const artifactPath = reactWebEvidenceArtifactPath(cwd, normalizedArtifact.id);
+  fs.writeFileSync(artifactPath, `${JSON.stringify(normalizedArtifact, null, 2)}\n`);
 
   const latest: ReactWebEvidenceArtifactIndex = {
     schemaVersion: 1,
     latest: {
-      id: artifact.id,
+      id: normalizedArtifact.id,
       path: artifactPath,
-      generatedAt: artifact.generatedAt,
-      filePath: artifact.filePath,
-      decision: artifact.decision,
-      evidenceStrength: artifact.evidenceStrength,
+      generatedAt: normalizedArtifact.generatedAt,
+      filePath: normalizedArtifact.filePath,
+      decision: normalizedArtifact.decision,
+      evidenceStrength: normalizedArtifact.evidenceStrength,
     },
   };
   fs.writeFileSync(reactWebEvidenceLatestPath(cwd), `${JSON.stringify(latest, null, 2)}\n`);
-  return { emitted: true, id: artifact.id, path: artifactPath };
+  return { emitted: true, id: normalizedArtifact.id, path: artifactPath };
 }
 
 export function emitReactWebEvidenceArtifact(cwd: string, runtimeDecision: CodexRuntimeHookDecision): ReactWebEvidenceArtifactRef | null {
@@ -305,7 +335,7 @@ export function readReactWebEvidenceArtifact(cwd: string, id: string): ReactWebE
   }
   const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8")) as ReactWebEvidenceArtifact;
   assertValidArtifact(artifact);
-  return artifact;
+  return normalizeReactWebEvidenceArtifact(artifact);
 }
 
 export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenceArtifact): string {
@@ -327,5 +357,5 @@ export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenc
     : "- none";
   const whyDenied = artifact.whyDenied.length > 0 ? artifact.whyDenied.map((reason) => `- ${reason}`).join("\n") : "- none";
 
-  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
+  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n- interop: stored=${artifact.interop.mayBeStored ? "yes" : "no"}, summarized=${artifact.interop.mayBeSummarized ? "yes" : "no"}, override=${artifact.interop.mayOverrideDecision ? "yes" : "no"}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
 }

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import { hashText } from "./hash";
 import {
   REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+  REACT_WEB_EVIDENCE_ARTIFACT_INTEROP,
   type ReactWebEvidenceArtifact,
+  type ReactWebEvidenceArtifactInterop,
   readReactWebEvidenceArtifact,
   reactWebEvidenceArtifactsDir,
 } from "./react-web-evidence-artifact";
@@ -24,6 +26,7 @@ export type ReactWebStatusResult = {
   profile: "react-web";
   generatedAt: string;
   claimBoundary: typeof REACT_WEB_STATUS_CLAIM_BOUNDARY;
+  interop: ReactWebEvidenceArtifactInterop;
   profileStatus: ReactWebProfileStatus;
   latestEvidenceId: string | null;
   latestEvidenceGeneratedAt: string | null;
@@ -82,6 +85,7 @@ function buildBlockedNoEvidenceStatus(cwd: string, generatedAt: string): ReactWe
     profile: "react-web",
     generatedAt,
     claimBoundary: REACT_WEB_STATUS_CLAIM_BOUNDARY,
+    interop: { ...REACT_WEB_EVIDENCE_ARTIFACT_INTEROP },
     profileStatus: "blocked",
     latestEvidenceId: null,
     latestEvidenceGeneratedAt: null,
@@ -251,6 +255,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
     profile: "react-web",
     generatedAt,
     claimBoundary: REACT_WEB_STATUS_CLAIM_BOUNDARY,
+    interop: artifact.interop,
     profileStatus: deriveProfileStatus(artifact, mixedRouting.status, freshness.status, repeatedSameFileReady, risks),
     latestEvidenceId: artifact.id,
     latestEvidenceGeneratedAt: artifact.generatedAt,
@@ -278,6 +283,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     "",
     "## Summary",
     `- profile status: ${status.profileStatus}`,
+    `- interop: stored=${status.interop.mayBeStored ? "yes" : "no"}, summarized=${status.interop.mayBeSummarized ? "yes" : "no"}, override=${status.interop.mayOverrideDecision ? "yes" : "no"}`,
     `- latest evidence id: ${status.latestEvidenceId ?? "none"}`,
     `- latest decision: ${status.latestDecision ?? "none"}`,
     `- evidence strength: ${status.evidenceStrength ?? "none"}`,

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -58,6 +58,11 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.equal(artifact.decision, "use");
   assert.equal(artifact.evidenceStrength, "direct");
   assert.equal(artifact.compressionPolicy, "do-not-summarize");
+  assert.deepEqual(artifact.interop, {
+    mayBeStored: true,
+    mayBeSummarized: false,
+    mayOverrideDecision: false,
+  });
   assert.equal(artifact.domainPayload?.domain, "react-web");
   assert.ok(artifact.sourceFingerprint);
   assert.ok(artifact.editGuidance?.patchTargets?.length > 0);
@@ -72,6 +77,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.match(markdown, /React Web evidence artifact/);
   assert.match(markdown, /do-not-summarize/);
   assert.match(markdown, /frontend-source-evidence/);
+  assert.match(markdown, /summarized=no/);
 
   const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id, "--json"], {
     cwd: tempDir,
@@ -81,6 +87,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   const parsed = JSON.parse(cliJson.stdout);
   assert.equal(parsed.id, artifact.id);
   assert.equal(parsed.decision, "use");
+  assert.deepEqual(parsed.interop, artifact.interop);
 
   const cliText = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id], {
     cwd: tempDir,
@@ -108,6 +115,11 @@ test("repeated unsupported boundary emits a denied evidence artifact instead of 
   const artifact = readReactWebEvidenceArtifact(tempDir, ref.id);
   assert.equal(artifact.decision, "deny");
   assert.equal(artifact.evidenceStrength, "denied");
+  assert.deepEqual(artifact.interop, {
+    mayBeStored: true,
+    mayBeSummarized: false,
+    mayOverrideDecision: false,
+  });
   assert.match(artifact.whyDenied.join("\n"), /unsupported-react-native-webview-boundary/);
   assert.equal("confidence" in artifact, false);
   assert.equal("confidenceScore" in artifact, false);

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -42,6 +42,11 @@ test("status react-web reports blocked without failing when no latest evidence e
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestEvidenceId, null);
   assert.equal(status.repeatedSameFileReady, false);
+  assert.deepEqual(status.interop, {
+    mayBeStored: true,
+    mayBeSummarized: false,
+    mayOverrideDecision: false,
+  });
   assert.match(status.claimBoundary, /source-context decision status only/);
   assert.ok(status.risks.some((risk) => /no React Web evidence artifact found/.test(risk)));
 
@@ -52,6 +57,7 @@ test("status react-web reports blocked without failing when no latest evidence e
   assert.equal(cliJson.status, 0, cliJson.stderr);
   const parsed = JSON.parse(cliJson.stdout);
   assert.equal(parsed.profileStatus, "blocked");
+  assert.deepEqual(parsed.interop, status.interop);
 });
 
 test("status react-web reports ready from a current repeated same-file use artifact", () => {
@@ -71,6 +77,11 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(status.repeatedSameFileReady, true);
   assert.equal(status.boundaryStatus.mixedRouting.status, "bounded");
   assert.equal(status.boundaryStatus.projectKnowledge.status, "advisory-only");
+  assert.deepEqual(status.interop, {
+    mayBeStored: true,
+    mayBeSummarized: false,
+    mayOverrideDecision: false,
+  });
   assert.deepEqual(status.risks, []);
   assert.equal(status.claimBoundary, REACT_WEB_STATUS_CLAIM_BOUNDARY);
 
@@ -81,6 +92,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(cliText.status, 0, cliText.stderr);
   assert.match(cliText.stdout, /React Web status/);
   assert.match(cliText.stdout, /profile status: ready/);
+  assert.match(cliText.stdout, /summarized=no/);
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {
@@ -98,6 +110,11 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestDecision, "deny");
   assert.equal(status.boundaryStatus.mixedRouting.status, "blocked");
+  assert.deepEqual(status.interop, {
+    mayBeStored: true,
+    mayBeSummarized: false,
+    mayOverrideDecision: false,
+  });
   assert.match(status.fallbackReasons.join("\n"), /unsupported-react-native-webview-boundary/);
   assert.ok(status.risks.some((risk) => /latest React Web decision is deny/.test(risk)));
 
@@ -109,6 +126,7 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   const parsed = JSON.parse(cliJson.stdout);
   assert.equal(parsed.profileStatus, "blocked");
   assert.equal(parsed.boundaryStatus.mixedRouting.status, "blocked");
+  assert.deepEqual(parsed.interop, status.interop);
 });
 
 test("status react-web fails non-zero when the latest artifact index is corrupt", () => {


### PR DESCRIPTION
## Summary
- add the canonical React Web interop contract to evidence artifacts
- expose the same additive interop contract from `fooks status react-web`
- keep inspect/status text renderers as thin consumers while preserving older local artifacts via read-time normalization

## Verification
- `npm run build`
- `node --test test/react-web-evidence-artifact.test.mjs test/react-web-status-surface.test.mjs`
- `npm run lint`
- `npm test`

Closes #640
