### PR TITLE
Clarify fooks architecture boundaries

### DIFF
--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -1,0 +1,57 @@
+# Architecture boundaries
+
+Issue #674 records the current fooks responsibility map. This page is a maintainer-facing architecture guide, not a runtime behavior change, support promise, benchmark claim, or release-readiness claim.
+
+The strongest bounded product path remains Codex repeated same-file React Web `.tsx` / `.jsx` work. React Native, WebView, and TUI / React CLI remain deferred, fallback, candidate, or evidence-only lanes unless a later PR adds explicit fixtures, policy gates, and claim-boundary tests.
+
+## Boundary doctrine
+
+1. **Runtime adapters invoke policy; they do not invent product claims.** CLI and adapter code may decide when to call the engine and how to install hooks, but extraction safety and domain maturity stay behind core policy gates.
+2. **The engine observes and decides from source facts.** Pure extraction, domain detection, payload policy, and model-facing packet assembly should be reusable without knowing which runtime called them.
+3. **Domain support is bounded by evidence gates.** React Web is the current strongest runtime path. RN, WebView, TUI, Mixed, and Unknown lanes can record source evidence, but that evidence is not a broad runtime-support claim.
+4. **Evidence/status/release reporting is descriptive.** Reporting surfaces summarize artifacts, freshness, claim boundaries, or release evidence. They do not authorize runtime compaction by themselves.
+5. **Ops/dogfood utilities are maintenance tooling.** Branch audits, PR alert guards, CI triage, and merge-cleanup scripts help maintain the repository. They are not product architecture seams and must not be cited as runtime support.
+
+## Current responsibility map
+
+| Boundary | Owns | Representative current paths | Must not own |
+| --- | --- | --- | --- |
+| CLI / user commands | Human-facing command parsing, setup/install/status/doctor dispatch, and concise output contracts. | `src/cli/index.ts`, `src/cli/doctor.ts`, `src/cli/run.ts`, `package.json` `bin` and user-facing npm scripts. | Source extraction policy, domain promotion, provider billing claims, or ops cleanup decisions. |
+| Runtime adapters | Codex, Claude, and opencode integration surfaces: hook presets, runtime hook payloads, session state, trust/readiness checks, and runtime-specific handoff files. | `src/adapters/codex-runtime-hook.ts`, `src/adapters/codex-native-hook.ts`, `src/adapters/codex-hook-preset.ts`, `src/adapters/claude-runtime-hook.ts`, `src/adapters/claude-hook-preset.ts`, `src/adapters/opencode-tool-preset.ts`. | Domain maturity decisions, broad support wording, benchmark conclusions, or PR/branch operations. |
+| Pure engine / extraction core | Source scanning, extraction, hashing, mode decisions, context selection, payload formatting, cache mechanics, and schema-level source facts. | `src/core/scan.ts`, `src/core/extract.ts`, `src/core/decide.ts`, `src/core/context-policy.ts`, `src/core/payload/model-facing.ts`, `src/core/payload/readiness.ts`, `src/core/schema.ts`, `src/core/cache.ts`. | Runtime-home writes, hook installation, release notes, issue/PR triage, or provider-invoice claims. |
+| Domain support boundaries | Domain classification, domain profiles, concern profiles, and payload-policy gates that decide whether source evidence may affect a model-facing packet. | `src/core/domain-detector.ts`, `src/core/domain-profiles/react-web.ts`, `src/core/domain-profiles/react-native.ts`, `src/core/domain-profiles/tui-ink.ts`, `src/core/domain-profiles/webview.ts`, `src/core/payload-policy/react-web.ts`, `src/core/payload-policy/react-native.ts`, `src/core/payload-policy/tui-ink.ts`, `src/core/payload-policy/webview.ts`, `src/core/concern-profiles/*`. | Claims that syntax evidence proves native, terminal, bridge, visual, accessibility, billing, or runtime correctness. |
+| Evidence / status / release reporting | Artifact reading/writing, freshness checks, local status summaries, release evidence reports, and claim-boundary report rendering. | `src/core/react-web-evidence-artifact.ts`, `src/core/react-web-status.ts`, `src/core/react-web-activation-mode.ts`, `src/core/react-web-ranked-bundle.ts`, `src/core/react-web-context-metadata.ts`, `src/core/worktree-evidence.ts`, `src/core/artifact-audit.ts`, `scripts/react-web-context-evidence.mjs`, `scripts/react-web-release-report-surface.mjs`, `scripts/release-benchmark-evidence.mjs`, `scripts/release-claim-guards.mjs`, `docs/benchmark-evidence.md`, `docs/release-readiness.md`. | Runtime permission to compact, domain support promotion, provider billing proof, or hook installation side effects. |
+| Ops / dogfood guard utilities | Repository maintenance, dogfood hygiene, CI/PR alert summaries, branch/worktree audit, and merge-cleanup classification. | `scripts/audit-remote-branches.mjs`, `scripts/guard-pr-alerts.mjs`, `scripts/triage-ci-alerts.mjs`, `scripts/classify-pr-merge-cleanup.mjs`, `scripts/validate-pr-merge-gate.mjs`, `docs/ci-alert-triage.md`, `docs/pr-alert-disambiguation.md`, `docs/remote-branch-audit.md`. | Product runtime behavior, support promotion, extraction policy, or user-facing setup semantics. |
+
+## Mixed-location rule
+
+Some files with evidence or status names currently live under `src/core/` because they share schemas, hashing, source fingerprints, and text rendering with the engine. That physical location does not make them runtime authority. Treat these files as reporting surfaces unless they are explicitly called by a payload-policy gate:
+
+- `src/core/react-web-evidence-artifact.ts`
+- `src/core/react-web-status.ts`
+- `src/core/react-web-activation-mode.ts`
+- `src/core/react-web-ranked-bundle.ts`
+- `src/core/worktree-evidence.ts`
+- `src/core/artifact-audit.ts`
+- `src/core/operator-activity.ts`
+
+A future move into folders such as `src/reporting/` or `src/ops/` can be useful only when it has a reviewer-readable reason, stable import/export tests, and no CLI/runtime behavior change. Until then, boundary documentation and tests are the safer seam.
+
+## React Web first, other lanes bounded
+
+React Web is the strongest bounded runtime path because it has the current repeated same-file Codex workflow, source-context policy, React Web status surfaces, and claim-boundary tests. Other frontend-family evidence remains narrower:
+
+- React Native source facts can be evidence for a measured narrow gate, but they are not mobile runtime correctness, device/simulator proof, native platform behavior proof, or broad product support.
+- WebView source facts can identify bridge/security boundaries, but they are not WebView support, bridge safety proof, or compact-payload reuse permission.
+- TUI / React CLI source facts can be syntax-level evidence, but they are not terminal semantics, terminal UX correctness, or default compact-reuse permission.
+
+## Cleanup rule for future PRs
+
+Before moving or renaming architecture files, a PR should answer:
+
+1. Which boundary does the file belong to: CLI, runtime adapter, engine, domain policy, evidence/status/release reporting, or ops/dogfood utility?
+2. Is the change required for behavior, or only for readability?
+3. Which public behavior proves unchanged: CLI output, package export, hook payload, setup/doctor/status behavior, or generated report shape?
+4. Which claim-boundary test prevents support wording from widening accidentally?
+
+If those answers are not concrete, prefer a doc/test cleanup over a file move.

