### PR TITLE
Add bounded related context to React Web issue cards

### DIFF
--- a/src/core/react-web-issue-related-context.ts
+++ b/src/core/react-web-issue-related-context.ts
@@ -1,0 +1,174 @@
+import path from "node:path";
+import { extractFile } from "./extract";
+import { toModelFacingPayload } from "./payload/model-facing";
+import type { ReactWebContextMetadataV0, SourceRange } from "./schema";
+import type { ReactWebLabelPatchPreviewFinding } from "./react-web-label-preview";
+
+export type ReactWebRelatedContextKind =
+  | "same-file-pattern"
+  | "react-web-context-anchor"
+  | "test-candidate"
+  | "manual-review-note";
+
+export type ReactWebRelatedContextConfidence = "high" | "medium" | "low";
+
+export type ReactWebRelatedContextSource =
+  | "label-preview"
+  | "react-web-context-metadata"
+  | "fixture-convention"
+  | "issue-safety";
+
+export type ReactWebIssueRelatedContext = {
+  kind: ReactWebRelatedContextKind;
+  reason: string;
+  confidence: ReactWebRelatedContextConfidence;
+  source: ReactWebRelatedContextSource;
+  action: "inspect-first";
+  filePath?: string;
+  line?: number;
+  endLine?: number;
+  context?: string;
+};
+
+const RELATED_CONTEXT_LIMIT = 3;
+const ISSUE_REPORT_TEST_FILE = "test/react-web-issue-report.test.mjs";
+
+type ContextAnchorCandidate = {
+  label: string;
+  kind: string;
+  loc?: SourceRange;
+};
+
+function absolutePathFor(filePath: string, cwd: string): string {
+  return path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+}
+
+export function getReactWebIssueContextMetadata(
+  filePath: string,
+  cwd: string,
+): ReactWebContextMetadataV0 | undefined {
+  try {
+    const result = extractFile(absolutePathFor(filePath, cwd));
+    const payload = toModelFacingPayload(result, cwd, {
+      includeEditGuidance: true,
+      includeReactWebContextMetadata: true,
+    });
+    return payload.reactWebContext;
+  } catch {
+    return undefined;
+  }
+}
+
+function sameFilePatternFor(
+  filePath: string,
+  finding: ReactWebLabelPatchPreviewFinding,
+): ReactWebIssueRelatedContext {
+  return {
+    kind: "same-file-pattern",
+    reason: "Inspect the exact same-file JSX evidence that produced this issue before choosing a fix.",
+    confidence: finding.confidence,
+    source: "label-preview",
+    action: "inspect-first",
+    filePath,
+    line: finding.loc.startLine,
+    endLine: finding.loc.endLine,
+    context: finding.context,
+  };
+}
+
+function anchorCandidates(metadata: ReactWebContextMetadataV0 | undefined): ContextAnchorCandidate[] {
+  if (!metadata) return [];
+  const candidates: ContextAnchorCandidate[] = [];
+  const add = (candidate: ContextAnchorCandidate) => {
+    if (!candidate.loc) return;
+    candidates.push(candidate);
+  };
+
+  for (const anchor of metadata.a11yAnchors ?? []) {
+    add({ label: anchor.label, kind: `a11y:${anchor.kind}`, loc: anchor.loc });
+  }
+  for (const flow of metadata.formStateFlow ?? []) {
+    add({ label: flow.label, kind: `form-state:${flow.kind}`, loc: flow.loc });
+  }
+  for (const route of metadata.editTargetRouting ?? []) {
+    add({ label: route.label, kind: `edit-target:${route.kind}`, loc: route.loc });
+  }
+  for (const region of metadata.layoutRegionHints ?? []) {
+    add({ label: region.label, kind: `layout:${region.kind}`, loc: region.loc });
+  }
+
+  return candidates;
+}
+
+function nearestAnchorFor(
+  filePath: string,
+  finding: ReactWebLabelPatchPreviewFinding,
+  metadata: ReactWebContextMetadataV0 | undefined,
+): ReactWebIssueRelatedContext | undefined {
+  const issueLine = finding.loc.startLine;
+  const nearest = anchorCandidates(metadata)
+    .map((candidate) => ({
+      candidate,
+      distance: Math.min(Math.abs(candidate.loc!.startLine - issueLine), Math.abs(candidate.loc!.endLine - issueLine)),
+    }))
+    .sort((a, b) => a.distance - b.distance)[0];
+
+  if (!nearest) return undefined;
+  const { candidate, distance } = nearest;
+  return {
+    kind: "react-web-context-anchor",
+    reason: `Inspect the nearest React Web context anchor (${candidate.kind}) before editing this control.`,
+    confidence: distance <= 3 ? "high" : "medium",
+    source: "react-web-context-metadata",
+    action: "inspect-first",
+    filePath,
+    line: candidate.loc?.startLine,
+    endLine: candidate.loc?.endLine,
+    context: candidate.label,
+  };
+}
+
+function testCandidateFor(): ReactWebIssueRelatedContext {
+  return {
+    kind: "test-candidate",
+    reason: "Update or add a regression case around this issue shape before broadening React Web issue-card behavior.",
+    confidence: "medium",
+    source: "fixture-convention",
+    action: "inspect-first",
+    filePath: ISSUE_REPORT_TEST_FILE,
+    context: "React Web issue report regression surface",
+  };
+}
+
+function manualReviewNoteFor(
+  filePath: string,
+  finding: ReactWebLabelPatchPreviewFinding,
+): ReactWebIssueRelatedContext | undefined {
+  if (finding.kind === "unassociated-nearby-label" && finding.confidence === "high") return undefined;
+  return {
+    kind: "manual-review-note",
+    reason: "Human review is required before writing accessible-name copy or accepting a weak label association.",
+    confidence: "medium",
+    source: "issue-safety",
+    action: "inspect-first",
+    filePath,
+    line: finding.loc.startLine,
+    endLine: finding.loc.endLine,
+    context: finding.context,
+  };
+}
+
+export function buildReactWebIssueRelatedContext(
+  filePath: string,
+  finding: ReactWebLabelPatchPreviewFinding,
+  metadata: ReactWebContextMetadataV0 | undefined,
+): ReactWebIssueRelatedContext[] {
+  const entries = [
+    sameFilePatternFor(filePath, finding),
+    nearestAnchorFor(filePath, finding, metadata),
+    testCandidateFor(),
+    manualReviewNoteFor(filePath, finding),
+  ].filter((entry): entry is ReactWebIssueRelatedContext => Boolean(entry));
+
+  return entries.slice(0, RELATED_CONTEXT_LIMIT);
+}

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -4,6 +4,11 @@ import {
   type ReactWebLabelPatchPreview,
   type ReactWebLabelPatchPreviewFinding,
 } from "./react-web-label-preview";
