### PR TITLE
Add React Web glob-match advisory activation lane

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -49,6 +49,10 @@ export type DoctorReactWebActivationReadiness = {
     verdict: ReactWebActivationVerdict | "unavailable";
     reasons: string[];
   };
+  globMatchAdvisory: {
+    verdict: ReactWebActivationVerdict | "unavailable";
+    reasons: string[];
+  };
   deferredTriggers: string[];
   risks: string[];
   nextAction: string;
@@ -609,12 +613,12 @@ function activationNextAction(
     return "Inspect the latest React Web evidence artifact, then rerun fooks doctor codex.";
   }
   if (state === "ready") {
-    return "React Web repeated-file activation is ready on the bounded Codex lane; keep deferred triggers unchanged unless a later lane explicitly promotes them.";
+    return "React Web repeated-file/profile-gate runtime activation is ready on the bounded Codex lane; keep glob-match advisory-only and leave deferred triggers unchanged unless a later lane explicitly promotes them.";
   }
   if (activationMode.verdict === "blocked") {
     return "Inspect the latest React Web evidence boundary blockers, fix the source-context issue if needed, and rerun fooks doctor codex.";
   }
-  return "Review the deferred repeated-file/profile-gate reasons, address freshness or evidence gaps if appropriate, and rerun fooks doctor codex.";
+  return "Review the deferred repeated-file/profile-gate/glob-match reasons, address freshness or evidence gaps if appropriate, and rerun fooks doctor codex.";
 }
 
 function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationReadiness {
@@ -639,6 +643,10 @@ function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationR
         verdict: activationMode?.profileGate.verdict ?? "unavailable",
         reasons: activationMode?.profileGate.reasons ?? [],
       },
+      globMatchAdvisory: {
+        verdict: activationMode?.globMatch.verdict ?? "unavailable",
+        reasons: activationMode?.globMatch.reasons ?? [],
+      },
       deferredTriggers: activationMode?.deferredTriggers.map((item) => item.name) ?? [...status.activationMode.deferredTriggers],
       risks: [...status.risks],
       nextAction: activationNextAction(state, status.latestEvidenceId, activationMode),
@@ -661,7 +669,11 @@ function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationR
         verdict: "unavailable",
         reasons: ["activation-readiness-unavailable"],
       },
-      deferredTriggers: ["always-on", "glob-match", "model-decision"],
+      globMatchAdvisory: {
+        verdict: "unavailable",
+        reasons: ["activation-readiness-unavailable"],
+      },
+      deferredTriggers: ["always-on", "model-decision"],
       risks: [`unable to read React Web activation readiness: ${readError}`],
       nextAction: "Repair the latest React Web evidence/status artifact read path, then rerun fooks doctor codex.",
       readError,