--- a/test/architecture-boundaries.test.mjs
+++ b/test/architecture-boundaries.test.mjs
@@ -1,0 +1,80 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "architecture-boundaries.md");
+const doc = fs.readFileSync(docPath, "utf8");
+
+const requiredSections = [
+  "# Architecture boundaries",
+  "## Boundary doctrine",
+  "## Current responsibility map",
+  "## Mixed-location rule",
+  "## React Web first, other lanes bounded",
+  "## Cleanup rule for future PRs",
+];
+
+const requiredBoundaries = [
+  "CLI / user commands",
+  "Runtime adapters",
+  "Pure engine / extraction core",
+  "Domain support boundaries",
+  "Evidence / status / release reporting",
+  "Ops / dogfood guard utilities",
+];
+
+const representativePaths = [
+  "src/cli/index.ts",
+  "src/adapters/codex-runtime-hook.ts",
+  "src/core/extract.ts",
+  "src/core/domain-detector.ts",
+  "src/core/payload-policy/react-web.ts",
+  "src/core/react-web-status.ts",
+  "src/core/react-web-evidence-artifact.ts",
+  "src/core/worktree-evidence.ts",
+  "src/core/artifact-audit.ts",
+  "scripts/react-web-context-evidence.mjs",
+  "scripts/release-claim-guards.mjs",
+  "scripts/audit-remote-branches.mjs",
+  "scripts/guard-pr-alerts.mjs",
+  "scripts/triage-ci-alerts.mjs",
+];
+
+test("architecture boundary doc names the required responsibility layers", () => {
+  for (const section of requiredSections) {
+    assert.match(doc, new RegExp(section.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `missing section: ${section}`);
+  }
+  for (const boundary of requiredBoundaries) {
+    assert.match(doc, new RegExp(boundary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `missing boundary: ${boundary}`);
+  }
+});
+
+test("architecture boundary doc anchors each layer to representative current paths", () => {
+  for (const pathName of representativePaths) {
+    assert.match(doc, new RegExp(pathName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `missing representative path: ${pathName}`);
+  }
+});
+
+test("architecture boundary doc keeps evidence and ops out of runtime authority", () => {
+  const requiredBoundarySentences = [
+    "Reporting surfaces summarize artifacts, freshness, claim boundaries, or release evidence. They do not authorize runtime compaction by themselves.",
+    "They are not product architecture seams and must not be cited as runtime support.",
+    "That physical location does not make them runtime authority.",
+  ];
+
+  for (const sentence of requiredBoundarySentences) {
+    assert.match(doc, new RegExp(sentence.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `missing boundary sentence: ${sentence}`);
+  }
+});
+
+test("architecture boundary doc preserves React Web as strongest and keeps other lanes bounded", () => {
+  assert.match(doc, /React Web is the strongest bounded runtime path/u);
+  assert.match(doc, /React Native[\s\S]{0,180}not mobile runtime correctness/u);
+  assert.match(doc, /WebView[\s\S]{0,180}not WebView support/u);
+  assert.match(doc, /TUI \/ React CLI[\s\S]{0,180}not terminal semantics/u);
+});


### PR DESCRIPTION
Closes #674

## Summary
- Add `docs/architecture-boundaries.md` as the canonical maintainer map for CLI/user commands, runtime adapters, pure engine/domain support, evidence/status/release reporting, and ops/dogfood guard utilities.
- Add `test/architecture-boundaries.test.mjs` to lock the boundary doc's required sections, representative paths, evidence/ops non-authority wording, and React Web / RN / WebView / TUI claim boundaries.
- Preserve public CLI/runtime behavior: this PR intentionally avoids file moves, mass renames, public command changes, runtime hook changes, and support-claim widening.

## Boundary decisions
- React Web remains the strongest bounded runtime path.
- React Native, WebView, and TUI / React CLI remain deferred, fallback, candidate, or evidence-only lanes.
- Evidence/status/release reporting is descriptive and does not authorize runtime compaction.
- Ops/dogfood scripts are maintenance utilities, not product runtime architecture.

## Validation
- `npm run typecheck`
- `node --test test/architecture-boundaries.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm test` — 688 passing

## Separate OMX PR review instructions
Do not merge from this session. For the required separate OMX PR review session, start a fresh OMX review on this PR and ask it to verify:
1. The new architecture doc accurately reflects current repository boundaries without implying physical file moves already happened.
2. The doc/test wording does not widen React Native, WebView, TUI / React CLI, provider billing, runtime-token, or runtime correctness claims.
3. Evidence/status/release reporting is clearly separated from runtime authorization semantics.
4. Ops/dogfood guard utilities are clearly separated from product architecture.
5. The no-churn choice is appropriate for #674, and any requested follow-up file moves are explicitly deferred to a later PR with behavior-preserving tests.
