### PR TITLE
Add the React Web profile-gate advisory surface

### DIFF
--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -10,16 +10,16 @@ import {
 
 export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
 export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
-export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-advisory";
 export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
-  "Local React Web repeated-file activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and now governs the Codex runtime promotion path for that same bounded lane. This surface does not widen support claims, does not enable always-on or model-driven activation, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and when the bounded profile-gate policy would activate in advisory mode. This surface does not widen support claims, does not enable always-on or model-driven activation, does not auto-promote profile-gate runtime behavior, and does not promote RN/TUI/WebView or generic context-manager behavior.";
 
 export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
+export const REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER = "profile-gate";
 export const REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS = [
   "always-on",
   "glob-match",
   "model-decision",
-  "profile-gate",
 ] as const;
 
 export type ReactWebActivationDeferredTrigger = (typeof REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS)[number];
@@ -42,6 +42,11 @@ export type ReactWebActivationModeResult = {
     positive: boolean;
     reasons: string[];
   };
+  profileGate: {
+    name: typeof REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER;
+    verdict: ReactWebActivationVerdict;
+    reasons: string[];
+  };
   deferredTriggers: Array<{
     name: ReactWebActivationDeferredTrigger;
     reason: string;
@@ -53,6 +58,8 @@ export type ReactWebActivationModeSummary = {
   available: boolean;
   verdict: ReactWebActivationVerdict | "unavailable";
   repeatedFilePositive: boolean;
+  profileGateVerdict: ReactWebActivationVerdict | "unavailable";
+  profileGateReasons: string[];
   deferredTriggers: ReactWebActivationDeferredTrigger[];
   blockedReasons: string[];
 };
@@ -133,9 +140,85 @@ function repeatedFilePositive(cwd: string, artifact: ReactWebEvidenceArtifact): 
   );
 }
 
