### PR TITLE
Add compact React Web issue summary JSON

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -649,7 +649,7 @@ Everyday commands:
   ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
-  ${displayCliName} inspect react-web-issues <file> [--json]
+  ${displayCliName} inspect react-web-issues <file> [--json|--summary-json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
@@ -712,6 +712,34 @@ function parseCompareArgs(args: string[]): { filePath: string; json: boolean } {
   }
 
   return { filePath: requireFilePath(filePath), json };
+}
+
+function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode: "text" | "json" | "summary-json" } {
+  let filePath: string | undefined;
+  let json = false;
+  let summaryJson = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--summary-json") {
+      summaryJson = true;
+      continue;
+    }
+    if (!filePath) {
+      filePath = arg;
+      continue;
+    }
+    throw new Error(`Unexpected react-web-issues argument: ${arg}`);
+  }
+
+  if (json && summaryJson) {
+    throw new Error("inspect react-web-issues accepts either --json or --summary-json, not both");
+  }
+
+  return { filePath: requireFilePath(filePath), outputMode: summaryJson ? "summary-json" : json ? "json" : "text" };
 }
 
 function parseInspectEvidenceArgs(args: string[]): { id: string; json: boolean } {
@@ -1319,10 +1347,12 @@ async function run(): Promise<void> {
         return;
       }
       if (arg1 === "react-web-issues") {
-        const { filePath: file, json } = parseCompareArgs(rest.slice(1));
-        const { buildReactWebIssueReport, renderReactWebIssueReportText } = await import("../core/react-web-issue-report.js");
+        const { filePath: file, outputMode } = parseReactWebIssuesArgs(rest.slice(1));
+        const { buildReactWebIssueReport, buildReactWebIssueReportSummaryJson, renderReactWebIssueReportText } = await import("../core/react-web-issue-report.js");
         const report = buildReactWebIssueReport(file, process.cwd());
-        if (json) {
+        if (outputMode === "summary-json") {
+          print(buildReactWebIssueReportSummaryJson(report));
+        } else if (outputMode === "json") {
           print(report);
         } else {
           process.stdout.write(renderReactWebIssueReportText(report));

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -158,6 +158,29 @@ export type ReactWebIssueReport = {
   issues: ReactWebIssueCard[];
 };
 
+export type ReactWebIssueReportSummaryJson = {
+  schemaVersion: "react-web-issue-report-summary.v1";
+  sourceReportSchemaVersion: typeof REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION;
+  command: typeof REACT_WEB_ISSUE_REPORT_COMMAND;
+  projection: "summary-json";
+  profile: "react-web";
+  filePath: string;
+  readOnly: true;
+  autoApply: false;
+  claimBoundary: typeof REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY;
+  inScope: boolean;
+  skippedReason?: string;
+  summary: ReactWebIssueReport["summary"];
+  triageTopIds: {
+    rankedIssueIds: string[];
+    topIssueIds: string[];
+    topManualReviewIssueIds: string[];
+    safePreviewIssueIds: string[];
+    manualReviewIssueIds: string[];
+  };
+  firstMinuteSummary: ReactWebIssueFirstMinuteSummary;
+};
+
 function issueKindFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueKind {
   return `react-web.${finding.kind}` as ReactWebIssueKind;
 }
@@ -635,6 +658,31 @@ export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()):
     triageRollup,
     firstMinuteSummary: buildFirstMinuteSummary(triageRollup, issues),
     issues,
+  };
+}
+
+export function buildReactWebIssueReportSummaryJson(report: ReactWebIssueReport): ReactWebIssueReportSummaryJson {
+  return {
+    schemaVersion: "react-web-issue-report-summary.v1",
+    sourceReportSchemaVersion: report.schemaVersion,
+    command: report.command,
+    projection: "summary-json",
+    profile: report.profile,
+    filePath: report.filePath,
+    readOnly: report.readOnly,
+    autoApply: report.autoApply,
+    claimBoundary: report.claimBoundary,
+    inScope: report.inScope,
+    ...(report.skippedReason ? { skippedReason: report.skippedReason } : {}),
+    summary: report.summary,
+    triageTopIds: {
+      rankedIssueIds: report.triageRollup.rankedIssueIds,
+      topIssueIds: report.triageRollup.topIssueIds,
+      topManualReviewIssueIds: report.triageRollup.topManualReviewIssueIds,
+      safePreviewIssueIds: report.triageRollup.safePreviewIssueIds,
+      manualReviewIssueIds: report.triageRollup.manualReviewIssueIds,
+    },
+    firstMinuteSummary: report.firstMinuteSummary,
   };
 }
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3821,7 +3821,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect activation-mode <id> \[--json\]/);
   assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
   assert.match(help, /fooks inspect react-web-label-preview <file> \[--json\]/);
