### PR TITLE
Recover React Web issue-card wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # fooks
 
-Frontend change intelligence for lower-cost frontend work.
+Frontend change intelligence for lower-cost React Web work.
 
-`fooks` helps agents spend less time and context rediscovering the same React Web facts before feature work, migrations, refactors, and tests. The first wedge is React Web: source-fact extraction, evidence gates, and actionable CLI reports point out narrow form/accessibility issues and, when confidence is high, show read-only patch previews a human or agent can review.
+`fooks` helps agents spend less time and context rediscovering the same React Web facts before feature work, migrations, refactors, and tests. The first wedge is React Web: source-fact extraction, evidence gates, and actionable issue cards point out narrow form/accessibility issues and, when confidence is high, show read-only safe preview candidates a human or agent can review. Ambiguous or risky cases stay as manual-review cards with skip reasons.
 
 Context reduction and caching remain supporting mechanisms. In the strongest current path, a Codex user mentions the same React `.tsx` / `.jsx` file more than once in one repo: the first eligible mention records compact context, and later same-file prompts may reuse a compact model-facing payload when safe. Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
 
@@ -19,18 +19,25 @@ fooks compare src/components/Button.tsx
 
 Then open Codex in that repo and work normally on the same supported file. `fooks setup` is explicit by design: installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files. `fooks doctor` checks local setup/hook readiness, `fooks inspect react-web-issues` renders actionable React Web issue cards, and `fooks compare` shows source size versus the compact fooks model-facing payload for one supported file.
 
-Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibility facts can reduce frontend change cost. The current CLI surface is advisory and read-only: it reports narrow native-control label/accessibility findings and shows patch previews only when confidence is high enough for review, not automatic application. There is also an experimental Codex-first `.ts` / `.js` same-file beta when module signals are strong enough. TUI / React CLI `.tsx` remains a candidate / evidence-only lane: syntax-level local evidence can exist, but terminal semantics or compact-reuse support are not current claims. The first-minute proof is local model-facing payload evidence and actionable report output, not provider billing or stable runtime-token proof. React Native/WebView, TUI / React CLI promotion, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap asks, not current support.
+To inspect the first frontend-change-intelligence wedge directly:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx
+fooks inspect react-web-issues src/components/Form.tsx --json
+```
+
+Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibility facts can reduce frontend change cost. The current CLI surface is advisory and read-only: it emits issue cards with `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`; only deterministic high-confidence native label/control associations receive preview candidates, while ambiguous or risky findings receive manual-review skip reasons. There is also an experimental Codex-first `.ts` / `.js` same-file beta when module signals are strong enough. TUI / React CLI `.tsx` remains a candidate / evidence-only lane: syntax-level local evidence can exist, but terminal semantics or compact-reuse support are not current claims. The first-minute proof is local model-facing payload evidence and actionable report output, not provider billing or stable runtime-token proof. React Native/WebView, TUI / React CLI promotion, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap asks, not current support.
 
 - Public npm package: `fxxk-frontend-hooks`
 - CLI command: `fooks`
 
 ## 30-second version
 
-Use fooks when you want frontend change intelligence for a supported React Web file: source-derived context that lowers the cost of repeated feature work, migrations, refactors, and tests, plus a CLI report that turns narrow form/accessibility findings into reviewable issue cards.
+Use fooks when you want frontend change intelligence for a supported React Web file: source-derived context that lowers the cost of repeated feature work, migrations, refactors, and tests, actionable issue cards before editing, conservative safe previews when confidence is high, and smaller model-facing context for repeated same-file Codex work.
 
 - **Product direction:** frontend work cost reduction through source facts, evidence gates, actionable reports, and bounded preview guidance.
 - **First wedge:** React Web `.tsx` / `.jsx`; repeated same-file Codex context reuse is the strongest current workflow.
-- **First surface/problem:** `fooks inspect react-web-issues <file>` reports narrow native-control form/accessibility issues, with read-only patch previews only when confidence is high.
+- **First surface/problem:** `fooks inspect react-web-issues <file> [--json]` reports narrow native-control form/accessibility issue cards, with read-only safe previews only for deterministic native label/control associations.
 - **Supporting mechanism:** context reduction and caching help avoid rediscovering the same source facts, but they are not the whole product positioning.
 - **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
 - **Roadmap asks, not current support:** React Native/WebView, TUI / React CLI promotion beyond candidate / evidence-only status, Vue/SFC, broader TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity.

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -31,11 +31,19 @@ export type ReactWebIssueCard = {
     sourceSignals: string[];
     element: ReactWebLabelPatchPreviewFinding["element"];
   };
+  whereToLook: {
+    filePath: string;
+    line: number;
+    endLine: number;
+    context: string;
+  };
   confidence: ReactWebIssueConfidence;
   fixability: ReactWebIssueFixability;
   autoFixSafety: ReactWebIssueAutoFixSafety;
   safetyRationale: string;
   suggestedFixIntent: string;
+  suggestedAction: string;
+  skipReason?: string;
   preview?: {
     type: "unified-diff-fragment";
     readOnly: true;
@@ -104,29 +112,46 @@ function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): strin
   }
 }
 
+function hasSafePreviewEvidence(finding: ReactWebLabelPatchPreviewFinding): boolean {
+  return finding.kind === "unassociated-nearby-label" && finding.confidence === "high";
+}
+
 function fixabilityFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueFixability {
-  return finding.kind === "unassociated-nearby-label" ? "safe-preview" : "manual-review";
+  return hasSafePreviewEvidence(finding) ? "safe-preview" : "manual-review";
 }
 
 function autoFixSafetyFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueAutoFixSafety {
-  return finding.kind === "unassociated-nearby-label" ? "not-auto-applied" : "unsafe-to-auto-apply";
+  return hasSafePreviewEvidence(finding) ? "not-auto-applied" : "unsafe-to-auto-apply";
 }
 
 function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
-  if (finding.kind === "unassociated-nearby-label") {
-    return "The report can preview a deterministic native htmlFor/id association from existing JSX evidence, but fooks remains read-only and does not apply it.";
+  if (hasSafePreviewEvidence(finding)) {
+    return "The report can preview a high-confidence deterministic native htmlFor/id association from existing JSX evidence, but fooks remains read-only and does not apply it.";
   }
-  return "The preview uses TODO accessible-name copy because correct user-facing label text requires human review; fooks reports the issue but does not auto-apply it.";
+  if (finding.kind === "unassociated-nearby-label") {
+    return "Nearby label/control evidence is not high-confidence enough for a safe preview, so fooks reports it for manual review and does not auto-apply it.";
+  }
+  return "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.";
+}
+
+function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
+  if (finding.kind === "unassociated-nearby-label") {
+    return "Preview skipped because the nearby label/control association is not high-confidence deterministic evidence.";
+  }
+  return "Preview skipped because generated accessible-name copy would require human review.";
 }
 
 function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFinding, index: number): ReactWebIssueCard {
-  const preview = finding.suggestedPatch.readOnly
+  const isSafePreview = hasSafePreviewEvidence(finding);
+  const preview = isSafePreview && finding.suggestedPatch.readOnly
     ? {
         type: finding.suggestedPatch.type,
         readOnly: true as const,
         text: finding.suggestedPatch.preview,
       }
     : undefined;
+  const suggestedAction = suggestedFixIntentFor(finding);
+  const safetyRationale = safetyRationaleFor(finding);
   return {
     id: `react-web-label-${index + 1}`,
     kind: issueKindFor(finding),
@@ -140,11 +165,19 @@ function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFindin
       sourceSignals: finding.evidence,
       element: finding.element,
     },
+    whereToLook: {
+      filePath,
+      line: finding.loc.startLine,
+      endLine: finding.loc.endLine,
+      context: finding.context,
+    },
     confidence: finding.confidence,
     fixability: fixabilityFor(finding),
     autoFixSafety: autoFixSafetyFor(finding),
-    safetyRationale: safetyRationaleFor(finding),
-    suggestedFixIntent: suggestedFixIntentFor(finding),
+    safetyRationale,
+    suggestedFixIntent: suggestedAction,
+    suggestedAction,
+    ...(!isSafePreview ? { skipReason: skipReasonFor(finding) } : {}),
     ...(preview ? { preview } : {}),
   };
 }
@@ -197,13 +230,14 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       "",
       `## Issue ${index + 1}: ${issue.problem}`,
       `- why: ${issue.whyItMatters}`,
