### PR TITLE
Add React Web activation-mode advisory surface

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -643,6 +643,7 @@ Everyday commands:
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
   ${displayCliName} inspect evidence <id> [--json]
+  ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
@@ -748,6 +749,29 @@ function parseInspectRankedBundleArgs(args: string[]): { id: string; json: boole
 
   if (!id) {
     throw new Error("inspect ranked-bundle requires an artifact id");
+  }
+
+  return { id, json };
+}
+
+function parseInspectActivationModeArgs(args: string[]): { id: string; json: boolean } {
+  let id: string | undefined;
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!id) {
+      id = arg;
+      continue;
+    }
+    throw new Error(`Unexpected inspect activation-mode argument: ${arg}`);
+  }
+
+  if (!id) {
+    throw new Error("inspect activation-mode requires an artifact id");
   }
 
   return { id, json };
@@ -1249,6 +1273,17 @@ async function run(): Promise<void> {
         }
         return;
       }
+      if (arg1 === "activation-mode") {
+        const { id, json } = parseInspectActivationModeArgs(rest.slice(1));
+        const { readReactWebActivationMode, renderReactWebActivationModeMarkdown } = await import("../core/react-web-activation-mode.js");
+        const activationMode = readReactWebActivationMode(process.cwd(), id);
+        if (json) {
+          print(activationMode);
+        } else {
+          process.stdout.write(renderReactWebActivationModeMarkdown(activationMode));
+        }
+        return;
+      }
       if (arg1 === "ranked-bundle") {
         const { id, json } = parseInspectRankedBundleArgs(rest.slice(1));
         const { readReactWebRankedBundle, renderReactWebRankedBundleMarkdown } = await import("../core/react-web-ranked-bundle.js");
@@ -1260,7 +1295,7 @@ async function run(): Promise<void> {
         }
         return;
       }
