### PR TITLE
Add React Web actionable issue report

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -646,6 +646,7 @@ Everyday commands:
   ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
+  ${displayCliName} inspect react-web-issues <file> [--json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
@@ -1313,7 +1314,18 @@ async function run(): Promise<void> {
         }
         return;
       }
-      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', or 'react-web-label-preview'");
+      if (arg1 === "react-web-issues") {
+        const { filePath: file, json } = parseCompareArgs(rest.slice(1));
+        const { buildReactWebIssueReport, renderReactWebIssueReportText } = await import("../core/react-web-issue-report.js");
+        const report = buildReactWebIssueReport(file, process.cwd());
+        if (json) {
+          print(report);
+        } else {
+          process.stdout.write(renderReactWebIssueReportText(report));
+        }
+        return;
+      }
+      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', or 'react-web-issues'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -1,0 +1,216 @@
+import {
+  buildReactWebLabelPatchPreview,
+  REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY,
+  type ReactWebLabelPatchPreview,
+  type ReactWebLabelPatchPreviewFinding,
+} from "./react-web-label-preview";
+
+export const REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION = "react-web-issue-report.v1" as const;
+export const REACT_WEB_ISSUE_REPORT_COMMAND = "inspect react-web-issues" as const;
+export const REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY =
+  "Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics." as const;
+
+type ReactWebIssueConfidence = "high" | "medium";
+type ReactWebIssueFixability = "safe-preview" | "manual-review";
+type ReactWebIssueAutoFixSafety = "not-auto-applied" | "unsafe-to-auto-apply";
+type ReactWebIssueKind =
+  | "react-web.missing-accessible-label"
+  | "react-web.ambiguous-accessible-label"
+  | "react-web.unassociated-nearby-label";
+
+export type ReactWebIssueCard = {
+  id: string;
+  kind: ReactWebIssueKind;
+  problem: string;
+  whyItMatters: string;
+  evidence: {
+    filePath: string;
+    line: number;
+    endLine: number;
+    context: string;
+    sourceSignals: string[];
+    element: ReactWebLabelPatchPreviewFinding["element"];
+  };
+  confidence: ReactWebIssueConfidence;
+  fixability: ReactWebIssueFixability;
+  autoFixSafety: ReactWebIssueAutoFixSafety;
+  safetyRationale: string;
+  suggestedFixIntent: string;
+  preview?: {
+    type: "unified-diff-fragment";
+    readOnly: true;
+    text: string;
+  };
+};
+
+export type ReactWebIssueReport = {
+  schemaVersion: typeof REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION;
+  command: typeof REACT_WEB_ISSUE_REPORT_COMMAND;
+  profile: "react-web";
+  filePath: string;
+  readOnly: true;
+  autoApply: false;
+  claimBoundary: typeof REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY;
+  sourcePreview: {
+    schemaVersion: ReactWebLabelPatchPreview["schemaVersion"];
+    claimBoundary: typeof REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY;
+    findingCount: number;
+  };
+  inScope: boolean;
+  skippedReason?: string;
+  summary: {
+    issueCount: number;
+    safePreviewCount: number;
+    manualReviewCount: number;
+    unsafeToAutoApplyCount: number;
+  };
+  issues: ReactWebIssueCard[];
+};
+
+function issueKindFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueKind {
+  return `react-web.${finding.kind}` as ReactWebIssueKind;
+}
+
+function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
+  switch (finding.kind) {
+    case "missing-accessible-label":
+      return `Native ${finding.element} lacks recognized accessible-label evidence.`;
+    case "ambiguous-accessible-label":
+      return `Native ${finding.element} only has ambiguous accessible-label evidence.`;
+    case "unassociated-nearby-label":
+      return `Nearby label text is not explicitly associated with this native ${finding.element}.`;
+  }
+}
+
+function whyItMattersFor(finding: ReactWebLabelPatchPreviewFinding): string {
+  switch (finding.kind) {
+    case "missing-accessible-label":
+      return "Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.";
+    case "ambiguous-accessible-label":
+      return "Placeholder-only labeling can disappear during input and is weaker than an explicit accessible name.";
+    case "unassociated-nearby-label":
+      return "Visible label text may not be programmatically connected to the native form control.";
+  }
+}
+
+function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): string {
+  switch (finding.kind) {
+    case "missing-accessible-label":
+      return "Add an explicit accessible label with human-reviewed copy for the native control.";
+    case "ambiguous-accessible-label":
+      return "Replace placeholder-only labeling with explicit label evidence or human-reviewed aria-label copy.";
+    case "unassociated-nearby-label":
+      return "Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.";
+  }
+}
+
+function fixabilityFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueFixability {
+  return finding.kind === "unassociated-nearby-label" ? "safe-preview" : "manual-review";
+}
+
+function autoFixSafetyFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueAutoFixSafety {
+  return finding.kind === "unassociated-nearby-label" ? "not-auto-applied" : "unsafe-to-auto-apply";
+}
+
+function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
+  if (finding.kind === "unassociated-nearby-label") {
+    return "The report can preview a deterministic native htmlFor/id association from existing JSX evidence, but fooks remains read-only and does not apply it.";
+  }
+  return "The preview uses TODO accessible-name copy because correct user-facing label text requires human review; fooks reports the issue but does not auto-apply it.";
+}
+
+function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFinding, index: number): ReactWebIssueCard {
+  const preview = finding.suggestedPatch.readOnly
+    ? {
+        type: finding.suggestedPatch.type,
+        readOnly: true as const,
+        text: finding.suggestedPatch.preview,
+      }
+    : undefined;
+  return {
+    id: `react-web-label-${index + 1}`,
+    kind: issueKindFor(finding),
+    problem: problemFor(finding),
+    whyItMatters: whyItMattersFor(finding),
+    evidence: {
+      filePath,
+      line: finding.loc.startLine,
+      endLine: finding.loc.endLine,
+      context: finding.context,
+      sourceSignals: finding.evidence,
+      element: finding.element,
+    },
+    confidence: finding.confidence,
+    fixability: fixabilityFor(finding),
+    autoFixSafety: autoFixSafetyFor(finding),
+    safetyRationale: safetyRationaleFor(finding),
+    suggestedFixIntent: suggestedFixIntentFor(finding),
+    ...(preview ? { preview } : {}),
+  };
+}
+
+export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()): ReactWebIssueReport {
+  const preview = buildReactWebLabelPatchPreview(filePath, cwd);
+  const issues = preview.findings.map((finding, index) => issueCardFor(preview.filePath, finding, index));
+  return {
+    schemaVersion: REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION,
+    command: REACT_WEB_ISSUE_REPORT_COMMAND,
+    profile: "react-web",
+    filePath: preview.filePath,
+    readOnly: true,
+    autoApply: false,
+    claimBoundary: REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
+    sourcePreview: {
+      schemaVersion: preview.schemaVersion,
+      claimBoundary: preview.claimBoundary,
+      findingCount: preview.summary.findingCount,
+    },
+    inScope: preview.inScope,
+    ...(preview.skippedReason ? { skippedReason: preview.skippedReason } : {}),
+    summary: {
+      issueCount: issues.length,
+      safePreviewCount: issues.filter((issue) => issue.fixability === "safe-preview").length,
+      manualReviewCount: issues.filter((issue) => issue.fixability === "manual-review").length,
+      unsafeToAutoApplyCount: issues.filter((issue) => issue.autoFixSafety === "unsafe-to-auto-apply").length,
+    },
+    issues,
+  };
+}
+
+export function renderReactWebIssueReportText(report: ReactWebIssueReport): string {
+  const lines = [
+    "# React Web issue report",
+    "",
+    report.claimBoundary,
+    "",
+    `File: ${report.filePath}`,
+    `Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `Auto-apply: ${report.autoApply ? "yes" : "no"}`,
+    `In scope: ${report.inScope ? "yes" : "no"}`,
+    `Issues: ${report.summary.issueCount} (safe preview: ${report.summary.safePreviewCount}, manual review: ${report.summary.manualReviewCount}, unsafe to auto-apply: ${report.summary.unsafeToAutoApplyCount})`,
+  ];
+  if (report.skippedReason) lines.push(`Skipped: ${report.skippedReason}`);
+  if (report.issues.length === 0) return `${lines.join("\n")}\n`;
+
+  report.issues.forEach((issue, index) => {
+    lines.push(
+      "",
+      `## Issue ${index + 1}: ${issue.problem}`,
+      `- why: ${issue.whyItMatters}`,
+      `- file/line: ${issue.evidence.filePath}:${issue.evidence.line}`,
+      `- element: ${issue.evidence.element}`,
+      `- confidence: ${issue.confidence}`,
+      `- fixability: ${issue.fixability}`,
+      `- auto-fix safety: ${issue.autoFixSafety}`,
+      `- safety rationale: ${issue.safetyRationale}`,
+      `- suggested fix: ${issue.suggestedFixIntent}`,
+      `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
+      `- context: ${issue.evidence.context}`,
+    );
+    if (issue.preview) {
+      lines.push("", "```diff", issue.preview.text, "```");
+    }
+  });
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,3 +130,12 @@ export type {
   ReactWebRankedBundleSummary,
   ReactWebRankedBundleVerdict,
 } from "./reporting/react-web-ranked-bundle";
+
+export {
+  REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
+  REACT_WEB_ISSUE_REPORT_COMMAND,
+  REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION,
+  buildReactWebIssueReport,
+  renderReactWebIssueReportText,
+} from "./core/react-web-issue-report";
+export type { ReactWebIssueCard, ReactWebIssueReport } from "./core/react-web-issue-report";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3820,6 +3820,8 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect evidence <id> \[--json\]/);
   assert.match(help, /fooks inspect activation-mode <id> \[--json\]/);
   assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
+  assert.match(help, /fooks inspect react-web-label-preview <file> \[--json\]/);
+  assert.match(help, /fooks inspect react-web-issues <file> \[--json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\]/);

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -1,0 +1,187 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+const { buildReactWebLabelPatchPreview } = require(path.join(repoRoot, "dist", "core", "react-web-label-preview.js"));
+const {
+  REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
+  buildReactWebIssueReport,
+} = require(path.join(repoRoot, "dist", "core", "react-web-issue-report.js"));
+
+const fixtures = {
+  missing: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-labels.tsx"),
+  labelled: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "labelled-controls.tsx"),
+  association: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-candidates.tsx"),
+  unsafeAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx"),
+  rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
+  customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
+};
+
+function runIssues(file, ...args) {
+  return spawnSync(process.execPath, [cliPath, "inspect", "react-web-issues", file, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+function parseIssues(file) {
+  const cli = runIssues(file, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  return JSON.parse(cli.stdout);
+}
+
+function matrixEntry({ fixture, expectedCards, report, preview, acceptedCards, rejectedCards = 0, noiseNotes = [], suggestionPlausibility }) {
+  return {
+    fixture,
+    expectedCards,
+    observedCards: report.summary.issueCount,
+    acceptedCards,
+    rejectedCards,
+    noiseNotes,
+    suggestionPlausibility,
+    parityWithPreviewFindings: report.summary.issueCount === preview.summary.findingCount,
+    verdict: report.summary.issueCount === expectedCards && acceptedCards === expectedCards && rejectedCards === 0 && noiseNotes.length === 0 && report.summary.issueCount === preview.summary.findingCount ? "pass" : "fail",
+  };
+}
+
+test("React Web issue report emits actionable issue cards over label preview findings", () => {
+  const report = parseIssues(fixtures.missing);
+  const preview = buildReactWebLabelPatchPreview(fixtures.missing, repoRoot);
+
+  assert.equal(report.schemaVersion, "react-web-issue-report.v1");
+  assert.equal(report.command, "inspect react-web-issues");
+  assert.equal(report.profile, "react-web");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.autoApply, false);
+  assert.equal(report.claimBoundary, REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY);
+  assert.match(report.claimBoundary, /Read-only React Web issue report/);
+  assert.match(report.claimBoundary, /does not auto-apply patches/);
+  assert.match(report.claimBoundary, /does not infer custom-component semantics/);
+  assert.equal(report.sourcePreview.findingCount, preview.summary.findingCount);
+  assert.equal(report.summary.issueCount, 5);
+  assert.equal(report.summary.manualReviewCount, 5);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 5);
+
+  assert.deepEqual(report.issues.map((issue) => [issue.kind, issue.evidence.element, issue.confidence, issue.fixability, issue.autoFixSafety]), [
+    ["react-web.missing-accessible-label", "button", "high", "manual-review", "unsafe-to-auto-apply"],
+    ["react-web.missing-accessible-label", "input", "high", "manual-review", "unsafe-to-auto-apply"],
+    ["react-web.ambiguous-accessible-label", "input", "medium", "manual-review", "unsafe-to-auto-apply"],
+    ["react-web.missing-accessible-label", "select", "high", "manual-review", "unsafe-to-auto-apply"],
+    ["react-web.ambiguous-accessible-label", "textarea", "medium", "manual-review", "unsafe-to-auto-apply"],
+  ]);
+
+  for (const issue of report.issues) {
+    assert.ok(issue.problem.length > 0);
+    assert.ok(issue.whyItMatters.length > 0);
+    assert.equal(issue.evidence.filePath, "test/fixtures/react-web-label-preview/missing-labels.tsx");
+    assert.ok(issue.evidence.line > 0);
+    assert.ok(issue.evidence.context.length > 0);
+    assert.ok(issue.evidence.sourceSignals.length > 0);
+    assert.ok(issue.safetyRationale.length > 0);
+    assert.ok(issue.suggestedFixIntent.length > 0);
+    assert.equal(issue.preview.readOnly, true);
+    assert.match(issue.preview.text, /aria-label="TODO:/);
+  }
+});
+
+test("React Web issue report turns nearby native associations into safe preview cards", () => {
+  const report = parseIssues(fixtures.association);
+  const preview = buildReactWebLabelPatchPreview(fixtures.association, repoRoot);
+
+  assert.equal(report.summary.issueCount, 3);
+  assert.equal(report.summary.safePreviewCount, 3);
+  assert.equal(report.summary.manualReviewCount, 0);
+  assert.equal(report.summary.issueCount, preview.summary.findingCount);
+  assert.ok(report.issues.every((issue) => issue.kind === "react-web.unassociated-nearby-label"));
+  assert.ok(report.issues.every((issue) => issue.fixability === "safe-preview"));
+  assert.ok(report.issues.every((issue) => issue.autoFixSafety === "not-auto-applied"));
+  assert.match(report.issues[0].preview.text, /htmlFor="email"/);
+});
+
+test("React Web issue report fixture usefulness gate records accepted cards, noise, plausibility, and parity", () => {
+  const cases = [
+    {
+      name: "missing-labels.tsx",
+      file: fixtures.missing,
+      expectedCards: 5,
+      acceptedCards: 5,
+      suggestionPlausibility: "TODO accessible-name previews are plausible but require human copy review.",
+    },
+    {
+      name: "label-association-candidates.tsx",
+      file: fixtures.association,
+      expectedCards: 3,
+      acceptedCards: 3,
+      suggestionPlausibility: "Native nearby label/control htmlFor/id previews are deterministic and read-only.",
+    },
+    {
+      name: "labelled-controls.tsx",
+      file: fixtures.labelled,
+      expectedCards: 0,
+      acceptedCards: 0,
+      suggestionPlausibility: "No suggestion needed because native controls already have label evidence.",
+    },
+  ];
+
+  const matrix = cases.map((item) => {
+    const report = buildReactWebIssueReport(item.file, repoRoot);
+    const preview = buildReactWebLabelPatchPreview(item.file, repoRoot);
+    return matrixEntry({ ...item, fixture: item.name, report, preview });
+  });
+
+  assert.deepEqual(matrix.map((entry) => entry.verdict), ["pass", "pass", "pass"]);
+  assert.ok(matrix.every((entry) => entry.parityWithPreviewFindings));
+  assert.ok(matrix.every((entry) => entry.noiseNotes.length === 0));
+});
+
+test("React Web issue report preserves skip and no unsupported custom-component inference boundaries", () => {
+  const rnReport = parseIssues(fixtures.rn);
+  assert.equal(rnReport.inScope, false);
+  assert.match(rnReport.skippedReason, /^domain-classification:react-native/);
+  assert.deepEqual(rnReport.issues, []);
+
+  const customReport = parseIssues(fixtures.customComponent);
+  assert.equal(customReport.inScope, true);
+  assert.equal(customReport.summary.issueCount, 0);
+  assert.deepEqual(customReport.issues, []);
+});
+
+test("React Web issue report avoids unsafe htmlFor inference and keeps fallback previews read-only", () => {
+  const report = parseIssues(fixtures.unsafeAssociation);
+  const preview = buildReactWebLabelPatchPreview(fixtures.unsafeAssociation, repoRoot);
+  const matrix = matrixEntry({
+    fixture: "label-association-unsafe.tsx",
+    expectedCards: preview.summary.findingCount,
+    observedCards: report.summary.issueCount,
+    report,
+    preview,
+    acceptedCards: report.summary.issueCount,
+    suggestionPlausibility: "Unsafe nearby association is rejected; fallback aria-label TODO previews remain read-only/manual-review.",
+  });
+
+  assert.equal(matrix.verdict, "pass");
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.ok(report.summary.manualReviewCount > 0);
+  assert.ok(report.issues.every((issue) => issue.fixability === "manual-review"));
+  assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
+  assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
+});
+
+test("React Web issue report text mode is issue-card-first and prints the claim boundary", () => {
+  const cli = runIssues(fixtures.association);
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.match(cli.stdout, /# React Web issue report/);
+  assert.match(cli.stdout, /Read-only React Web issue report/);
+  assert.match(cli.stdout, /## Issue 1:/);
+  assert.match(cli.stdout, /- why:/);
+  assert.match(cli.stdout, /- file\/line:/);
+  assert.match(cli.stdout, /- fixability: safe-preview/);
+  assert.match(cli.stdout, /- auto-fix safety: not-auto-applied/);
+  assert.match(cli.stdout, /```diff/);
+  assert.doesNotMatch(cli.stdout, /Auto-apply: yes/);
+});


### PR DESCRIPTION
## Summary\n- add `inspect react-web-issues <file> [--json]` as a read-only issue-card adapter over the existing React Web label preview detector\n- expose problem, why-it-matters, evidence, confidence, fixability, auto-fix safety, and suggested fix intent without auto-applying patches\n- add a structured fixture usefulness gate covering positive, quiet, RN skip, custom-component negative, unsafe association, and preview/report parity cases\n\n## Boundaries\n- React Web native JSX label/accessibility subset only\n- no operator cleanup, broad lane expansion, auto-apply behavior, large refactors, or unsupported custom-component inference\n\n## Tests\n- `npm run build`\n- `node --test test/react-web-issue-report.test.mjs test/react-web-label-preview.test.mjs`\n- `node --test --test-name-pattern 'cli help advertises' test/fooks.test.mjs`\n- `env -u FOOKS_TARGET_ACCOUNT npm test`\n- CLI spot checks for `inspect react-web-issues` JSON/text output\n\nRefs: follow-up to React Web actionable report planning; no linked issue.

Fixes #695