+function profileGateReasons(cwd: string, artifact: ReactWebEvidenceArtifact): string[] {
+  const reasons: string[] = [];
+  if (artifact.domainPayload?.domain === "react-web") {
+    reasons.push("react-web-domain-payload-present");
+  } else {
+    reasons.push("missing-react-web-domain-payload");
+  }
+  if (artifact.domainPayload?.claimStatus === "current-supported-lane") {
+    reasons.push("current-supported-lane-claim");
+  } else {
+    reasons.push("non-current-supported-lane-claim");
+  }
+  if (artifact.domainPayload?.plannerDecision === "compact-safe") {
+    reasons.push("planner-decision-compact-safe");
+  } else {
+    reasons.push("planner-decision-not-compact-safe");
+  }
+  if (artifact.evidenceStrength === "direct") {
+    reasons.push("direct-evidence-strength");
+  } else {
+    reasons.push(`evidence-strength-${artifact.evidenceStrength}`);
+  }
+  if (artifact.sourceFingerprint) {
+    const current = currentSourceFingerprint(path.resolve(cwd, artifact.filePath));
+    if (!current) {
+      reasons.push("source-file-missing");
+    } else if (sourceFingerprintsEqual(artifact.sourceFingerprint, current)) {
+      reasons.push("freshness-current");
+    } else {
+      reasons.push("freshness-stale");
+    }
+  } else {
+    reasons.push("missing-sourceFingerprint");
+  }
+  if (artifact.files.some((file) => file.whySelected.some((reason) => reason === "exact-file-prompt-target" || reason === "exact-file-runtime-target"))) {
+    reasons.push("direct-file-evidence-present");
+  } else {
+    reasons.push("missing-direct-file-evidence");
+  }
+  if (artifact.decision === "use") {
+    reasons.push("runtime-decision-use");
+  } else if (artifact.decision === "fallback") {
+    reasons.push("runtime-decision-fallback");
+  } else {
+    reasons.push("runtime-decision-deny");
+  }
+  return uniqueSorted(reasons);
+}
+
+function profileGateVerdict(cwd: string, artifact: ReactWebEvidenceArtifact): {
+  verdict: ReactWebActivationVerdict;
+  reasons: string[];
+} {
+  const reasons = profileGateReasons(cwd, artifact);
+  const blockedReasons = blockedReasonsFor(artifact);
+  if (blockedReasons.length > 0 || artifact.decision === "deny") {
+    return { verdict: "blocked", reasons };
+  }
+
+  const current = artifact.sourceFingerprint ? currentSourceFingerprint(path.resolve(cwd, artifact.filePath)) : null;
+  const wouldActivate =
+    artifact.decision === "use" &&
+    artifact.domainPayload?.domain === "react-web" &&
+    artifact.domainPayload?.claimStatus === "current-supported-lane" &&
+    artifact.domainPayload?.plannerDecision === "compact-safe" &&
+    artifact.evidenceStrength === "direct" &&
+    artifact.files.some((file) => file.whySelected.some((reason) => reason === "exact-file-prompt-target" || reason === "exact-file-runtime-target")) &&
+    sourceFingerprintsEqual(artifact.sourceFingerprint, current);
+
+  return {
+    verdict: wouldActivate ? "would-activate" : "deferred",
+    reasons,
+  };
+}
+
 export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebActivationModeResult {
   const positive = repeatedFilePositive(cwd, artifact);
   const blockedReasons = blockedReasonsFor(artifact);
+  const profileGate = profileGateVerdict(cwd, artifact);
   const verdict: ReactWebActivationVerdict =
     blockedReasons.length > 0 || artifact.decision === "deny"
       ? "blocked"
@@ -159,6 +242,11 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
       name: REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER,
       positive,
       reasons: repeatedFileReasons(cwd, artifact),
+    },
+    profileGate: {
+      name: REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER,
+      verdict: profileGate.verdict,
+      reasons: profileGate.reasons,
     },
     deferredTriggers: REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS.map((name) => ({
       name,
@@ -188,6 +276,8 @@ export function summarizeReactWebActivationMode(
       available: false,
       verdict: "unavailable",
       repeatedFilePositive: false,
+      profileGateVerdict: "unavailable",
+      profileGateReasons: [],
       deferredTriggers: [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
       blockedReasons: [],
     };
@@ -197,6 +287,8 @@ export function summarizeReactWebActivationMode(
     available: true,
     verdict: activationMode.verdict,
     repeatedFilePositive: activationMode.supportedTrigger.positive,
+    profileGateVerdict: activationMode.profileGate.verdict,
+    profileGateReasons: activationMode.profileGate.reasons,
     deferredTriggers: activationMode.deferredTriggers.map((item) => item.name),
     blockedReasons: activationMode.blockedReasons,
   };
@@ -210,6 +302,7 @@ export function renderReactWebActivationModeMarkdown(activationMode: ReactWebAct
   const blockedReasons = activationMode.blockedReasons.length > 0
     ? activationMode.blockedReasons.map((reason) => `- ${reason}`).join("\n")
     : "- none";
+  const profileGateReasons = activationMode.profileGate.reasons.map((reason) => `- ${reason}`).join("\n");
 
-  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
+  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Advisory profile-gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
 }

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -286,6 +286,9 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
 export function renderReactWebStatusText(status: ReactWebStatusResult): string {
   const risks = status.risks.length > 0 ? status.risks.map((risk) => `- ${risk}`).join("\n") : "- none";
   const fallbackReasons = status.fallbackReasons.length > 0 ? status.fallbackReasons.join(", ") : "none";
+  const profileGateReasons = status.activationMode.profileGateReasons.length > 0
+    ? status.activationMode.profileGateReasons.join(", ")
+    : "none";
   return [
     "# React Web status",
     "",
@@ -303,6 +306,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
     `- freshness: ${status.freshness.status}`,
     `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
+    `- profile-gate advisory: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -733,6 +733,8 @@ export type CodexRuntimeHookDecision = {
       available: boolean;
       verdict: "would-activate" | "deferred" | "blocked" | "unavailable";
       repeatedFilePositive: boolean;
+      profileGateVerdict: "would-activate" | "deferred" | "blocked" | "unavailable";
+      profileGateReasons: string[];
       promoted: boolean;
       deferredTriggers: string[];
       blockedReasons: string[];

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2250,8 +2250,18 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
     available: true,
     verdict: "would-activate",
     repeatedFilePositive: true,
+    profileGateVerdict: "would-activate",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "direct-file-evidence-present",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
     blockedReasons: [],
   });
   const runtimePayload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
@@ -2397,8 +2407,18 @@ test("runtime hook gates edit guidance to repeated exact-file edit intent prompt
     available: true,
     verdict: "would-activate",
     repeatedFilePositive: true,
+    profileGateVerdict: "would-activate",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "direct-file-evidence-present",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
     blockedReasons: [],
   });
 
@@ -2468,8 +2488,18 @@ test("runtime hook fail-closes repeated React Web activation promotion when fres
     available: true,
     verdict: "deferred",
     repeatedFilePositive: false,
+    profileGateVerdict: "deferred",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-file-evidence-present",
+      "evidence-strength-adjacent",
+      "missing-sourceFingerprint",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-fallback",
+    ],
     promoted: false,
-    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
     blockedReasons: [],
   });
 });

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -122,6 +122,8 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   assert.equal(activationMode.verdict, "would-activate");
   assert.equal(activationMode.supportedTrigger.name, "repeated-file");
   assert.equal(activationMode.supportedTrigger.positive, true);