-      throw new Error("inspect expects 'evidence' or 'ranked-bundle'");
+      throw new Error("inspect expects 'evidence', 'activation-mode', or 'ranked-bundle'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import path from "node:path";
+import { hashText } from "./hash";
+import type { SourceFingerprint } from "./schema";
+import {
+  type ReactWebEvidenceArtifact,
+  readReactWebEvidenceArtifact,
+} from "./react-web-evidence-artifact";
+
+export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
+export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "shadow-advisory";
+export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
+  "Local React Web activation-mode advisory only: reports when bounded repeated-file React Web evidence would qualify for activation under the current contract, while leaving runtime selection and injection behavior unchanged. This surface does not widen support claims, does not enable always-on or model-driven activation, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+
+export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
+export const REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS = [
+  "always-on",
+  "glob-match",
+  "model-decision",
+  "profile-gate",
+] as const;
+
+export type ReactWebActivationDeferredTrigger = (typeof REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS)[number];
+export type ReactWebActivationVerdict = "would-activate" | "deferred" | "blocked";
+
+export type ReactWebActivationModeResult = {
+  schemaVersion: typeof REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION;
+  command: typeof REACT_WEB_ACTIVATION_MODE_COMMAND;
+  profile: "react-web";
+  mode: typeof REACT_WEB_ACTIVATION_MODE_MODE;
+  artifactId: string;
+  artifactGeneratedAt: string;
+  filePath: string;
+  claimBoundary: typeof REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY;
+  verdict: ReactWebActivationVerdict;
+  runtimeDecision: ReactWebEvidenceArtifact["decision"];
+  evidenceStrength: ReactWebEvidenceArtifact["evidenceStrength"];
+  supportedTrigger: {
+    name: typeof REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER;
+    positive: boolean;
+    reasons: string[];
+  };
+  deferredTriggers: Array<{
+    name: ReactWebActivationDeferredTrigger;
+    reason: string;
+  }>;
+  blockedReasons: string[];
+};
+
+export type ReactWebActivationModeSummary = {
+  available: boolean;
+  verdict: ReactWebActivationVerdict | "unavailable";
+  repeatedFilePositive: boolean;
+  deferredTriggers: ReactWebActivationDeferredTrigger[];
+  blockedReasons: string[];
+};
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function currentSourceFingerprint(filePath: string): SourceFingerprint | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const source = fs.readFileSync(filePath, "utf8");
+  return {
+    fileHash: hashText(source),
+    lineCount: source.split(/\r?\n/u).length,
+  };
+}
+
+function sourceFingerprintsEqual(left: SourceFingerprint | undefined, right: SourceFingerprint | null): boolean {
+  if (!left || !right) return false;
+  return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
+}
+
+function blockedReasonsFor(artifact: ReactWebEvidenceArtifact): string[] {
+  if (artifact.decision !== "deny") {
+    return [];
+  }
+  return uniqueSorted(
+    artifact.whyDenied.filter(
+      (reason) => reason === "unsupported-react-native-webview-boundary" || reason.startsWith("unsupported-classification:"),
+    ),
+  );
+}
+
+function repeatedFileReasons(cwd: string, artifact: ReactWebEvidenceArtifact): string[] {
+  const reasons: string[] = [];
+  if (artifact.domainPayload?.domain === "react-web") {
+    reasons.push("react-web-domain-payload-present");
+  } else {
+    reasons.push("missing-react-web-domain-payload");
+  }
+  if (artifact.editGuidance?.patchTargets?.length) {
+    reasons.push("patch-targets-present");
+  } else {
+    reasons.push("missing-patch-targets");
+  }
+  if (artifact.sourceFingerprint) {
+    reasons.push("sourceFingerprint-present");
+    const current = currentSourceFingerprint(path.resolve(cwd, artifact.filePath));
+    if (!current) {
+      reasons.push("source-file-missing");
+    } else if (sourceFingerprintsEqual(artifact.sourceFingerprint, current)) {
+      reasons.push("freshness-current");
+    } else {
+      reasons.push("freshness-stale");
+    }
+  } else {
+    reasons.push("missing-sourceFingerprint");
+  }
+  if (artifact.decision === "use") {
+    reasons.push("runtime-decision-use");
+  } else if (artifact.decision === "fallback") {
+    reasons.push("runtime-decision-fallback");
+  } else {
+    reasons.push("runtime-decision-deny");
+  }
+  return uniqueSorted(reasons);
+}
+
+function repeatedFilePositive(cwd: string, artifact: ReactWebEvidenceArtifact): boolean {
+  const current = artifact.sourceFingerprint ? currentSourceFingerprint(path.resolve(cwd, artifact.filePath)) : null;
+  return (
+    artifact.decision === "use" &&
+    artifact.domainPayload?.domain === "react-web" &&
+    Boolean(artifact.editGuidance?.patchTargets?.length) &&
+    Boolean(artifact.sourceFingerprint) &&
+    sourceFingerprintsEqual(artifact.sourceFingerprint, current)
+  );
+}
+
+export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebActivationModeResult {
+  const positive = repeatedFilePositive(cwd, artifact);
+  const blockedReasons = blockedReasonsFor(artifact);
+  const verdict: ReactWebActivationVerdict =
+    blockedReasons.length > 0 || artifact.decision === "deny"
+      ? "blocked"
+      : positive
+        ? "would-activate"
+        : "deferred";
+
+  return {
+    schemaVersion: REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION,
+    command: REACT_WEB_ACTIVATION_MODE_COMMAND,
+    profile: "react-web",
+    mode: REACT_WEB_ACTIVATION_MODE_MODE,
+    artifactId: artifact.id,
+    artifactGeneratedAt: artifact.generatedAt,
+    filePath: artifact.filePath,
+    claimBoundary: REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY,
+    verdict,
+    runtimeDecision: artifact.decision,
+    evidenceStrength: artifact.evidenceStrength,
+    supportedTrigger: {
+      name: REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER,
+      positive,
+      reasons: repeatedFileReasons(cwd, artifact),
+    },
+    deferredTriggers: REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS.map((name) => ({
+      name,
+      reason: "deferred-in-first-activation-pass",
+    })),
+    blockedReasons,
+  };
+}
+
+export function readReactWebActivationMode(cwd: string, id: string): ReactWebActivationModeResult {
+  return buildReactWebActivationMode(cwd, readReactWebEvidenceArtifact(cwd, id));
+}
+
+export function summarizeReactWebActivationMode(
+  activationMode: ReactWebActivationModeResult | null,
+): ReactWebActivationModeSummary {
+  if (!activationMode) {
+    return {
+      available: false,
+      verdict: "unavailable",
+      repeatedFilePositive: false,
+      deferredTriggers: [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
+      blockedReasons: [],
+    };
+  }
+
+  return {
+    available: true,
+    verdict: activationMode.verdict,
+    repeatedFilePositive: activationMode.supportedTrigger.positive,
+    deferredTriggers: activationMode.deferredTriggers.map((item) => item.name),
+    blockedReasons: activationMode.blockedReasons,
+  };
+}
+
+export function renderReactWebActivationModeMarkdown(activationMode: ReactWebActivationModeResult): string {
+  const deferred = activationMode.deferredTriggers
+    .map((item) => `- ${item.name}: ${item.reason}`)
+    .join("\n");
+  const reasons = activationMode.supportedTrigger.reasons.map((reason) => `- ${reason}`).join("\n");
+  const blockedReasons = activationMode.blockedReasons.length > 0
+    ? activationMode.blockedReasons.map((reason) => `- ${reason}`).join("\n")
+    : "- none";
+
+  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
+}

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -9,6 +9,7 @@ import {
   readReactWebEvidenceArtifact,
   reactWebEvidenceArtifactsDir,
 } from "./react-web-evidence-artifact";
+import { buildReactWebActivationMode, summarizeReactWebActivationMode, type ReactWebActivationModeSummary } from "./react-web-activation-mode";
 import { buildReactWebRankedBundle, summarizeReactWebRankedBundle, type ReactWebRankedBundleSummary } from "./react-web-ranked-bundle";
 import type { SourceFingerprint } from "./schema";
 
@@ -52,6 +53,7 @@ export type ReactWebStatusResult = {
     currentSourceFingerprint: SourceFingerprint | null;
     staleWhen: string[];
   };
+  activationMode: ReactWebActivationModeSummary;
   rankedBundle: ReactWebRankedBundleSummary;
   risks: string[];
 };
