### PR TITLE
Add React Web ranked bundle diagnostic surface

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -643,6 +643,7 @@ Everyday commands:
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
   ${displayCliName} inspect evidence <id> [--json]
+  ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
@@ -724,6 +725,29 @@ function parseInspectEvidenceArgs(args: string[]): { id: string; json: boolean }
 
   if (!id) {
     throw new Error("inspect evidence requires an artifact id");
+  }
+
+  return { id, json };
+}
+
+function parseInspectRankedBundleArgs(args: string[]): { id: string; json: boolean } {
+  let id: string | undefined;
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!id) {
+      id = arg;
+      continue;
+    }
+    throw new Error(`Unexpected inspect ranked-bundle argument: ${arg}`);
+  }
+
+  if (!id) {
+    throw new Error("inspect ranked-bundle requires an artifact id");
   }
 
   return { id, json };
@@ -1214,18 +1238,29 @@ async function run(): Promise<void> {
       return;
     }
     case "inspect": {
-      if (arg1 !== "evidence") {
-        throw new Error("inspect expects 'evidence'");
+      if (arg1 === "evidence") {
+        const { id, json } = parseInspectEvidenceArgs(rest.slice(1));
+        const { readReactWebEvidenceArtifact, renderReactWebEvidenceArtifactMarkdown } = await import("../core/react-web-evidence-artifact.js");
+        const artifact = readReactWebEvidenceArtifact(process.cwd(), id);
+        if (json) {
+          print(artifact);
+        } else {
+          process.stdout.write(renderReactWebEvidenceArtifactMarkdown(artifact));
+        }
+        return;
       }
-      const { id, json } = parseInspectEvidenceArgs(rest.slice(1));
-      const { readReactWebEvidenceArtifact, renderReactWebEvidenceArtifactMarkdown } = await import("../core/react-web-evidence-artifact.js");
-      const artifact = readReactWebEvidenceArtifact(process.cwd(), id);
-      if (json) {
-        print(artifact);
-      } else {
-        process.stdout.write(renderReactWebEvidenceArtifactMarkdown(artifact));
+      if (arg1 === "ranked-bundle") {
+        const { id, json } = parseInspectRankedBundleArgs(rest.slice(1));
+        const { readReactWebRankedBundle, renderReactWebRankedBundleMarkdown } = await import("../core/react-web-ranked-bundle.js");
+        const bundle = readReactWebRankedBundle(process.cwd(), id);
+        if (json) {
+          print(bundle);
+        } else {
+          process.stdout.write(renderReactWebRankedBundleMarkdown(bundle));
+        }
+        return;
       }
-      return;
+      throw new Error("inspect expects 'evidence' or 'ranked-bundle'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-ranked-bundle.ts
+++ b/src/core/react-web-ranked-bundle.ts
@@ -1,0 +1,238 @@
+import {
+  type ReactWebEvidenceArtifact,
+  readReactWebEvidenceArtifact,
+} from "./react-web-evidence-artifact";
+import type { FrontendConcernProfile } from "./concern-profiles/types";
+
+export const REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION = "react-web-ranked-bundle.v1";
+export const REACT_WEB_RANKED_BUNDLE_COMMAND = "inspect ranked-bundle";
+export const REACT_WEB_RANKED_BUNDLE_MODE = "shadow-diagnostic";
+export const REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT = 6;
+export const REACT_WEB_RANKED_BUNDLE_CLAIM_BOUNDARY =
+  "Local React Web same-file ranked-context diagnostic only: explains which same-file source facts would be prioritized under a bounded budget and why fallback or fail-closed boundaries apply. This surface does not change runtime selection behavior, does not widen React Web support claims, and does not promote RN/TUI/WebView or generic context-manager capabilities.";
+
+export type ReactWebRankedBundleVerdict = "ranked" | "fallback" | "blocked";
+export type ReactWebRankedBundleEntryClass = "direct" | "adjacent";
+export type ReactWebRankedBundleEntrySource = "patch-target" | "concern-profile" | "domain-payload";
+
+export type ReactWebRankedBundleEntry = {
+  label: string;
+  entryClass: ReactWebRankedBundleEntryClass;
+  source: ReactWebRankedBundleEntrySource;
+  priority: number;
+  evidence: string[];
+};
+
+export type ReactWebRankedBundleResult = {
+  schemaVersion: typeof REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION;
+  command: typeof REACT_WEB_RANKED_BUNDLE_COMMAND;
+  profile: "react-web";
+  mode: typeof REACT_WEB_RANKED_BUNDLE_MODE;
+  artifactId: string;
+  artifactGeneratedAt: string;
+  filePath: string;
+  claimBoundary: typeof REACT_WEB_RANKED_BUNDLE_CLAIM_BOUNDARY;
+  verdict: ReactWebRankedBundleVerdict;
+  runtimeDecision: ReactWebEvidenceArtifact["decision"];
+  evidenceStrength: ReactWebEvidenceArtifact["evidenceStrength"];
+  budget: {
+    limit: number;
+    selected: number;
+    deferred: number;
+    overflow: boolean;
+  };
+  repeatedSameFileEligible: boolean;
+  failClosed: boolean;
+  fallbackReasons: string[];
+  selected: ReactWebRankedBundleEntry[];
+  deferred: ReactWebRankedBundleEntry[];
+};
+
+export type ReactWebRankedBundleSummary = {
+  available: boolean;
+  verdict: ReactWebRankedBundleVerdict | "unavailable";
+  budgetLimit: number | null;
+  selectedCount: number;
+  deferredCount: number;
+  overflow: boolean;
+  fallbackReasons: string[];
+};
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function patchTargetPriority(kind: string): number {
+  switch (kind) {
+    case "component":
+      return 100;
+    case "props":
+      return 95;
+    case "effect":
+      return 90;
+    case "callback":
+      return 88;
+    case "event-handler":
+      return 86;
+    case "form-control":
+      return 82;
+    case "submit-handler":
+      return 80;
+    case "validation-anchor":
+      return 78;
+    case "snippet":
+      return 70;
+    default:
+      return 60;
+  }
+}
+
+function concernPriority(profile: FrontendConcernProfile): number {
+  switch (profile.id) {
+    case "form-state":
+      return 56;
+    case "validation-schema":
+      return 54;
+    case "client-state":
+      return 52;
+    case "routing":
+      return 46;
+    case "styling":
+      return 36;
+    default:
+      return 20;
+  }
+}
+
+function buildPatchTargetEntries(artifact: ReactWebEvidenceArtifact): ReactWebRankedBundleEntry[] {
+  return (artifact.editGuidance?.patchTargets ?? []).map((target) => ({
+    label: `${target.kind}: ${target.label}`,
+    entryClass: "direct",
+    source: "patch-target",
+    priority: patchTargetPriority(target.kind),
+    evidence: uniqueSorted([`editGuidance.patchTargets.${target.kind}`, target.reason]),
+  }));
+}
+
+function buildConcernProfileEntries(artifact: ReactWebEvidenceArtifact): ReactWebRankedBundleEntry[] {
+  return (artifact.concernProfiles ?? []).map((profile) => ({
+    label: `${profile.id}: ${profile.signals.slice(0, 3).join(", ") || profile.claim}`,
+    entryClass: "adjacent",
+    source: "concern-profile",
+    priority: concernPriority(profile),
+    evidence: uniqueSorted([profile.claim, ...profile.signals.map((signal) => `concern:${signal}`)]),
+  }));
+}
+
+function buildDomainPayloadEntry(artifact: ReactWebEvidenceArtifact): ReactWebRankedBundleEntry[] {
+  if (artifact.domainPayload?.domain !== "react-web") return [];
+  return [
+    {
+      label: `react-web-domain-payload: ${artifact.domainPayload.policy}`,
+      entryClass: "adjacent",
+      source: "domain-payload",
+      priority: 50,
+      evidence: uniqueSorted([
+        `plannerDecision:${artifact.domainPayload.plannerDecision}`,
+        `claimStatus:${artifact.domainPayload.claimStatus}`,
+        ...artifact.domainPayload.evidence.slice(0, 4),
+      ]),
+    },
+  ];
+}
+
+function failClosedReasons(artifact: ReactWebEvidenceArtifact): string[] {
+  return uniqueSorted(
+    artifact.whyDenied.filter(
+      (reason) => reason === "unsupported-react-native-webview-boundary" || reason.startsWith("unsupported-classification:"),
+    ),
+  );
+}
+
+function compareEntries(left: ReactWebRankedBundleEntry, right: ReactWebRankedBundleEntry): number {
+  if (left.priority !== right.priority) return right.priority - left.priority;
+  if (left.entryClass !== right.entryClass) return left.entryClass === "direct" ? -1 : 1;
+  return left.label.localeCompare(right.label);
+}
+
+export function buildReactWebRankedBundle(artifact: ReactWebEvidenceArtifact): ReactWebRankedBundleResult {
+  const failClosed = artifact.decision === "deny" || failClosedReasons(artifact).length > 0 || artifact.domainPayload?.domain !== "react-web";
+  const fallbackReasons = uniqueSorted([
+    ...artifact.whyDenied,
+    ...(failClosed ? failClosedReasons(artifact) : []),
+  ]);
+  const candidates = [...buildPatchTargetEntries(artifact), ...buildConcernProfileEntries(artifact), ...buildDomainPayloadEntry(artifact)].sort(compareEntries);
+  const selected = failClosed ? [] : candidates.slice(0, REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT);
+  const deferred = failClosed ? candidates : candidates.slice(REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT);
+  const overflow = !failClosed && deferred.length > 0;
+  const repeatedSameFileEligible =
+    artifact.decision === "use" &&
+    artifact.domainPayload?.domain === "react-web" &&
+    Boolean(artifact.sourceFingerprint) &&
+    Boolean(artifact.editGuidance?.patchTargets?.length);
+
+  return {
+    schemaVersion: REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION,
+    command: REACT_WEB_RANKED_BUNDLE_COMMAND,
+    profile: "react-web",
+    mode: REACT_WEB_RANKED_BUNDLE_MODE,
+    artifactId: artifact.id,
+    artifactGeneratedAt: artifact.generatedAt,
+    filePath: artifact.filePath,
+    claimBoundary: REACT_WEB_RANKED_BUNDLE_CLAIM_BOUNDARY,
+    verdict: failClosed ? "blocked" : artifact.decision === "fallback" || overflow ? "fallback" : "ranked",
+    runtimeDecision: artifact.decision,
+    evidenceStrength: artifact.evidenceStrength,
+    budget: {
+      limit: REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT,
+      selected: selected.length,
+      deferred: deferred.length,
+      overflow,
+    },
+    repeatedSameFileEligible,
+    failClosed,
+    fallbackReasons: uniqueSorted([...fallbackReasons, ...(overflow ? ["bundle-budget-exceeded"] : [])]),
+    selected,
+    deferred,
+  };
+}
+
+export function readReactWebRankedBundle(cwd: string, id: string): ReactWebRankedBundleResult {
+  return buildReactWebRankedBundle(readReactWebEvidenceArtifact(cwd, id));
+}
+
+export function summarizeReactWebRankedBundle(bundle: ReactWebRankedBundleResult | null): ReactWebRankedBundleSummary {
+  if (!bundle) {
+    return {
+      available: false,
+      verdict: "unavailable",
+      budgetLimit: null,
+      selectedCount: 0,
+      deferredCount: 0,
+      overflow: false,
+      fallbackReasons: [],
+    };
+  }
+
+  return {
+    available: true,
+    verdict: bundle.verdict,
+    budgetLimit: bundle.budget.limit,
+    selectedCount: bundle.selected.length,
+    deferredCount: bundle.deferred.length,
+    overflow: bundle.budget.overflow,
+    fallbackReasons: bundle.fallbackReasons,
+  };
+}
+
+export function renderReactWebRankedBundleMarkdown(bundle: ReactWebRankedBundleResult): string {
+  const selected = bundle.selected.length > 0
+    ? bundle.selected.map((entry) => `- [${entry.entryClass}] ${entry.label} (priority ${entry.priority}; ${entry.source})`).join("\n")
+    : "- none";
+  const deferred = bundle.deferred.length > 0
+    ? bundle.deferred.map((entry) => `- [${entry.entryClass}] ${entry.label} (priority ${entry.priority}; ${entry.source})`).join("\n")
+    : "- none";
+  const fallbackReasons = bundle.fallbackReasons.length > 0 ? bundle.fallbackReasons.map((reason) => `- ${reason}`).join("\n") : "- none";
+
+  return `# React Web ranked bundle\n\n${bundle.claimBoundary}\n\n## Summary\n\n- artifact id: ${bundle.artifactId}\n- file: ${bundle.filePath}\n- mode: ${bundle.mode}\n- verdict: ${bundle.verdict}\n- runtime decision: ${bundle.runtimeDecision}\n- evidence strength: ${bundle.evidenceStrength}\n- repeated same-file eligible: ${bundle.repeatedSameFileEligible ? "yes" : "no"}\n- fail-closed: ${bundle.failClosed ? "yes" : "no"}\n- budget: ${bundle.budget.selected}/${bundle.budget.limit} selected, ${bundle.budget.deferred} deferred\n\n## Selected\n\n${selected}\n\n## Deferred\n\n${deferred}\n\n## Fallback reasons\n\n${fallbackReasons}\n`;
+}

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -9,6 +9,7 @@ import {
   readReactWebEvidenceArtifact,
   reactWebEvidenceArtifactsDir,
 } from "./react-web-evidence-artifact";
+import { buildReactWebRankedBundle, summarizeReactWebRankedBundle, type ReactWebRankedBundleSummary } from "./react-web-ranked-bundle";
 import type { SourceFingerprint } from "./schema";
 
 export const REACT_WEB_STATUS_SCHEMA_VERSION = 1;
@@ -51,6 +52,7 @@ export type ReactWebStatusResult = {
     currentSourceFingerprint: SourceFingerprint | null;
     staleWhen: string[];
   };
+  rankedBundle: ReactWebRankedBundleSummary;
   risks: string[];
 };
 
@@ -110,6 +112,7 @@ function buildBlockedNoEvidenceStatus(cwd: string, generatedAt: string): ReactWe
       currentSourceFingerprint: null,
       staleWhen: [],
     },
+    rankedBundle: summarizeReactWebRankedBundle(null),
     risks: [
       `no React Web evidence artifact found at ${path.relative(cwd, latestArtifactIndexPath(cwd)) || ".fooks/artifacts/react-web-evidence/latest.json"}`,
     ],
@@ -247,6 +250,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
   const mixedRouting = buildMixedRoutingBoundary(artifact);
   const projectKnowledge = buildProjectKnowledgeBoundary(artifact);
   const fallbackReasons = artifact.decision === "use" ? [] : uniqueSorted(artifact.whyDenied);
+  const rankedBundle = buildReactWebRankedBundle(artifact);
   const risks = buildRisks(artifact, freshness, repeatedSameFileReady);
 
   return {
@@ -269,6 +273,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
       projectKnowledge,
     },
     freshness,
+    rankedBundle: summarizeReactWebRankedBundle(rankedBundle),
     risks,
   };
 }
