### PR TITLE
Guard root maintenance sessions before main sync

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -101,6 +101,8 @@ Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summarie
 
 `fooks status artifacts` is also read-only. It audits local fooks-scoped tmux panes, git worktrees, and branches against `origin/main` when available, falling back to `main`. It reports conservative statuses (`activeOrUnknown`, `likelyMerged`, `missingPath`, `candidateCleanup`) and a claim boundary that local evidence does not prove inactivity. The command never deletes anything and never runs cleanup commands. If JSON includes `manualCleanupCommands`, copy them only after verifying the PR merged and the session/worktree is inactive. Missing worktree paths only suggest `git worktree prune --dry-run`; inspect that output before deciding whether to run any real cleanup manually. If stale tmux panes still point at deleted worktree paths, `staleRuntimeCleanups` documents the safe manual order: verify inactivity, stop the tmux/OMX/Codex session, then run git worktree prune/remove follow-up only after the runtime is stopped.
 
+Root-cwd maintenance sessions need an extra operator guard before any local main-sync, reset, or `fooks check` flow runs from the repository root. If `tmux list-panes -a -F '#{session_name}\t#{pane_current_path}'` shows a fooks/OMX maintenance session whose pane is the root checkout, isolate that session into a disposable worktree or stop it before resetting/syncing the root checkout. Do not treat `fooks status activity` or `fooks status artifacts` as permission to reset a root checkout that still has a live maintenance pane; they are read-only evidence surfaces, not cleanup authority.
+
 ## 4. Compare one frontend file locally
 
 Before opening a runtime, you can inspect the local file-level estimate for a supported frontend file:

--- a/test/claim-boundary-doc-audit.test.mjs
+++ b/test/claim-boundary-doc-audit.test.mjs
@@ -301,6 +301,15 @@ test("current docs do not make schema-facing edit-guidance or fallback execution
   assert.deepEqual(findings, [], `forbidden schema-facing edit-guidance/fallback claims found:\n${findings.join("\n")}`);
 });
 
+test("setup docs preserve root-cwd maintenance session guard for main-sync flows", () => {
+  const setup = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
+
+  assert.match(setup, /Root-cwd maintenance sessions need an extra operator guard/);
+  assert.match(setup, /main-sync, reset, or `fooks check` flow/);
+  assert.match(setup, /isolate that session into a disposable worktree or stop it before resetting\/syncing the root checkout/);
+  assert.match(setup, /not cleanup authority/);
+});
+
 test("claim-boundary doc audit preserves measured narrow evidence wording", () => {
   const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");
   const contract = fs.readFileSync(path.join(repoRoot, "docs", "frontend-domain-contract.md"), "utf8");


### PR DESCRIPTION
## Summary
- document the root-cwd maintenance-session guard before local main-sync/reset/`fooks check` flows
- pin that guard in the claim-boundary doc audit so the operator safety wording stays present

## Validation
- `node --test test/claim-boundary-doc-audit.test.mjs`
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #666
