### PR TITLE
Promote React Web repeated-file activation into the Codex runtime path

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -21,6 +21,7 @@ import {
 } from "../core/session-metrics";
 import { finalizeWorktreeEvidenceSafe, initializeWorktreeEvidenceSafe } from "../core/worktree-evidence";
 import { emitReactWebEvidenceArtifact } from "../core/react-web-evidence-artifact";
+import { buildReactWebActivationModeFromRuntimeDecision, summarizeReactWebActivationMode } from "../core/react-web-activation-mode";
 
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
@@ -361,6 +362,27 @@ function attachReactWebEvidenceArtifact(
   return runtimeDecision;
 }
 
+function attachReactWebActivationDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  options: { promoted: boolean },
+  cwd: string,
+): CodexRuntimeHookDecision {
+  const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    reactWebActivationMode: {
+      ...summarizeReactWebActivationMode(activationMode),
+      promoted: options.promoted,
+    },
+  };
+  return runtimeDecision;
+}
+
 export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = process.cwd()): CodexRuntimeHookDecision {
   const hookEventName = input.hookEventName;
   const sessionKey = resolveCodexRuntimeSessionKey(input.sessionId, input.threadId);
@@ -593,6 +615,37 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         ...(reactWebContextPacking ? { reactWebContextPacking } : {}),
       },
     };
+
+    if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
+      const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
+      if (!activationMode || activationMode.verdict !== "would-activate") {
+        const activationFallback = attachReactWebActivationDebug(
+          fallbackDecision(
+            hookEventName,
+            target,
+            statePath,
+            ["repeated-file", "activation-mode-not-promoted"],
+            true,
+            true,
+            false,
+            "activation-mode-not-promoted",
+            policy,
+            decision,
+          ),
+          { promoted: false },
+          cwd,
+        );
+        recordRuntimeDecisionMetric(cwd, sessionKey, activationFallback, {
+          originalEstimatedBytes,
+          actualEstimatedBytes: originalEstimatedBytes,
+          comparableForSavings: originalEstimatedBytes !== undefined,
+        });
+        return attachReactWebEvidenceArtifact(cwd, activationFallback);
+      }
+
+      attachReactWebActivationDebug(runtimeDecision, { promoted: true }, cwd);
+    }
+
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
       actualEstimatedBytes: estimateTextBytes(additionalContext),

--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -1,17 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import { hashText } from "./hash";
-import type { SourceFingerprint } from "./schema";
+import type { CodexRuntimeHookDecision, SourceFingerprint } from "./schema";
 import {
+  buildReactWebEvidenceArtifact,
   type ReactWebEvidenceArtifact,
   readReactWebEvidenceArtifact,
 } from "./react-web-evidence-artifact";
 
 export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
 export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
-export const REACT_WEB_ACTIVATION_MODE_MODE = "shadow-advisory";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime";
 export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
