### PR TITLE
Add React Web issue context packets

### DIFF
--- a/docs/react-web-issue-context-packet.md
+++ b/docs/react-web-issue-context-packet.md
@@ -1,0 +1,15 @@
+# React Web issue context packet
+
+`inspect react-web-issues` now attaches a `contextPacket` to each full issue card. The packet is intentionally report-only: it explains why the card exists and what nearby evidence is worth inspecting, without expanding into apply/codemod behavior.
+
+## Fields
+
+- `whyThisFile`: direct source location that produced the issue card.
+- `relatedPattern`: the detected native React Web label/accessibility pattern and whether it is `safe-preview` or `manual-review`.
+- `nearbyPrecedent`: strongest local inspect-first anchor from same-file, imports, nearby tests, or sibling source context.
+- `confidence`: the label-preview confidence carried through to the issue card.
+- `excludedInference`: explicit non-claims, including no custom-component semantics, no broad accessibility audit, and no auto-apply.
+
+## Boundaries
+
+Context packets are included in full JSON and text reports only. The compact `--summary-json` projection stays first-minute sized and omits detailed issue-card fields such as `contextPacket`, `relatedContext`, preview diffs, source snippets, and suggested actions.

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -69,6 +69,14 @@ export type ReactWebIssueFixShapeGuidance = {
   autoApply: false;
 };
 
