### PR TITLE
Keep boundary behavior tests on canonical moved surfaces

### DIFF
--- a/test/artifact-audit.test.mjs
+++ b/test/artifact-audit.test.mjs
@@ -19,7 +19,7 @@ const {
   parseGitBranchList,
   parseGitWorktreePorcelain,
   parseTmuxPaneList,
-} = require(path.join(repoRoot, "dist", "core", "artifact-audit.js"));
+} = require(path.join(repoRoot, "dist", "ops", "artifact-audit.js"));
 
 function makeRunner(outputs, calls = []) {
   return (command, args, cwd) => {

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -21,7 +21,7 @@ const {
   OPERATOR_ACTIVITY_TMUX_COMMAND,
   parseOperatorActivityTmuxPanes,
   readOperatorActivitySnapshot,
-} = require(path.join(repoRoot, "dist", "core", "operator-activity.js"));
+} = require(path.join(repoRoot, "dist", "ops", "operator-activity.js"));
 
 function run(args, cwd, envOverrides = {}) {
   return JSON.parse(execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } }));

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -19,7 +19,7 @@ const {
   buildReactWebActivationModeFromRuntimeDecision,
   readReactWebActivationMode,
   renderReactWebActivationModeMarkdown,
-} = require(path.join(repoRoot, "dist", "core", "react-web-activation-mode.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-activation-mode.js"));
 const {
   REACT_WEB_EVIDENCE_ARTIFACT_CLAIM_BOUNDARY,
   REACT_WEB_EVIDENCE_ARTIFACT_COMPRESSION_POLICY,
@@ -28,7 +28,7 @@ const {
   REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
   REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
   REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
-} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
 const { hashText } = require(path.join(repoRoot, "dist", "core", "hash.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -13,7 +13,7 @@ const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const { runDoctor } = require(path.join(repoRoot, "dist", "cli", "doctor.js"));
-const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
 

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -16,7 +16,7 @@ const {
   REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
   readReactWebEvidenceArtifact,
   renderReactWebEvidenceArtifactMarkdown,
-} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
 

--- a/test/react-web-ranked-bundle.test.mjs
+++ b/test/react-web-ranked-bundle.test.mjs
@@ -20,14 +20,14 @@ const {
   REACT_WEB_EVIDENCE_ARTIFACT_PRODUCER,
   REACT_WEB_EVIDENCE_ARTIFACT_PROFILE,
   REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION,
-} = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
 const {
   REACT_WEB_RANKED_BUNDLE_BUDGET_LIMIT,
   REACT_WEB_RANKED_BUNDLE_SCHEMA_VERSION,
   buildReactWebRankedBundle,
   readReactWebRankedBundle,
   renderReactWebRankedBundleMarkdown,
-} = require(path.join(repoRoot, "dist", "core", "react-web-ranked-bundle.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-ranked-bundle.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
 

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -16,8 +16,8 @@ const {
   REACT_WEB_STATUS_COMMAND,
   REACT_WEB_STATUS_CLAIM_BOUNDARY,
   readReactWebStatus,
-} = require(path.join(repoRoot, "dist", "core", "react-web-status.js"));
-const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "core", "react-web-evidence-artifact.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "react-web-status.js"));
+const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
 
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
 

--- a/test/worktree-evidence.test.mjs
+++ b/test/worktree-evidence.test.mjs
@@ -23,7 +23,7 @@ const {
   finalizeWorktreeEvidenceSafe,
   initializeWorktreeEvidenceSafe,
   readWorktreeEvidence,
-} = require(path.join(repoRoot, "dist", "core", "worktree-evidence.js"));
+} = require(path.join(repoRoot, "dist", "reporting", "worktree-evidence.js"));
 const { sessionWorktreeEvidencePath } = require(path.join(repoRoot, "dist", "core", "paths.js"));
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const { handleClaudeRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "claude-runtime-hook.js"));


### PR DESCRIPTION
## Summary
- Audited post-#677 boundary ownership across source imports, package exports, scripts, docs, and tests.
- Found one real residual hygiene seam: behavioral tests still imported moved reporting/ops modules through legacy `dist/core/*` compatibility shims.
- Switched those behavioral tests to canonical `dist/reporting/*` and `dist/ops/*` imports, leaving `test/physical-boundaries.test.mjs` as the intentional shim compatibility guard.

Closes #678.

## Boundary evidence
- `src/core/{react-web-status,react-web-evidence-artifact,react-web-activation-mode,react-web-ranked-bundle,worktree-evidence,artifact-audit,operator-activity}.ts` remain single-line compatibility shims only.
- `src/cli/*`, `src/adapters/*`, and `src/index.ts` already consume/export moved implementations from `src/reporting/*` and `src/ops/*`.
- `package.json` has no stale explicit `exports` map; `main` remains `dist/index.js` and `bin` remains `dist/cli/index.js`.
- Docs preserve React Web as the strongest bounded runtime path and keep RN/WebView/TUI claims fallback/evidence-only.

## Validation
- `git diff --check`
- `npm run build`
- `node --test test/react-web-evidence-artifact.test.mjs test/react-web-activation-mode.test.mjs test/react-web-ranked-bundle.test.mjs test/react-web-status-surface.test.mjs test/react-web-doctor-surface.test.mjs test/worktree-evidence.test.mjs test/artifact-audit.test.mjs test/operator-activity.test.mjs test/architecture-boundaries.test.mjs test/physical-boundaries.test.mjs` (55 passing)
- `npm test` (690 passing)

## Review instructions
Please review that:
1. Behavioral tests now use canonical reporting/ops module paths.
2. `test/physical-boundaries.test.mjs` remains the only intentional old `dist/core/*` coverage for moved surfaces.
3. No public CLI/runtime behavior, package entrypoint, or RN/TUI/WebView claim boundary changed.

## Do not merge yet
Please leave this PR open for a separate OMX PR review session before merge.