-      `- file/line: ${issue.evidence.filePath}:${issue.evidence.line}`,
+      `- where to look: ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
       `- element: ${issue.evidence.element}`,
       `- confidence: ${issue.confidence}`,
       `- fixability: ${issue.fixability}`,
       `- auto-fix safety: ${issue.autoFixSafety}`,
       `- safety rationale: ${issue.safetyRationale}`,
-      `- suggested fix: ${issue.suggestedFixIntent}`,
+      ...(issue.skipReason ? [`- skip reason: ${issue.skipReason}`] : []),
+      `- suggested action: ${issue.suggestedAction}`,
       `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
       `- context: ${issue.evidence.context}`,
     );

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -5028,7 +5028,7 @@ test("docs describe local compare estimates without billing-cost claims", () => 
 ${setup}
 ${release}`;
 
-  assert.match(readme, /Frontend change intelligence for lower-cost frontend work\./);
+  assert.match(readme, /Frontend change intelligence for lower-cost React Web work\./);
   assert.match(readme, /Context reduction and caching remain supporting mechanisms\./);
   assert.match(readme, /fooks inspect react-web-issues/);
   assert.match(readme, /fooks inspect react-web-issues <supported-file>` for actionable React Web issue cards[\s\S]*`fooks compare <supported-file>` is supporting local source-vs-payload evidence/);

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -79,13 +79,17 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.problem.length > 0);
     assert.ok(issue.whyItMatters.length > 0);
     assert.equal(issue.evidence.filePath, "test/fixtures/react-web-label-preview/missing-labels.tsx");
+    assert.equal(issue.whereToLook.filePath, "test/fixtures/react-web-label-preview/missing-labels.tsx");
+    assert.ok(issue.whereToLook.line > 0);
+    assert.ok(issue.whereToLook.context.length > 0);
     assert.ok(issue.evidence.line > 0);
     assert.ok(issue.evidence.context.length > 0);
     assert.ok(issue.evidence.sourceSignals.length > 0);
     assert.ok(issue.safetyRationale.length > 0);
     assert.ok(issue.suggestedFixIntent.length > 0);
-    assert.equal(issue.preview.readOnly, true);
-    assert.match(issue.preview.text, /aria-label="TODO:/);
+    assert.equal(issue.suggestedAction, issue.suggestedFixIntent);
+    assert.match(issue.skipReason, /human review|accessible-name copy/);
+    assert.equal(issue.preview, undefined);
   }
 });
 