+export type ReactWebIssueContextPacket = {
+  whyThisFile: string;
+  relatedPattern: string;
+  nearbyPrecedent: string;
+  confidence: ReactWebIssueConfidence;
+  excludedInference: string[];
+};
+
 export type ReactWebIssueCard = {
   id: string;
   kind: ReactWebIssueKind;
@@ -95,6 +103,7 @@ export type ReactWebIssueCard = {
   safetyRationale: string;
   suggestedFixIntent: string;
   suggestedAction: string;
+  contextPacket: ReactWebIssueContextPacket;
   fixShapeGuidance: ReactWebIssueFixShapeGuidance;
   triage: ReactWebIssueTriage;
   skipReason?: string;
@@ -470,6 +479,78 @@ function fixShapeGuidanceFor(options: {
   };
 }
 
+function contextPacketRelatedPatternFor(options: {
+  finding: ReactWebLabelPatchPreviewFinding;
+  fixability: ReactWebIssueFixability;
+  previewAvailable: boolean;
+}): string {
+  const base = `${issueKindFor(options.finding)} on a native ${options.finding.element}`;
+  if (options.previewAvailable) {
+    return `${base}; safe-preview pattern because existing JSX provides deterministic nearby label/control association evidence.`;
+  }
+  if (options.finding.kind === "unassociated-nearby-label") {
+    return `${base}; manual-review association pattern because nearby label/control evidence is not deterministic enough for a safe preview.`;
+  }
+  return `${base}; ${options.fixability} pattern because final accessible-name copy requires human review.`;
+}
+
+function contextPacketNearbyPrecedentFor(relatedContext: ReactWebIssueRelatedContext[]): string {
+  const precedent =
+    relatedContext.find((item) => item.source === "local-import" || item.source === "nearby-test") ??
+    relatedContext.find((item) => item.kind !== "same-file-pattern") ??
+    relatedContext[0];
+
+  if (!precedent) {
+    return "No nearby precedent found; inspect only the source finding before considering edits.";
+  }
+
+  const location = `${precedent.file}${precedent.line ? `:${precedent.line}${precedent.endLine && precedent.endLine !== precedent.line ? `-${precedent.endLine}` : ""}` : ""}`;
+  return `${precedent.kind} (${precedent.source}, ${precedent.confidence}) at ${location}: ${precedent.reason}`;
+}
+
+function excludedInferenceFor(options: {
+  finding: ReactWebLabelPatchPreviewFinding;
+  previewAvailable: boolean;
+}): string[] {
+  const excluded = [
+    "Does not infer custom-component semantics.",
+    "Does not claim broad accessibility coverage beyond the native JSX label subset.",
+    "Does not auto-apply patches or make files editable from this report.",
+  ];
+  if (options.previewAvailable) {
+    excluded.push("Safe preview is a candidate diff only; it is not an applied migration.");
+  } else {
+    excluded.push("Does not generate final accessible-name copy for manual-review cards.");
+  }
+  if (options.finding.kind === "unassociated-nearby-label" && !options.previewAvailable) {
+    excluded.push("Does not infer htmlFor/id association when nearby label evidence is not high-confidence deterministic.");
+  }
+  return excluded;
+}
+
+function contextPacketFor(options: {
+  filePath: string;
+  finding: ReactWebLabelPatchPreviewFinding;
+  fixability: ReactWebIssueFixability;
+  previewAvailable: boolean;
+  relatedContext: ReactWebIssueRelatedContext[];
+}): ReactWebIssueContextPacket {
+  return {
+    whyThisFile: `Direct label-preview evidence in ${options.filePath}:${options.finding.loc.startLine}-${options.finding.loc.endLine} produced this native ${options.finding.element} issue card.`,
+    relatedPattern: contextPacketRelatedPatternFor({
+      finding: options.finding,
+      fixability: options.fixability,
+      previewAvailable: options.previewAvailable,
+    }),
+    nearbyPrecedent: contextPacketNearbyPrecedentFor(options.relatedContext),
+    confidence: options.finding.confidence,
+    excludedInference: excludedInferenceFor({
+      finding: options.finding,
+      previewAvailable: options.previewAvailable,
+    }),
+  };
+}
+
 function issueCardFor(
   filePath: string,
   finding: ReactWebLabelPatchPreviewFinding,
@@ -486,6 +567,7 @@ function issueCardFor(
     : undefined;
   const suggestedAction = suggestedFixIntentFor(finding);
   const safetyRationale = safetyRationaleFor(finding);
+  const fixability = fixabilityFor(finding);
   const fixShapeGuidance = fixShapeGuidanceFor({
     filePath,
     finding,
@@ -513,11 +595,18 @@ function issueCardFor(
     },
     relatedContext,
     confidence: finding.confidence,
-    fixability: fixabilityFor(finding),
+    fixability,
     autoFixSafety: autoFixSafetyFor(finding),
     safetyRationale,
     suggestedFixIntent: suggestedAction,
     suggestedAction,
+    contextPacket: contextPacketFor({
+      filePath,
+      finding,
+      fixability,
+      previewAvailable: Boolean(preview),
+      relatedContext,
+    }),
     fixShapeGuidance,
     ...(!isSafePreview ? { skipReason: skipReasonFor(finding) } : {}),
     ...(preview ? { preview } : {}),
@@ -744,6 +833,12 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       `- safety rationale: ${issue.safetyRationale}`,
       ...(issue.skipReason ? [`- skip reason: ${issue.skipReason}`] : []),
       `- suggested action: ${issue.suggestedAction}`,
+      "- context packet:",
+      `  - why this file: ${issue.contextPacket.whyThisFile}`,
+      `  - related pattern: ${issue.contextPacket.relatedPattern}`,
+      `  - nearby precedent: ${issue.contextPacket.nearbyPrecedent}`,
+      `  - confidence: ${issue.contextPacket.confidence}`,
+      `  - excluded inference: ${issue.contextPacket.excludedInference.join("; ")}`,
       `- fix shape: ${issue.fixShapeGuidance.shape} — ${issue.fixShapeGuidance.summary}`,
       `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
       `- context: ${issue.evidence.context}`,

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -89,6 +89,19 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.safetyRationale.length > 0);
     assert.ok(issue.suggestedFixIntent.length > 0);
     assert.equal(issue.suggestedAction, issue.suggestedFixIntent);
+    assert.equal(typeof issue.contextPacket.whyThisFile, "string");
+    assert.equal(typeof issue.contextPacket.relatedPattern, "string");
+    assert.equal(typeof issue.contextPacket.nearbyPrecedent, "string");
+    assert.equal(issue.contextPacket.confidence, issue.confidence);
+    assert.ok(Array.isArray(issue.contextPacket.excludedInference));
+    assert.ok(issue.contextPacket.excludedInference.length >= 3);
+    assert.match(issue.contextPacket.whyThisFile, /missing-labels\.tsx:\d+-\d+/);
+    assert.match(issue.contextPacket.relatedPattern, /native (button|input|select|textarea)/);
+    assert.match(issue.contextPacket.nearbyPrecedent, /same-file-pattern|nearby-test|same-directory-source|No nearby precedent/);
+    assert.ok(issue.contextPacket.excludedInference.some((entry) => /custom-component semantics/.test(entry)));
+    assert.ok(issue.contextPacket.excludedInference.some((entry) => /broad accessibility coverage/.test(entry)));
+    assert.ok(issue.contextPacket.excludedInference.some((entry) => /auto-apply patches/.test(entry)));
+    assert.doesNotMatch(JSON.stringify(issue.contextPacket), /must-edit/i);
     assert.match(issue.skipReason, /human review|accessible-name copy/);
     assert.ok(issue.triage.rank > 0);
     assert.ok(["high", "medium", "low"].includes(issue.triage.priority));
@@ -140,6 +153,8 @@ test("React Web issue report turns nearby native associations into safe preview 
   assert.equal(report.issues[0].triage.evidence.safePreviewAvailable, true);
   assert.equal(report.issues[0].triage.bucket, "safe-preview");
   assert.equal(report.issues[0].triage.rank, 1);
+  assert.match(report.issues[0].contextPacket.relatedPattern, /safe-preview pattern/);
+  assert.ok(report.issues[0].contextPacket.excludedInference.some((entry) => /candidate diff only/.test(entry)));
   assert.match(report.issues[0].preview.text, /htmlFor="email"/);
   assert.ok(report.issues.every((issue) => issue.relatedContext.length > 0));
   assert.ok(report.issues.every((issue) => issue.relatedContext.length <= 5));
@@ -259,6 +274,11 @@ test("React Web issue report recommends bounded local related context from impor
   assert.ok(entries.some((entry) => entry.file.endsWith("/Input.tsx") && entry.confidence === "medium"));
   assert.ok(entries.some((entry) => entry.kind === "nearby-test" && entry.file.endsWith("/related-context-form.test.tsx") && entry.confidence === "medium"));
   assert.ok(entries.some((entry) => entry.kind === "same-directory-source" && entry.confidence === "low"));
+  assert.match(
+    report.issues[0].contextPacket.nearbyPrecedent,
+    /(FormField\.tsx|Input\.tsx|related-context-form\.test\.tsx)/,
+  );
+  assert.match(report.issues[0].contextPacket.nearbyPrecedent, /(imported-local-component|nearby-test)/);
 
   const buttonEntries = report.issues[1].relatedContext;
   assert.ok(buttonEntries.some((entry) => entry.kind === "same-file-pattern" && entry.file.endsWith("/related-context-form.tsx")));
@@ -400,6 +420,11 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /- fixability: safe-preview/);
   assert.match(cli.stdout, /- auto-fix safety: not-auto-applied/);
   assert.match(cli.stdout, /- suggested action:/);
+  assert.match(cli.stdout, /- context packet:/);
+  assert.match(cli.stdout, /  - why this file:/);
+  assert.match(cli.stdout, /  - related pattern:/);
+  assert.match(cli.stdout, /  - nearby precedent:/);
+  assert.match(cli.stdout, /  - excluded inference:/);
   assert.match(cli.stdout, /- fix shape: safe-preview-htmlFor-association/);
   assert.match(cli.stdout, /- inspect first for fix shape:/);
   assert.match(cli.stdout, /Review the safe preview diff as a candidate shape; fooks still does not apply it/);
@@ -552,7 +577,7 @@ test("React Web issue report summary JSON is compact first-minute data without d
   assert.deepEqual(Object.hasOwn(summary, "issues"), false);
 
   const compactText = JSON.stringify(summary);
-  for (const detailedCardKey of ["issues", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
+  for (const detailedCardKey of ["issues", "contextPacket", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
     assert.equal(hasNestedKey(summary, detailedCardKey), false, `summary-json should not include detailed key ${detailedCardKey}`);
   }
   assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller/i);


### PR DESCRIPTION
## Summary
- Add per-card `contextPacket` to full React Web issue reports with `whyThisFile`, `relatedPattern`, `nearbyPrecedent`, `confidence`, and `excludedInference`.
- Render context packets in text mode while keeping `--summary-json` compact and detail-free.
- Document the context packet fields and non-claim boundaries.

## Boundaries
- Report-only / safe-preview-only: no apply, codemod, migration runner, or `.fooks` policy surface.
- Context packets explain local evidence; they do not authorize edits or infer custom-component semantics.

Closes #743

## Tests
- `npm run build && node --test test/react-web-issue-report.test.mjs`
- `npm test`