### PR TITLE
Promote React Web profile-gate into the bounded Codex runtime path

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -618,7 +618,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
     if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
       const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
-      if (!activationMode || activationMode.verdict !== "would-activate") {
+      if (!activationMode || activationMode.profileGate.verdict !== "would-activate") {
         const activationFallback = attachReactWebActivationDebug(
           fallbackDecision(
             hookEventName,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -774,7 +774,7 @@ export function formatDoctor(result: DoctorResult): string {
     lines.push(`- state: ${result.reactWebActivation.state}`);
     lines.push(`- latest evidence id: ${result.reactWebActivation.latestEvidenceId ?? "none"}`);
     lines.push(`- repeated-file runtime: ${result.reactWebActivation.repeatedFileRuntime.verdict}`);
-    lines.push(`- profile-gate advisory: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
+    lines.push(`- profile-gate runtime gate: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
     lines.push(`- deferred triggers: ${result.reactWebActivation.deferredTriggers.join(", ")}`);
     if (result.reactWebActivation.repeatedFileRuntime.reasons.length > 0) {
       lines.push(`- repeated-file reasons: ${result.reactWebActivation.repeatedFileRuntime.reasons.join(", ")}`);

--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -10,9 +10,9 @@ import {
 
 export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
 export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
-export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-advisory";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-runtime";
 export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
-  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and when the bounded profile-gate policy would activate in advisory mode. This surface does not widen support claims, does not enable always-on or model-driven activation, does not auto-promote profile-gate runtime behavior, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and when the bounded profile-gate policy qualifies for runtime promotion. This surface does not widen support claims, does not enable always-on or model-driven activation, does not promote triggers beyond the bounded Codex React Web lane, and does not promote RN/TUI/WebView or generic context-manager behavior.";
 
 export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
 export const REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER = "profile-gate";
@@ -63,6 +63,12 @@ export type ReactWebActivationModeSummary = {
   deferredTriggers: ReactWebActivationDeferredTrigger[];
   blockedReasons: string[];
 };
+
+function profileGatePromotable(activationMode: {
+  profileGate: { verdict: ReactWebActivationVerdict };
+}): boolean {
+  return activationMode.profileGate.verdict === "would-activate";
+}
 
 function uniqueSorted(values: Iterable<string>): string[] {
   return [...new Set([...values].filter(Boolean))].sort((left, right) => left.localeCompare(right));
@@ -222,7 +228,7 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
   const verdict: ReactWebActivationVerdict =
     blockedReasons.length > 0 || artifact.decision === "deny"
       ? "blocked"
-      : positive
+      : profileGatePromotable({ profileGate })
         ? "would-activate"
         : "deferred";
 
@@ -304,5 +310,5 @@ export function renderReactWebActivationModeMarkdown(activationMode: ReactWebAct
     : "- none";
   const profileGateReasons = activationMode.profileGate.reasons.map((reason) => `- ${reason}`).join("\n");
 
-  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Advisory profile-gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
+  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Profile-gate runtime gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
 }

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -306,7 +306,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
     `- freshness: ${status.freshness.status}`,
     `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
-    `- profile-gate advisory: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
+    `- profile-gate runtime gate: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2504,6 +2504,66 @@ test("runtime hook fail-closes repeated React Web activation promotion when fres
   });
 });
 
+test("runtime hook fail-closes repeated React Web activation promotion when profile-gate planner policy is not compact-safe", () => {
+  const target = path.join("fixtures", "compressed", "FormSection.tsx");
+  const sessionId = `hook-react-web-profile-gate-fallback-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+  handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please update ${target}`,
+    },
+    repoRoot,
+  );
+
+  const second = withPatchedCodexPreRead((decision) => {
+    if (decision?.decision === "payload" && decision.payload?.domainPayload?.domain === "react-web") {
+      return {
+        ...decision,
+        payload: {
+          ...decision.payload,
+          domainPayload: {
+            ...decision.payload.domainPayload,
+            plannerDecision: "fallback-only",
+          },
+        },
+      };
+    }
+    return decision;
+  }, () =>
+    handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: `Again, update ${target}`,
+      },
+      repoRoot,
+    ));
+
+  assert.equal(second.action, "fallback");
+  assert.equal(second.contextModeReason, "activation-mode-not-promoted");
+  assert.deepEqual(second.reasons, ["repeated-file", "activation-mode-not-promoted"]);
+  assert.deepEqual(second.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "deferred",
+    repeatedFilePositive: false,
+    profileGateVerdict: "deferred",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-file-evidence-present",
+      "evidence-strength-adjacent",
+      "freshness-current",
+      "planner-decision-not-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-fallback",
+    ],
+    promoted: false,
+    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    blockedReasons: [],
+  });
+});
+
 test("bare status reports fast estimated session savings without exposing session contribution internals", () => {
   const tempDir = makeTempProject();
   const empty = run(["status"], tempDir);

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -173,6 +173,33 @@ test("activation mode keeps non-repeated activation triggers explicitly deferred
   );
 });
 
+test("activation mode requires bounded profile-gate evidence before reporting runtime promotion", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-profile-gate-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  const source = "export function FormSection() { return null; }\n";
+  fs.writeFileSync(path.join(tempDir, "src", "components", "FormSection.tsx"), source);
+
+  const currentFingerprint = {
+    fileHash: hashText(source),
+    lineCount: 2,
+  };
+
+  const activationMode = buildReactWebActivationMode(tempDir, makeArtifact({
+    filePath: "src/components/FormSection.tsx",
+    sourceFingerprint: currentFingerprint,
+    freshness: {
+      sourceFingerprint: currentFingerprint,
+      staleWhen: ["sourceFingerprint.fileHash changes"],
+    },
+    evidenceStrength: "adjacent",
+  }));
+
+  assert.equal(activationMode.supportedTrigger.positive, true);
+  assert.equal(activationMode.profileGate.verdict, "deferred");
+  assert.equal(activationMode.verdict, "deferred");
+  assert.ok(activationMode.profileGate.reasons.includes("evidence-strength-adjacent"));
+});
+
 test("runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-runtime-candidate-"));
   fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -68,7 +68,7 @@ test("doctor codex reports ready React Web activation readiness from a current r
   assert.equal(cliText.status, 0, cliText.stderr);
   assert.match(cliText.stdout, /React Web activation/);
   assert.match(cliText.stdout, /repeated-file runtime: would-activate/);
-  assert.match(cliText.stdout, /profile-gate advisory: would-activate/);
+  assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
 });
 
 test("doctor codex reports partial React Web activation readiness when freshness goes stale", () => {

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -118,7 +118,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.match(cliText.stdout, /React Web status/);
   assert.match(cliText.stdout, /profile status: ready/);
   assert.match(cliText.stdout, /summarized=no/);
-  assert.match(cliText.stdout, /profile-gate advisory: would-activate/);
+  assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {


### PR DESCRIPTION
Closes #654

## Summary
- promote React Web runtime activation only when the bounded profile-gate contract is satisfied
- keep repeated-file supported React Web cases green while fail-closing planner-policy drift and stale/unsupported cases
- update status/doctor wording and regression coverage to reflect the runtime gate surface

## Verification
- `npm run build`
- `node --test --test-name-pattern "activation mode requires bounded profile-gate evidence before reporting runtime promotion|runtime hook fail-closes repeated React Web activation promotion when profile-gate planner policy is not compact-safe|status react-web reports ready from a current repeated same-file use artifact|doctor codex reports ready React Web activation readiness from a current repeated same-file artifact|codex runtime activates React Web payload semantics only for the React Web lane" test/react-web-activation-mode.test.mjs test/fooks.test.mjs test/react-web-status-surface.test.mjs test/react-web-doctor-surface.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm run lint`
- `npm test`
