### PR TITLE
Preserve cache resilience on first safe write

### DIFF
--- a/src/core/cache-resilience.ts
+++ b/src/core/cache-resilience.ts
@@ -89,6 +89,8 @@ export class CacheResilience {
     const indexPath = join(this.cacheDir, "index.json");
     const tempPath = `${indexPath}.tmp`;
     
+    mkdirSync(this.cacheDir, { recursive: true });
+
     // Atomic write: temp → rename
     writeFileSync(tempPath, JSON.stringify(index, null, 2));
     

--- a/test/cache-resilience.test.mjs
+++ b/test/cache-resilience.test.mjs
@@ -42,6 +42,21 @@ test("CacheResilience: write and read valid cache", () => {
   fs.rmSync(cacheDir, { recursive: true });
 });
 
+test("CacheResilience: first write creates missing cache directory", () => {
+  const parentDir = makeTempCacheDir();
+  const cacheDir = path.join(parentDir, "missing-cache");
+  const resilience = new CacheResilience(cacheDir);
+
+  resilience.writeIndexSafe({
+    version: "1.0.0",
+    entries: { "test.ts": { hash: "xyz", timestamp: 12345, path: "/test.ts" } },
+  });
+
+  assert.equal(fs.existsSync(path.join(cacheDir, "index.json")), true);
+
+  fs.rmSync(parentDir, { recursive: true });
+});
+
 test("CacheResilience: corrupted cache returns null and regenerates", () => {
   const cacheDir = makeTempCacheDir();
   


### PR DESCRIPTION
Closes #664

## Summary
- preserve cache resilience marker behavior when the first safe write creates the cache directory
- add focused regression coverage for the first-write directory path

## Verification
- npm run build
- npm run lint
- node --test test/cache-resilience.test.mjs
- git diff --check