### PR TITLE
Productize React Web issue cards as first change-intelligence wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # fooks
 
-Stop paying the frontend context tax twice.
+Frontend change intelligence for React work.
+
+fooks helps frontend teams reduce the cost of feature work, migrations, refactors, and tests by mapping relevant React Web context, surfacing actionable issues, and suggesting safe previews when confidence is high.
+
+First wedge: a React Web form/a11y issue report that produces actionable issue cards and read-only safe preview candidates for deterministic native label/control associations. Ambiguous or risky cases stay as manual-review cards with skip reasons.
 
 Smaller model-facing context for repeated same-file work in Codex.
 
@@ -18,6 +22,15 @@ fooks compare src/components/Button.tsx
 
 Then open Codex in that repo and work normally on the same supported file. `fooks setup` is explicit by design: installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files. `fooks doctor` checks local setup/hook readiness, and `fooks compare` shows source size versus the compact fooks model-facing payload for one supported file.
 
+To inspect the first frontend-change-intelligence wedge directly:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx
+fooks inspect react-web-issues src/components/Form.tsx --json
+```
+
+The React Web issue report is read-only. It emits issue cards with `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`; only deterministic high-confidence native label/control associations receive preview candidates, while ambiguous or risky findings receive manual-review skip reasons.
+
 Best fit: repeated same-file React `.tsx` / `.jsx` work in Codex. There is also an experimental Codex-first `.ts` / `.js` same-file beta when module signals are strong enough. TUI / React CLI `.tsx` remains a candidate / evidence-only lane: syntax-level local evidence can exist, but terminal semantics or compact-reuse support are not current claims. The first-minute proof is local model-facing payload evidence, not provider billing or stable runtime-token proof. React Native/WebView, TUI / React CLI promotion, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap asks, not current support.
 
 - Public npm package: `fxxk-frontend-hooks`
@@ -25,9 +38,10 @@ Best fit: repeated same-file React `.tsx` / `.jsx` work in Codex. There is also 
 
 ## 30-second version
 
-Use fooks when you are iterating on the same large supported file in Codex and want to avoid repeatedly sending the full file context.
+Use fooks when you want less wasted frontend change work: actionable React Web issue cards before editing, conservative safe previews when confidence is high, and smaller model-facing context for repeated same-file Codex work.
 
 - **Best today:** Codex + repeated same-file `.tsx` / `.jsx` work.
+- **First frontend-change-intelligence wedge:** `fooks inspect react-web-issues <file> [--json]` reports narrow React Web form/a11y issue cards with safe previews only for deterministic native label/control associations.
 - **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
 - **Roadmap asks, not current support:** React Native/WebView, TUI / React CLI promotion beyond candidate / evidence-only status, Vue/SFC, broader TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity.
 - **Local proof:** `fooks compare` shows the original source size versus the compact fooks model-facing payload for one supported file.

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -31,11 +31,19 @@ export type ReactWebIssueCard = {
     sourceSignals: string[];
     element: ReactWebLabelPatchPreviewFinding["element"];
   };
+  whereToLook: {
+    filePath: string;
+    line: number;
+    endLine: number;
+    context: string;
+  };
   confidence: ReactWebIssueConfidence;
   fixability: ReactWebIssueFixability;
   autoFixSafety: ReactWebIssueAutoFixSafety;
   safetyRationale: string;
   suggestedFixIntent: string;
+  suggestedAction: string;
+  skipReason?: string;
   preview?: {
     type: "unified-diff-fragment";
     readOnly: true;
@@ -120,13 +128,16 @@ function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
 }
 
 function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFinding, index: number): ReactWebIssueCard {
-  const preview = finding.suggestedPatch.readOnly
+  const isSafePreview = fixabilityFor(finding) === "safe-preview";
+  const preview = isSafePreview && finding.suggestedPatch.readOnly
     ? {
         type: finding.suggestedPatch.type,
         readOnly: true as const,
         text: finding.suggestedPatch.preview,
       }
     : undefined;
+  const suggestedAction = suggestedFixIntentFor(finding);
+  const safetyRationale = safetyRationaleFor(finding);
   return {
     id: `react-web-label-${index + 1}`,
     kind: issueKindFor(finding),
@@ -140,11 +151,19 @@ function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFindin
       sourceSignals: finding.evidence,
       element: finding.element,
     },
+    whereToLook: {
+      filePath,
+      line: finding.loc.startLine,
+      endLine: finding.loc.endLine,
+      context: finding.context,
+    },
     confidence: finding.confidence,
     fixability: fixabilityFor(finding),
     autoFixSafety: autoFixSafetyFor(finding),
-    safetyRationale: safetyRationaleFor(finding),
-    suggestedFixIntent: suggestedFixIntentFor(finding),
+    safetyRationale,
+    suggestedFixIntent: suggestedAction,
+    suggestedAction,
+    ...(!isSafePreview ? { skipReason: safetyRationale } : {}),
     ...(preview ? { preview } : {}),
   };
 }
@@ -197,13 +216,14 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       "",
       `## Issue ${index + 1}: ${issue.problem}`,
       `- why: ${issue.whyItMatters}`,
