### PR TITLE
Add the React Web activation-readiness doctor surface

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,6 +8,8 @@ import { runtimeManifestPath } from "../adapters/shared";
 import { CacheMonitor } from "../core/cache-monitor";
 import { adapterDir, canonicalProjectDataDir } from "../core/paths";
 import { discoverProjectFiles } from "../core/discover";
+import { readReactWebActivationMode, type ReactWebActivationModeResult, type ReactWebActivationVerdict } from "../core/react-web-activation-mode";
+import { readReactWebStatus } from "../core/react-web-status";
 import { discoverSetupEligibleSources } from "../core/setup-eligibility";
 import { currentWorktreeEvidenceStatus, WORKTREE_BRANCH_DIVERGENCE_SOURCE } from "../core/worktree-evidence";
 
@@ -31,6 +33,28 @@ export type DoctorReadiness = {
   nextAction: string;
 };
 
+export type DoctorReactWebActivationReadiness = {
+  available: boolean;
+  state: "ready" | "partial" | "blocked";
+  latestEvidenceId: string | null;
+  latestDecision: "use" | "fallback" | "deny" | null;
+  freshness: "current" | "stale" | "missing-source-file" | "unavailable";
+  claimBoundary: string;
+  repeatedFileRuntime: {
+    verdict: ReactWebActivationVerdict | "unavailable";
+    positive: boolean;
+    reasons: string[];
+  };
+  profileGateAdvisory: {
+    verdict: ReactWebActivationVerdict | "unavailable";
+    reasons: string[];
+  };
+  deferredTriggers: string[];
+  risks: string[];
+  nextAction: string;
+  readError?: string;
+};
+
 export type DoctorResult = {
   command: "doctor";
   target: DoctorTarget;
@@ -40,6 +64,7 @@ export type DoctorResult = {
   checks: DoctorCheck[];
   nextSteps: string[];
   claimBoundaries: string[];
+  reactWebActivation?: DoctorReactWebActivationReadiness;
 };
 
 export type DoctorOptions = {
@@ -562,6 +587,88 @@ function aggregateChecks(cwd: string, cliName: string): DoctorCheck[] {
   return checks;
 }
 
+function activationStateFor(verdict: ReactWebActivationVerdict | "unavailable", latestEvidenceId: string | null): DoctorReactWebActivationReadiness["state"] {
+  if (!latestEvidenceId || verdict === "blocked" || verdict === "unavailable") {
+    return "blocked";
+  }
+  if (verdict === "deferred") {
+    return "partial";
+  }
+  return "ready";
+}
+
+function activationNextAction(
+  state: DoctorReactWebActivationReadiness["state"],
+  latestEvidenceId: string | null,
+  activationMode: ReactWebActivationModeResult | null,
+): string {
+  if (!latestEvidenceId) {
+    return "Create one repeated same-file React Web Codex cycle, then rerun fooks doctor codex to inspect activation readiness.";
+  }
+  if (!activationMode) {
+    return "Inspect the latest React Web evidence artifact, then rerun fooks doctor codex.";
+  }
+  if (state === "ready") {
+    return "React Web repeated-file activation is ready on the bounded Codex lane; keep deferred triggers unchanged unless a later lane explicitly promotes them.";
+  }
+  if (activationMode.verdict === "blocked") {
+    return "Inspect the latest React Web evidence boundary blockers, fix the source-context issue if needed, and rerun fooks doctor codex.";
+  }
+  return "Review the deferred repeated-file/profile-gate reasons, address freshness or evidence gaps if appropriate, and rerun fooks doctor codex.";
+}
+
+function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationReadiness {
+  try {
+    const status = readReactWebStatus(cwd);
+    const activationMode = status.latestEvidenceId ? readReactWebActivationMode(cwd, "latest") : null;
+    const verdict = activationMode?.verdict ?? "unavailable";
+    const state = activationStateFor(verdict, status.latestEvidenceId);
+    return {
+      available: Boolean(activationMode),
+      state,
+      latestEvidenceId: status.latestEvidenceId,
+      latestDecision: status.latestDecision,
+      freshness: status.freshness.status,
+      claimBoundary: activationMode?.claimBoundary ?? status.claimBoundary,
+      repeatedFileRuntime: {
+        verdict,
+        positive: activationMode?.supportedTrigger.positive ?? false,
+        reasons: activationMode?.supportedTrigger.reasons ?? [],
+      },
+      profileGateAdvisory: {
+        verdict: activationMode?.profileGate.verdict ?? "unavailable",
+        reasons: activationMode?.profileGate.reasons ?? [],
+      },
+      deferredTriggers: activationMode?.deferredTriggers.map((item) => item.name) ?? [...status.activationMode.deferredTriggers],
+      risks: [...status.risks],
+      nextAction: activationNextAction(state, status.latestEvidenceId, activationMode),
+    };
+  } catch (error) {
+    const readError = error instanceof Error ? error.message : String(error);
+    return {
+      available: false,
+      state: "blocked",
+      latestEvidenceId: null,
+      latestDecision: null,
+      freshness: "unavailable",
+      claimBoundary: "Local React Web activation readiness only: doctor reports bounded readiness and advisory state from existing evidence/status surfaces without changing runtime behavior or widening support claims.",
+      repeatedFileRuntime: {
+        verdict: "unavailable",
+        positive: false,
+        reasons: ["activation-readiness-unavailable"],
+      },
+      profileGateAdvisory: {
+        verdict: "unavailable",
+        reasons: ["activation-readiness-unavailable"],
+      },
+      deferredTriggers: ["always-on", "glob-match", "model-decision"],
+      risks: [`unable to read React Web activation readiness: ${readError}`],
+      nextAction: "Repair the latest React Web evidence/status artifact read path, then rerun fooks doctor codex.",
+      readError,
+    };
+  }
+}
+
 function summaryFor(checks: DoctorCheck[]): DoctorResult["summary"] {
   return {
     pass: checks.filter((item) => item.status === "pass").length,
@@ -629,6 +736,7 @@ export function runDoctor(options: DoctorOptions = {}): DoctorResult {
       : aggregateChecks(cwd, cliName);
   const summary = summaryFor(checks);
   const nextSteps = unique(checks.filter((item) => item.status !== "pass").map((item) => item.fix));
+  const reactWebActivation = target === "claude" ? undefined : readReactWebActivationReadiness(cwd);
   return {
     command: "doctor",
     target,
@@ -638,6 +746,7 @@ export function runDoctor(options: DoctorOptions = {}): DoctorResult {
     checks,
     nextSteps,
     claimBoundaries: doctorClaimBoundaries(),
+    reactWebActivation,
   };
 }
 
@@ -660,6 +769,28 @@ export function formatDoctor(result: DoctorResult): string {
   }
   lines.push(`Next action: ${result.readiness.nextAction}`);
   lines.push("");
+  if (result.reactWebActivation) {
+    lines.push("React Web activation");
+    lines.push(`- state: ${result.reactWebActivation.state}`);
+    lines.push(`- latest evidence id: ${result.reactWebActivation.latestEvidenceId ?? "none"}`);
+    lines.push(`- repeated-file runtime: ${result.reactWebActivation.repeatedFileRuntime.verdict}`);
+    lines.push(`- profile-gate advisory: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
+    lines.push(`- deferred triggers: ${result.reactWebActivation.deferredTriggers.join(", ")}`);
+    if (result.reactWebActivation.repeatedFileRuntime.reasons.length > 0) {
+      lines.push(`- repeated-file reasons: ${result.reactWebActivation.repeatedFileRuntime.reasons.join(", ")}`);
+    }
+    if (result.reactWebActivation.profileGateAdvisory.reasons.length > 0) {
+      lines.push(`- profile-gate reasons: ${result.reactWebActivation.profileGateAdvisory.reasons.join(", ")}`);
+    }
+    if (result.reactWebActivation.risks.length > 0) {
+      lines.push(`- risks: ${result.reactWebActivation.risks.join(", ")}`);
+    }
+    if (result.reactWebActivation.readError) {
+      lines.push(`- read error: ${result.reactWebActivation.readError}`);
+    }
+    lines.push(`- next activation action: ${result.reactWebActivation.nextAction}`);
+    lines.push("");
+  }
   lines.push("Checks");
   for (const check of result.checks) {
     lines.push(`${iconFor(check.status)} ${check.name}`);

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -1,0 +1,110 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const { runDoctor } = require(path.join(repoRoot, "dist", "cli", "doctor.js"));
+const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function writeFixture(tempDir, fixturePath, fileName) {
+  fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
+}
+
+function runRepeatedDecision(tempDir, fileName, secondPrompt) {
+  const sessionId = `react-web-doctor-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: `Please inspect ${fileName}` }, tempDir);
+  const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
+  handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
+  return second;
+}
+
+test("doctor codex reports blocked React Web activation readiness without latest evidence", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-doctor-empty-"));
+
+  const result = runDoctor({ target: "codex", cwd: tempDir, cliName: "fooks" });
+  assert.ok(result.reactWebActivation);
+  assert.equal(result.reactWebActivation.state, "blocked");
+  assert.equal(result.reactWebActivation.latestEvidenceId, null);
+  assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "unavailable");
+  assert.deepEqual(result.reactWebActivation.deferredTriggers, ["always-on", "glob-match", "model-decision"]);
+  assert.match(result.reactWebActivation.nextAction, /Create one repeated same-file React Web Codex cycle/);
+});
+
+test("doctor codex reports ready React Web activation readiness from a current repeated same-file artifact", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-doctor-ready-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+  assert.equal(second.action, "inject");
+
+  const result = runDoctor({ target: "codex", cwd: tempDir, cliName: "fooks" });
+  assert.ok(result.reactWebActivation);
+  assert.equal(result.reactWebActivation.state, "ready");
+  assert.equal(result.reactWebActivation.latestDecision, "use");
+  assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "would-activate");
+  assert.equal(result.reactWebActivation.repeatedFileRuntime.positive, true);
+  assert.equal(result.reactWebActivation.profileGateAdvisory.verdict, "would-activate");
+
+  const cliText = spawnSync(process.execPath, [cliPath, "doctor", "codex"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliText.status, 0, cliText.stderr);
+  assert.match(cliText.stdout, /React Web activation/);
+  assert.match(cliText.stdout, /repeated-file runtime: would-activate/);
+  assert.match(cliText.stdout, /profile-gate advisory: would-activate/);
+});
+
+test("doctor codex reports partial React Web activation readiness when freshness goes stale", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-doctor-partial-"));
+  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+
+  const second = runRepeatedDecision(
+    tempDir,
+    "FormSection.tsx",
+    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+  );
+  assert.equal(second.action, "inject");
+  fs.appendFileSync(path.join(tempDir, "FormSection.tsx"), "\n// stale now\n");
+
+  const result = runDoctor({ target: "codex", cwd: tempDir, cliName: "fooks" });
+  assert.ok(result.reactWebActivation);
+  assert.equal(result.reactWebActivation.state, "partial");
+  assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "deferred");
+  assert.equal(result.reactWebActivation.profileGateAdvisory.verdict, "deferred");
+  assert.ok(result.reactWebActivation.risks.some((risk) => /stale/.test(risk)));
+});
+
+test("doctor codex keeps React Web activation read errors bounded in JSON output", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-doctor-corrupt-"));
+  const artifactsDir = reactWebEvidenceArtifactsDir(tempDir);
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.writeFileSync(path.join(artifactsDir, "latest.json"), "{not-valid-json\n");
+
+  const cliJson = spawnSync(process.execPath, [cliPath, "doctor", "codex", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  const parsed = JSON.parse(cliJson.stdout);
+  assert.equal(parsed.reactWebActivation.state, "blocked");
+  assert.equal(parsed.reactWebActivation.available, false);
+  assert.match(parsed.reactWebActivation.readError, /Unexpected token|Expected property name|JSON/);
+  assert.ok(parsed.reactWebActivation.risks.some((risk) => /unable to read React Web activation readiness/.test(risk)));
+});


### PR DESCRIPTION
Closes #652

## Summary
- add a React-Web-only, Codex-only, read-only activation-readiness surface to `fooks doctor codex`
- surface repeated-file runtime readiness, profile-gate advisory verdicts, and intentionally deferred triggers
- keep repeated-file runtime promotion semantics unchanged
- leave profile-gate runtime promotion and multi-runtime parity deferred

## Verification
- npm run build
- node --test test/react-web-doctor-surface.test.mjs test/react-web-activation-mode.test.mjs test/react-web-status-surface.test.mjs test/runtime-bridge-contract.test.mjs --test-name-pattern "doctor codex reports blocked React Web activation readiness without latest evidence|doctor codex reports ready React Web activation readiness from a current repeated same-file artifact|doctor codex reports partial React Web activation readiness when freshness goes stale|doctor codex keeps React Web activation read errors bounded in JSON output|inspect activation-mode reads a repeated React Web artifact and stays advisory-only|activation mode keeps non-repeated activation triggers explicitly deferred|runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh|activation mode fail-closes deny boundary artifacts instead of widening support|status react-web reports blocked without failing when no latest evidence exists|status react-web reports ready from a current repeated same-file use artifact|status react-web reports blocked mixed-routing boundary from a deny artifact without failing|codex runtime activates React Web payload semantics only for the React Web lane"
- git diff --check
- npm run lint
- npm test