+import {
+  buildReactWebIssueRelatedContext,
+  getReactWebIssueContextMetadata,
+  type ReactWebIssueRelatedContext,
+} from "./react-web-issue-related-context";
 
 export const REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION = "react-web-issue-report.v1" as const;
 export const REACT_WEB_ISSUE_REPORT_COMMAND = "inspect react-web-issues" as const;
@@ -37,6 +42,7 @@ export type ReactWebIssueCard = {
     endLine: number;
     context: string;
   };
+  relatedContext: ReactWebIssueRelatedContext[];
   confidence: ReactWebIssueConfidence;
   fixability: ReactWebIssueFixability;
   autoFixSafety: ReactWebIssueAutoFixSafety;
@@ -141,7 +147,12 @@ function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
   return "Preview skipped because generated accessible-name copy would require human review.";
 }
 
-function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFinding, index: number): ReactWebIssueCard {
+function issueCardFor(
+  filePath: string,
+  finding: ReactWebLabelPatchPreviewFinding,
+  index: number,
+  relatedContext: ReactWebIssueRelatedContext[],
+): ReactWebIssueCard {
   const isSafePreview = hasSafePreviewEvidence(finding);
   const preview = isSafePreview && finding.suggestedPatch.readOnly
     ? {
@@ -171,6 +182,7 @@ function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFindin
       endLine: finding.loc.endLine,
       context: finding.context,
     },
+    relatedContext,
     confidence: finding.confidence,
     fixability: fixabilityFor(finding),
     autoFixSafety: autoFixSafetyFor(finding),
@@ -184,7 +196,17 @@ function issueCardFor(filePath: string, finding: ReactWebLabelPatchPreviewFindin
 
 export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()): ReactWebIssueReport {
   const preview = buildReactWebLabelPatchPreview(filePath, cwd);
-  const issues = preview.findings.map((finding, index) => issueCardFor(preview.filePath, finding, index));
+  const contextMetadata = preview.inScope && preview.findings.length > 0
+    ? getReactWebIssueContextMetadata(preview.filePath, cwd)
+    : undefined;
+  const issues = preview.findings.map((finding, index) =>
+    issueCardFor(
+      preview.filePath,
+      finding,
+      index,
+      buildReactWebIssueRelatedContext(preview.filePath, finding, contextMetadata),
+    ),
+  );
   return {
     schemaVersion: REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION,
     command: REACT_WEB_ISSUE_REPORT_COMMAND,
@@ -241,6 +263,14 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
       `- context: ${issue.evidence.context}`,
     );
+    if (issue.relatedContext.length > 0) {
+      lines.push("- inspect first:");
+      for (const item of issue.relatedContext) {
+        const location = item.filePath ? ` ${item.filePath}${item.line ? `:${item.line}${item.endLine && item.endLine !== item.line ? `-${item.endLine}` : ""}` : ""}` : "";
+        const context = item.context ? ` — ${item.context}` : "";
+        lines.push(`  - ${item.kind} (${item.confidence}, ${item.source}): ${item.reason}${location}${context}`);
+      }
+    }
     if (issue.preview) {
       lines.push("", "```diff", issue.preview.text, "```");
     }

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -89,6 +89,21 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.suggestedFixIntent.length > 0);
     assert.equal(issue.suggestedAction, issue.suggestedFixIntent);
     assert.match(issue.skipReason, /human review|accessible-name copy/);
+
+    assert.ok(Array.isArray(issue.relatedContext));
+    assert.ok(issue.relatedContext.length > 0);
+    assert.ok(issue.relatedContext.length <= 3);
+    const requiredContextKeys = Object.keys(issue.relatedContext[0])
+      .filter((key) => ["kind", "reason", "confidence", "source", "action"].includes(key))
+      .sort();
+    assert.deepEqual(requiredContextKeys, ["action", "confidence", "kind", "reason", "source"]);
+    assert.equal(issue.relatedContext[0].kind, "same-file-pattern");
+    assert.equal(issue.relatedContext[0].action, "inspect-first");
+    assert.equal(issue.relatedContext[0].source, "label-preview");
+    assert.equal(issue.relatedContext[0].filePath, issue.whereToLook.filePath);
+    assert.equal(issue.relatedContext[0].line, issue.whereToLook.line);
+    assert.ok(issue.relatedContext.some((entry) => entry.kind === "test-candidate"));
+    assert.doesNotMatch(JSON.stringify(issue.relatedContext), /must-edit|auto-apply/i);
     assert.equal(issue.preview, undefined);
   }
 });
