### PR TITLE
Expose bounded React Web glob trigger surfaces

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,7 +8,7 @@ import { runtimeManifestPath } from "../adapters/shared";
 import { CacheMonitor } from "../core/cache-monitor";
 import { adapterDir, canonicalProjectDataDir } from "../core/paths";
 import { discoverProjectFiles } from "../core/discover";
-import { readReactWebActivationMode, type ReactWebActivationModeResult, type ReactWebActivationVerdict } from "../core/react-web-activation-mode";
+import { readReactWebActivationMode, type ReactWebActivationModeResult, type ReactWebActivationPromotedTrigger, type ReactWebActivationVerdict } from "../core/react-web-activation-mode";
 import { readReactWebStatus } from "../core/react-web-status";
 import { discoverSetupEligibleSources } from "../core/setup-eligibility";
 import { currentWorktreeEvidenceStatus, WORKTREE_BRANCH_DIVERGENCE_SOURCE } from "../core/worktree-evidence";
@@ -53,6 +53,7 @@ export type DoctorReactWebActivationReadiness = {
     verdict: ReactWebActivationVerdict | "unavailable";
     reasons: string[];
   };
+  promotedTrigger: ReactWebActivationPromotedTrigger | null;
   deferredTriggers: string[];
   risks: string[];
   nextAction: string;
@@ -647,6 +648,7 @@ function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationR
         verdict: activationMode?.globMatch.verdict ?? "unavailable",
         reasons: activationMode?.globMatch.reasons ?? [],
       },
+      promotedTrigger: activationMode?.promotedTrigger ?? null,
       deferredTriggers: activationMode?.deferredTriggers.map((item) => item.name) ?? [...status.activationMode.deferredTriggers],
       risks: [...status.risks],
       nextAction: activationNextAction(state, status.latestEvidenceId, activationMode),
@@ -673,6 +675,7 @@ function readReactWebActivationReadiness(cwd: string): DoctorReactWebActivationR
         verdict: "unavailable",
         reasons: ["activation-readiness-unavailable"],
       },
+      promotedTrigger: null,
       deferredTriggers: ["always-on", "model-decision"],
       risks: [`unable to read React Web activation readiness: ${readError}`],
       nextAction: "Repair the latest React Web evidence/status artifact read path, then rerun fooks doctor codex.",