-  assert.match(help, /fooks inspect react-web-issues <file> \[--json\]/);
+  assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\]/);

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -11,6 +11,7 @@ const { buildReactWebLabelPatchPreview } = require(path.join(repoRoot, "dist", "
 const {
   REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
   buildReactWebIssueReport,
+  buildReactWebIssueReportSummaryJson,
 } = require(path.join(repoRoot, "dist", "core", "react-web-issue-report.js"));
 
 const fixtures = {
@@ -35,6 +36,12 @@ function parseIssues(file) {
   const cli = runIssues(file, "--json");
   assert.equal(cli.status, 0, cli.stderr);
   return JSON.parse(cli.stdout);
+}
+
+function hasNestedKey(value, key) {
+  if (!value || typeof value !== "object") return false;
+  if (Object.hasOwn(value, key)) return true;
+  return Object.values(value).some((entry) => hasNestedKey(entry, key));
 }
 
 function matrixEntry({ fixture, expectedCards, report, preview, acceptedCards, rejectedCards = 0, noiseNotes = [], suggestionPlausibility }) {
@@ -469,4 +476,89 @@ test("React Web issue report JSON includes machine-readable first-minute summary
     ],
   );
   assert.doesNotMatch(JSON.stringify(report.firstMinuteSummary), /must-edit|Auto-apply: yes|Controller/i);
+});
+
+
+test("React Web issue report summary JSON is compact first-minute data without detailed issue cards", () => {
+  const fullCli = runIssues(fixtures.formControls, "--json");
+  const summaryCli = runIssues(fixtures.formControls, "--summary-json");
+  assert.equal(fullCli.status, 0, fullCli.stderr);
+  assert.equal(summaryCli.status, 0, summaryCli.stderr);
+  assert.ok(summaryCli.stdout.length < fullCli.stdout.length, `summary ${summaryCli.stdout.length} should be smaller than full ${fullCli.stdout.length}`);
+
+  const fullReport = JSON.parse(fullCli.stdout);
+  const summary = JSON.parse(summaryCli.stdout);
+  const projected = buildReactWebIssueReportSummaryJson(fullReport);
+
+  assert.equal(fullReport.schemaVersion, "react-web-issue-report.v1");
+  assert.ok(Array.isArray(fullReport.issues));
+  assert.ok(fullReport.issues.length > 0);
+  assert.equal(summary.schemaVersion, "react-web-issue-report-summary.v1");
+  assert.equal(summary.sourceReportSchemaVersion, fullReport.schemaVersion);
+  assert.equal(summary.command, "inspect react-web-issues");
+  assert.equal(summary.projection, "summary-json");
+  assert.equal(summary.profile, "react-web");
+  assert.equal(summary.filePath, fullReport.filePath);
+  assert.equal(summary.readOnly, true);
+  assert.equal(summary.autoApply, false);
+  assert.equal(summary.claimBoundary, REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY);
+  assert.match(summary.claimBoundary, /Read-only React Web issue report/);
+  assert.match(summary.claimBoundary, /does not auto-apply patches/);
+  assert.match(summary.claimBoundary, /does not infer custom-component semantics/);
+  assert.deepEqual(summary.summary, fullReport.summary);
+  assert.deepEqual(summary.triageTopIds, {
+    rankedIssueIds: fullReport.triageRollup.rankedIssueIds,
+    topIssueIds: fullReport.triageRollup.topIssueIds,
+    topManualReviewIssueIds: fullReport.triageRollup.topManualReviewIssueIds,
+    safePreviewIssueIds: fullReport.triageRollup.safePreviewIssueIds,
+    manualReviewIssueIds: fullReport.triageRollup.manualReviewIssueIds,
+  });
+  assert.deepEqual(summary.firstMinuteSummary, fullReport.firstMinuteSummary);
+  assert.deepEqual(summary, projected);
+
+  assert.deepEqual(summary.triageTopIds.topIssueIds, [
+    "react-web-label-1",
+    "react-web-label-4",
+    "react-web-label-5",
+  ]);
+  assert.deepEqual(summary.firstMinuteSummary.sourceTopIssueIds, summary.triageTopIds.topIssueIds);
+  assert.deepEqual(Object.hasOwn(summary, "issues"), false);
+
+  const compactText = JSON.stringify(summary);
+  for (const detailedCardKey of ["issues", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
+    assert.equal(hasNestedKey(summary, detailedCardKey), false, `summary-json should not include detailed key ${detailedCardKey}`);
+  }
+  assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller/i);
+});
+
+test("React Web issue report summary JSON preserves skip boundaries without detailed cards", () => {
+  const rnCli = runIssues(fixtures.rn, "--summary-json");
+  assert.equal(rnCli.status, 0, rnCli.stderr);
+  const summary = JSON.parse(rnCli.stdout);
+
+  assert.equal(summary.inScope, false);
+  assert.match(summary.skippedReason, /^domain-classification:react-native/);
+  assert.equal(summary.readOnly, true);
+  assert.equal(summary.autoApply, false);
+  assert.deepEqual(summary.summary, {
+    issueCount: 0,
+    safePreviewCount: 0,
+    manualReviewCount: 0,
+    unsafeToAutoApplyCount: 0,
+  });
+  assert.deepEqual(summary.triageTopIds, {
+    rankedIssueIds: [],
+    topIssueIds: [],
+    topManualReviewIssueIds: [],
+    safePreviewIssueIds: [],
+    manualReviewIssueIds: [],
+  });
+  assert.deepEqual(summary.firstMinuteSummary, { sourceTopIssueIds: [], items: [] });
+  assert.deepEqual(Object.hasOwn(summary, "issues"), false);
+});
+
+test("React Web issue report rejects conflicting JSON output flags", () => {
+  const cli = runIssues(fixtures.formControls, "--json", "--summary-json");
+  assert.notEqual(cli.status, 0);
+  assert.match(cli.stderr, /either --json or --summary-json, not both/);
 });


### PR DESCRIPTION
## Summary
- Adds `--summary-json` for `fooks inspect react-web-issues <file>` as a compact projection of the existing React Web issue report.
- Keeps `--json` as the unchanged full report, including detailed issue cards.
- Retains read-only/no-auto-apply/human-review claim boundaries while omitting detailed issue-card fields from compact output.

## Verification
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `node --test test/fooks.test.mjs`
- Manual size check on `fixtures/compressed/FormControls.tsx`: full `--json` 25902 bytes; `--summary-json` 4219 bytes.

Document-refresh: not-needed | CLI help and focused CLI contract tests were updated; broader README/getting-started docs do not document this advanced inspect submode today.

Fixes #735

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
