### PR TITLE
Add compact React Web issue summary

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -615,6 +615,23 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
     `- criteria: ${report.triageRollup.criteria.join("; ")}`,
   );
 
+  const issuesById = new Map(report.issues.map((issue) => [issue.id, issue]));
+  const compactIssues = report.triageRollup.topIssueIds
+    .map((id) => issuesById.get(id))
+    .filter((issue): issue is ReactWebIssueCard => Boolean(issue));
+  if (compactIssues.length > 0) {
+    lines.push(
+      "",
+      "## First-minute summary",
+      "- Compact read-only triage from existing ranked issue evidence; inspect before editing and keep human review for final label/name decisions.",
+    );
+    for (const issue of compactIssues) {
+      lines.push(
+        `- ${issue.id}: ${issue.fixShapeGuidance.shape}; first inspect: ${issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`}`,
+      );
+    }
+  }
+
   report.issues.forEach((issue, index) => {
     lines.push(
       "",

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -385,3 +385,45 @@ test("React Web issue report text mode prints per-card manual-review fix-shape g
   assert.match(cli.stdout, /- inspect first for fix shape:/);
   assert.doesNotMatch(cli.stdout, /must-edit|Auto-apply: yes|Controller/);
 });
+
+test("React Web issue report text mode adds compact first-minute summary before detailed cards", () => {
+  const cli = runIssues(fixtures.formControls);
+  assert.equal(cli.status, 0, cli.stderr);
+
+  const summaryIndex = cli.stdout.indexOf("## First-minute summary");
+  const issueIndex = cli.stdout.indexOf("## Issue 1:");
+  assert.ok(summaryIndex > 0, "expected compact first-minute summary");
+  assert.ok(issueIndex > summaryIndex, "compact summary should appear before detailed issue cards");
+
+  assert.match(cli.stdout, /Compact read-only triage from existing ranked issue evidence/);
+  assert.match(cli.stdout, /inspect before editing and keep human review/);
+  assert.match(
+    cli.stdout,
+    /- react-web-label-1: human-reviewed-native-control-name; first inspect: Inspect fixtures\/compressed\/FormControls\.tsx:23-23 \(input\) before editing\./,
+  );
+  assert.match(
+    cli.stdout,
+    /- react-web-label-4: human-reviewed-native-control-name; first inspect: Inspect fixtures\/compressed\/FormControls\.tsx:32-32 \(input\) before editing\./,
+  );
+  assert.match(
+    cli.stdout,
+    /- react-web-label-5: human-reviewed-native-control-name; first inspect: Inspect fixtures\/compressed\/FormControls\.tsx:34-34 \(input\) before editing\./,
+  );
+  const compactBlock = cli.stdout.slice(summaryIndex, issueIndex);
+  assert.doesNotMatch(compactBlock, /must-edit|Auto-apply: yes|generated accessible-name copy/);
+});
+
+test("React Web issue report compact first-minute summary stays text-only", () => {
+  const cli = runIssues(fixtures.formControls, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.doesNotMatch(cli.stdout, /First-minute summary/);
+
+  const report = JSON.parse(cli.stdout);
+  assert.equal(report.schemaVersion, "react-web-issue-report.v1");
+  assert.equal(report.firstMinuteSummary, undefined);
+  assert.deepEqual(report.triageRollup.topIssueIds, [
+    "react-web-label-1",
+    "react-web-label-4",
+    "react-web-label-5",
+  ]);
+});


### PR DESCRIPTION
## Linked issue

Fixes #729

## Summary

- Adds a compact first-minute summary to `inspect react-web-issues` text output before detailed issue cards.
- Lists the top ranked issue IDs with their fix shape and first inspect target using existing report evidence only.
- Keeps JSON fields/schema, detailed cards, claim boundaries, safety rationale, and read-only/no-auto-apply boundaries intact.

## Verification

- `npm run build && node --test test/react-web-issue-report.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test` (727/727 passing)

## Review gate

- [x] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*