### PR TITLE
Prevent stale PR alert guard instructions

### DIFF
--- a/docs/pr-alert-disambiguation.md
+++ b/docs/pr-alert-disambiguation.md
@@ -13,7 +13,7 @@ The guard is read-only. It never comments, closes, reopens, deletes branches, or
 ```sh
 gh api repos/minislively/fooks/issues/226 > /tmp/fooks-226.json
 printf 'clawhip/relay surfaced fooks#226 as PR closed/commented\n' > /tmp/alerts.txt
-npm run --silent pr:guard -- --repo minislively/fooks --alerts /tmp/alerts.txt --events /tmp/fooks-226.json --json
+npm run --silent pr:alerts -- --repo minislively/fooks --alerts /tmp/alerts.txt --events /tmp/fooks-226.json --json
 ```
 
 For issue-only payloads like `fooks#226`, expect `kind: "issue"` and `prHandling: "skip"`.
@@ -21,7 +21,7 @@ For issue-only payloads like `fooks#226`, expect `kind: "issue"` and `prHandling
 ## Live read-only check
 
 ```sh
-npm run --silent pr:guard -- --repo minislively/fooks --alerts /tmp/alerts.txt
+npm run --silent pr:alerts -- --repo minislively/fooks --alerts /tmp/alerts.txt
 ```
 
 This invokes `gh api repos/<owner>/<repo>/issues/<number>` for each matching alert reference and prints a small markdown report. Use rows with `prHandling=skip` as a hard stop before any PR recovery workflow. Use `prHandling=echo` rows only to verify the already-merged GitHub state; do not start fresh PR recovery from that alert.

--- a/test/pr-alert-guard.test.mjs
+++ b/test/pr-alert-guard.test.mjs
@@ -186,3 +186,14 @@ test("PR alert guard treats already merged pruned dogfood runtime cleanup as no-
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("PR alert disambiguation docs reference an existing package script", () => {
+  const doc = fs.readFileSync(path.join(repoRoot, "docs", "pr-alert-disambiguation.md"), "utf8");
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  const referencedScripts = [...doc.matchAll(/npm run --silent ([^\s]+)/g)].map((match) => match[1]);
+
+  assert.deepEqual(referencedScripts, ["pr:alerts", "pr:alerts"]);
+  for (const script of referencedScripts) {
+    assert.ok(pkg.scripts[script], `docs reference missing npm script: ${script}`);
+  }
+});


### PR DESCRIPTION
Closes #672

## Summary
- replace the stale documented `pr:guard` command with the existing `pr:alerts` script
- add a regression test that verifies documented npm scripts exist
- keep the PR alert disambiguation offline replay path covered

## Validation
- `node --test test/pr-alert-guard.test.mjs`
- `npm run typecheck`
- `npm run build`
- offline replay with `npm run --silent pr:alerts ... --json`

Commit: `4bbcb1e`