@@ -108,6 +123,9 @@ test("React Web issue report turns nearby native associations into safe preview 
     ["medium", "manual-review", "unsafe-to-auto-apply", false],
   ]);
   assert.match(report.issues[0].preview.text, /htmlFor="email"/);
+  assert.ok(report.issues.every((issue) => issue.relatedContext.length > 0));
+  assert.ok(report.issues.every((issue) => issue.relatedContext.length <= 3));
+  assert.ok(report.issues.every((issue) => issue.relatedContext[0].action === "inspect-first"));
   assert.match(report.issues[1].skipReason, /not high-confidence deterministic evidence/);
 });
 
@@ -179,6 +197,9 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
   assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
   assert.ok(report.issues.every((issue) => issue.skipReason));
   assert.ok(report.issues.every((issue) => issue.preview === undefined));
+  assert.ok(report.issues.every((issue) => issue.relatedContext.length <= 3));
+  assert.ok(report.issues.every((issue) => issue.relatedContext.every((entry) => entry.action === "inspect-first")));
+  assert.doesNotMatch(JSON.stringify(report.issues.flatMap((issue) => issue.relatedContext)), /must-edit|auto-apply/i);
   assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
 });
 
@@ -193,6 +214,9 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /- fixability: safe-preview/);
   assert.match(cli.stdout, /- auto-fix safety: not-auto-applied/);
   assert.match(cli.stdout, /- suggested action:/);
+  assert.match(cli.stdout, /- inspect first:/);
+  assert.match(cli.stdout, /same-file-pattern/);
+  assert.match(cli.stdout, /test-candidate/);
   assert.match(cli.stdout, /```diff/);
   assert.doesNotMatch(cli.stdout, /Auto-apply: yes/);
 });


### PR DESCRIPTION
## Summary
- Add bounded `relatedContext` recommendations to React Web issue cards.
- Keep every recommendation `inspect-first`, capped at 3 entries, and sourced from same-file label preview/context metadata or the issue-report regression surface.
- Render the recommendations in both JSON and text output without changing safe-preview gating or RN/custom-component boundaries.

Closes #702

## Verification
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT npm test` (711/711 passing)

## Notes
- A plain `npm test` initially failed because the shell had `FOOKS_TARGET_ACCOUNT=minislively`, which changes an init-contract expectation. Re-running with that env var removed passed the full suite.