@@ -94,13 +98,17 @@ test("React Web issue report turns nearby native associations into safe preview 
   const preview = buildReactWebLabelPatchPreview(fixtures.association, repoRoot);
 
   assert.equal(report.summary.issueCount, 3);
-  assert.equal(report.summary.safePreviewCount, 3);
-  assert.equal(report.summary.manualReviewCount, 0);
+  assert.equal(report.summary.safePreviewCount, 1);
+  assert.equal(report.summary.manualReviewCount, 2);
   assert.equal(report.summary.issueCount, preview.summary.findingCount);
   assert.ok(report.issues.every((issue) => issue.kind === "react-web.unassociated-nearby-label"));
-  assert.ok(report.issues.every((issue) => issue.fixability === "safe-preview"));
-  assert.ok(report.issues.every((issue) => issue.autoFixSafety === "not-auto-applied"));
+  assert.deepEqual(report.issues.map((issue) => [issue.confidence, issue.fixability, issue.autoFixSafety, Boolean(issue.preview)]), [
+    ["high", "safe-preview", "not-auto-applied", true],
+    ["medium", "manual-review", "unsafe-to-auto-apply", false],
+    ["medium", "manual-review", "unsafe-to-auto-apply", false],
+  ]);
   assert.match(report.issues[0].preview.text, /htmlFor="email"/);
+  assert.match(report.issues[1].skipReason, /not high-confidence deterministic evidence/);
 });
 
 test("React Web issue report fixture usefulness gate records accepted cards, noise, plausibility, and parity", () => {
@@ -110,14 +118,14 @@ test("React Web issue report fixture usefulness gate records accepted cards, noi
       file: fixtures.missing,
       expectedCards: 5,
       acceptedCards: 5,
-      suggestionPlausibility: "TODO accessible-name previews are plausible but require human copy review.",
+      suggestionPlausibility: "TODO accessible-name suggestions are plausible but require human copy review, so no preview is emitted.",
     },
     {
       name: "label-association-candidates.tsx",
       file: fixtures.association,
       expectedCards: 3,
       acceptedCards: 3,
-      suggestionPlausibility: "Native nearby label/control htmlFor/id previews are deterministic and read-only.",
+      suggestionPlausibility: "High-confidence native nearby label/control htmlFor/id previews are deterministic and read-only; medium-confidence associations stay manual review.",
     },
     {
       name: "labelled-controls.tsx",
@@ -161,7 +169,7 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
     report,
     preview,
     acceptedCards: report.summary.issueCount,
-    suggestionPlausibility: "Unsafe nearby association is rejected; fallback aria-label TODO previews remain read-only/manual-review.",
+    suggestionPlausibility: "Unsafe nearby association is rejected; fallback aria-label TODO suggestions remain manual-review without preview.",
   });
 
   assert.equal(matrix.verdict, "pass");
@@ -169,6 +177,8 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
   assert.ok(report.summary.manualReviewCount > 0);
   assert.ok(report.issues.every((issue) => issue.fixability === "manual-review"));
   assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
+  assert.ok(report.issues.every((issue) => issue.skipReason));
+  assert.ok(report.issues.every((issue) => issue.preview === undefined));
   assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
 });
 
@@ -179,9 +189,10 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /Read-only React Web issue report/);
   assert.match(cli.stdout, /## Issue 1:/);
   assert.match(cli.stdout, /- why:/);
-  assert.match(cli.stdout, /- file\/line:/);
+  assert.match(cli.stdout, /- where to look:/);
   assert.match(cli.stdout, /- fixability: safe-preview/);
   assert.match(cli.stdout, /- auto-fix safety: not-auto-applied/);
+  assert.match(cli.stdout, /- suggested action:/);
   assert.match(cli.stdout, /```diff/);
   assert.doesNotMatch(cli.stdout, /Auto-apply: yes/);
 });


### PR DESCRIPTION
## Summary
Closes #697

- Recovers the valid React Web form/a11y issue-report wedge from closed-unmerged PR #699 after its head branch was deleted.
- Adds product-facing issue-card fields (`whereToLook`, `suggestedAction`, `skipReason`) while keeping the report read-only.
- Keeps preview candidates restricted to high-confidence deterministic native label/control associations; medium-confidence or copy-requiring cards stay manual review with skip reasons.
- Aligns README/test wording with the React Web product direction.

## PR #699 recovery evidence
- PR #699 was CLOSED, `mergedAt: null`.
- Timeline included `head_ref_deleted`.
- Recovered intended commits: `83caa68` and merge-resolution intent from `99629ce`.
- The prior CI issue was the stale README assertion expecting `Frontend change intelligence for lower-cost frontend work.` while README now says `Frontend change intelligence for lower-cost React Web work.`

## Scope boundaries
- React Web form/a11y issue report wedge only.
- No broad React Native, TUI, or WebView support claim.
- No auto-apply/autofix behavior.
- No operator cleanup docs.

## Tests
- `npm ci`
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs`
- `node --test test/fooks.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT npm test` — 711/711 pass

## Not tested
- Browser/runtime a11y validation.
- Non-React-Web frameworks; out of scope for this wedge.