### PR TITLE
Separate orphan worktree triage from active dogfood signals

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -662,6 +662,7 @@ Everyday commands:
   ${displayCliName} status worktree
   ${displayCliName} status react-web [--json]
   ${displayCliName} status artifacts [--json]
+  ${displayCliName} status orphan-worktrees [--json]
   ${displayCliName} status activity [--include-remote-counts]
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
@@ -1428,6 +1429,17 @@ async function run(): Promise<void> {
         print(auditArtifacts(process.cwd()));
         return;
       }
+      if (arg1 === "orphan-worktrees") {
+        const allowed = new Set(["--json"]);
+        for (const arg of rest.slice(1)) {
+          if (!allowed.has(arg)) {
+            throw new Error(`Unexpected status orphan-worktrees argument: ${arg}`);
+          }
+        }
+        const { triageOrphanLocalWorktrees } = await import("../ops/orphan-local-worktree-triage.js");
+        print(triageOrphanLocalWorktrees(process.cwd()));
+        return;
+      }
       if (arg1 === "activity") {
         const allowed = new Set(["--include-remote-counts", "--json"]);
         for (const arg of rest.slice(1)) {
@@ -1439,7 +1451,7 @@ async function run(): Promise<void> {
         print(readOperatorActivitySnapshot(process.cwd(), { includeRemoteCounts: rest.includes("--include-remote-counts") }));
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'react-web', 'artifacts', or 'activity'");
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'react-web', 'artifacts', 'orphan-worktrees', or 'activity'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,29 @@ export type {
   ArtifactAuditStatus,
   ArtifactAuditWorktree,
 } from "./ops/artifact-audit";
+
+export {
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_COMMAND,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_SCHEMA_VERSION,
+  defaultOrphanLocalWorktreeCommandRunner,
+  parseOrphanLocalWorktreePorcelain,
+  parseOrphanLocalWorktreeRemoteBranches,
+  parseOrphanLocalWorktreeTmuxPanes,
+  triageOrphanLocalWorktrees,
+} from "./ops/orphan-local-worktree-triage";
+export type {
+  OrphanLocalWorktreeCategory,
+  OrphanLocalWorktreeCommandRunner,
+  OrphanLocalWorktreeEntry,
+  OrphanLocalWorktreePathExists,
+  OrphanLocalWorktreePullRequestEvidence,
+  OrphanLocalWorktreeTriageOptions,
+  OrphanLocalWorktreeTriageResult,
+} from "./ops/orphan-local-worktree-triage";
 export {
   REACT_WEB_STATUS_CLAIM_BOUNDARY,
   REACT_WEB_STATUS_COMMAND,

--- a/src/ops/orphan-local-worktree-triage.ts
+++ b/src/ops/orphan-local-worktree-triage.ts
@@ -1,0 +1,370 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { parseAndSummarizeWorktreeStatus } from "../core/worktree-status";
+
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_SCHEMA_VERSION = 1;
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_COMMAND = "status orphan-worktrees";
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE = "#709";
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL = "https://github.com/minislively/fooks/issues/709";
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY =
+  "Read-only issue #709 local sibling worktree triage; does not fetch, delete branches/worktrees, open PRs, or change runtime/provider/merge-gate policy.";
+export const DEFAULT_ORPHAN_LOCAL_WORKTREE_TRIAGE_TIMEOUT_MS = 3000;
+
+export type OrphanLocalWorktreeCategory = "safe-cleanup" | "salvage-review" | "keep";
+export type OrphanLocalWorktreeCommandRunner = (command: string, args: string[], cwd: string) => string;
+export type OrphanLocalWorktreePathExists = (targetPath: string) => boolean;
+
+export const ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE = "gh pr list --state open --json number,url,headRefName --limit 200";
+
+export type OrphanLocalWorktreePullRequestEvidence =
+  | { state: "none"; source: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE }
+  | { state: "open"; source: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE; pullRequests: { number?: number; url?: string; headRefName?: string }[] }
+  | { state: "unknown"; source: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE; reason: string };
+
+export type OrphanLocalWorktreeEntry = {
+  path: string;
+  branch?: string;
+  head?: string;
+  current: boolean;
+  exists: boolean;
+  category: OrphanLocalWorktreeCategory;
+  reasons: string[];
+  dirty: boolean | "unknown";
+  changedPathCount?: number;
+  aheadOfBase?: number;
+  baseRef?: string;
+  remoteBranchExists: boolean | "unknown";
+  remoteBranchRef?: string;
+  openPullRequest: OrphanLocalWorktreePullRequestEvidence;
+  activeTmuxPaneCount: number;
+  manualReviewCommands: string[];
+  manualCleanupCommands: string[];
+};
+
+export type OrphanLocalWorktreeTriageResult = {
+  schemaVersion: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_SCHEMA_VERSION;
+  command: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_COMMAND;
+  linkedIssue: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE;
+  linkedIssueUrl: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL;
+  generatedAt: string;
+  cwd: string;
+  siblingRoot?: string;
+  baseRef?: string;
+  claimBoundary: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY;
+  readOnly: true;
+  categories: Record<OrphanLocalWorktreeCategory, OrphanLocalWorktreeEntry[]>;
+  entries: OrphanLocalWorktreeEntry[];
+  blockers: string[];
+};
+
+export type OrphanLocalWorktreeTriageOptions = {
+  runner?: OrphanLocalWorktreeCommandRunner;
+  pathExists?: OrphanLocalWorktreePathExists;
+  now?: () => string;
+};
+
+type ParsedWorktree = {
+  path: string;
+  branch?: string;
+  head?: string;
+};
+
+type ParsedPane = {
+  session: string;
+  path: string;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function errorDetail(error: unknown): string {
+  const maybeError = error && typeof error === "object" ? (error as { message?: unknown; stderr?: unknown; signal?: unknown; code?: unknown }) : {};
+  const stderr = maybeError.stderr;
+  const stderrText = Buffer.isBuffer(stderr) ? stderr.toString("utf8").trim() : typeof stderr === "string" ? stderr.trim() : "";
+  const message = typeof maybeError.message === "string" ? maybeError.message.trim() : String(error);
+  const status = maybeError.signal ? `signal ${String(maybeError.signal)}` : maybeError.code !== undefined ? `code ${String(maybeError.code)}` : "";
+  const detail = stderrText || message || "unknown error";
+  return status ? `${detail} (${status})` : detail;
+}
+
+function normalizeBranch(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function safeResolve(targetPath: string): string {
+  return path.resolve(targetPath.replace(/ \(deleted\)$/u, ""));
+}
+
+function isInsidePath(child: string, parent: string): boolean {
+  const relative = path.relative(safeResolve(parent), safeResolve(child));
+  return relative === "" || (Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function parseCount(output: string): number | undefined {
+  const parsed = Number.parseInt(output.trim(), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function remoteBranchName(remoteRef: string): string {
+  const normalized = remoteRef.startsWith("refs/remotes/") ? remoteRef.slice("refs/remotes/".length) : remoteRef;
+  const firstSlash = normalized.indexOf("/");
+  return firstSlash >= 0 ? normalized.slice(firstSlash + 1) : normalized;
+}
+
+function readOptional(runner: OrphanLocalWorktreeCommandRunner, command: string, args: string[], cwd: string, blockers: string[], label: string): string {
+  try {
+    return runner(command, args, cwd);
+  } catch (error) {
+    blockers.push(`${label} unavailable: ${errorDetail(error)}`);
+    return "";
+  }
+}
+
+function resolveBaseRef(runner: OrphanLocalWorktreeCommandRunner, cwd: string, blockers: string[]): string | undefined {
+  for (const baseRef of ["origin/main", "main"]) {
+    try {
+      runner("git", ["rev-parse", "--verify", baseRef], cwd);
+      return baseRef;
+    } catch {
+      // Try the next local read-only base candidate.
+    }
+  }
+  blockers.push("git base ref unavailable: neither origin/main nor main could be verified");
+  return undefined;
+}
+
+export function defaultOrphanLocalWorktreeCommandRunner(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: DEFAULT_ORPHAN_LOCAL_WORKTREE_TRIAGE_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+export function parseOrphanLocalWorktreePorcelain(output: string): ParsedWorktree[] {
+  const worktrees: ParsedWorktree[] = [];
+  for (const block of output.split(/\n\n/u).map((item) => item.trim()).filter(Boolean)) {
+    const lines = block.split(/\r?\n/u);
+    const worktreePath = lines.find((line) => line.startsWith("worktree "))?.slice("worktree ".length);
+    if (!worktreePath) continue;
+    worktrees.push({
+      path: worktreePath,
+      head: lines.find((line) => line.startsWith("HEAD "))?.slice("HEAD ".length),
+      branch: normalizeBranch(lines.find((line) => line.startsWith("branch "))?.slice("branch ".length)),
+    });
+  }
+  return worktrees;
+}
+
+export function parseOrphanLocalWorktreeRemoteBranches(output: string): Set<string> {
+  return new Set(output.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean).map(remoteBranchName));
+}
+
+export function parseOrphanLocalWorktreeTmuxPanes(output: string): ParsedPane[] {
+  return output.split(/\r?\n/u).map((line) => line.trimEnd()).filter(Boolean).map((line) => {
+    const [session, ...pathParts] = line.split("\t");
+    const panePath = pathParts.join("\t");
+    return session && panePath ? { session, path: panePath } : undefined;
+  }).filter((entry): entry is ParsedPane => Boolean(entry));
+}
+
+function readOpenPullRequestIndex(runner: OrphanLocalWorktreeCommandRunner, cwd: string): { pullRequestsByHead: Map<string, { number?: number; url?: string; headRefName?: string }[]>; blocker?: string } {
+  try {
+    const output = runner("gh", ["pr", "list", "--state", "open", "--json", "number,url,headRefName", "--limit", "200"], cwd);
+    const parsed = JSON.parse(output) as { number?: number; url?: string; headRefName?: string }[];
+    const pullRequestsByHead = new Map<string, { number?: number; url?: string; headRefName?: string }[]>();
+    if (!Array.isArray(parsed)) return { pullRequestsByHead };
+    for (const pullRequest of parsed) {
+      if (!pullRequest.headRefName) continue;
+      const entries = pullRequestsByHead.get(pullRequest.headRefName) ?? [];
+      entries.push(pullRequest);
+      pullRequestsByHead.set(pullRequest.headRefName, entries);
+    }
+    return { pullRequestsByHead };
+  } catch (error) {
+    return { pullRequestsByHead: new Map(), blocker: `gh open PR list unavailable: ${errorDetail(error)}` };
+  }
+}
+
+function openPullRequestEvidence(branch: string | undefined, pullRequestIndex: ReturnType<typeof readOpenPullRequestIndex>): OrphanLocalWorktreePullRequestEvidence {
+  if (!branch) return { state: "unknown", source: ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE, reason: "branch unknown" };
+  if (pullRequestIndex.blocker) return { state: "unknown", source: ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE, reason: pullRequestIndex.blocker };
+  const pullRequests = pullRequestIndex.pullRequestsByHead.get(branch) ?? [];
+  return pullRequests.length > 0
+    ? { state: "open", source: ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE, pullRequests }
+    : { state: "none", source: ORPHAN_LOCAL_WORKTREE_TRIAGE_PR_SOURCE };
+}
+
+function worktreeStatus(runner: OrphanLocalWorktreeCommandRunner, worktreePath: string): { dirty: boolean | "unknown"; changedPathCount?: number; blocker?: string } {
+  try {
+    const summary = parseAndSummarizeWorktreeStatus(runner("git", ["status", "--porcelain=v1", "-z"], worktreePath), { nulTerminated: true });
+    return { dirty: !summary.clean, changedPathCount: summary.changedPaths.length };
+  } catch (error) {
+    return { dirty: "unknown", blocker: `git status unavailable for ${worktreePath}: ${errorDetail(error)}` };
+  }
+}
+
+function aheadOfBase(runner: OrphanLocalWorktreeCommandRunner, worktreePath: string, baseRef: string | undefined): { ahead?: number; blocker?: string } {
+  if (!baseRef) return {};
+  try {
+    const parsed = parseCount(runner("git", ["rev-list", "--count", `${baseRef}..HEAD`], worktreePath));
+    if (parsed === undefined) return { blocker: `git rev-list ${baseRef}..HEAD returned an unparsable count for ${worktreePath}` };
+    return { ahead: parsed };
+  } catch (error) {
+    return { blocker: `git rev-list ${baseRef}..HEAD unavailable for ${worktreePath}: ${errorDetail(error)}` };
+  }
+}
+
+function classifyEntry(input: {
+  current: boolean;
+  exists: boolean;
+  branch?: string;
+  dirty: boolean | "unknown";
+  ahead?: number;
+  remoteBranchExists: boolean | "unknown";
+  openPullRequest: OrphanLocalWorktreePullRequestEvidence;
+  activeTmuxPaneCount: number;
+  baseRef?: string;
+}): Pick<OrphanLocalWorktreeEntry, "category" | "reasons" | "manualCleanupCommands" | "manualReviewCommands"> {
+  const reasons: string[] = [];
+  const manualCleanupCommands: string[] = [];
+  const manualReviewCommands: string[] = [];
+
+  if (input.current) reasons.push("worktree is the current working directory");
+  if (!input.exists) reasons.push("worktree path is missing from the filesystem");
+  if (!input.branch) reasons.push("worktree is detached or branch is unknown");
+  if (input.activeTmuxPaneCount > 0) reasons.push("one or more tmux panes are mapped inside this worktree");
+  if (input.remoteBranchExists === true) reasons.push("a local remote-tracking branch exists for this branch");
+  if (input.remoteBranchExists === false) reasons.push("no local remote-tracking branch exists for this branch");
+  if (input.openPullRequest.state === "open") reasons.push("an open pull request exists for this branch");
+  if (input.openPullRequest.state === "none") reasons.push("no open pull request was found for this branch");
+  if (input.openPullRequest.state === "unknown") reasons.push("open pull request evidence is unavailable");
+  if (input.dirty === true) reasons.push("worktree has uncommitted changes");
+  if (input.dirty === false) reasons.push("worktree is clean");
+  if (input.dirty === "unknown") reasons.push("worktree cleanliness is unknown");
+  if (input.ahead !== undefined && input.ahead > 0) reasons.push(`HEAD has ${input.ahead} commit(s) not reachable from ${input.baseRef ?? "the selected base"}`);
+  if (input.ahead === 0) reasons.push(`HEAD has no commits ahead of ${input.baseRef ?? "the selected base"}`);
+
+  const protectedByActiveEvidence = input.current || input.activeTmuxPaneCount > 0 || input.remoteBranchExists === true || input.openPullRequest.state === "open" || !input.branch;
+  if (protectedByActiveEvidence) {
+    manualReviewCommands.push("inspect active worktree/PR/remote evidence before cleanup");
+    return { category: "keep", reasons: uniqueSorted(reasons), manualCleanupCommands, manualReviewCommands: uniqueSorted(manualReviewCommands) };
+  }
+
+  if (input.remoteBranchExists === false && input.ahead !== undefined && input.ahead > 0) {
+    manualReviewCommands.push(`git -C <worktree> log --oneline --decorate --max-count=20 ${input.baseRef ?? "origin/main"}..HEAD`);
+    manualReviewCommands.push("review or cherry-pick local-only commits before deleting any branch/worktree");
+    return { category: "salvage-review", reasons: uniqueSorted(reasons), manualCleanupCommands, manualReviewCommands: uniqueSorted(manualReviewCommands) };
+  }
+
+  if (input.remoteBranchExists === false && input.openPullRequest.state === "none" && input.dirty === false && input.ahead === 0) {
+    manualCleanupCommands.push("git worktree remove <path>");
+    if (input.branch) manualCleanupCommands.push(`git branch -d ${shellQuote(input.branch)}`);
+    return { category: "safe-cleanup", reasons: uniqueSorted(reasons), manualCleanupCommands: uniqueSorted(manualCleanupCommands), manualReviewCommands };
+  }
+
+  if (input.remoteBranchExists === false && (input.dirty === true || input.dirty === "unknown" || input.ahead === undefined || input.openPullRequest.state === "unknown")) {
+    manualReviewCommands.push("inspect dirty/unknown local-only evidence before deleting any branch/worktree");
+    return { category: "salvage-review", reasons: uniqueSorted(reasons), manualCleanupCommands, manualReviewCommands: uniqueSorted(manualReviewCommands) };
+  }
+
+  manualReviewCommands.push("inspect unresolved orphan evidence before cleanup");
+  return { category: "keep", reasons: uniqueSorted(reasons), manualCleanupCommands, manualReviewCommands: uniqueSorted(manualReviewCommands) };
+}
+
+export function triageOrphanLocalWorktrees(cwd = process.cwd(), options: OrphanLocalWorktreeTriageOptions = {}): OrphanLocalWorktreeTriageResult {
+  const runner = options.runner ?? defaultOrphanLocalWorktreeCommandRunner;
+  const pathExists = options.pathExists ?? fs.existsSync;
+  const generatedAt = options.now?.() ?? nowIso();
+  const blockers: string[] = [];
+  const worktreeOutput = readOptional(runner, "git", ["worktree", "list", "--porcelain"], cwd, blockers, "git worktree list");
+  const baseRef = resolveBaseRef(runner, cwd, blockers);
+  const remoteBranches = parseOrphanLocalWorktreeRemoteBranches(readOptional(runner, "git", ["branch", "-r", "--format=%(refname:short)"], cwd, blockers, "git remote branch list"));
+  const tmuxOutput = readOptional(runner, "tmux", ["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}"], cwd, blockers, "tmux pane list");
+  const pullRequestIndex = readOpenPullRequestIndex(runner, cwd);
+  if (pullRequestIndex.blocker) blockers.push(pullRequestIndex.blocker);
+
+  const parsedWorktrees = parseOrphanLocalWorktreePorcelain(worktreeOutput);
+  const currentWorktree = parsedWorktrees.find((worktree) => isInsidePath(cwd, worktree.path));
+  const siblingRoot = currentWorktree ? path.dirname(safeResolve(currentWorktree.path)) : undefined;
+  const panes = parseOrphanLocalWorktreeTmuxPanes(tmuxOutput);
+  const candidateWorktrees = parsedWorktrees.filter((worktree) => {
+    if (!siblingRoot) return true;
+    return path.dirname(safeResolve(worktree.path)) === siblingRoot;
+  });
+
+  const entries = candidateWorktrees.map((worktree) => {
+    const exists = pathExists(worktree.path);
+    const current = isInsidePath(cwd, worktree.path);
+    const status = exists ? worktreeStatus(runner, worktree.path) : { dirty: "unknown" as const, blocker: `worktree path is missing: ${worktree.path}` };
+    if (status.blocker) blockers.push(status.blocker);
+    const ahead = exists ? aheadOfBase(runner, worktree.path, baseRef) : {};
+    if (ahead.blocker) blockers.push(ahead.blocker);
+    const branch = worktree.branch;
+    const remoteBranchExists = branch ? remoteBranches.has(branch) : "unknown";
+    const openPullRequest = openPullRequestEvidence(branch, pullRequestIndex);
+    const activeTmuxPaneCount = panes.filter((pane) => exists && isInsidePath(pane.path, worktree.path)).length;
+    const classified = classifyEntry({
+      current,
+      exists,
+      branch,
+      dirty: status.dirty,
+      ahead: ahead.ahead,
+      remoteBranchExists,
+      openPullRequest,
+      activeTmuxPaneCount,
+      baseRef,
+    });
+
+    return {
+      path: worktree.path,
+      branch,
+      head: worktree.head,
+      current,
+      exists,
+      dirty: status.dirty,
+      changedPathCount: status.changedPathCount,
+      aheadOfBase: ahead.ahead,
+      baseRef,
+      remoteBranchExists,
+      remoteBranchRef: branch && remoteBranchExists === true ? [...remoteBranches].find((remoteBranch) => remoteBranch === branch) : undefined,
+      openPullRequest,
+      activeTmuxPaneCount,
+      ...classified,
+    } satisfies OrphanLocalWorktreeEntry;
+  }).sort((left, right) => left.path.localeCompare(right.path));
+
+  return {
+    schemaVersion: ORPHAN_LOCAL_WORKTREE_TRIAGE_SCHEMA_VERSION,
+    command: ORPHAN_LOCAL_WORKTREE_TRIAGE_COMMAND,
+    linkedIssue: ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE,
+    linkedIssueUrl: ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL,
+    generatedAt,
+    cwd,
+    siblingRoot,
+    baseRef,
+    claimBoundary: ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY,
+    readOnly: true,
+    categories: {
+      "safe-cleanup": entries.filter((entry) => entry.category === "safe-cleanup"),
+      "salvage-review": entries.filter((entry) => entry.category === "salvage-review"),
+      keep: entries.filter((entry) => entry.category === "keep"),
+    },
+    entries,
+    blockers: uniqueSorted(blockers),
+  };
+}

--- a/test/orphan-local-worktree-triage.test.mjs
+++ b/test/orphan-local-worktree-triage.test.mjs
@@ -1,0 +1,133 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+
+const {
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY,
+  ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE,
+  parseOrphanLocalWorktreePorcelain,
+  parseOrphanLocalWorktreeRemoteBranches,
+  parseOrphanLocalWorktreeTmuxPanes,
+  triageOrphanLocalWorktrees,
+} = require(path.join(repoRoot, "dist", "ops", "orphan-local-worktree-triage.js"));
+
+function makeRunner(outputs, calls = []) {
+  return (command, args, cwd) => {
+    calls.push([command, args, cwd]);
+    const key = `${cwd} :: ${command} ${args.join(" ")}`;
+    const globalKey = `${command} ${args.join(" ")}`;
+    const value = Object.hasOwn(outputs, key) ? outputs[key] : outputs[globalKey];
+    if (value instanceof Error) throw value;
+    if (value === undefined) throw new Error(`unexpected command: ${key}`);
+    return value;
+  };
+}
+
+test("orphan local worktree triage parsers normalize worktrees, remote branches, and tmux panes", () => {
+  assert.deepEqual(parseOrphanLocalWorktreePorcelain("worktree /repo/fooks-main\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo/fooks-local\nHEAD def\nbranch refs/heads/dogfood/local\n"), [
+    { path: "/repo/fooks-main", head: "abc", branch: "main" },
+    { path: "/repo/fooks-local", head: "def", branch: "dogfood/local" },
+  ]);
+  assert.deepEqual([...parseOrphanLocalWorktreeRemoteBranches("origin/main\nupstream/dogfood/kept\n")].sort(), ["dogfood/kept", "main"]);
+  assert.deepEqual(parseOrphanLocalWorktreeTmuxPanes("fooks-a\t/work/fooks-a\nz\t/path\twith-tab\n"), [
+    { session: "fooks-a", path: "/work/fooks-a" },
+    { session: "z", path: "/path\twith-tab" },
+  ]);
+});
+
+test("orphan local worktree triage classifies safe cleanup, salvage review, and keep without mutation commands", () => {
+  const cwd = "/work/fooks.omx-worktrees/current";
+  const safe = "/work/fooks.omx-worktrees/old-merged";
+  const salvage = "/work/fooks.omx-worktrees/local-ahead";
+  const keepRemote = "/work/fooks.omx-worktrees/has-remote";
+  const keepPr = "/work/fooks.omx-worktrees/has-pr";
+  const calls = [];
+  const result = triageOrphanLocalWorktrees(cwd, {
+    now: () => "2026-05-11T00:00:00.000Z",
+    pathExists: (target) => [cwd, safe, salvage, keepRemote, keepPr].includes(target),
+    runner: makeRunner({
+      "git worktree list --porcelain": [
+        `worktree ${cwd}`,
+        "HEAD 111",
+        "branch refs/heads/dogfood/current",
+        "",
+        `worktree ${safe}`,
+        "HEAD 222",
+        "branch refs/heads/dogfood/old-merged",
+        "",
+        `worktree ${salvage}`,
+        "HEAD 333",
+        "branch refs/heads/dogfood/local-ahead",
+        "",
+        `worktree ${keepRemote}`,
+        "HEAD 444",
+        "branch refs/heads/dogfood/has-remote",
+        "",
+        `worktree ${keepPr}`,
+        "HEAD 555",
+        "branch refs/heads/dogfood/has-pr",
+        "",
+      ].join("\n"),
+      "git rev-parse --verify origin/main": "origin-main-sha\n",
+      "git branch -r --format=%(refname:short)": "origin/main\norigin/dogfood/has-remote\n",
+      "tmux list-panes -a -F #{session_name}\t#{pane_current_path}": `current\t${cwd}\n`,
+      [`${cwd} :: git status --porcelain=v1 -z`]: "",
+      [`${safe} :: git status --porcelain=v1 -z`]: "",
+      [`${salvage} :: git status --porcelain=v1 -z`]: "",
+      [`${keepRemote} :: git status --porcelain=v1 -z`]: "",
+      [`${keepPr} :: git status --porcelain=v1 -z`]: "",
+      [`${cwd} :: git rev-list --count origin/main..HEAD`]: "0\n",
+      [`${safe} :: git rev-list --count origin/main..HEAD`]: "0\n",
+      [`${salvage} :: git rev-list --count origin/main..HEAD`]: "2\n",
+      [`${keepRemote} :: git rev-list --count origin/main..HEAD`]: "1\n",
+      [`${keepPr} :: git rev-list --count origin/main..HEAD`]: "1\n",
+      "gh pr list --state open --json number,url,headRefName --limit 200": JSON.stringify([{ number: 709, url: "https://github.com/minislively/fooks/pull/709", headRefName: "dogfood/has-pr" }]),
+    }, calls),
+  });
+
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "status orphan-worktrees");
+  assert.equal(result.linkedIssue, ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE);
+  assert.equal(result.claimBoundary, ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY);
+  assert.equal(result.readOnly, true);
+  assert.equal(result.siblingRoot, "/work/fooks.omx-worktrees");
+  assert.deepEqual(result.blockers, []);
+
+  assert.deepEqual(result.categories["safe-cleanup"].map((entry) => entry.branch), ["dogfood/old-merged"]);
+  assert.deepEqual(result.categories["salvage-review"].map((entry) => entry.branch), ["dogfood/local-ahead"]);
+  assert.deepEqual(result.categories.keep.map((entry) => entry.branch).sort(), ["dogfood/current", "dogfood/has-pr", "dogfood/has-remote"]);
+
+  const salvageEntry = result.entries.find((entry) => entry.branch === "dogfood/local-ahead");
+  assert.equal(salvageEntry?.aheadOfBase, 2);
+  assert.equal(salvageEntry?.remoteBranchExists, false);
+  assert.match(salvageEntry?.manualReviewCommands.join("\n") ?? "", /review or cherry-pick local-only commits/i);
+  assert.deepEqual(salvageEntry?.manualCleanupCommands, []);
+
+  const safeEntry = result.entries.find((entry) => entry.branch === "dogfood/old-merged");
+  assert.equal(safeEntry?.aheadOfBase, 0);
+  assert.ok(safeEntry?.manualCleanupCommands.includes("git worktree remove <path>"));
+
+  assert.equal(calls.some(([command, args]) => command === "git" && ["fetch", "worktree remove", "branch -d"].includes(args.join(" "))), false);
+});
+
+test("status orphan-worktrees emits parseable JSON", () => {
+  const stdout = execFileSync(process.execPath, [cli, "status", "orphan-worktrees", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  const result = JSON.parse(stdout);
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "status orphan-worktrees");
+  assert.equal(result.linkedIssue, "#709");
+  assert.equal(result.readOnly, true);
+  assert.ok(Array.isArray(result.entries));
+});


### PR DESCRIPTION
Fixes #709

## Delta
- classify orphan local worktree evidence separately from active dogfood work
- add read-only operator activity evidence for safe-cleanup/salvage/keep decisions
- keep local-only commits from being auto-deleted or reported as current active sessions

## Verification
- npm run build
- node --test test/operator-activity.test.mjs
- npm run typecheck -- --pretty false
