### PR TITLE
Prioritize React Web issue reports for first-minute triage

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -17,10 +17,32 @@ export const REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY =
 type ReactWebIssueConfidence = "high" | "medium";
 type ReactWebIssueFixability = "safe-preview" | "manual-review";
 type ReactWebIssueAutoFixSafety = "not-auto-applied" | "unsafe-to-auto-apply";
+export type ReactWebIssuePriority = "high" | "medium" | "low";
+export type ReactWebIssueTriageBucket = "safe-preview" | "high-confidence-manual-review" | "manual-review";
+export type ReactWebRelatedContextQuality = "same-file-only" | "local-supporting-context" | "thin-local-context";
 type ReactWebIssueKind =
   | "react-web.missing-accessible-label"
   | "react-web.ambiguous-accessible-label"
   | "react-web.unassociated-nearby-label";
+
+export type ReactWebIssueTriageEvidence = {
+  safePreviewAvailable: boolean;
+  confidence: ReactWebIssueConfidence;
+  nativeElement: ReactWebLabelPatchPreviewFinding["element"];
+  sameFileContextAvailable: boolean;
+  relatedContextCount: number;
+  relatedContextSources: ReactWebIssueRelatedContext["source"][];
+  relatedContextQuality: ReactWebRelatedContextQuality;
+  score: number;
+  reasons: string[];
+};
+
+export type ReactWebIssueTriage = {
+  rank: number;
+  priority: ReactWebIssuePriority;
+  bucket: ReactWebIssueTriageBucket;
+  evidence: ReactWebIssueTriageEvidence;
+};
 
 export type ReactWebIssueCard = {
   id: string;
@@ -48,6 +70,7 @@ export type ReactWebIssueCard = {
   safetyRationale: string;
   suggestedFixIntent: string;
   suggestedAction: string;
+  triage: ReactWebIssueTriage;
   skipReason?: string;
   preview?: {
     type: "unified-diff-fragment";
@@ -76,6 +99,17 @@ export type ReactWebIssueReport = {
     safePreviewCount: number;
     manualReviewCount: number;
     unsafeToAutoApplyCount: number;
+  };
+  triageRollup: {
+    claimBoundary: string;
+    criteria: string[];
+    priorityCounts: Record<ReactWebIssuePriority, number>;
+    bucketCounts: Record<ReactWebIssueTriageBucket, number>;
+    rankedIssueIds: string[];
+    topIssueIds: string[];
+    topManualReviewIssueIds: string[];
+    safePreviewIssueIds: string[];
+    manualReviewIssueIds: string[];
   };
   issues: ReactWebIssueCard[];
 };
@@ -146,6 +180,101 @@ function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
   return "Preview skipped because generated accessible-name copy would require human review.";
 }
 
+function uniqueRelatedContextSources(
+  relatedContext: ReactWebIssueRelatedContext[],
+): ReactWebIssueRelatedContext["source"][] {
+  return [...new Set(relatedContext.map((item) => item.source))].sort();
+}
+
+function relatedContextQualityFor(relatedContext: ReactWebIssueRelatedContext[]): ReactWebRelatedContextQuality {
+  const sources = new Set(relatedContext.map((item) => item.source));
+  if (sources.has("local-import") || sources.has("nearby-test")) {
+    return "local-supporting-context";
+  }
+  if (sources.has("label-preview")) return "same-file-only";
+  return "thin-local-context";
+}
+
+function nativeElementWeight(element: ReactWebLabelPatchPreviewFinding["element"]): number {
+  switch (element) {
+    case "input":
+    case "select":
+    case "textarea":
+      return 2;
+    case "button":
+      return 1;
+  }
+}
+
+function triageBucketFor(issue: Pick<ReactWebIssueCard, "confidence" | "fixability">): ReactWebIssueTriageBucket {
+  if (issue.fixability === "safe-preview") return "safe-preview";
+  return issue.confidence === "high" ? "high-confidence-manual-review" : "manual-review";
+}
+
+function priorityFor(score: number): ReactWebIssuePriority {
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  return "low";
+}
+
+function triageEvidenceFor(issue: Omit<ReactWebIssueCard, "triage">): ReactWebIssueTriageEvidence {
+  const safePreviewAvailable = issue.fixability === "safe-preview" && Boolean(issue.preview);
+  const sameFileContextAvailable = issue.relatedContext.some(
+    (item) => item.kind === "same-file-pattern" && item.source === "label-preview",
+  );
+  const relatedContextSources = uniqueRelatedContextSources(issue.relatedContext);
+  const relatedContextQuality = relatedContextQualityFor(issue.relatedContext);
+  const reasons: string[] = [];
+  let score = 0;
+
+  if (safePreviewAvailable) {
+    score += 4;
+    reasons.push("safe read-only preview is available");
+  }
+  if (issue.confidence === "high") {
+    score += 3;
+    reasons.push("label-preview confidence is high");
+  } else {
+    score += 1;
+    reasons.push("label-preview confidence is medium");
+  }
+
+  const elementWeight = nativeElementWeight(issue.evidence.element);
+  score += elementWeight;
+  reasons.push(`native ${issue.evidence.element} element weight +${elementWeight}`);
+
+  if (sameFileContextAvailable) {
+    score += 1;
+    reasons.push("same-file JSX context is available");
+  }
+
+  if (relatedContextQuality === "local-supporting-context") {
+    score += 2;
+    reasons.push("related local source context is available");
+  } else if (relatedContextQuality === "same-file-only") {
+    score += 1;
+    reasons.push("related context is same-file only");
+  } else {
+    reasons.push("related context is thin");
+  }
+  if (issue.relatedContext.length >= 3) {
+    score += 1;
+    reasons.push("related context has at least three local anchors");
+  }
+
+  return {
+    safePreviewAvailable,
+    confidence: issue.confidence,
+    nativeElement: issue.evidence.element,
+    sameFileContextAvailable,
+    relatedContextCount: issue.relatedContext.length,
+    relatedContextSources,
+    relatedContextQuality,
+    score,
+    reasons,
+  };
+}
+
 function issueCardFor(
   filePath: string,
   finding: ReactWebLabelPatchPreviewFinding,
@@ -162,7 +291,7 @@ function issueCardFor(
     : undefined;
   const suggestedAction = suggestedFixIntentFor(finding);
   const safetyRationale = safetyRationaleFor(finding);
-  return {
+  const issueWithoutTriage = {
     id: `react-web-label-${index + 1}`,
     kind: issueKindFor(finding),
     problem: problemFor(finding),
@@ -191,18 +320,88 @@ function issueCardFor(
     ...(!isSafePreview ? { skipReason: skipReasonFor(finding) } : {}),
     ...(preview ? { preview } : {}),
   };
+  const evidence = triageEvidenceFor(issueWithoutTriage);
+  return {
+    ...issueWithoutTriage,
+    triage: {
+      rank: index + 1,
+      priority: priorityFor(evidence.score),
+      bucket: triageBucketFor(issueWithoutTriage),
+      evidence,
+    },
+  };
+}
+
+function compareIssuePriority(a: ReactWebIssueCard, b: ReactWebIssueCard): number {
+  return (
+    b.triage.evidence.score - a.triage.evidence.score ||
+    Number(b.triage.evidence.safePreviewAvailable) - Number(a.triage.evidence.safePreviewAvailable) ||
+    (b.confidence === "high" ? 1 : 0) - (a.confidence === "high" ? 1 : 0) ||
+    nativeElementWeight(b.evidence.element) - nativeElementWeight(a.evidence.element) ||
+    b.triage.evidence.relatedContextCount - a.triage.evidence.relatedContextCount ||
+    a.whereToLook.line - b.whereToLook.line
+  );
+}
+
+function withTriageRanks(issues: ReactWebIssueCard[]): ReactWebIssueCard[] {
+  const ranks = new Map<string, number>();
+  [...issues].sort(compareIssuePriority).forEach((issue, index) => ranks.set(issue.id, index + 1));
+  return issues.map((issue) => ({
+    ...issue,
+    triage: {
+      ...issue.triage,
+      rank: ranks.get(issue.id) ?? issue.triage.rank,
+    },
+  }));
+}
+
+function buildTriageRollup(issues: ReactWebIssueCard[]): ReactWebIssueReport["triageRollup"] {
+  const ranked = [...issues].sort(compareIssuePriority);
+  return {
+    claimBoundary:
+      "Conservative local triage only: ranks issue cards from existing report evidence and does not edit files, auto-apply patches, infer custom-component semantics, or claim a broad accessibility audit.",
+    criteria: [
+      "safe preview availability",
+      "label-preview confidence",
+      "native element type",
+      "same-file JSX context",
+      "related-context count and source quality",
+    ],
+    priorityCounts: {
+      high: issues.filter((issue) => issue.triage.priority === "high").length,
+      medium: issues.filter((issue) => issue.triage.priority === "medium").length,
+      low: issues.filter((issue) => issue.triage.priority === "low").length,
+    },
+    bucketCounts: {
+      "safe-preview": issues.filter((issue) => issue.triage.bucket === "safe-preview").length,
+      "high-confidence-manual-review": issues.filter((issue) => issue.triage.bucket === "high-confidence-manual-review").length,
+      "manual-review": issues.filter((issue) => issue.triage.bucket === "manual-review").length,
+    },
+    rankedIssueIds: ranked.map((issue) => issue.id),
+    topIssueIds: ranked.slice(0, 3).map((issue) => issue.id),
+    topManualReviewIssueIds: ranked
+      .filter((issue) => issue.fixability === "manual-review")
+      .slice(0, 3)
+      .map((issue) => issue.id),
+    safePreviewIssueIds: ranked
+      .filter((issue) => issue.fixability === "safe-preview")
+      .map((issue) => issue.id),
+    manualReviewIssueIds: ranked
+      .filter((issue) => issue.fixability === "manual-review")
+      .map((issue) => issue.id),
+  };
 }
 
 export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()): ReactWebIssueReport {
   const preview = buildReactWebLabelPatchPreview(filePath, cwd);
-  const issues = preview.findings.map((finding, index) =>
+  const issues = withTriageRanks(preview.findings.map((finding, index) =>
     issueCardFor(
       preview.filePath,
       finding,
       index,
       buildReactWebIssueRelatedContext(preview.filePath, finding, cwd),
     ),
-  );
+  ));
   return {
     schemaVersion: REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION,
     command: REACT_WEB_ISSUE_REPORT_COMMAND,
@@ -224,6 +423,7 @@ export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()):
       manualReviewCount: issues.filter((issue) => issue.fixability === "manual-review").length,
       unsafeToAutoApplyCount: issues.filter((issue) => issue.autoFixSafety === "unsafe-to-auto-apply").length,
     },
+    triageRollup: buildTriageRollup(issues),
     issues,
   };
 }
@@ -243,10 +443,23 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
   if (report.skippedReason) lines.push(`Skipped: ${report.skippedReason}`);
   if (report.issues.length === 0) return `${lines.join("\n")}\n`;
 
+  lines.push(
+    "",
+    "## Triage rollup",
+    report.triageRollup.claimBoundary,
+    `- priority counts: high ${report.triageRollup.priorityCounts.high}, medium ${report.triageRollup.priorityCounts.medium}, low ${report.triageRollup.priorityCounts.low}`,
+    `- buckets: safe preview ${report.triageRollup.bucketCounts["safe-preview"]}, high-confidence manual review ${report.triageRollup.bucketCounts["high-confidence-manual-review"]}, manual review ${report.triageRollup.bucketCounts["manual-review"]}`,
+    `- ranked issue ids: ${report.triageRollup.rankedIssueIds.join(", ") || "none"}`,
+    `- top manual-review ids: ${report.triageRollup.topManualReviewIssueIds.join(", ") || "none"}`,
+    `- criteria: ${report.triageRollup.criteria.join("; ")}`,
+  );
+
   report.issues.forEach((issue, index) => {
     lines.push(
       "",
       `## Issue ${index + 1}: ${issue.problem}`,
+      `- triage: rank ${issue.triage.rank}, ${issue.triage.priority} priority, ${issue.triage.bucket}, score ${issue.triage.evidence.score}`,
+      `- triage evidence: safe preview ${issue.triage.evidence.safePreviewAvailable ? "yes" : "no"}, same-file context ${issue.triage.evidence.sameFileContextAvailable ? "yes" : "no"}, related context ${issue.triage.evidence.relatedContextCount} (${issue.triage.evidence.relatedContextQuality})`,
       `- why: ${issue.whyItMatters}`,
       `- where to look: ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
       `- element: ${issue.evidence.element}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,4 +186,12 @@ export {
   buildReactWebIssueReport,
   renderReactWebIssueReportText,
 } from "./core/react-web-issue-report";
-export type { ReactWebIssueCard, ReactWebIssueReport } from "./core/react-web-issue-report";
+export type {
+  ReactWebIssueCard,
+  ReactWebIssuePriority,
+  ReactWebIssueReport,
+  ReactWebIssueTriageBucket,
+  ReactWebIssueTriage,
+  ReactWebIssueTriageEvidence,
+  ReactWebRelatedContextQuality,
+} from "./core/react-web-issue-report";

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -19,6 +19,7 @@ const fixtures = {
   association: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-candidates.tsx"),
   unsafeAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx"),
   relatedContext: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "related-context-form.tsx"),
+  formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
 };
@@ -90,6 +91,15 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.suggestedFixIntent.length > 0);
     assert.equal(issue.suggestedAction, issue.suggestedFixIntent);
     assert.match(issue.skipReason, /human review|accessible-name copy/);
+    assert.ok(issue.triage.rank > 0);
+    assert.ok(["high", "medium", "low"].includes(issue.triage.priority));
+    assert.ok(["safe-preview", "high-confidence-manual-review", "manual-review"].includes(issue.triage.bucket));
+    assert.equal(issue.triage.evidence.safePreviewAvailable, false);
+    assert.equal(issue.triage.evidence.confidence, issue.confidence);
+    assert.equal(issue.triage.evidence.nativeElement, issue.evidence.element);
+    assert.equal(issue.triage.evidence.sameFileContextAvailable, true);
+    assert.equal(issue.triage.evidence.relatedContextCount, issue.relatedContext.length);
+    assert.ok(issue.triage.evidence.reasons.length > 0);
 
     assert.ok(Array.isArray(issue.relatedContext));
     assert.ok(issue.relatedContext.length > 0);
@@ -122,11 +132,72 @@ test("React Web issue report turns nearby native associations into safe preview 
     ["medium", "manual-review", "unsafe-to-auto-apply", false],
     ["medium", "manual-review", "unsafe-to-auto-apply", false],
   ]);
+  assert.deepEqual(report.triageRollup.safePreviewIssueIds, ["react-web-label-1"]);
+  assert.deepEqual(report.triageRollup.bucketCounts, {
+    "safe-preview": 1,
+    "high-confidence-manual-review": 0,
+    "manual-review": 2,
+  });
+  assert.equal(report.issues[0].triage.evidence.safePreviewAvailable, true);
+  assert.equal(report.issues[0].triage.bucket, "safe-preview");
+  assert.equal(report.issues[0].triage.rank, 1);
   assert.match(report.issues[0].preview.text, /htmlFor="email"/);
   assert.ok(report.issues.every((issue) => issue.relatedContext.length > 0));
   assert.ok(report.issues.every((issue) => issue.relatedContext.length <= 5));
   assert.ok(report.issues.every((issue) => issue.relatedContext[0].action === "inspect-first"));
   assert.match(report.issues[1].skipReason, /not high-confidence deterministic evidence/);
+});
+
+test("React Web issue report JSON includes conservative priority rollup for first-minute compressed fixture", () => {
+  const report = parseIssues(fixtures.formControls);
+
+  assert.equal(report.summary.issueCount, 5);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.manualReviewCount, 5);
+  assert.match(report.triageRollup.claimBoundary, /Conservative local triage only/);
+  assert.match(report.triageRollup.claimBoundary, /does not edit files/);
+  assert.match(report.triageRollup.claimBoundary, /does not.*infer custom-component semantics/);
+  assert.deepEqual(report.triageRollup.criteria, [
+    "safe preview availability",
+    "label-preview confidence",
+    "native element type",
+    "same-file JSX context",
+    "related-context count and source quality",
+  ]);
+  assert.deepEqual(report.triageRollup.bucketCounts, {
+    "safe-preview": 0,
+    "high-confidence-manual-review": 5,
+    "manual-review": 0,
+  });
+  assert.deepEqual(report.triageRollup.priorityCounts, { high: 5, medium: 0, low: 0 });
+  assert.deepEqual(report.triageRollup.rankedIssueIds, [
+    "react-web-label-1",
+    "react-web-label-4",
+    "react-web-label-5",
+    "react-web-label-2",
+    "react-web-label-3",
+  ]);
+  assert.deepEqual(report.triageRollup.topManualReviewIssueIds, [
+    "react-web-label-1",
+    "react-web-label-4",
+    "react-web-label-5",
+  ]);
+  assert.deepEqual(report.triageRollup.safePreviewIssueIds, []);
+  assert.deepEqual(report.triageRollup.manualReviewIssueIds, report.triageRollup.rankedIssueIds);
+
+  const byId = Object.fromEntries(report.issues.map((issue) => [issue.id, issue]));
+  assert.equal(byId["react-web-label-1"].triage.rank, 1);
+  assert.equal(byId["react-web-label-2"].triage.rank, 4);
+  assert.equal(byId["react-web-label-3"].triage.rank, 5);
+  assert.equal(byId["react-web-label-1"].triage.evidence.relatedContextQuality, "same-file-only");
+  assert.deepEqual(byId["react-web-label-1"].triage.evidence.relatedContextSources, [
+    "label-preview",
+    "same-directory",
+  ]);
+  assert.equal(byId["react-web-label-1"].triage.evidence.safePreviewAvailable, false);
+  assert.equal(byId["react-web-label-1"].triage.evidence.sameFileContextAvailable, true);
+  assert.ok(byId["react-web-label-1"].triage.evidence.reasons.some((reason) => /same-file JSX context/.test(reason)));
+  assert.doesNotMatch(JSON.stringify(report.triageRollup), /must-edit/i);
 });
 
 test("React Web issue report recommends bounded local related context from imports, siblings, tests, and same-file patterns", () => {
@@ -245,7 +316,14 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.equal(cli.status, 0, cli.stderr);
   assert.match(cli.stdout, /# React Web issue report/);
   assert.match(cli.stdout, /Read-only React Web issue report/);
+  assert.match(cli.stdout, /## Triage rollup/);
+  assert.match(cli.stdout, /- priority counts:/);
+  assert.match(cli.stdout, /- ranked issue ids:/);
+  assert.match(cli.stdout, /- top manual-review ids:/);
+  assert.match(cli.stdout, /- criteria: safe preview availability; label-preview confidence; native element type; same-file JSX context; related-context count and source quality/);
   assert.match(cli.stdout, /## Issue 1:/);
+  assert.match(cli.stdout, /- triage: rank 1, high priority, safe-preview, score \d+/);
+  assert.match(cli.stdout, /- triage evidence: safe preview yes, same-file context yes, related context \d+ \(/);
   assert.match(cli.stdout, /- why:/);
   assert.match(cli.stdout, /- where to look:/);
   assert.match(cli.stdout, /- fixability: safe-preview/);


### PR DESCRIPTION
## Linked issue

Fixes #719

## Summary

- Add additive `triageRollup` JSON to `inspect react-web-issues` with ranked issue ids, bucket counts, priority counts, and bounded criteria.
- Add per-issue `triage` metadata derived only from existing report evidence: safe preview availability, confidence, native element type, same-file context, and related-context count/source quality.
- Render a human-readable triage rollup before issue cards while preserving read-only/no-auto-apply/no-custom-component boundary wording.

## Verification

- `npm run typecheck`
- `npm test` (721/721 passing)

## Review gate

- [x] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.