@@ -292,6 +297,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- mixed-routing boundary: ${status.boundaryStatus.mixedRouting.status}`,
     `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
     `- freshness: ${status.freshness.status}`,
+    `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",
     risks,

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,3 +90,22 @@ export type {
   ReactWebProfileStatus,
   ReactWebStatusResult,
 } from "./core/react-web-status";
+export {
+  REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT,
+  REACT_WEB_RANKED_BUNDLE_CLAIM_BOUNDARY,
+  REACT_WEB_RANKED_BUNDLE_COMMAND,
+  REACT_WEB_RANKED_BUNDLE_MODE,
+  REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION,
+  buildReactWebRankedBundle,
+  readReactWebRankedBundle,
+  renderReactWebRankedBundleMarkdown,
+  summarizeReactWebRankedBundle,
+} from "./core/react-web-ranked-bundle";
+export type {
+  ReactWebRankedBundleEntry,
+  ReactWebRankedBundleEntryClass,
+  ReactWebRankedBundleEntrySource,
+  ReactWebRankedBundleResult,
+  ReactWebRankedBundleSummary,
+  ReactWebRankedBundleVerdict,
+} from "./core/react-web-ranked-bundle";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3520,6 +3520,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks doctor \[codex\|claude\] \[--json\]/);
   assert.match(help, /fooks compare <file> \[--json\]/);
   assert.match(help, /fooks inspect evidence <id> \[--json\]/);
+  assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\]/);

--- a/test/react-web-ranked-bundle.test.mjs
+++ b/test/react-web-ranked-bundle.test.mjs
@@ -1,0 +1,217 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+  REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+  REACT_WEB_EVIDENCE_ARTIFACT_INTEROP,
+  REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND,
+  REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
+  REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
+  REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+const {
+  REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT,
+  REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION,
+  buildReactWebRankedBundle,
+  readReactWebRankedBundle,
+  renderReactWebRankedBundleMarkdown,
+} = require(path.join(repoRoot, "dist", "core", "react-web-ranked-bundle.js"));
+
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function writeFixture(tempDir, fixturePath, fileName) {
+  fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
+}
+
+function runRepeatedDecision(tempDir, fileName, secondPrompt) {
+  const sessionId = `react-web-ranked-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Please inspect ${fileName}` }, tempDir);
+  const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  return second;
+}
+
+function makeArtifact(overrides = {}) {
+  return {
+    schemaVersion: REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+    id: "react-web-evidence-synthetic",
+    generatedAt: "2026-05-09T00:00:00.000Z",
+    producer: REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
+    profile: REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
+    payloadKind: REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND,
+    runtime: "codex",
+    hookEventName: "UserPromptSubmit",
+    decision: "use",
+    evidenceStrength: "direct",
+    filePath: "src/components/FormSection.tsx",
+    reasons: ["repeated-same-file-runtime-decision"],
+    whyDenied: [],
+    claimBoundary: REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+    compressionPolicy: REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+    interop: { ...REACT_WEB_EVIDENCE_ARTIFACT_INTEROP },
+    sourceFingerprint: {
+      fileHash: "abc123",
+      lineCount: 42,
+    },
+    freshness: {
+      sourceFingerprint: {
+        fileHash: "abc123",
+        lineCount: 42,
+      },
+      staleWhen: ["sourceFingerprint.fileHash changes"],
+    },
+    files: [
+      {
+        path: "src/components/FormSection.tsx",
+        symbols: ["FormSection"],
+        lineRanges: ["1-40"],
+        whySelected: ["exact-file-prompt-target"],
+      },
+    ],
+    editGuidance: {
+      patchTargets: [
+        { kind: "component", label: "FormSection", reason: "primary component", loc: { startLine: 1, endLine: 40 } },
+        { kind: "event-handler", label: "handleSubmit", reason: "submit behavior", loc: { startLine: 18, endLine: 24 } },
+      ],
+    },
+    concernProfiles: [
+      {
+        kind: "concern",
+        id: "routing",
+        claim: "This source contains routing concern evidence.",
+        signals: ["react-router"],
+        nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+      },
+      {
+        kind: "concern",
+        id: "styling",
+        claim: "This source contains styling concern evidence.",
+        signals: ["clsx"],
+        nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+      },
+    ],
+    domainPayload: {
+      domain: "react-web",
+      policy: "measured-source-context",
+      plannerDecision: "compact-safe",
+      claimStatus: "current-supported-lane",
+      claimBoundary: "react-web-measured-extraction",
+      evidence: ["same-file-evidence", "direct-component-target"],
+      facts: {},
+      warnings: [],
+    },
+    ...overrides,
+  };
+}
+
+test("inspect ranked-bundle reads a repeated React Web artifact and exposes a shadow diagnostic bundle", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-ranked-bundle-runtime-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+
+  assert.equal(second.action, "inject");
+  const ref = second.debug?.reactWebEvidenceArtifact;
+  assert.equal(ref?.emitted, true);
+
+  const bundle = readReactWebRankedBundle(tempDir, ref.id);
+  assert.equal(bundle.schemaVersion, REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION);
+  assert.equal(bundle.artifactId, ref.id);
+  assert.equal(bundle.verdict, "ranked");
+  assert.equal(bundle.failClosed, false);
+  assert.equal(bundle.repeatedSameFileEligible, true);
+  assert.ok(bundle.selected.length > 0);
+
+  const markdown = renderReactWebRankedBundleMarkdown(bundle);
+  assert.match(markdown, /React Web ranked bundle/);
+  assert.match(markdown, /shadow-diagnostic/);
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "ranked-bundle", ref.id, "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.artifactId, ref.id);
+  assert.equal(parsed.verdict, "ranked");
+  assert.equal(parsed.mode, "shadow-diagnostic");
+});
+
+test("ranked bundle prioritizes direct same-file patch targets ahead of adjacent concern signals", () => {
+  const bundle = buildReactWebRankedBundle(makeArtifact());
+  assert.equal(bundle.selected[0].source, "patch-target");
+  assert.equal(bundle.selected[0].entryClass, "direct");
+  assert.match(bundle.selected[0].label, /component:/);
+  assert.equal(bundle.selected.at(-1)?.entryClass, "adjacent");
+});
+
+test("ranked bundle marks overflow as fallback and defers entries beyond the budget", () => {
+  const patchTargets = Array.from({ length: REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT + 2 }, (_, index) => ({
+    kind: index === 0 ? "component" : "snippet",
+    label: `target-${index}`,
+    reason: `reason-${index}`,
+    loc: { startLine: index + 1, endLine: index + 1 },
+  }));
+  const concernProfiles = [
+    {
+      kind: "concern",
+      id: "client-state",
+      claim: "This source contains client-state concern evidence.",
+      signals: ["zustand"],
+      nonAuthorizationBoundary: "concern-evidence-only; never domain evidence; never standalone compact-payload authorization",
+    },
+  ];
+
+  const bundle = buildReactWebRankedBundle(makeArtifact({
+    editGuidance: { patchTargets },
+    concernProfiles,
+  }));
+
+  assert.equal(bundle.verdict, "fallback");
+  assert.equal(bundle.budget.limit, REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT);
+  assert.equal(bundle.budget.selected, REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT);
+  assert.ok(bundle.budget.deferred > 0);
+  assert.equal(bundle.budget.overflow, true);
+  assert.ok(bundle.fallbackReasons.includes("bundle-budget-exceeded"));
+  assert.equal(bundle.deferred.length, patchTargets.length + concernProfiles.length + 1 - REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT);
+});
+
+test("ranked bundle fail-closes mixed boundary deny artifacts instead of widening support", () => {
+  const bundle = buildReactWebRankedBundle(makeArtifact({
+    decision: "deny",
+    evidenceStrength: "denied",
+    whyDenied: ["unsupported-react-native-webview-boundary"],
+    domainPayload: {
+      domain: "webview",
+      policy: "fallback-first",
+      plannerDecision: "fallback-only",
+      claimStatus: "unsupported-lane",
+      claimBoundary: "unsupported-react-native-webview-boundary",
+      evidence: ["webview-signal"],
+      facts: {},
+      warnings: ["boundary"],
+    },
+  }));
+
+  assert.equal(bundle.verdict, "blocked");
+  assert.equal(bundle.failClosed, true);
+  assert.equal(bundle.selected.length, 0);
+  assert.ok(bundle.fallbackReasons.includes("unsupported-react-native-webview-boundary"));
+});

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -42,6 +42,15 @@ test("status react-web reports blocked without failing when no latest evidence e
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestEvidenceId, null);
   assert.equal(status.repeatedSameFileReady, false);
+  assert.deepEqual(status.rankedBundle, {
+    available: false,
+    verdict: "unavailable",
+    budgetLimit: null,
+    selectedCount: 0,
+    deferredCount: 0,
+    overflow: false,
+    fallbackReasons: [],
+  });
   assert.deepEqual(status.interop, {
     mayBeStored: true,
     mayBeSummarized: false,
@@ -77,6 +86,9 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(status.repeatedSameFileReady, true);
   assert.equal(status.boundaryStatus.mixedRouting.status, "bounded");
   assert.equal(status.boundaryStatus.projectKnowledge.status, "advisory-only");
+  assert.equal(status.rankedBundle.available, true);
+  assert.equal(status.rankedBundle.verdict, "ranked");
+  assert.ok(status.rankedBundle.selectedCount > 0);
   assert.deepEqual(status.interop, {
     mayBeStored: true,
     mayBeSummarized: false,
@@ -110,6 +122,8 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestDecision, "deny");
   assert.equal(status.boundaryStatus.mixedRouting.status, "blocked");
+  assert.equal(status.rankedBundle.available, true);
+  assert.equal(status.rankedBundle.verdict, "blocked");
   assert.deepEqual(status.interop, {
     mayBeStored: true,
     mayBeSummarized: false,


### PR DESCRIPTION
Closes #642

## Summary
- add a React Web ranked-bundle shadow diagnostic surface over existing evidence artifacts
- expose `fooks inspect ranked-bundle <id> [--json]` and include ranked-bundle summary in `fooks status react-web`
- lock direct-vs-adjacent ranking, budget overflow fallback, and fail-closed mixed-boundary behavior with tests

## Verification
- npm run build
- node --test test/react-web-ranked-bundle.test.mjs test/react-web-status-surface.test.mjs
- npm run lint
- npm test