@@ -112,6 +114,7 @@ function buildBlockedNoEvidenceStatus(cwd: string, generatedAt: string): ReactWe
       currentSourceFingerprint: null,
       staleWhen: [],
     },
+    activationMode: summarizeReactWebActivationMode(null),
     rankedBundle: summarizeReactWebRankedBundle(null),
     risks: [
       `no React Web evidence artifact found at ${path.relative(cwd, latestArtifactIndexPath(cwd)) || ".fooks/artifacts/react-web-evidence/latest.json"}`,
@@ -250,6 +253,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
   const mixedRouting = buildMixedRoutingBoundary(artifact);
   const projectKnowledge = buildProjectKnowledgeBoundary(artifact);
   const fallbackReasons = artifact.decision === "use" ? [] : uniqueSorted(artifact.whyDenied);
+  const activationMode = buildReactWebActivationMode(cwd, artifact);
   const rankedBundle = buildReactWebRankedBundle(artifact);
   const risks = buildRisks(artifact, freshness, repeatedSameFileReady);
 
@@ -273,6 +277,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
       projectKnowledge,
     },
     freshness,
+    activationMode: summarizeReactWebActivationMode(activationMode),
     rankedBundle: summarizeReactWebRankedBundle(rankedBundle),
     risks,
   };
@@ -297,6 +302,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- mixed-routing boundary: ${status.boundaryStatus.mixedRouting.status}`,
     `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
     `- freshness: ${status.freshness.status}`,
