### PR TITLE
Expose first-minute React Web JSON summary

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -105,6 +105,23 @@ export type ReactWebIssueCard = {
   };
 };
 
+export type ReactWebIssueFirstMinuteSummaryItem = {
+  issueId: string;
+  fixShape: ReactWebIssueFixShape;
+  firstInspectStep: string;
+  inspectFirst: string[];
+  fixShapeGuidance: {
+    claimBoundary: ReactWebIssueFixShapeGuidance["claimBoundary"];
+    humanReviewRequired: true;
+    autoApply: false;
+  };
+};
+
+export type ReactWebIssueFirstMinuteSummary = {
+  sourceTopIssueIds: string[];
+  items: ReactWebIssueFirstMinuteSummaryItem[];
+};
+
 export type ReactWebIssueReport = {
   schemaVersion: typeof REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION;
   command: typeof REACT_WEB_ISSUE_REPORT_COMMAND;
@@ -137,6 +154,7 @@ export type ReactWebIssueReport = {
     safePreviewIssueIds: string[];
     manualReviewIssueIds: string[];
   };
+  firstMinuteSummary: ReactWebIssueFirstMinuteSummary;
   issues: ReactWebIssueCard[];
 };
 
@@ -553,6 +571,35 @@ function buildTriageRollup(issues: ReactWebIssueCard[]): ReactWebIssueReport["tr
   };
 }
 