-  "Local React Web activation-mode advisory only: reports when bounded repeated-file React Web evidence would qualify for activation under the current contract, while leaving runtime selection and injection behavior unchanged. This surface does not widen support claims, does not enable always-on or model-driven activation, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+  "Local React Web repeated-file activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and now governs the Codex runtime promotion path for that same bounded lane. This surface does not widen support claims, does not enable always-on or model-driven activation, and does not promote RN/TUI/WebView or generic context-manager behavior.";
 
 export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
 export const REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS = [
@@ -127,7 +128,6 @@ function repeatedFilePositive(cwd: string, artifact: ReactWebEvidenceArtifact): 
   return (
     artifact.decision === "use" &&
     artifact.domainPayload?.domain === "react-web" &&
-    Boolean(artifact.editGuidance?.patchTargets?.length) &&
     Boolean(artifact.sourceFingerprint) &&
     sourceFingerprintsEqual(artifact.sourceFingerprint, current)
   );
@@ -170,6 +170,14 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
 
 export function readReactWebActivationMode(cwd: string, id: string): ReactWebActivationModeResult {
   return buildReactWebActivationMode(cwd, readReactWebEvidenceArtifact(cwd, id));
+}
+
+export function buildReactWebActivationModeFromRuntimeDecision(
+  cwd: string,
+  runtimeDecision: CodexRuntimeHookDecision,
+): ReactWebActivationModeResult | null {
+  const artifact = buildReactWebEvidenceArtifact(runtimeDecision);
+  return artifact ? buildReactWebActivationMode(cwd, artifact) : null;
 }
 
 export function summarizeReactWebActivationMode(

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -729,6 +729,14 @@ export type CodexRuntimeHookDecision = {
       totalAnchors: number;
       priority: string[];
     };
+    reactWebActivationMode?: {
+      available: boolean;
+      verdict: "would-activate" | "deferred" | "blocked" | "unavailable";
+      repeatedFilePositive: boolean;
+      promoted: boolean;
+      deferredTriggers: string[];
+      blockedReasons: string[];
+    };
   };
   fallback?: {
     action: "full-read";

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export {
   REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION,
   REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER,
   buildReactWebActivationMode,
+  buildReactWebActivationModeFromRuntimeDecision,
   readReactWebActivationMode,
   renderReactWebActivationModeMarkdown,
   summarizeReactWebActivationMode,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -189,6 +189,21 @@ function withThrowingCodexPreRead(callback) {
   }
 }
 
+function withPatchedCodexPreRead(patchDecision, callback) {
+  const originalDecideCodexPreRead = codexPreReadModule.decideCodexPreRead;
+  const originalDecidePreRead = preReadModule.decidePreRead;
+  const patchedFn = (...args) => patchDecision(originalDecidePreRead(...args));
+  codexPreReadModule.decideCodexPreRead = patchedFn;
+  preReadModule.decidePreRead = patchedFn;
+
+  try {
+    return callback();
+  } finally {
+    codexPreReadModule.decideCodexPreRead = originalDecideCodexPreRead;
+    preReadModule.decidePreRead = originalDecidePreRead;
+  }
+}
+
 function makeTempProject(repositoryUrl = "https://github.com/minislively/temp-project.git") {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-"));
   fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
@@ -2231,6 +2246,14 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.ok(second.debug.decision.payload.editGuidance.patchTargets.length <= 12);
   assert.equal(second.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
   assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+  assert.deepEqual(second.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "would-activate",
+    repeatedFilePositive: true,
+    promoted: true,
+    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    blockedReasons: [],
+  });
   const runtimePayload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
   assert.ok(Array.isArray(runtimePayload.reactWebContext.editTargetRouting));
   assert.ok(runtimePayload.reactWebContext.editTargetRouting.length > 0);
@@ -2370,6 +2393,14 @@ test("runtime hook gates edit guidance to repeated exact-file edit intent prompt
   assert.equal(reviewOnly.action, "inject");
   assert.equal(reviewOnly.additionalContext.includes("\"editGuidance\""), false);
   assert.equal(reviewOnly.reasons.includes("edit-guidance-opt-in"), false);
+  assert.deepEqual(reviewOnly.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "would-activate",
+    repeatedFilePositive: true,
+    promoted: true,
+    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    blockedReasons: [],
+  });
 
   const multiFileSession = `hook-multifile-no-edit-guidance-${Date.now()}`;
   const otherTarget = path.join("fixtures", "jsx", "SimpleWidget.jsx");
@@ -2394,6 +2425,53 @@ test("runtime hook gates edit guidance to repeated exact-file edit intent prompt
   assert.equal(multiFile.promptSpecificity, "exact-file");
   assert.equal(multiFile.additionalContext.includes("\"editGuidance\""), false);
   assert.equal(multiFile.reasons.includes("edit-guidance-opt-in"), false);
+});
+
+test("runtime hook fail-closes repeated React Web activation promotion when freshness evidence is missing", () => {
+  const target = path.join("fixtures", "compressed", "FormSection.tsx");
+  const sessionId = `hook-react-web-activation-fallback-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+  handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please update ${target}`,
+    },
+    repoRoot,
+  );
+
+  const second = withPatchedCodexPreRead((decision) => {
+    if (decision?.decision === "payload" && decision.payload?.domainPayload?.domain === "react-web") {
+      return {
+        ...decision,
+        payload: {
+          ...decision.payload,
+          sourceFingerprint: undefined,
+        },
+      };
+    }
+    return decision;
+  }, () =>
+    handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: `Again, update ${target}`,
+      },
+      repoRoot,
+    ));
+
+  assert.equal(second.action, "fallback");
+  assert.equal(second.contextModeReason, "activation-mode-not-promoted");
+  assert.deepEqual(second.reasons, ["repeated-file", "activation-mode-not-promoted"]);
+  assert.deepEqual(second.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "deferred",
+    repeatedFilePositive: false,
+    promoted: false,
+    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    blockedReasons: [],
+  });
 });
 
 test("bare status reports fast estimated session savings without exposing session contribution internals", () => {

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -16,6 +16,7 @@ const {
   REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS,
   REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION,
   buildReactWebActivationMode,
+  buildReactWebActivationModeFromRuntimeDecision,
   readReactWebActivationMode,
   renderReactWebActivationModeMarkdown,
 } = require(path.join(repoRoot, "dist", "core", "react-web-activation-mode.js"));
@@ -28,6 +29,7 @@ const {
   REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
   REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
 } = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+const { hashText } = require(path.join(repoRoot, "dist", "core", "hash.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
 
@@ -127,7 +129,7 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
 
   const markdown = renderReactWebActivationModeMarkdown(activationMode);
   assert.match(markdown, /React Web activation mode/);
-  assert.match(markdown, /shadow-advisory/);
+  assert.match(markdown, /repeated-file-runtime/);
 
   const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "activation-mode", ref.id, "--json"], {
     cwd: tempDir,
@@ -165,6 +167,59 @@ test("activation mode keeps non-repeated activation triggers explicitly deferred
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
   );
+});
+
+test("runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-runtime-candidate-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  const source = "export function FormSection() { return null; }\n";
+  const filePath = path.join(tempDir, "src", "components", "FormSection.tsx");
+  fs.writeFileSync(filePath, source);
+
+  const runtimeDecision = {
+    runtime: "codex",
+    hookEventName: "UserPromptSubmit",
+    action: "inject",
+    filePath: "src/components/FormSection.tsx",
+    reasons: ["repeated-file"],
+    contextMode: "light",
+    contextModeReason: "repeated-exact-file-react-web-payload",
+    promptSpecificity: "exact-file",
+    debug: {
+      repeatedFile: true,
+      eligible: true,
+      escapeHatchUsed: false,
+      decision: {
+        decision: "payload",
+        eligible: true,
+        reasons: ["react-web-current-supported-payload"],
+        payload: makeArtifact({
+          filePath: "src/components/FormSection.tsx",
+          sourceFingerprint: {
+            fileHash: hashText(source),
+            lineCount: 2,
+          },
+          freshness: {
+            sourceFingerprint: {
+              fileHash: hashText(source),
+              lineCount: 2,
+            },
+            staleWhen: ["sourceFingerprint.fileHash changes"],
+          },
+          editGuidance: undefined,
+        }),
+        debug: {
+          domainDetection: {
+            classification: "react-web",
+          },
+        },
+      },
+    },
+  };
+
+  const activationMode = buildReactWebActivationModeFromRuntimeDecision(tempDir, runtimeDecision);
+  assert.equal(activationMode?.verdict, "would-activate");
+  assert.equal(activationMode?.supportedTrigger.positive, true);
 });
 
 test("activation mode fail-closes deny boundary artifacts instead of widening support", () => {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -759,6 +759,14 @@ test("codex runtime activates React Web payload semantics only for the React Web
   assert.equal(reactWeb.second.debug.decision.debug.frontendPayloadPolicy.name, REACT_WEB_CURRENT_SUPPORTED_PAYLOAD_POLICY);
   assert.equal(reactWeb.second.debug.decision.payload.domainPayload.domain, "react-web");
   assert.equal(reactWeb.second.debug.decision.payload.domainPayload.plannerDecision, "compact-safe");
+  assert.deepEqual(reactWeb.second.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "would-activate",
+    repeatedFilePositive: true,
+    promoted: true,
+    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    blockedReasons: [],
+  });
 
   const rnPrimitive = runRepeatedPrompt("rn-primitive", "inspect test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx");
   assert.equal(rnPrimitive.second.action, "inject");
@@ -770,6 +778,7 @@ test("codex runtime activates React Web payload semantics only for the React Web
   assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
   assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.reuseContract.policy, RN_PRIMITIVE_INPUT_NARROW_PAYLOAD_POLICY);
   assert.equal(rnPrimitive.second.debug.decision.payload.domainPayload.reuseContract.freshnessSource, "sourceFingerprint");
+  assert.equal(rnPrimitive.second.debug.reactWebActivationMode, undefined);
   assert.equal(rnPrimitive.second.additionalContext.includes('"domainPayload"'), true);
   assert.equal(rnPrimitive.second.additionalContext.includes('"reuseContract"'), true);
   assert.match(rnPrimitive.second.additionalContext, /"domain":\s*"react-native"/);


### PR DESCRIPTION
Closes #646

## Summary
- promote the bounded React Web repeated-file activation contract into the Codex runtime path
- attach activation-promotion evidence to Codex runtime debug surfaces
- keep the runtime gate fail-closed when activation freshness evidence is missing
- leave raw originals and non-React-Web lanes untouched

## Verification
- npm run build
- node --test test/react-web-activation-mode.test.mjs test/runtime-bridge-contract.test.mjs test/fooks.test.mjs --test-name-pattern "runtime hook reuses payload only on repeated same-file prompts in one session|runtime hook gates edit guidance to repeated exact-file edit intent prompts|runtime hook fail-closes repeated React Web activation promotion when freshness evidence is missing|runtime hook injects tiny raw originals and still honors escape hatch fallbacks|native hook bridge injects tiny raw originals on repeated prompts|codex runtime activates React Web payload semantics only for the React Web lane"
- npm run lint
- npm test