-      `- file/line: ${issue.evidence.filePath}:${issue.evidence.line}`,
+      `- where to look: ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
       `- element: ${issue.evidence.element}`,
       `- confidence: ${issue.confidence}`,
       `- fixability: ${issue.fixability}`,
       `- auto-fix safety: ${issue.autoFixSafety}`,
       `- safety rationale: ${issue.safetyRationale}`,
-      `- suggested fix: ${issue.suggestedFixIntent}`,
+      ...(issue.skipReason ? [`- skip reason: ${issue.skipReason}`] : []),
+      `- suggested action: ${issue.suggestedAction}`,
       `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
       `- context: ${issue.evidence.context}`,
     );

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -79,13 +79,17 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.problem.length > 0);
     assert.ok(issue.whyItMatters.length > 0);
     assert.equal(issue.evidence.filePath, "test/fixtures/react-web-label-preview/missing-labels.tsx");
+    assert.equal(issue.whereToLook.filePath, "test/fixtures/react-web-label-preview/missing-labels.tsx");
+    assert.ok(issue.whereToLook.line > 0);
+    assert.ok(issue.whereToLook.context.length > 0);
     assert.ok(issue.evidence.line > 0);
     assert.ok(issue.evidence.context.length > 0);
     assert.ok(issue.evidence.sourceSignals.length > 0);
     assert.ok(issue.safetyRationale.length > 0);
     assert.ok(issue.suggestedFixIntent.length > 0);
-    assert.equal(issue.preview.readOnly, true);
-    assert.match(issue.preview.text, /aria-label="TODO:/);
+    assert.equal(issue.suggestedAction, issue.suggestedFixIntent);
+    assert.match(issue.skipReason, /human review|correct user-facing label text/);
+    assert.equal(issue.preview, undefined);
   }
 });
 
@@ -110,7 +114,7 @@ test("React Web issue report fixture usefulness gate records accepted cards, noi
       file: fixtures.missing,
       expectedCards: 5,
       acceptedCards: 5,
-      suggestionPlausibility: "TODO accessible-name previews are plausible but require human copy review.",
+      suggestionPlausibility: "TODO accessible-name suggestions are plausible but require human copy review, so no preview is emitted.",
     },
     {
       name: "label-association-candidates.tsx",
@@ -161,7 +165,7 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
     report,
     preview,
     acceptedCards: report.summary.issueCount,
-    suggestionPlausibility: "Unsafe nearby association is rejected; fallback aria-label TODO previews remain read-only/manual-review.",
+    suggestionPlausibility: "Unsafe nearby association is rejected; fallback aria-label TODO suggestions remain manual-review without preview.",
   });
 
   assert.equal(matrix.verdict, "pass");
@@ -169,6 +173,8 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
   assert.ok(report.summary.manualReviewCount > 0);
   assert.ok(report.issues.every((issue) => issue.fixability === "manual-review"));
   assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
+  assert.ok(report.issues.every((issue) => issue.skipReason));
+  assert.ok(report.issues.every((issue) => issue.preview === undefined));
   assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
 });
 
@@ -179,9 +185,10 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /Read-only React Web issue report/);
   assert.match(cli.stdout, /## Issue 1:/);
   assert.match(cli.stdout, /- why:/);
-  assert.match(cli.stdout, /- file\/line:/);
+  assert.match(cli.stdout, /- where to look:/);
   assert.match(cli.stdout, /- fixability: safe-preview/);
   assert.match(cli.stdout, /- auto-fix safety: not-auto-applied/);
+  assert.match(cli.stdout, /- suggested action:/);
   assert.match(cli.stdout, /```diff/);
   assert.doesNotMatch(cli.stdout, /Auto-apply: yes/);
 });


### PR DESCRIPTION
## Summary
- Closes #697
- Productizes the existing React Web issue-report path as the first frontend change intelligence wedge
- Adds product-facing issue-card fields: `whereToLook`, `suggestedAction`, and `skipReason` for manual-review cards
- Keeps preview candidates restricted to `safe-preview` cards; manual-review cards now omit preview even when upstream label-preview findings carry read-only patch fragments
- Updates README positioning around frontend change intelligence and `fooks inspect react-web-issues <file> [--json]`

## Ralplan / Ultragoal evidence
- Ralplan consensus chose the existing label-preview → issue-report stack over broadening or preview-first autofix
- Architect ITERATE was addressed by locking card fields, safe-preview-only preview gating, and README docs scope
- Critic APPROVE confirmed the amended plan and implementation surface
- Ultragoal fallback artifacts were tracked locally under `.omx/ultragoal/` because this installed `omx` CLI has no `ultragoal` subcommand

## Verification
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs`
- `node --test test/react-web-issue-report.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT npm test` — 711/711 pass
- CLI JSON acceptance check for manual-review cards without preview
- CLI text acceptance check for `where to look`, `suggested action`, and diff preview on safe associations

## Boundaries
- No browser/runtime a11y validation
- No risky autofix or auto-apply
- No full design-system inference
- No non-React-Web framework support