+  assert.equal(activationMode.profileGate.name, "profile-gate");
+  assert.equal(activationMode.profileGate.verdict, "would-activate");
   assert.deepEqual(
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
@@ -139,6 +141,7 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   const parsed = JSON.parse(cliJson.stdout);
   assert.equal(parsed.artifactId, ref.id);
   assert.equal(parsed.verdict, "would-activate");
+  assert.equal(parsed.profileGate.verdict, "would-activate");
 });
 
 test("activation mode keeps non-repeated activation triggers explicitly deferred", () => {
@@ -163,6 +166,7 @@ test("activation mode keeps non-repeated activation triggers explicitly deferred
 
   assert.equal(activationMode.verdict, "deferred");
   assert.equal(activationMode.supportedTrigger.positive, false);
+  assert.equal(activationMode.profileGate.verdict, "deferred");
   assert.deepEqual(
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
@@ -220,6 +224,7 @@ test("runtime activation promotion does not require patchTargets when repeated R
   const activationMode = buildReactWebActivationModeFromRuntimeDecision(tempDir, runtimeDecision);
   assert.equal(activationMode?.verdict, "would-activate");
   assert.equal(activationMode?.supportedTrigger.positive, true);
+  assert.equal(activationMode?.profileGate.verdict, "would-activate");
 });
 
 test("activation mode fail-closes deny boundary artifacts instead of widening support", () => {
@@ -242,5 +247,6 @@ test("activation mode fail-closes deny boundary artifacts instead of widening su
 
   assert.equal(activationMode.verdict, "blocked");
   assert.equal(activationMode.supportedTrigger.positive, false);
+  assert.equal(activationMode.profileGate.verdict, "blocked");
   assert.ok(activationMode.blockedReasons.includes("unsupported-react-native-webview-boundary"));
 });

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -46,7 +46,9 @@ test("status react-web reports blocked without failing when no latest evidence e
     available: false,
     verdict: "unavailable",
     repeatedFilePositive: false,
-    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    profileGateVerdict: "unavailable",
+    profileGateReasons: [],
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
     blockedReasons: [],
   });
   assert.deepEqual(status.rankedBundle, {
@@ -96,6 +98,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(status.activationMode.available, true);
   assert.equal(status.activationMode.verdict, "would-activate");
   assert.equal(status.activationMode.repeatedFilePositive, true);
+  assert.equal(status.activationMode.profileGateVerdict, "would-activate");
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "ranked");
   assert.ok(status.rankedBundle.selectedCount > 0);
@@ -115,6 +118,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.match(cliText.stdout, /React Web status/);
   assert.match(cliText.stdout, /profile status: ready/);
   assert.match(cliText.stdout, /summarized=no/);
+  assert.match(cliText.stdout, /profile-gate advisory: would-activate/);
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {
@@ -135,6 +139,7 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   assert.equal(status.activationMode.available, true);
   assert.equal(status.activationMode.verdict, "blocked");
   assert.equal(status.activationMode.repeatedFilePositive, false);
+  assert.equal(status.activationMode.profileGateVerdict, "blocked");
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "blocked");
   assert.deepEqual(status.interop, {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -763,8 +763,18 @@ test("codex runtime activates React Web payload semantics only for the React Web
     available: true,
     verdict: "would-activate",
     repeatedFilePositive: true,
+    profileGateVerdict: "would-activate",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "direct-file-evidence-present",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision", "profile-gate"],
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
     blockedReasons: [],
   });
 


### PR DESCRIPTION
Closes #648

## Summary
- expose profile-gate would-activate/deferred/blocked reasoning in the React Web activation inspect surface
- surface the advisory verdict in `fooks status react-web`
- keep repeated-file runtime promotion semantics unchanged
- leave runtime auto-promotion and multi-runtime parity deferred

## Verification
- npm run build
- node --test test/react-web-activation-mode.test.mjs test/react-web-status-surface.test.mjs test/runtime-bridge-contract.test.mjs test/fooks.test.mjs --test-name-pattern "inspect activation-mode reads a repeated React Web artifact and stays advisory-only|activation mode keeps non-repeated activation triggers explicitly deferred|runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh|activation mode fail-closes deny boundary artifacts instead of widening support|status react-web reports blocked without failing when no latest evidence exists|status react-web reports ready from a current repeated same-file use artifact|status react-web reports blocked mixed-routing boundary from a deny artifact without failing|runtime hook reuses payload only on repeated same-file prompts in one session|runtime hook gates edit guidance to repeated exact-file edit intent prompts|runtime hook fail-closes repeated React Web activation promotion when freshness evidence is missing|codex runtime activates React Web payload semantics only for the React Web lane"
- npm run lint
- npm test