@@ -775,12 +787,16 @@ export function formatDoctor(result: DoctorResult): string {
     lines.push(`- latest evidence id: ${result.reactWebActivation.latestEvidenceId ?? "none"}`);
     lines.push(`- repeated-file runtime: ${result.reactWebActivation.repeatedFileRuntime.verdict}`);
     lines.push(`- profile-gate runtime gate: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
+    lines.push(`- glob-match advisory: ${result.reactWebActivation.globMatchAdvisory.verdict}`);
     lines.push(`- deferred triggers: ${result.reactWebActivation.deferredTriggers.join(", ")}`);
     if (result.reactWebActivation.repeatedFileRuntime.reasons.length > 0) {
       lines.push(`- repeated-file reasons: ${result.reactWebActivation.repeatedFileRuntime.reasons.join(", ")}`);
     }
     if (result.reactWebActivation.profileGateAdvisory.reasons.length > 0) {
       lines.push(`- profile-gate reasons: ${result.reactWebActivation.profileGateAdvisory.reasons.join(", ")}`);
+    }
+    if (result.reactWebActivation.globMatchAdvisory.reasons.length > 0) {
+      lines.push(`- glob-match reasons: ${result.reactWebActivation.globMatchAdvisory.reasons.join(", ")}`);
     }
     if (result.reactWebActivation.risks.length > 0) {
       lines.push(`- risks: ${result.reactWebActivation.risks.join(", ")}`);

--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -10,15 +10,15 @@ import {
 
 export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
 export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
-export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-runtime";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-runtime+glob-match-advisory";
 export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
-  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation and when the bounded profile-gate policy qualifies for runtime promotion. This surface does not widen support claims, does not enable always-on or model-driven activation, does not promote triggers beyond the bounded Codex React Web lane, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation, when the bounded profile-gate policy qualifies for runtime promotion, and when the bounded glob-match trigger would activate in advisory mode. This surface does not widen support claims, does not enable always-on or model-driven activation, does not promote triggers beyond the bounded Codex React Web lane, and does not promote RN/TUI/WebView or generic context-manager behavior.";
 
 export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
 export const REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER = "profile-gate";
+export const REACT_WEB_ACTIVATION_GLOB_MATCH_TRIGGER = "glob-match";
 export const REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS = [
   "always-on",
-  "glob-match",
   "model-decision",
 ] as const;
 
@@ -47,6 +47,11 @@ export type ReactWebActivationModeResult = {
     verdict: ReactWebActivationVerdict;
     reasons: string[];
   };
+  globMatch: {
+    name: typeof REACT_WEB_ACTIVATION_GLOB_MATCH_TRIGGER;
+    verdict: ReactWebActivationVerdict;
+    reasons: string[];
+  };
   deferredTriggers: Array<{
     name: ReactWebActivationDeferredTrigger;
     reason: string;
@@ -60,6 +65,8 @@ export type ReactWebActivationModeSummary = {
   repeatedFilePositive: boolean;
   profileGateVerdict: ReactWebActivationVerdict | "unavailable";
   profileGateReasons: string[];
+  globMatchVerdict: ReactWebActivationVerdict | "unavailable";
+  globMatchReasons: string[];
   deferredTriggers: ReactWebActivationDeferredTrigger[];
   blockedReasons: string[];
 };
@@ -146,6 +153,11 @@ function repeatedFilePositive(cwd: string, artifact: ReactWebEvidenceArtifact): 
   );
 }
 
+function globMatchableFilePath(filePath: string): boolean {
+  const extension = path.extname(filePath).toLowerCase();
+  return extension === ".tsx" || extension === ".jsx";
+}
+
 function profileGateReasons(cwd: string, artifact: ReactWebEvidenceArtifact): string[] {
   const reasons: string[] = [];
   if (artifact.domainPayload?.domain === "react-web") {
@@ -221,10 +233,86 @@ function profileGateVerdict(cwd: string, artifact: ReactWebEvidenceArtifact): {
   };
 }
 
+function globMatchReasons(cwd: string, artifact: ReactWebEvidenceArtifact): string[] {
+  const reasons: string[] = [];
+  if (artifact.domainPayload?.domain === "react-web") {
+    reasons.push("react-web-domain-payload-present");
+  } else {
+    reasons.push("missing-react-web-domain-payload");
+  }
+  if (artifact.domainPayload?.claimStatus === "current-supported-lane") {
+    reasons.push("current-supported-lane-claim");
+  } else {
+    reasons.push("non-current-supported-lane-claim");
+  }
+  if (artifact.domainPayload?.plannerDecision === "compact-safe") {
+    reasons.push("planner-decision-compact-safe");
+  } else {
+    reasons.push("planner-decision-not-compact-safe");
+  }
+  if (artifact.evidenceStrength === "direct") {
+    reasons.push("direct-evidence-strength");
+  } else {
+    reasons.push(`evidence-strength-${artifact.evidenceStrength}`);
+  }
+  if (globMatchableFilePath(artifact.filePath)) {
+    reasons.push("file-path-glob-react-extension-match");
+  } else {
+    reasons.push("file-path-glob-no-react-extension-match");
+  }
+  if (artifact.sourceFingerprint) {
+    const current = currentSourceFingerprint(path.resolve(cwd, artifact.filePath));
+    if (!current) {
+      reasons.push("source-file-missing");
+    } else if (sourceFingerprintsEqual(artifact.sourceFingerprint, current)) {
+      reasons.push("freshness-current");
+    } else {
+      reasons.push("freshness-stale");
+    }
+  } else {
+    reasons.push("missing-sourceFingerprint");
+  }
+  if (artifact.decision === "use") {
+    reasons.push("runtime-decision-use");
+  } else if (artifact.decision === "fallback") {
+    reasons.push("runtime-decision-fallback");
+  } else {
+    reasons.push("runtime-decision-deny");
+  }
+  return uniqueSorted(reasons);
+}
+
+function globMatchVerdict(cwd: string, artifact: ReactWebEvidenceArtifact): {
+  verdict: ReactWebActivationVerdict;
+  reasons: string[];
+} {
+  const reasons = globMatchReasons(cwd, artifact);
+  const blockedReasons = blockedReasonsFor(artifact);
+  if (blockedReasons.length > 0 || artifact.decision === "deny") {
+    return { verdict: "blocked", reasons };
+  }
+
+  const current = artifact.sourceFingerprint ? currentSourceFingerprint(path.resolve(cwd, artifact.filePath)) : null;
+  const wouldActivate =
+    artifact.decision === "use" &&
+    artifact.domainPayload?.domain === "react-web" &&
+    artifact.domainPayload?.claimStatus === "current-supported-lane" &&
+    artifact.domainPayload?.plannerDecision === "compact-safe" &&
+    artifact.evidenceStrength === "direct" &&
+    globMatchableFilePath(artifact.filePath) &&
+    sourceFingerprintsEqual(artifact.sourceFingerprint, current);
+
+  return {
+    verdict: wouldActivate ? "would-activate" : "deferred",
+    reasons,
+  };
+}
+
 export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvidenceArtifact): ReactWebActivationModeResult {
   const positive = repeatedFilePositive(cwd, artifact);
   const blockedReasons = blockedReasonsFor(artifact);
   const profileGate = profileGateVerdict(cwd, artifact);
+  const globMatch = globMatchVerdict(cwd, artifact);
   const verdict: ReactWebActivationVerdict =
     blockedReasons.length > 0 || artifact.decision === "deny"
       ? "blocked"
@@ -253,6 +341,11 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
       name: REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER,
       verdict: profileGate.verdict,
       reasons: profileGate.reasons,
+    },
+    globMatch: {
+      name: REACT_WEB_ACTIVATION_GLOB_MATCH_TRIGGER,
+      verdict: globMatch.verdict,
+      reasons: globMatch.reasons,
     },
     deferredTriggers: REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS.map((name) => ({
       name,
@@ -284,6 +377,8 @@ export function summarizeReactWebActivationMode(
       repeatedFilePositive: false,
       profileGateVerdict: "unavailable",
       profileGateReasons: [],
+      globMatchVerdict: "unavailable",
+      globMatchReasons: [],
       deferredTriggers: [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
       blockedReasons: [],
     };
@@ -295,6 +390,8 @@ export function summarizeReactWebActivationMode(
     repeatedFilePositive: activationMode.supportedTrigger.positive,
     profileGateVerdict: activationMode.profileGate.verdict,
     profileGateReasons: activationMode.profileGate.reasons,
+    globMatchVerdict: activationMode.globMatch.verdict,
+    globMatchReasons: activationMode.globMatch.reasons,
     deferredTriggers: activationMode.deferredTriggers.map((item) => item.name),
     blockedReasons: activationMode.blockedReasons,
   };
@@ -309,6 +406,7 @@ export function renderReactWebActivationModeMarkdown(activationMode: ReactWebAct
     ? activationMode.blockedReasons.map((reason) => `- ${reason}`).join("\n")
     : "- none";
   const profileGateReasons = activationMode.profileGate.reasons.map((reason) => `- ${reason}`).join("\n");
+  const globMatchReasons = activationMode.globMatch.reasons.map((reason) => `- ${reason}`).join("\n");
 
-  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Profile-gate runtime gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
+  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n- glob-match advisory: ${activationMode.globMatch.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Profile-gate runtime gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Glob-match advisory\n\n- ${activationMode.globMatch.name}\n${globMatchReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
 }

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -289,6 +289,9 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
   const profileGateReasons = status.activationMode.profileGateReasons.length > 0
     ? status.activationMode.profileGateReasons.join(", ")
     : "none";
+  const globMatchReasons = status.activationMode.globMatchReasons.length > 0
+    ? status.activationMode.globMatchReasons.join(", ")
+    : "none";
   return [
     "# React Web status",
     "",
@@ -307,6 +310,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- freshness: ${status.freshness.status}`,
     `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
     `- profile-gate runtime gate: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
+    `- glob-match advisory: ${status.activationMode.globMatchVerdict} (${globMatchReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -735,6 +735,8 @@ export type CodexRuntimeHookDecision = {
       repeatedFilePositive: boolean;
       profileGateVerdict: "would-activate" | "deferred" | "blocked" | "unavailable";
       profileGateReasons: string[];
+      globMatchVerdict: "would-activate" | "deferred" | "blocked" | "unavailable";
+      globMatchReasons: string[];
       promoted: boolean;
       deferredTriggers: string[];
       blockedReasons: string[];

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2260,8 +2260,18 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    globMatchVerdict: "would-activate",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "file-path-glob-react-extension-match",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
   const runtimePayload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
@@ -2417,8 +2427,18 @@ test("runtime hook gates edit guidance to repeated exact-file edit intent prompt
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    globMatchVerdict: "would-activate",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "file-path-glob-react-extension-match",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
 
@@ -2498,8 +2518,18 @@ test("runtime hook fail-closes repeated React Web activation promotion when fres
       "react-web-domain-payload-present",
       "runtime-decision-fallback",
     ],
+    globMatchVerdict: "deferred",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "evidence-strength-adjacent",
+      "file-path-glob-react-extension-match",
+      "missing-sourceFingerprint",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-fallback",
+    ],
     promoted: false,
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
 });
@@ -2558,8 +2588,18 @@ test("runtime hook fail-closes repeated React Web activation promotion when prof
       "react-web-domain-payload-present",
       "runtime-decision-fallback",
     ],
+    globMatchVerdict: "deferred",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "evidence-strength-adjacent",
+      "file-path-glob-react-extension-match",
+      "freshness-current",
+      "planner-decision-not-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-fallback",
+    ],
     promoted: false,
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
 });

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -124,6 +124,8 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   assert.equal(activationMode.supportedTrigger.positive, true);
   assert.equal(activationMode.profileGate.name, "profile-gate");
   assert.equal(activationMode.profileGate.verdict, "would-activate");
+  assert.equal(activationMode.globMatch.name, "glob-match");
+  assert.equal(activationMode.globMatch.verdict, "would-activate");
   assert.deepEqual(
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
@@ -142,6 +144,7 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   assert.equal(parsed.artifactId, ref.id);
   assert.equal(parsed.verdict, "would-activate");
   assert.equal(parsed.profileGate.verdict, "would-activate");
+  assert.equal(parsed.globMatch.verdict, "would-activate");
 });
 
 test("activation mode keeps non-repeated activation triggers explicitly deferred", () => {
@@ -167,6 +170,7 @@ test("activation mode keeps non-repeated activation triggers explicitly deferred
   assert.equal(activationMode.verdict, "deferred");
   assert.equal(activationMode.supportedTrigger.positive, false);
   assert.equal(activationMode.profileGate.verdict, "deferred");
+  assert.equal(activationMode.globMatch.verdict, "deferred");
   assert.deepEqual(
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
@@ -196,8 +200,10 @@ test("activation mode requires bounded profile-gate evidence before reporting ru
 
   assert.equal(activationMode.supportedTrigger.positive, true);
   assert.equal(activationMode.profileGate.verdict, "deferred");
+  assert.equal(activationMode.globMatch.verdict, "deferred");
   assert.equal(activationMode.verdict, "deferred");
   assert.ok(activationMode.profileGate.reasons.includes("evidence-strength-adjacent"));
+  assert.ok(activationMode.globMatch.reasons.includes("evidence-strength-adjacent"));
 });
 
 test("runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh", () => {
@@ -252,6 +258,7 @@ test("runtime activation promotion does not require patchTargets when repeated R
   assert.equal(activationMode?.verdict, "would-activate");
   assert.equal(activationMode?.supportedTrigger.positive, true);
   assert.equal(activationMode?.profileGate.verdict, "would-activate");
+  assert.equal(activationMode?.globMatch.verdict, "would-activate");
 });
 
 test("activation mode fail-closes deny boundary artifacts instead of widening support", () => {
@@ -275,5 +282,6 @@ test("activation mode fail-closes deny boundary artifacts instead of widening su
   assert.equal(activationMode.verdict, "blocked");
   assert.equal(activationMode.supportedTrigger.positive, false);
   assert.equal(activationMode.profileGate.verdict, "blocked");
+  assert.equal(activationMode.globMatch.verdict, "blocked");
   assert.ok(activationMode.blockedReasons.includes("unsupported-react-native-webview-boundary"));
 });

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -38,7 +38,8 @@ test("doctor codex reports blocked React Web activation readiness without latest
   assert.equal(result.reactWebActivation.state, "blocked");
   assert.equal(result.reactWebActivation.latestEvidenceId, null);
   assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "unavailable");
-  assert.deepEqual(result.reactWebActivation.deferredTriggers, ["always-on", "glob-match", "model-decision"]);
+  assert.equal(result.reactWebActivation.globMatchAdvisory.verdict, "unavailable");
+  assert.deepEqual(result.reactWebActivation.deferredTriggers, ["always-on", "model-decision"]);
   assert.match(result.reactWebActivation.nextAction, /Create one repeated same-file React Web Codex cycle/);
 });
 
@@ -60,6 +61,7 @@ test("doctor codex reports ready React Web activation readiness from a current r
   assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "would-activate");
   assert.equal(result.reactWebActivation.repeatedFileRuntime.positive, true);
   assert.equal(result.reactWebActivation.profileGateAdvisory.verdict, "would-activate");
+  assert.equal(result.reactWebActivation.globMatchAdvisory.verdict, "would-activate");
 
   const cliText = spawnSync(process.execPath, [cliPath, "doctor", "codex"], {
     cwd: tempDir,
@@ -69,6 +71,7 @@ test("doctor codex reports ready React Web activation readiness from a current r
   assert.match(cliText.stdout, /React Web activation/);
   assert.match(cliText.stdout, /repeated-file runtime: would-activate/);
   assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
+  assert.match(cliText.stdout, /glob-match advisory: would-activate/);
 });
 
 test("doctor codex reports partial React Web activation readiness when freshness goes stale", () => {
@@ -88,6 +91,7 @@ test("doctor codex reports partial React Web activation readiness when freshness
   assert.equal(result.reactWebActivation.state, "partial");
   assert.equal(result.reactWebActivation.repeatedFileRuntime.verdict, "deferred");
   assert.equal(result.reactWebActivation.profileGateAdvisory.verdict, "deferred");
+  assert.equal(result.reactWebActivation.globMatchAdvisory.verdict, "deferred");
   assert.ok(result.reactWebActivation.risks.some((risk) => /stale/.test(risk)));
 });
 

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -48,7 +48,9 @@ test("status react-web reports blocked without failing when no latest evidence e
     repeatedFilePositive: false,
     profileGateVerdict: "unavailable",
     profileGateReasons: [],
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    globMatchVerdict: "unavailable",
+    globMatchReasons: [],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
   assert.deepEqual(status.rankedBundle, {
@@ -99,6 +101,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.equal(status.activationMode.verdict, "would-activate");
   assert.equal(status.activationMode.repeatedFilePositive, true);
   assert.equal(status.activationMode.profileGateVerdict, "would-activate");
+  assert.equal(status.activationMode.globMatchVerdict, "would-activate");
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "ranked");
   assert.ok(status.rankedBundle.selectedCount > 0);
@@ -119,6 +122,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.match(cliText.stdout, /profile status: ready/);
   assert.match(cliText.stdout, /summarized=no/);
   assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
+  assert.match(cliText.stdout, /glob-match advisory: would-activate/);
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {
@@ -140,6 +144,7 @@ test("status react-web reports blocked mixed-routing boundary from a deny artifa
   assert.equal(status.activationMode.verdict, "blocked");
   assert.equal(status.activationMode.repeatedFilePositive, false);
   assert.equal(status.activationMode.profileGateVerdict, "blocked");
+  assert.equal(status.activationMode.globMatchVerdict, "blocked");
   assert.equal(status.rankedBundle.available, true);
   assert.equal(status.rankedBundle.verdict, "blocked");
   assert.deepEqual(status.interop, {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -773,8 +773,18 @@ test("codex runtime activates React Web payload semantics only for the React Web
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    globMatchVerdict: "would-activate",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "file-path-glob-react-extension-match",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
     promoted: true,
-    deferredTriggers: ["always-on", "glob-match", "model-decision"],
+    deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
 


### PR DESCRIPTION
Closes #656

## Summary
- add a bounded React Web `glob-match` advisory trigger to activation-mode surfaces
- surface glob-match advisory verdict/reasons through `status react-web` and `doctor codex`
- keep runtime promotion behavior unchanged while reducing deferred triggers to the still-unimplemented set

## Verification
- `git diff --check`
- `npm run build`
- `node --test test/react-web-activation-mode.test.mjs test/react-web-status-surface.test.mjs test/react-web-doctor-surface.test.mjs test/runtime-bridge-contract.test.mjs test/fooks.test.mjs --test-name-pattern 'React Web activation mode|status react-web|doctor codex|codex runtime activates React Web payload semantics only for the React Web lane|runtime hook fail-closes repeated React Web activation promotion|runtime hook gates edit guidance to repeated exact-file edit intent prompts|repeated React Web payload'`
- `npm run lint`
- `npm test`

## Boundaries
- Codex only
- React Web only
- advisory only for `glob-match`
- no runtime auto-promotion in this pass