+function firstInspectStepFor(issue: ReactWebIssueCard): string {
+  return issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`;
+}
+
+function buildFirstMinuteSummary(
+  triageRollup: ReactWebIssueReport["triageRollup"],
+  issues: ReactWebIssueCard[],
+): ReactWebIssueFirstMinuteSummary {
+  const issuesById = new Map(issues.map((issue) => [issue.id, issue]));
+  const items = triageRollup.topIssueIds
+    .map((id) => issuesById.get(id))
+    .filter((issue): issue is ReactWebIssueCard => Boolean(issue))
+    .map((issue) => ({
+      issueId: issue.id,
+      fixShape: issue.fixShapeGuidance.shape,
+      firstInspectStep: firstInspectStepFor(issue),
+      inspectFirst: [...issue.fixShapeGuidance.inspectFirst],
+      fixShapeGuidance: {
+        claimBoundary: issue.fixShapeGuidance.claimBoundary,
+        humanReviewRequired: issue.fixShapeGuidance.humanReviewRequired,
+        autoApply: issue.fixShapeGuidance.autoApply,
+      },
+    }));
+  return {
+    sourceTopIssueIds: [...triageRollup.topIssueIds],
+    items,
+  };
+}
+
 export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()): ReactWebIssueReport {
   const preview = buildReactWebLabelPatchPreview(filePath, cwd);
   const issues = withTriageRanks(preview.findings.map((finding, index) =>
@@ -563,6 +610,7 @@ export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()):
       buildReactWebIssueRelatedContext(preview.filePath, finding, cwd),
     ),
   ));
+  const triageRollup = buildTriageRollup(issues);
   return {
     schemaVersion: REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION,
     command: REACT_WEB_ISSUE_REPORT_COMMAND,
@@ -584,7 +632,8 @@ export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()):
       manualReviewCount: issues.filter((issue) => issue.fixability === "manual-review").length,
       unsafeToAutoApplyCount: issues.filter((issue) => issue.autoFixSafety === "unsafe-to-auto-apply").length,
     },
-    triageRollup: buildTriageRollup(issues),
+    triageRollup,
+    firstMinuteSummary: buildFirstMinuteSummary(triageRollup, issues),
     issues,
   };
 }

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -313,11 +313,13 @@ test("React Web issue report preserves skip and no unsupported custom-component 
   assert.equal(rnReport.inScope, false);
   assert.match(rnReport.skippedReason, /^domain-classification:react-native/);
   assert.deepEqual(rnReport.issues, []);
+  assert.deepEqual(rnReport.firstMinuteSummary, { sourceTopIssueIds: [], items: [] });
 
   const customReport = parseIssues(fixtures.customComponent);
   assert.equal(customReport.inScope, true);
   assert.equal(customReport.summary.issueCount, 0);
   assert.deepEqual(customReport.issues, []);
+  assert.deepEqual(customReport.firstMinuteSummary, { sourceTopIssueIds: [], items: [] });
 });
 
 test("React Web issue report avoids unsafe htmlFor inference and keeps fallback previews read-only", () => {
@@ -413,17 +415,58 @@ test("React Web issue report text mode adds compact first-minute summary before 
   assert.doesNotMatch(compactBlock, /must-edit|Auto-apply: yes|generated accessible-name copy/);
 });
 
-test("React Web issue report compact first-minute summary stays text-only", () => {
+test("React Web issue report JSON includes machine-readable first-minute summary projection", () => {
   const cli = runIssues(fixtures.formControls, "--json");
   assert.equal(cli.status, 0, cli.stderr);
   assert.doesNotMatch(cli.stdout, /First-minute summary/);
 
   const report = JSON.parse(cli.stdout);
   assert.equal(report.schemaVersion, "react-web-issue-report.v1");
-  assert.equal(report.firstMinuteSummary, undefined);
   assert.deepEqual(report.triageRollup.topIssueIds, [
     "react-web-label-1",
     "react-web-label-4",
     "react-web-label-5",
   ]);
+  assert.deepEqual(report.firstMinuteSummary.sourceTopIssueIds, report.triageRollup.topIssueIds);
+  assert.deepEqual(
+    report.firstMinuteSummary.items.map((item) => item.issueId),
+    report.triageRollup.topIssueIds,
+  );
+
+  const byId = Object.fromEntries(report.issues.map((issue) => [issue.id, issue]));
+  for (const item of report.firstMinuteSummary.items) {
+    const issue = byId[item.issueId];
+    assert.ok(issue, `expected first-minute item to reference an existing issue: ${item.issueId}`);
+    assert.equal(item.fixShape, issue.fixShapeGuidance.shape);
+    assert.equal(
+      item.firstInspectStep,
+      issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
+    );
+    assert.deepEqual(item.inspectFirst, issue.fixShapeGuidance.inspectFirst);
+    assert.equal(item.fixShapeGuidance.claimBoundary, issue.fixShapeGuidance.claimBoundary);
+    assert.equal(item.fixShapeGuidance.humanReviewRequired, true);
+    assert.equal(item.fixShapeGuidance.autoApply, false);
+  }
+
+  assert.deepEqual(
+    report.firstMinuteSummary.items.map((item) => [item.issueId, item.fixShape, item.firstInspectStep]),
+    [
+      [
+        "react-web-label-1",
+        "human-reviewed-native-control-name",
+        "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+      ],
+      [
+        "react-web-label-4",
+        "human-reviewed-native-control-name",
+        "Inspect fixtures/compressed/FormControls.tsx:32-32 (input) before editing.",
+      ],
+      [
+        "react-web-label-5",
+        "human-reviewed-native-control-name",
+        "Inspect fixtures/compressed/FormControls.tsx:34-34 (input) before editing.",
+      ],
+    ],
+  );
+  assert.doesNotMatch(JSON.stringify(report.firstMinuteSummary), /must-edit|Auto-apply: yes|Controller/i);
 });


### PR DESCRIPTION
## Linked issue

Fixes #731

## Summary

- Adds additive `firstMinuteSummary` JSON to `inspect react-web-issues --json` as a compact projection for downstream first-minute tooling.
- Builds the projection only from `triageRollup.topIssueIds`, existing issue-card `fixShapeGuidance`, and the existing first inspect step / `whereToLook` fallback.
- Keeps text output, detailed issue-card fields, read-only/no-auto-apply/human-review boundaries, and React-Web-only scope intact.

## Verification

- `npm run build`
- `npm run typecheck`
- `npm test` (727/727 passing)
- `git diff --check`
- Ralph architect review: APPROVE
- Bounded ai-slop-cleaner pass on changed files only; post-deslop verification reran and passed

## Review gate

- [x] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