+    `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,24 @@ export type {
   ReactWebStatusResult,
 } from "./core/react-web-status";
 export {
+  REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS,
+  REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY,
+  REACT_WEB_ACTIVATION_MODE_COMMAND,
+  REACT_WEB_ACTIVATION_MODE_MODE,
+  REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION,
+  REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER,
+  buildReactWebActivationMode,
+  readReactWebActivationMode,
+  renderReactWebActivationModeMarkdown,
+  summarizeReactWebActivationMode,
+} from "./core/react-web-activation-mode";
+export type {
+  ReactWebActivationDeferredTrigger,
+  ReactWebActivationModeResult,
+  ReactWebActivationModeSummary,
+  ReactWebActivationVerdict,
+} from "./core/react-web-activation-mode";
+export {
   REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT,
   REACT_WEB_RANKED_BUNDLE_CLAIM_BOUNDARY,
   REACT_WEB_RANKED_BUNDLE_COMMAND,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3520,6 +3520,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks doctor \[codex\|claude\] \[--json\]/);
   assert.match(help, /fooks compare <file> \[--json\]/);
   assert.match(help, /fooks inspect evidence <id> \[--json\]/);
+  assert.match(help, /fooks inspect activation-mode <id> \[--json\]/);
   assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -1,0 +1,191 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS,
+  REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION,
+  buildReactWebActivationMode,
+  readReactWebActivationMode,
+  renderReactWebActivationModeMarkdown,
+} = require(path.join(repoRoot, "dist", "core", "react-web-activation-mode.js"));
+const {
+  REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+  REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+  REACT_WEB_EVIDENCE_ARTIFACT_INTEROP,
+  REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND,
+  REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
+  REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
+  REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function writeFixture(tempDir, fixturePath, fileName) {
+  fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
+}
+
+function runRepeatedDecision(tempDir, fileName, secondPrompt) {
+  const sessionId = `react-web-activation-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Please inspect ${fileName}` }, tempDir);
+  const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  return second;
+}
+
+function makeArtifact(overrides = {}) {
+  return {
+    schemaVersion: REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
+    id: "react-web-evidence-activation-synthetic",
+    generatedAt: "2026-05-09T00:00:00.000Z",
+    producer: REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
+    profile: REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
+    payloadKind: REACT_WEB_EVIDENCE_ARTIFACT_PAYLOAD_KIND,
+    runtime: "codex",
+    hookEventName: "UserPromptSubmit",
+    decision: "use",
+    evidenceStrength: "direct",
+    filePath: "src/components/FormSection.tsx",
+    reasons: ["repeated-same-file-runtime-decision"],
+    whyDenied: [],
+    claimBoundary: REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
+    compressionPolicy: REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
+    interop: { ...REACT_WEB_EVIDENCE_ARTIFACT_INTEROP },
+    sourceFingerprint: {
+      fileHash: "abc123",
+      lineCount: 42,
+    },
+    freshness: {
+      sourceFingerprint: {
+        fileHash: "abc123",
+        lineCount: 42,
+      },
+      staleWhen: ["sourceFingerprint.fileHash changes"],
+    },
+    files: [
+      {
+        path: "src/components/FormSection.tsx",
+        symbols: ["FormSection"],
+        lineRanges: ["1-40"],
+        whySelected: ["exact-file-prompt-target"],
+      },
+    ],
+    editGuidance: {
+      patchTargets: [
+        { kind: "component", label: "FormSection", reason: "primary component", loc: { startLine: 1, endLine: 40 } },
+      ],
+    },
+    concernProfiles: [],
+    domainPayload: {
+      domain: "react-web",
+      policy: "measured-source-context",
+      plannerDecision: "compact-safe",
+      claimStatus: "current-supported-lane",
+      claimBoundary: "react-web-measured-extraction",
+      evidence: ["same-file-evidence"],
+      facts: {},
+      warnings: [],
+    },
+    ...overrides,
+  };
+}
+
+test("inspect activation-mode reads a repeated React Web artifact and stays advisory-only", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-runtime-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+
+  assert.equal(second.action, "inject");
+  const ref = second.debug?.reactWebEvidenceArtifact;
+  assert.equal(ref?.emitted, true);
+
+  const activationMode = readReactWebActivationMode(tempDir, ref.id);
+  assert.equal(activationMode.schemaVersion, REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION);
+  assert.equal(activationMode.verdict, "would-activate");
+  assert.equal(activationMode.supportedTrigger.name, "repeated-file");
+  assert.equal(activationMode.supportedTrigger.positive, true);
+  assert.deepEqual(
+    activationMode.deferredTriggers.map((item) => item.name),
+    [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
+  );
+
+  const markdown = renderReactWebActivationModeMarkdown(activationMode);
+  assert.match(markdown, /React Web activation mode/);
+  assert.match(markdown, /shadow-advisory/);
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "activation-mode", ref.id, "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.artifactId, ref.id);
+  assert.equal(parsed.verdict, "would-activate");
+});
+
+test("activation mode keeps non-repeated activation triggers explicitly deferred", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-deferred-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, "src", "components", "FormSection.tsx"), "export function FormSection() { return null; }\n");
+
+  const activationMode = buildReactWebActivationMode(tempDir, makeArtifact({
+    filePath: "src/components/FormSection.tsx",
+    sourceFingerprint: {
+      fileHash: "not-current",
+      lineCount: 999,
+    },
+    freshness: {
+      sourceFingerprint: {
+        fileHash: "not-current",
+        lineCount: 999,
+      },
+      staleWhen: ["sourceFingerprint.fileHash changes"],
+    },
+  }));
+
+  assert.equal(activationMode.verdict, "deferred");
+  assert.equal(activationMode.supportedTrigger.positive, false);
+  assert.deepEqual(
+    activationMode.deferredTriggers.map((item) => item.name),
+    [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
+  );
+});
+
+test("activation mode fail-closes deny boundary artifacts instead of widening support", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-blocked-"));
+  const activationMode = buildReactWebActivationMode(tempDir, makeArtifact({
+    decision: "deny",
+    evidenceStrength: "denied",
+    whyDenied: ["unsupported-react-native-webview-boundary"],
+    domainPayload: {
+      domain: "webview",
+      policy: "fallback-first",
+      plannerDecision: "fallback-only",
+      claimStatus: "unsupported-lane",
+      claimBoundary: "unsupported-react-native-webview-boundary",
+      evidence: ["webview-signal"],
+      facts: {},
+      warnings: [],
+    },
+  }));
+
+  assert.equal(activationMode.verdict, "blocked");
+  assert.equal(activationMode.supportedTrigger.positive, false);
+  assert.ok(activationMode.blockedReasons.includes("unsupported-react-native-webview-boundary"));
+});

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -42,6 +42,13 @@ test("status react-web reports blocked without failing when no latest evidence e
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestEvidenceId, null);
   assert.equal(status.repeatedSameFileReady, false);
+  assert.deepEqual(status.activationMode, {
+    available: false,
+    verdict: "unavailable",
+    repeatedFilePositive: false,
+    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    blockedReasons: [],
+  });
   assert.deepEqual(status.rankedBundle, {
     available: false,
     verdict: "unavailable",
@@ -86,6 +93,9 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(status.repeatedSameFileReady, true);
   assert.equal(status.boundaryStatus.mixedRouting.status, "bounded");
   assert.equal(status.boundaryStatus.projectKnowledge.status, "advisory-only");
+  assert.equal(status.activationMode.available, true);
+  assert.equal(status.activationMode.verdict, "would-activate");
+  assert.equal(status.activationMode.repeatedFilePositive, true);
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "ranked");
   assert.ok(status.rankedBundle.selectedCount > 0);
@@ -122,6 +132,9 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   assert.equal(status.profileStatus, "blocked");
   assert.equal(status.latestDecision, "deny");
   assert.equal(status.boundaryStatus.mixedRouting.status, "blocked");
+  assert.equal(status.activationMode.available, true);
+  assert.equal(status.activationMode.verdict, "blocked");
+  assert.equal(status.activationMode.repeatedFilePositive, false);
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "blocked");
   assert.deepEqual(status.interop, {


### PR DESCRIPTION
Closes #644

## Summary
- add a React Web-only activation-mode advisory diagnostic surface
- expose `fooks inspect activation-mode <id> [--json]`
- surface activation summary in `fooks status react-web`
- keep activation bounded to the repeated-file trigger while deferring all other modes

## Verification
- npm run build
- node --test test/react-web-activation-mode.test.mjs test/react-web-status-surface.test.mjs
- npm run lint
- npm test