@@ -786,6 +789,7 @@ export function formatDoctor(result: DoctorResult): string {
     lines.push(`- state: ${result.reactWebActivation.state}`);
     lines.push(`- latest evidence id: ${result.reactWebActivation.latestEvidenceId ?? "none"}`);
     lines.push(`- repeated-file runtime: ${result.reactWebActivation.repeatedFileRuntime.verdict}`);
+    lines.push(`- promoted trigger: ${result.reactWebActivation.promotedTrigger ?? "none"}`);
     lines.push(`- profile-gate runtime gate: ${result.reactWebActivation.profileGateAdvisory.verdict}`);
     lines.push(`- glob-match runtime gate: ${result.reactWebActivation.globMatchAdvisory.verdict}`);
     lines.push(`- deferred triggers: ${result.reactWebActivation.deferredTriggers.join(", ")}`);

--- a/src/core/react-web-status.ts
+++ b/src/core/react-web-status.ts
@@ -309,6 +309,7 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- project-knowledge boundary: ${status.boundaryStatus.projectKnowledge.status}`,
     `- freshness: ${status.freshness.status}`,
     `- activation mode: ${status.activationMode.verdict} (repeated-file positive=${status.activationMode.repeatedFilePositive ? "yes" : "no"})`,
+    `- promoted trigger: ${status.activationMode.promotedTrigger ?? "none"}`,
     `- profile-gate runtime gate: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
     `- glob-match runtime gate: ${status.activationMode.globMatchVerdict} (${globMatchReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,

--- a/test/react-web-glob-runtime-cli-surfaces.test.mjs
+++ b/test/react-web-glob-runtime-cli-surfaces.test.mjs
@@ -1,0 +1,93 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function runCli(cwd, args) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, `${args.join(" ")}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  return result.stdout;
+}
+
+function runCliJson(cwd, args) {
+  return JSON.parse(runCli(cwd, args));
+}
+
+test("Codex glob-match runtime promotion is inspectable from CLI, status, and doctor surfaces", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-glob-cli-"));
+  const componentDir = path.join(tempDir, "src", "components");
+  fs.mkdirSync(componentDir, { recursive: true });
+  fs.copyFileSync(
+    path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"),
+    path.join(componentDir, "FormSection.tsx"),
+  );
+
+  const sessionId = `glob-runtime-cli-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  runCliJson(tempDir, ["codex-runtime-hook", "--event", "SessionStart", "--session-id", sessionId, "--json"]);
+  const first = runCliJson(tempDir, [
+    "codex-runtime-hook",
+    "--event",
+    "UserPromptSubmit",
+    "--session-id",
+    sessionId,
+    "--prompt",
+    "Please update FormSection.tsx",
+    "--json",
+  ]);
+  const second = runCliJson(tempDir, [
+    "codex-runtime-hook",
+    "--event",
+    "UserPromptSubmit",
+    "--session-id",
+    sessionId,
+    "--prompt",
+    "Again, update FormSection.tsx and keep the React Web context compact if safe",
+    "--json",
+  ]);
+
+  assert.equal(first.action, "record");
+  assert.equal(first.promptSpecificity, "file-hinted");
+  assert.equal(second.action, "inject");
+  assert.equal(second.promptSpecificity, "file-hinted");
+  assert.ok(second.reasons.includes("glob-match-runtime-target"));
+  assert.equal(second.debug.reactWebActivationMode.profileGateVerdict, "deferred");
+  assert.equal(second.debug.reactWebActivationMode.globMatchVerdict, "would-activate");
+  assert.equal(second.debug.reactWebActivationMode.promotedTrigger, "glob-match");
+
+  const activationId = second.debug.reactWebEvidenceArtifact.id;
+  const activation = runCliJson(tempDir, ["inspect", "activation-mode", activationId, "--json"]);
+  assert.equal(activation.profileGate.verdict, "deferred");
+  assert.equal(activation.globMatch.verdict, "would-activate");
+  assert.equal(activation.promotedTrigger, "glob-match");
+
+  const statusJson = runCliJson(tempDir, ["status", "react-web", "--json"]);
+  assert.equal(statusJson.activationMode.profileGateVerdict, "deferred");
+  assert.equal(statusJson.activationMode.globMatchVerdict, "would-activate");
+  assert.equal(statusJson.activationMode.promotedTrigger, "glob-match");
+
+  const statusText = runCli(tempDir, ["status", "react-web"]);
+  assert.match(statusText, /promoted trigger: glob-match/);
+  assert.match(statusText, /profile-gate runtime gate: deferred/);
+  assert.match(statusText, /glob-match runtime gate: would-activate/);
+
+  const doctorJson = runCliJson(tempDir, ["doctor", "codex", "--json"]);
+  assert.equal(doctorJson.reactWebActivation.profileGateAdvisory.verdict, "deferred");
+  assert.equal(doctorJson.reactWebActivation.globMatchAdvisory.verdict, "would-activate");
+  assert.equal(doctorJson.reactWebActivation.promotedTrigger, "glob-match");
+
+  const doctorText = runCli(tempDir, ["doctor", "codex"]);
+  assert.match(doctorText, /promoted trigger: glob-match/);
+  assert.match(doctorText, /profile-gate runtime gate: deferred/);
+  assert.match(doctorText, /glob-match runtime gate: would-activate/);
+});


### PR DESCRIPTION
Closes #661

## Summary
- Exposes the bounded React Web activation promoted trigger through `fooks status react-web` text output.
- Exposes the same promoted trigger through `fooks doctor codex` JSON/text readiness.
- Adds focused CLI surface regression coverage for the promoted Codex React Web glob-match lane using `fooks codex-runtime-hook`, `inspect activation-mode`, `status react-web`, and `doctor codex`.

## Scope boundary
- Codex + React Web glob-match inspectability only.
- No merge-gate policy changes, detector widening, or product/perf/runtime-token claims.

## Validation
- `npm run build`
- `node --test test/react-web-glob-runtime-cli-surfaces.test.mjs test/react-web-status-surface.test.mjs test/react-web-doctor-surface.test.mjs test/react-web-activation-mode.test.mjs`
- `npm run lint`
- `npm test`