### PR TITLE
Promote React Web glob-match advisory into the bounded Codex runtime path

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { decidePreRead } from "./pre-read";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
+import { discoverProjectFiles } from "../core/discover";
 import { appendProjectKnowledgeBlock, resolveProjectKnowledgeContext } from "../core/project-knowledge";
 import { buildPreReadReuseStatus } from "./codex-runtime-status";
 import { clearCodexActiveFile, ensureFreshCodexContextForTarget, markCodexAttachPrepared, markCodexReady } from "./codex-runtime-trust";
@@ -64,12 +65,16 @@ function payloadContextModeReason(
   contextMode: ContextMode,
   payload: ModelFacingPayload,
   editGuidanceIncluded: boolean,
+  promptSpecificity: ReturnType<typeof resolvePromptFileContext>["policy"]["promptSpecificity"],
 ): string {
   if (editGuidanceIncluded) return `${phase}-exact-file-edit-guidance`;
-  if (contextMode === "light-minimal") return `${phase}-exact-file-tiny-raw-original`;
+  if (contextMode === "light-minimal") {
+    return promptSpecificity === "file-hinted" ? `${phase}-file-hinted-tiny-raw-original` : `${phase}-exact-file-tiny-raw-original`;
+  }
+  const targetPrefix = promptSpecificity === "file-hinted" ? "file-hinted" : "exact-file";
   return payload.domainPayload?.domain === "react-web"
-    ? `${phase}-exact-file-react-web-payload`
-    : `${phase}-exact-file-narrow-payload`;
+    ? `${phase}-${targetPrefix}-react-web-payload`
+    : `${phase}-${targetPrefix}-narrow-payload`;
 }
 
 function minimalRuntimeReactWebContext(reactWebContext: RuntimeReactWebContext): PackedRuntimeReactWebContext {
@@ -217,6 +222,57 @@ function buildAdditionalContext(
 
 function targetEstimatedBytes(cwd: string, filePath: string): number | undefined {
   return estimateFileBytes(path.join(cwd, filePath));
+}
+
+function resolveFileHintedGlobMatchContext(
+  prompt: string,
+  cwd: string,
+): { filePath?: string; source: "prompt-target" | "none"; policy: ReturnType<typeof resolvePromptFileContext>["policy"] } {
+  const promptContext = resolvePromptFileContext(prompt, cwd, "codex-ts-js-beta");
+  const policy = promptContext.policy;
+  const hintedTarget = policy.targets[0];
+
+  if (promptContext.filePath && (!hintedTarget || hintedTarget.exists)) {
+    return promptContext;
+  }
+
+  if (
+    policy.promptSpecificity !== "exact-file" ||
+    policy.targets.length !== 1 ||
+    !hintedTarget ||
+    hintedTarget.exists ||
+    path.basename(hintedTarget.filePath) !== hintedTarget.filePath
+  ) {
+    return promptContext;
+  }
+
+  const matches = discoverProjectFiles(cwd)
+    .filter((target) => target.kind === "component")
+    .map((target) => target.filePath)
+    .filter((filePath) => path.basename(filePath).toLowerCase() === hintedTarget.filePath.toLowerCase());
+
+  if (matches.length !== 1) {
+    return promptContext;
+  }
+
+  const matchedTarget = path.relative(cwd, matches[0]) || path.basename(matches[0]);
+  return {
+    filePath: matchedTarget,
+    source: "prompt-target",
+    policy: {
+      ...policy,
+      promptSpecificity: "file-hinted",
+      selectionSource: "keyword-discovery",
+      contextMode: "light",
+      contextModeReason: "file-hinted-glob-match-target",
+      contextBudget: {
+        maxFiles: 1,
+        selectedFiles: 1,
+        totalBytes: targetEstimatedBytes(cwd, matchedTarget) ?? 0,
+        skippedFiles: 0,
+      },
+    },
+  };
 }
 
 export function isEditIntentPrompt(prompt: string): boolean {
@@ -430,7 +486,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   }
 
   const prompt = input.prompt ?? "";
-  const promptContext = resolvePromptFileContext(prompt, cwd, "codex-ts-js-beta");
+  const promptContext = resolveFileHintedGlobMatchContext(prompt, cwd);
   const target = promptContext.filePath;
   const policy = promptContext.policy;
   const escapeHatchUsed = hasFullReadEscapeHatch(prompt);
@@ -516,7 +572,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       reasons: ["first-seen-file", "context-mode:no-op"],
       statePath,
       contextMode: "no-op",
-      contextModeReason: "first-turn-exact-file-record-only",
+      contextModeReason: policy.promptSpecificity === "file-hinted" ? "first-turn-file-hinted-record-only" : "first-turn-exact-file-record-only",
       contextBudget: { ...policy.contextBudget, selectedFiles: 0, totalBytes: 0, skippedFiles: policy.contextBudget.selectedFiles },
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
@@ -596,13 +652,14 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       filePath: target,
       reasons: [
         "repeated-file",
+        ...(policy.promptSpecificity === "file-hinted" ? ["glob-match-runtime-target"] : []),
         ...(freshness.refreshed ? ["refreshed-before-attach"] : []),
         ...(editGuidanceIncluded ? ["edit-guidance-opt-in"] : []),
       ],
       statePath,
       additionalContext,
       contextMode,
-      contextModeReason: payloadContextModeReason("repeated", contextMode, decision.payload, editGuidanceIncluded),
+      contextModeReason: payloadContextModeReason("repeated", contextMode, decision.payload, editGuidanceIncluded, policy.promptSpecificity),
       contextBudget: policy.contextBudget,
       promptSpecificity: policy.promptSpecificity,
       contextPolicyVersion: policy.contextPolicyVersion,
@@ -618,7 +675,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
 
     if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
       const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
-      if (!activationMode || activationMode.profileGate.verdict !== "would-activate") {
+      const promoted =
+        activationMode?.profileGate.verdict === "would-activate" || activationMode?.globMatch.verdict === "would-activate";
+      if (!activationMode || !promoted) {
         const activationFallback = attachReactWebActivationDebug(
           fallbackDecision(
             hookEventName,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -613,12 +613,12 @@ function activationNextAction(
     return "Inspect the latest React Web evidence artifact, then rerun fooks doctor codex.";
   }
   if (state === "ready") {
-    return "React Web repeated-file/profile-gate runtime activation is ready on the bounded Codex lane; keep glob-match advisory-only and leave deferred triggers unchanged unless a later lane explicitly promotes them.";
+    return "React Web repeated-file/profile-gate/glob-match runtime activation is ready on the bounded Codex lane; keep deferred triggers unchanged unless a later lane explicitly promotes them.";
   }
   if (activationMode.verdict === "blocked") {
     return "Inspect the latest React Web evidence boundary blockers, fix the source-context issue if needed, and rerun fooks doctor codex.";
   }
-  return "Review the deferred repeated-file/profile-gate/glob-match reasons, address freshness or evidence gaps if appropriate, and rerun fooks doctor codex.";
+  return "Review the deferred repeated-file/profile-gate/glob-match runtime reasons, address freshness or evidence gaps if appropriate, and rerun fooks doctor codex.";
 }
 
 function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationReadiness {
@@ -787,7 +787,7 @@ export function formatDoctor(result: DoctorResult): string {
     lines.push(`- latest evidence id: ${result.reactWebActivation.latestEvidenceId ?? "none"}`);
     lines.push(`- repeated-file runtime: ${result.reactWebActivation.repeatedFileRuntime.verdict}`);
     lines.push(`- profile-gate runtime gate: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
-    lines.push(`- glob-match advisory: ${result.reactWebActivation.globMatchAdvisory.verdict}`);
+    lines.push(`- glob-match runtime gate: ${result.reactWebActivation.globMatchAdvisory.verdict}`);
     lines.push(`- deferred triggers: ${result.reactWebActivation.deferredTriggers.join(", ")}`);
     if (result.reactWebActivation.repeatedFileRuntime.reasons.length > 0) {
       lines.push(`- repeated-file reasons: ${result.reactWebActivation.repeatedFileRuntime.reasons.join(", ")}`);

--- a/src/core/react-web-activation-mode.ts
+++ b/src/core/react-web-activation-mode.ts
@@ -10,9 +10,9 @@ import {
 
 export const REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION = "react-web-activation-mode.v1";
 export const REACT_WEB_ACTIVATION_MODE_COMMAND = "inspect activation-mode";
-export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-runtime+glob-match-advisory";
+export const REACT_WEB_ACTIVATION_MODE_MODE = "repeated-file-runtime+profile-gate-runtime+glob-match-runtime";
 export const REACT_WEB_ACTIVATION_MODE_CLAIM_BOUNDARY =
-  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation, when the bounded profile-gate policy qualifies for runtime promotion, and when the bounded glob-match trigger would activate in advisory mode. This surface does not widen support claims, does not enable always-on or model-driven activation, does not promote triggers beyond the bounded Codex React Web lane, and does not promote RN/TUI/WebView or generic context-manager behavior.";
+  "Local React Web activation contract only: reports when bounded repeated-file React Web evidence qualifies for activation, when the bounded profile-gate policy qualifies for runtime promotion, and when the bounded glob-match trigger qualifies for runtime promotion on the Codex React Web lane. This surface does not widen support claims, does not enable always-on or model-driven activation, does not promote triggers beyond the bounded Codex React Web lane, and does not promote RN/TUI/WebView or generic context-manager behavior.";
 
 export const REACT_WEB_ACTIVATION_SUPPORTED_TRIGGER = "repeated-file";
 export const REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER = "profile-gate";
@@ -24,6 +24,7 @@ export const REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS = [
 
 export type ReactWebActivationDeferredTrigger = (typeof REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS)[number];
 export type ReactWebActivationVerdict = "would-activate" | "deferred" | "blocked";
+export type ReactWebActivationPromotedTrigger = typeof REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER | typeof REACT_WEB_ACTIVATION_GLOB_MATCH_TRIGGER;
 
 export type ReactWebActivationModeResult = {
   schemaVersion: typeof REACT_WEB_ACTIVATION_MODE_SCHEMA_VERSION;
@@ -52,6 +53,7 @@ export type ReactWebActivationModeResult = {
     verdict: ReactWebActivationVerdict;
     reasons: string[];
   };
+  promotedTrigger: ReactWebActivationPromotedTrigger | null;
   deferredTriggers: Array<{
     name: ReactWebActivationDeferredTrigger;
     reason: string;
@@ -67,14 +69,22 @@ export type ReactWebActivationModeSummary = {
   profileGateReasons: string[];
   globMatchVerdict: ReactWebActivationVerdict | "unavailable";
   globMatchReasons: string[];
+  promotedTrigger: ReactWebActivationPromotedTrigger | null;
   deferredTriggers: ReactWebActivationDeferredTrigger[];
   blockedReasons: string[];
 };
 
-function profileGatePromotable(activationMode: {
+function promotedTriggerFor(activationMode: {
   profileGate: { verdict: ReactWebActivationVerdict };
-}): boolean {
-  return activationMode.profileGate.verdict === "would-activate";
+  globMatch: { verdict: ReactWebActivationVerdict };
+}): ReactWebActivationPromotedTrigger | null {
+  if (activationMode.profileGate.verdict === "would-activate") {
+    return REACT_WEB_ACTIVATION_PROFILE_GATE_TRIGGER;
+  }
+  if (activationMode.globMatch.verdict === "would-activate") {
+    return REACT_WEB_ACTIVATION_GLOB_MATCH_TRIGGER;
+  }
+  return null;
 }
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -313,10 +323,11 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
   const blockedReasons = blockedReasonsFor(artifact);
   const profileGate = profileGateVerdict(cwd, artifact);
   const globMatch = globMatchVerdict(cwd, artifact);
+  const promotedTrigger = promotedTriggerFor({ profileGate, globMatch });
   const verdict: ReactWebActivationVerdict =
     blockedReasons.length > 0 || artifact.decision === "deny"
       ? "blocked"
-      : profileGatePromotable({ profileGate })
+      : promotedTrigger
         ? "would-activate"
         : "deferred";
 
@@ -347,6 +358,7 @@ export function buildReactWebActivationMode(cwd: string, artifact: ReactWebEvide
       verdict: globMatch.verdict,
       reasons: globMatch.reasons,
     },
+    promotedTrigger,
     deferredTriggers: REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS.map((name) => ({
       name,
       reason: "deferred-in-first-activation-pass",
@@ -379,11 +391,13 @@ export function summarizeReactWebActivationMode(
       profileGateReasons: [],
       globMatchVerdict: "unavailable",
       globMatchReasons: [],
+      promotedTrigger: null,
       deferredTriggers: [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
       blockedReasons: [],
     };
   }
 
+  const promotedTrigger = promotedTriggerFor(activationMode);
   return {
     available: true,
     verdict: activationMode.verdict,
@@ -392,6 +406,7 @@ export function summarizeReactWebActivationMode(
     profileGateReasons: activationMode.profileGate.reasons,
     globMatchVerdict: activationMode.globMatch.verdict,
     globMatchReasons: activationMode.globMatch.reasons,
+    promotedTrigger,
     deferredTriggers: activationMode.deferredTriggers.map((item) => item.name),
     blockedReasons: activationMode.blockedReasons,
   };
@@ -408,5 +423,6 @@ export function renderReactWebActivationModeMarkdown(activationMode: ReactWebAct
   const profileGateReasons = activationMode.profileGate.reasons.map((reason) => `- ${reason}`).join("\n");
   const globMatchReasons = activationMode.globMatch.reasons.map((reason) => `- ${reason}`).join("\n");
 
-  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n- glob-match advisory: ${activationMode.globMatch.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Profile-gate runtime gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Glob-match advisory\n\n- ${activationMode.globMatch.name}\n${globMatchReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
+  const promotedTrigger = promotedTriggerFor(activationMode) ?? "none";
+  return `# React Web activation mode\n\n${activationMode.claimBoundary}\n\n## Summary\n\n- artifact id: ${activationMode.artifactId}\n- file: ${activationMode.filePath}\n- mode: ${activationMode.mode}\n- verdict: ${activationMode.verdict}\n- runtime decision: ${activationMode.runtimeDecision}\n- evidence strength: ${activationMode.evidenceStrength}\n- repeated-file positive: ${activationMode.supportedTrigger.positive ? "yes" : "no"}\n- promoted trigger: ${promotedTrigger}\n- profile-gate verdict: ${activationMode.profileGate.verdict}\n- glob-match runtime gate: ${activationMode.globMatch.verdict}\n\n## Supported trigger\n\n- ${activationMode.supportedTrigger.name}\n${reasons}\n\n## Profile-gate runtime gate\n\n- ${activationMode.profileGate.name}\n${profileGateReasons}\n\n## Glob-match runtime gate\n\n- ${activationMode.globMatch.name}\n${globMatchReasons}\n\n## Deferred triggers\n\n${deferred}\n\n## Blocked reasons\n\n${blockedReasons}\n`;
 }

--- a/src/core/react-web-evidence-artifact.ts
+++ b/src/core/react-web-evidence-artifact.ts
@@ -115,6 +115,8 @@ function buildWhySelected(runtimeDecision: CodexRuntimeHookDecision, payload: Mo
   }
   if (runtimeDecision.promptSpecificity === "exact-file") {
     reasons.push("exact-file-prompt-target");
+  } else if (runtimeDecision.promptSpecificity === "file-hinted") {
+    reasons.push("file-hinted-glob-match-target");
   }
   if (runtimeDecision.contextModeReason) {
     reasons.push(runtimeDecision.contextModeReason);
@@ -238,7 +240,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
   if (runtimeDecision.hookEventName !== "UserPromptSubmit") return null;
   if (runtimeDecision.action !== "inject" && runtimeDecision.action !== "fallback") return null;
   if (!runtimeDecision.debug?.repeatedFile) return null;
-  if (runtimeDecision.promptSpecificity !== "exact-file") return null;
+  if (runtimeDecision.promptSpecificity !== "exact-file" && runtimeDecision.promptSpecificity !== "file-hinted") return null;
 
   const payload = runtimeDecision.debug.decision?.payload;
   const classification = runtimeDecision.debug.decision?.debug?.domainDetection?.classification ?? payload?.domainPayload?.domain;

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -310,7 +310,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- freshness: ${status.freshness.status}`,
     `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
     `- profile-gate runtime gate: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
-    `- glob-match advisory: ${status.activationMode.globMatchVerdict} (${globMatchReasons})`,
+    `- glob-match runtime gate: ${status.activationMode.globMatchVerdict} (${globMatchReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
     "",
     "## Risks",

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -737,6 +737,7 @@ export type CodexRuntimeHookDecision = {
       profileGateReasons: string[];
       globMatchVerdict: "would-activate" | "deferred" | "blocked" | "unavailable";
       globMatchReasons: string[];
+      promotedTrigger?: "profile-gate" | "glob-match" | null;
       promoted: boolean;
       deferredTriggers: string[];
       blockedReasons: string[];

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2197,6 +2197,68 @@ test("codex runtime hook no-ops missing exact-file targets without recording rep
   }
 });
 
+test("codex runtime hook promotes a unique basename React hint through the bounded glob-match runtime gate", () => {
+  const sessionId = `hook-file-hinted-glob-match-${Date.now()}`;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Please update FormSection.tsx",
+    },
+    repoRoot,
+  );
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "Again, update FormSection.tsx and keep the React context compact if safe",
+    },
+    repoRoot,
+  );
+
+  assert.equal(first.action, "record");
+  assert.equal(first.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(first.promptSpecificity, "file-hinted");
+  assert.equal(first.contextModeReason, "first-turn-file-hinted-record-only");
+
+  assert.equal(second.action, "inject");
+  assert.equal(second.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
+  assert.equal(second.promptSpecificity, "file-hinted");
+  assert.equal(second.contextModeReason, "repeated-file-hinted-react-web-payload");
+  assert.ok(second.reasons.includes("glob-match-runtime-target"));
+  assert.deepEqual(second.debug.reactWebActivationMode, {
+    available: true,
+    verdict: "would-activate",
+    repeatedFilePositive: true,
+    profileGateVerdict: "deferred",
+    profileGateReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "freshness-current",
+      "missing-direct-file-evidence",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
+    globMatchVerdict: "would-activate",
+    globMatchReasons: [
+      "current-supported-lane-claim",
+      "direct-evidence-strength",
+      "file-path-glob-react-extension-match",
+      "freshness-current",
+      "planner-decision-compact-safe",
+      "react-web-domain-payload-present",
+      "runtime-decision-use",
+    ],
+    promotedTrigger: "glob-match",
+    promoted: true,
+    deferredTriggers: ["always-on", "model-decision"],
+    blockedReasons: [],
+  });
+});
+
 test("runtime hook reuses payload only on repeated same-file prompts in one session", () => {
   const sessionId = `hook-repeat-${Date.now()}`;
   const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
@@ -2270,6 +2332,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    promotedTrigger: "profile-gate",
     promoted: true,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
@@ -2437,6 +2500,7 @@ test("runtime hook gates edit guidance to repeated exact-file edit intent prompt
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    promotedTrigger: "profile-gate",
     promoted: true,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
@@ -2528,6 +2592,7 @@ test("runtime hook fail-closes repeated React Web activation promotion when fres
       "react-web-domain-payload-present",
       "runtime-decision-fallback",
     ],
+    promotedTrigger: null,
     promoted: false,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
@@ -2598,6 +2663,7 @@ test("runtime hook fail-closes repeated React Web activation promotion when prof
       "react-web-domain-payload-present",
       "runtime-decision-fallback",
     ],
+    promotedTrigger: null,
     promoted: false,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -145,6 +145,7 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   assert.equal(parsed.verdict, "would-activate");
   assert.equal(parsed.profileGate.verdict, "would-activate");
   assert.equal(parsed.globMatch.verdict, "would-activate");
+  assert.equal(parsed.promotedTrigger, "profile-gate");
 });
 
 test("activation mode keeps non-repeated activation triggers explicitly deferred", () => {
@@ -171,6 +172,7 @@ test("activation mode keeps non-repeated activation triggers explicitly deferred
   assert.equal(activationMode.supportedTrigger.positive, false);
   assert.equal(activationMode.profileGate.verdict, "deferred");
   assert.equal(activationMode.globMatch.verdict, "deferred");
+  assert.equal(activationMode.globMatch.reasons.includes("freshness-stale"), true);
   assert.deepEqual(
     activationMode.deferredTriggers.map((item) => item.name),
     [...REACT_WEB_ACTIVATION_DEFERRED_TRIGGERS],
@@ -204,6 +206,40 @@ test("activation mode requires bounded profile-gate evidence before reporting ru
   assert.equal(activationMode.verdict, "deferred");
   assert.ok(activationMode.profileGate.reasons.includes("evidence-strength-adjacent"));
   assert.ok(activationMode.globMatch.reasons.includes("evidence-strength-adjacent"));
+});
+
+test("activation mode allows glob-match runtime promotion without exact-file evidence", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-activation-glob-runtime-"));
+  fs.mkdirSync(path.join(tempDir, "src", "components"), { recursive: true });
+  const source = "export function FormSection() { return null; }\n";
+  fs.writeFileSync(path.join(tempDir, "src", "components", "FormSection.tsx"), source);
+
+  const currentFingerprint = {
+    fileHash: hashText(source),
+    lineCount: 2,
+  };
+
+  const activationMode = buildReactWebActivationMode(tempDir, makeArtifact({
+    filePath: "src/components/FormSection.tsx",
+    sourceFingerprint: currentFingerprint,
+    freshness: {
+      sourceFingerprint: currentFingerprint,
+      staleWhen: ["sourceFingerprint.fileHash changes"],
+    },
+    files: [
+      {
+        path: "src/components/FormSection.tsx",
+        symbols: ["FormSection"],
+        lineRanges: ["1-2"],
+        whySelected: ["file-hinted-glob-match-target"],
+      },
+    ],
+  }));
+
+  assert.equal(activationMode.supportedTrigger.positive, true);
+  assert.equal(activationMode.profileGate.verdict, "deferred");
+  assert.equal(activationMode.globMatch.verdict, "would-activate");
+  assert.equal(activationMode.verdict, "would-activate");
 });
 
 test("runtime activation promotion does not require patchTargets when repeated React Web evidence is fresh", () => {

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -71,7 +71,7 @@ test("doctor codex reports ready React Web activation readiness from a current r
   assert.match(cliText.stdout, /React Web activation/);
   assert.match(cliText.stdout, /repeated-file runtime: would-activate/);
   assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
-  assert.match(cliText.stdout, /glob-match advisory: would-activate/);
+  assert.match(cliText.stdout, /glob-match runtime gate: would-activate/);
 });
 
 test("doctor codex reports partial React Web activation readiness when freshness goes stale", () => {

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -50,6 +50,7 @@ test("status react-web reports blocked without failing when no latest evidence e
     profileGateReasons: [],
     globMatchVerdict: "unavailable",
     globMatchReasons: [],
+    promotedTrigger: null,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],
   });
@@ -122,7 +123,7 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.match(cliText.stdout, /profile status: ready/);
   assert.match(cliText.stdout, /summarized=no/);
   assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
-  assert.match(cliText.stdout, /glob-match advisory: would-activate/);
+  assert.match(cliText.stdout, /glob-match runtime gate: would-activate/);
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -783,6 +783,7 @@ test("codex runtime activates React Web payload semantics only for the React Web
       "react-web-domain-payload-present",
       "runtime-decision-use",
     ],
+    promotedTrigger: "profile-gate",
     promoted: true,
     deferredTriggers: ["always-on", "model-decision"],
     blockedReasons: [],


### PR DESCRIPTION
Closes #659

## Summary
- promote bounded React Web file-hinted glob-match decisions into the Codex runtime path
- keep exact-file/profile-gate behavior unchanged while preserving fail-closed stale, fallback, deny, mixed, and unsupported paths
- update activation/status/doctor surfaces to report glob-match as a runtime gate and expose the promoted trigger

## Verification
- git diff --check
- npm run build
- npm run lint
- npm test