### PR TITLE
Keep run handoff prompts free of option noise

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -639,7 +639,7 @@ Everyday commands:
   ${displayCliName} doctor [codex|claude] [--json]
       Read-only local setup and runtime hook readiness diagnostics.
 
-  ${displayCliName} run <prompt>
+  ${displayCliName} run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
   ${displayCliName} inspect evidence <id> [--json]
@@ -1120,13 +1120,19 @@ async function run(): Promise<void> {
       return;
     }
     case "run": {
-      const { runTask } = await import("./run.js");
-      const prompt = rest.join(" ");
-      if (!prompt) {
-        console.error("Usage: fooks run <prompt>");
+      const { parseRunCliArgs, runTask } = await import("./run.js");
+      let options: ReturnType<typeof parseRunCliArgs>;
+      try {
+        options = parseRunCliArgs(rest);
+      } catch (error) {
+        console.error(`fooks run: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
-      const result = await runTask({ prompt });
+      if (!options.prompt) {
+        console.error("Usage: fooks run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>");
+        process.exit(1);
+      }
+      const result = await runTask(options);
       if (result.success) {
         console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, processed ${result.filesProcessed} files, estimated extraction opportunity ${result.reductionPercent}%`);
       } else {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -27,6 +27,49 @@ export interface RunResult {
   error?: string;
 }
 
+export function parseRunCliArgs(args: string[]): RunOptions {
+  let mode: RunOptions["mode"];
+  let runner: RunOptions["runner"];
+  const promptParts: string[] = [];
+
+  const readOptionValue = (arg: string, index: number): { value: string; consumed: number } => {
+    const equalsIndex = arg.indexOf("=");
+    if (equalsIndex >= 0) {
+      return { value: arg.slice(equalsIndex + 1), consumed: 0 };
+    }
+    const value = args[index + 1];
+    if (!value) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    return { value, consumed: 1 };
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--mode" || arg.startsWith("--mode=")) {
+      const { value, consumed } = readOptionValue(arg, index);
+      if (value !== "auto" && value !== "raw" && value !== "hybrid" && value !== "compressed") {
+        throw new Error(`Unsupported run mode: ${value}`);
+      }
+      mode = value;
+      index += consumed;
+      continue;
+    }
+    if (arg === "--runner" || arg.startsWith("--runner=")) {
+      const { value, consumed } = readOptionValue(arg, index);
+      if (value !== "auto" && value !== "codex" && value !== "claude") {
+        throw new Error(`Unsupported run runner: ${value}`);
+      }
+      runner = value;
+      index += consumed;
+      continue;
+    }
+    promptParts.push(arg);
+  }
+
+  return { prompt: promptParts.join(" "), mode, runner };
+}
+
 function shellQuote(value: string): string {
   return JSON.stringify(value);
 }
@@ -98,12 +141,16 @@ export async function runTask(options: RunOptions): Promise<RunResult> {
     for (const filePath of relevantFiles) {
       try {
         // Try compressed -> hybrid -> raw
-        let result = await tryExtract(filePath, "compressed");
+        const extractionModes: ("raw" | "hybrid" | "compressed")[] =
+          options.mode && options.mode !== "auto"
+            ? [options.mode]
+            : ["compressed", "hybrid", "raw"];
+        let result = await tryExtract(filePath, extractionModes[0]);
         if (!result.success) {
-          result = await tryExtract(filePath, "hybrid");
+          result = await tryExtract(filePath, extractionModes[1] ?? extractionModes[0]);
         }
         if (!result.success) {
-          result = await tryExtract(filePath, "raw");
+          result = await tryExtract(filePath, extractionModes[2] ?? extractionModes[0]);
         }
         
         if (result.success) {
@@ -162,9 +209,10 @@ async function tryExtract(filePath: string, mode: "raw" | "hybrid" | "compressed
   try {
     const result = extractFile(filePath);
     const metrics = decideMode(result);
+    const effectiveMode = mode === "raw" || mode === "hybrid" || mode === "compressed" ? mode : metrics.mode;
     
     // Use decideMode result to determine if extraction helped
-    const tokensSaved = metrics.useOriginal ? 0 : result.meta.rawSizeBytes * 0.5; // Estimated 50% for compressed/hybrid
+    const tokensSaved = effectiveMode === "raw" || metrics.useOriginal ? 0 : result.meta.rawSizeBytes * 0.5; // Estimated 50% for compressed/hybrid
     
     return {
       success: true,
@@ -195,13 +243,19 @@ export function detectRunner(): "codex" {
 // CLI entry - run if executed directly
 const isDirectExecution = process.argv[1]?.endsWith("run.js");
 if (isDirectExecution) {
-  const prompt = process.argv[2];
-  if (!prompt) {
-    console.error("Usage: fooks run <prompt>");
+  let options: RunOptions;
+  try {
+    options = parseRunCliArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`fooks run: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+  if (!options.prompt) {
+    console.error("Usage: fooks run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>");
     process.exit(1);
   }
   
-  runTask({ prompt }).then(result => {
+  runTask(options).then(result => {
     if (result.success) {
       console.log(`✓ Done: ${(result.durationMs / 1000).toFixed(1)}s, processed ${result.filesProcessed} files, estimated extraction opportunity ${result.reductionPercent}%`);
     } else {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -73,7 +73,7 @@ const { handleClaudeRuntimeHook, CLAUDE_ADDITIONAL_CONTEXT_MAX_CHARS } = require
 const { readCodexTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-trust.js"));
 const { readClaudeTrustStatus } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-trust.js"));
 const { handleClaudeNativeHookPayload } = require(path.join(repoRoot, "dist", "adapters", "claude-native-hook.js"));
-const { detectRunner } = require(path.join(repoRoot, "dist", "cli", "run.js"));
+const { detectRunner, parseRunCliArgs } = require(path.join(repoRoot, "dist", "cli", "run.js"));
 const { discoverProjectFilesWithStats } = require(path.join(repoRoot, "dist", "core", "discover.js"));
 const ts = require("typescript");
 
@@ -389,6 +389,15 @@ test("detectRunner keeps codex as the compatibility fallback when no runner sign
   withEnv({ FOOKS_CODEX_HOME: codexHome, PATH: emptyBin }, () => {
     assert.equal(detectRunner(), "codex");
   });
+});
+
+test("run CLI parser keeps options separate from prompt text", () => {
+  assert.deepEqual(parseRunCliArgs(["--mode=raw", "--runner", "codex", "Please", "update", "src/components/FormSection.tsx"]), {
+    prompt: "Please update src/components/FormSection.tsx",
+    mode: "raw",
+    runner: "codex",
+  });
+  assert.throws(() => parseRunCliArgs(["--mode=unsafe", "Please", "update"]), /Unsupported run mode: unsafe/);
 });
 
 test("extract keeps small fixture raw", () => {
@@ -1932,6 +1941,21 @@ test("cli run keeps exact-file prompts to one light context file", () => {
   assert.match(context, /"contextMode":"light"/);
   assert.match(context, /## src\/components\/FormSection.tsx/);
   assert.doesNotMatch(context, /## src\/components\/SimpleButton.tsx/);
+});
+
+test("cli run parses run options without leaking them into the handoff prompt", () => {
+  const tempDir = makeTempProject();
+  const output = runText(["run", "--mode=raw", "--runner", "codex", "Please", "update", "src/components/FormSection.tsx"], tempDir);
+  assert.match(output, /Shared Handoff Context/);
+  assert.match(output, /Prompt: "Please update src\/components\/FormSection\.tsx"/);
+  assert.match(output, /estimated extraction opportunity 0%/);
+  assert.doesNotMatch(output, /--mode=raw/);
+  assert.doesNotMatch(output, /--runner/);
+
+  const context = fs.readFileSync(path.join(tempDir, ".fooks", "temp-context.md"), "utf8");
+  assert.match(context, /## src\/components\/FormSection\.tsx/);
+  assert.doesNotMatch(context, /--mode=raw/);
+  assert.doesNotMatch(context, /--runner/);
 });
 
 test("cli run gives direct no-op guidance for new or missing exact-file targets", () => {


### PR DESCRIPTION
Closes #668

## Summary
- parse `fooks run` option tokens before constructing handoff prompts
- prevent `--mode` / `--runner` tokens from leaking into exact-file prompts
- add regression coverage for run option parsing and raw-mode conservative estimates

## Validation
- `npm run build`
- `node --test test/fooks.test.mjs`
- `npm run typecheck -- --pretty false`