### PR TITLE
Prototype repo-owned convention hints

### DIFF
--- a/docs/repo-owned-convention-hints.md
+++ b/docs/repo-owned-convention-hints.md
@@ -1,0 +1,26 @@
+# Repo-owned convention hints prototype
+
+Repo-owned convention hints are a first prototype for future team-owned fooks checks. The current shape is intentionally internal and fixture-backed: it proves how local conventions can improve report context without creating a public config contract.
+
+## What the prototype does
+
+- Defines an internal convention-hints manifest schema.
+- Matches hints to React Web issue cards by profile, issue kind, native element, and file extension.
+- Projects matching hints into full React Web issue reports as advisory context.
+- Keeps compact summary output free of detailed convention-hint data.
+
+## Boundaries
+
+This is not the future tracked config surface yet. The first pass does **not** add tracked `.fooks` policy/check files, a public CLI, CI enforcement, merge enforcement, codemod behavior, or edit authority.
+
+Convention hints should remain inspect-first context. They may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, or custom-component semantic inference.
+
+## Graduation path
+
+A later PR can promote this internal fixture contract into tracked repo-owned config only after separately designing:
+
+1. config file names and loading precedence,
+2. schema versioning and migration rules,
+3. warning vs failure behavior,
+4. CLI/CI exposure,
+5. fixture usefulness gates for false positives and unsupported boundaries.

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -8,6 +8,10 @@ import {
   buildReactWebIssueRelatedContext,
   type ReactWebIssueRelatedContext,
 } from "./react-web-issue-related-context";
+import {
+  findRepoOwnedConventionHintsForIssue,
+  type RepoOwnedConventionHintProjection,
+} from "./repo-owned-convention-hints";
 
 export const REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION = "react-web-issue-report.v1" as const;
 export const REACT_WEB_ISSUE_REPORT_COMMAND = "inspect react-web-issues" as const;
@@ -75,6 +79,7 @@ export type ReactWebIssueContextPacket = {
   nearbyPrecedent: string;
   confidence: ReactWebIssueConfidence;
   excludedInference: string[];
+  conventionHints: string[];
 };
 
 export type ReactWebIssueCard = {
@@ -104,6 +109,7 @@ export type ReactWebIssueCard = {
   suggestedFixIntent: string;
   suggestedAction: string;
   contextPacket: ReactWebIssueContextPacket;
+  conventionHints: RepoOwnedConventionHintProjection[];
   fixShapeGuidance: ReactWebIssueFixShapeGuidance;
   triage: ReactWebIssueTriage;
   skipReason?: string;
@@ -534,6 +540,7 @@ function contextPacketFor(options: {
   fixability: ReactWebIssueFixability;
   previewAvailable: boolean;
   relatedContext: ReactWebIssueRelatedContext[];
+  conventionHints: RepoOwnedConventionHintProjection[];
 }): ReactWebIssueContextPacket {
   return {
     whyThisFile: `Direct label-preview evidence in ${options.filePath}:${options.finding.loc.startLine}-${options.finding.loc.endLine} produced this native ${options.finding.element} issue card.`,
@@ -548,6 +555,7 @@ function contextPacketFor(options: {
       finding: options.finding,
       previewAvailable: options.previewAvailable,
     }),
+    conventionHints: options.conventionHints.map((hint) => `${hint.id}: ${hint.summary}`),
   };
 }
 
@@ -568,6 +576,12 @@ function issueCardFor(
   const suggestedAction = suggestedFixIntentFor(finding);
   const safetyRationale = safetyRationaleFor(finding);
   const fixability = fixabilityFor(finding);
+  const conventionHints = findRepoOwnedConventionHintsForIssue({
+    profile: "react-web",
+    issueKind: issueKindFor(finding),
+    element: finding.element,
+    filePath,
+  });
   const fixShapeGuidance = fixShapeGuidanceFor({
     filePath,
     finding,
@@ -606,7 +620,9 @@ function issueCardFor(
       fixability,
       previewAvailable: Boolean(preview),
       relatedContext,
+      conventionHints,
     }),
+    conventionHints,
     fixShapeGuidance,
     ...(!isSafePreview ? { skipReason: skipReasonFor(finding) } : {}),
     ...(preview ? { preview } : {}),
@@ -843,6 +859,14 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       `- evidence: ${issue.evidence.sourceSignals.join(", ")}`,
       `- context: ${issue.evidence.context}`,
     );
+    if (issue.conventionHints.length > 0) {
+      lines.push("- convention hints:");
+      for (const hint of issue.conventionHints) {
+        lines.push(`  - ${hint.id} (${hint.confidence}, advisory): ${hint.summary}`);
+        lines.push(`    boundary: ${hint.policyBoundary}`);
+        lines.push(`    inspect first: ${hint.inspectFirst.join("; ")}`);
+      }
+    }
     if (issue.fixShapeGuidance.inspectFirst.length > 0) {
       lines.push("- inspect first for fix shape:");
       for (const item of issue.fixShapeGuidance.inspectFirst) {

--- a/src/core/repo-owned-convention-hints.ts
+++ b/src/core/repo-owned-convention-hints.ts
@@ -1,0 +1,204 @@
+export const REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION = "repo-owned-convention-hints.prototype.v1" as const;
+export const REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY =
+  "Internal fixture-backed convention-hints prototype only: advisory report context, no public config contract, no CI enforcement, no edit authority, and no broad semantic inference." as const;
+
+type RepoOwnedConventionHintProfile = "react-web";
+type RepoOwnedConventionHintConfidence = "high" | "medium" | "low";
+
+type RepoOwnedConventionHintAppliesTo = {
+  profile: RepoOwnedConventionHintProfile;
+  issueKinds: string[];
+  elements?: string[];
+  filePatterns?: string[];
+};
+
+export type RepoOwnedConventionHint = {
+  id: string;
+  purpose: "convention-hint";
+  source: "internal-prototype-fixture";
+  advisoryOnly: true;
+  enforcement: "none";
+  publicConfig: false;
+  appliesTo: RepoOwnedConventionHintAppliesTo;
+  confidence: RepoOwnedConventionHintConfidence;
+  summary: string;
+  inspectFirst: string[];
+  policyBoundary: string;
+  excludedInference: string[];
+};
+
+export type RepoOwnedConventionHintsManifest = {
+  schemaVersion: typeof REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION;
+  claimBoundary: typeof REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY;
+  hints: RepoOwnedConventionHint[];
+};
+
+export type RepoOwnedConventionHintMatchInput = {
+  profile: RepoOwnedConventionHintProfile;
+  issueKind: string;
+  element: string;
+  filePath: string;
+};
+
+export type RepoOwnedConventionHintProjection = {
+  id: string;
+  summary: string;
+  inspectFirst: string[];
+  confidence: RepoOwnedConventionHintConfidence;
+  policyBoundary: string;
+  excludedInference: string[];
+  advisoryOnly: true;
+  enforcement: "none";
+  source: "internal-prototype-fixture";
+};
+
+const UNSAFE_HINT_WORDING = /\b(?:must-edit|auto-apply|ci gate|merge gate|public config contract)\b/i;
+
+export const REPO_OWNED_CONVENTION_HINTS_PROTOTYPE: RepoOwnedConventionHintsManifest = {
+  schemaVersion: REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION,
+  claimBoundary: REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY,
+  hints: [
+    {
+      id: "react-web.native-label-context",
+      purpose: "convention-hint",
+      source: "internal-prototype-fixture",
+      advisoryOnly: true,
+      enforcement: "none",
+      publicConfig: false,
+      appliesTo: {
+        profile: "react-web",
+        issueKinds: [
+          "react-web.missing-accessible-label",
+          "react-web.ambiguous-accessible-label",
+          "react-web.unassociated-nearby-label",
+        ],
+        elements: ["button", "input", "select", "textarea"],
+        filePatterns: ["*.tsx", "*.jsx"],
+      },
+      confidence: "medium",
+      summary:
+        "Prefer existing visible label, nearby native label/control structure, or source-observed naming hints before choosing final accessible-name copy.",
+      inspectFirst: [
+        "Inspect same-file JSX around the native control before using broader conventions.",
+        "Use local related-context entries as evidence hints only; final label/name decisions stay human-reviewed.",
+      ],
+      policyBoundary:
+        "Advisory convention hint only; it does not enforce team policy, authorize edits, or infer custom-component semantics.",
+      excludedInference: [
+        "Does not create a public repo config contract.",
+        "Does not enforce CI or merge policy.",
+        "Does not authorize edits or generated accessible-name copy.",
+      ],
+    },
+  ],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid convention hint manifest: ${label} must be a non-empty string`);
+  }
+  if (UNSAFE_HINT_WORDING.test(value)) {
+    throw new Error(`Invalid convention hint manifest: ${label} contains enforcement or apply-authority wording`);
+  }
+  return value;
+}
+
+function assertStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid convention hint manifest: ${label} must be a non-empty string array`);
+  }
+  return value.map((item, index) => assertString(item, `${label}[${index}]`));
+}
+
+function assertLiteral<T extends string | boolean>(value: unknown, expected: T, label: string): T {
+  if (value !== expected) {
+    throw new Error(`Invalid convention hint manifest: ${label} must be ${String(expected)}`);
+  }
+  return expected;
+}
+
+function parseHint(value: unknown, index: number): RepoOwnedConventionHint {
+  if (!isRecord(value)) throw new Error(`Invalid convention hint manifest: hints[${index}] must be an object`);
+  const appliesTo = value.appliesTo;
+  if (!isRecord(appliesTo)) throw new Error(`Invalid convention hint manifest: hints[${index}].appliesTo must be an object`);
+  const profile = assertString(appliesTo.profile, `hints[${index}].appliesTo.profile`);
+  if (profile !== "react-web") throw new Error(`Invalid convention hint manifest: hints[${index}].appliesTo.profile is unsupported`);
+  const confidence = assertString(value.confidence, `hints[${index}].confidence`);
+  if (!(["high", "medium", "low"] as string[]).includes(confidence)) {
+    throw new Error(`Invalid convention hint manifest: hints[${index}].confidence is unsupported`);
+  }
+  const hint: RepoOwnedConventionHint = {
+    id: assertString(value.id, `hints[${index}].id`),
+    purpose: assertLiteral(value.purpose, "convention-hint", `hints[${index}].purpose`),
+    source: assertLiteral(value.source, "internal-prototype-fixture", `hints[${index}].source`),
+    advisoryOnly: assertLiteral(value.advisoryOnly, true, `hints[${index}].advisoryOnly`),
+    enforcement: assertLiteral(value.enforcement, "none", `hints[${index}].enforcement`),
+    publicConfig: assertLiteral(value.publicConfig, false, `hints[${index}].publicConfig`),
+    appliesTo: {
+      profile,
+      issueKinds: assertStringArray(appliesTo.issueKinds, `hints[${index}].appliesTo.issueKinds`),
+      ...(appliesTo.elements === undefined ? {} : { elements: assertStringArray(appliesTo.elements, `hints[${index}].appliesTo.elements`) }),
+      ...(appliesTo.filePatterns === undefined ? {} : { filePatterns: assertStringArray(appliesTo.filePatterns, `hints[${index}].appliesTo.filePatterns`) }),
+    },
+    confidence: confidence as RepoOwnedConventionHintConfidence,
+    summary: assertString(value.summary, `hints[${index}].summary`),
+    inspectFirst: assertStringArray(value.inspectFirst, `hints[${index}].inspectFirst`),
+    policyBoundary: assertString(value.policyBoundary, `hints[${index}].policyBoundary`),
+    excludedInference: assertStringArray(value.excludedInference, `hints[${index}].excludedInference`),
+  };
+  return hint;
+}
+
+export function parseRepoOwnedConventionHintsManifest(value: unknown): RepoOwnedConventionHintsManifest {
+  if (!isRecord(value)) throw new Error("Invalid convention hint manifest: root must be an object");
+  if (value.schemaVersion !== REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION) {
+    throw new Error("Invalid convention hint manifest: unsupported schemaVersion");
+  }
+  if (value.claimBoundary !== REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY) {
+    throw new Error("Invalid convention hint manifest: claimBoundary must match the prototype boundary");
+  }
+  if (!Array.isArray(value.hints)) throw new Error("Invalid convention hint manifest: hints must be an array");
+  return {
+    schemaVersion: REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION,
+    claimBoundary: REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY,
+    hints: value.hints.map(parseHint),
+  };
+}
+
+function filePatternMatches(filePath: string, pattern: string): boolean {
+  if (pattern === "*.tsx") return filePath.endsWith(".tsx");
+  if (pattern === "*.jsx") return filePath.endsWith(".jsx");
+  return filePath.includes(pattern.replaceAll("*", ""));
+}
+
+function hintMatches(hint: RepoOwnedConventionHint, input: RepoOwnedConventionHintMatchInput): boolean {
+  if (hint.appliesTo.profile !== input.profile) return false;
+  if (!hint.appliesTo.issueKinds.includes(input.issueKind)) return false;
+  if (hint.appliesTo.elements && !hint.appliesTo.elements.includes(input.element)) return false;
+  if (hint.appliesTo.filePatterns && !hint.appliesTo.filePatterns.some((pattern) => filePatternMatches(input.filePath, pattern))) return false;
+  return true;
+}
+
+export function findRepoOwnedConventionHintsForIssue(
+  input: RepoOwnedConventionHintMatchInput,
+  manifest: RepoOwnedConventionHintsManifest = REPO_OWNED_CONVENTION_HINTS_PROTOTYPE,
+): RepoOwnedConventionHintProjection[] {
+  const parsed = parseRepoOwnedConventionHintsManifest(manifest);
+  return parsed.hints
+    .filter((hint) => hintMatches(hint, input))
+    .map((hint) => ({
+      id: hint.id,
+      summary: hint.summary,
+      inspectFirst: [...hint.inspectFirst],
+      confidence: hint.confidence,
+      policyBoundary: hint.policyBoundary,
+      excludedInference: [...hint.excludedInference],
+      advisoryOnly: hint.advisoryOnly,
+      enforcement: hint.enforcement,
+      source: hint.source,
+    }));
+}

--- a/test/fixtures/repo-owned-convention-hints/react-web-conventions.json
+++ b/test/fixtures/repo-owned-convention-hints/react-web-conventions.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "repo-owned-convention-hints.prototype.v1",
+  "claimBoundary": "Internal fixture-backed convention-hints prototype only: advisory report context, no public config contract, no CI enforcement, no edit authority, and no broad semantic inference.",
+  "hints": [
+    {
+      "id": "react-web.native-label-context",
+      "purpose": "convention-hint",
+      "source": "internal-prototype-fixture",
+      "advisoryOnly": true,
+      "enforcement": "none",
+      "publicConfig": false,
+      "appliesTo": {
+        "profile": "react-web",
+        "issueKinds": [
+          "react-web.missing-accessible-label",
+          "react-web.ambiguous-accessible-label",
+          "react-web.unassociated-nearby-label"
+        ],
+        "elements": ["button", "input", "select", "textarea"],
+        "filePatterns": ["*.tsx", "*.jsx"]
+      },
+      "confidence": "medium",
+      "summary": "Prefer existing visible label, nearby native label/control structure, or source-observed naming hints before choosing final accessible-name copy.",
+      "inspectFirst": [
+        "Inspect same-file JSX around the native control before using broader conventions.",
+        "Use local related-context entries as evidence hints only; final label/name decisions stay human-reviewed."
+      ],
+      "policyBoundary": "Advisory convention hint only; it does not enforce team policy, authorize edits, or infer custom-component semantics.",
+      "excludedInference": [
+        "Does not create a public repo config contract.",
+        "Does not enforce CI or merge policy.",
+        "Does not authorize edits or generated accessible-name copy."
+      ]
+    }
+  ]
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -102,6 +102,16 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.ok(issue.contextPacket.excludedInference.some((entry) => /broad accessibility coverage/.test(entry)));
     assert.ok(issue.contextPacket.excludedInference.some((entry) => /auto-apply patches/.test(entry)));
     assert.doesNotMatch(JSON.stringify(issue.contextPacket), /must-edit/i);
+    assert.ok(Array.isArray(issue.contextPacket.conventionHints));
+    assert.ok(issue.contextPacket.conventionHints.some((entry) => /react-web\.native-label-context/.test(entry)));
+    assert.ok(Array.isArray(issue.conventionHints));
+    assert.equal(issue.conventionHints.length, 1);
+    assert.equal(issue.conventionHints[0].id, "react-web.native-label-context");
+    assert.equal(issue.conventionHints[0].advisoryOnly, true);
+    assert.equal(issue.conventionHints[0].enforcement, "none");
+    assert.equal(issue.conventionHints[0].source, "internal-prototype-fixture");
+    assert.match(issue.conventionHints[0].policyBoundary, /Advisory convention hint only/);
+    assert.doesNotMatch(JSON.stringify(issue.conventionHints), /must-edit|auto-apply|CI gate|merge gate/i);
     assert.match(issue.skipReason, /human review|accessible-name copy/);
     assert.ok(issue.triage.rank > 0);
     assert.ok(["high", "medium", "low"].includes(issue.triage.priority));
@@ -425,6 +435,9 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /  - related pattern:/);
   assert.match(cli.stdout, /  - nearby precedent:/);
   assert.match(cli.stdout, /  - excluded inference:/);
+  assert.match(cli.stdout, /- convention hints:/);
+  assert.match(cli.stdout, /react-web\.native-label-context/);
+  assert.match(cli.stdout, /Advisory convention hint only/);
   assert.match(cli.stdout, /- fix shape: safe-preview-htmlFor-association/);
   assert.match(cli.stdout, /- inspect first for fix shape:/);
   assert.match(cli.stdout, /Review the safe preview diff as a candidate shape; fooks still does not apply it/);
@@ -577,7 +590,7 @@ test("React Web issue report summary JSON is compact first-minute data without d
   assert.deepEqual(Object.hasOwn(summary, "issues"), false);
 
   const compactText = JSON.stringify(summary);
-  for (const detailedCardKey of ["issues", "contextPacket", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
+  for (const detailedCardKey of ["issues", "contextPacket", "conventionHints", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
     assert.equal(hasNestedKey(summary, detailedCardKey), false, `summary-json should not include detailed key ${detailedCardKey}`);
   }
   assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller/i);

--- a/test/repo-owned-convention-hints.test.mjs
+++ b/test/repo-owned-convention-hints.test.mjs
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const {
+  REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY,
+  REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION,
+  findRepoOwnedConventionHintsForIssue,
+  parseRepoOwnedConventionHintsManifest,
+} = require(path.join(repoRoot, "dist", "core", "repo-owned-convention-hints.js"));
+
+const fixturePath = path.join(repoRoot, "test", "fixtures", "repo-owned-convention-hints", "react-web-conventions.json");
+
+function fixtureManifest() {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+}
+
+test("repo-owned convention hints parse an internal fixture-backed prototype manifest", () => {
+  const manifest = parseRepoOwnedConventionHintsManifest(fixtureManifest());
+
+  assert.equal(manifest.schemaVersion, REPO_OWNED_CONVENTION_HINTS_SCHEMA_VERSION);
+  assert.equal(manifest.claimBoundary, REPO_OWNED_CONVENTION_HINTS_CLAIM_BOUNDARY);
+  assert.equal(manifest.hints.length, 1);
+  assert.deepEqual(manifest.hints.map((hint) => [hint.id, hint.purpose, hint.source, hint.enforcement, hint.publicConfig]), [
+    ["react-web.native-label-context", "convention-hint", "internal-prototype-fixture", "none", false],
+  ]);
+
+  const hint = manifest.hints[0];
+  assert.equal(hint.advisoryOnly, true);
+  assert.equal(hint.appliesTo.profile, "react-web");
+  assert.ok(hint.appliesTo.issueKinds.includes("react-web.missing-accessible-label"));
+  assert.ok(hint.inspectFirst.length >= 2);
+  assert.ok(hint.excludedInference.some((entry) => /public repo config contract/.test(entry)));
+  assert.ok(hint.excludedInference.some((entry) => /CI or merge policy/.test(entry)));
+  assert.doesNotMatch(JSON.stringify(hint), /must-edit|auto-apply|CI gate|merge gate/i);
+});
+
+test("repo-owned convention hints match React Web issue facts without public config loading", () => {
+  const hints = findRepoOwnedConventionHintsForIssue(
+    {
+      profile: "react-web",
+      issueKind: "react-web.missing-accessible-label",
+      element: "input",
+      filePath: "test/fixtures/react-web-label-preview/missing-labels.tsx",
+    },
+    parseRepoOwnedConventionHintsManifest(fixtureManifest()),
+  );
+
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].id, "react-web.native-label-context");
+  assert.equal(hints[0].advisoryOnly, true);
+  assert.equal(hints[0].enforcement, "none");
+  assert.equal(hints[0].source, "internal-prototype-fixture");
+  assert.match(hints[0].policyBoundary, /Advisory convention hint only/);
+  assert.doesNotMatch(JSON.stringify(hints), /must-edit|auto-apply|CI gate|merge gate/i);
+
+  assert.deepEqual(
+    findRepoOwnedConventionHintsForIssue({
+      profile: "react-web",
+      issueKind: "react-web.missing-accessible-label",
+      element: "input",
+      filePath: "fixtures/example.ts",
+    }, parseRepoOwnedConventionHintsManifest(fixtureManifest())),
+    [],
+  );
+});
+
+test("repo-owned convention hints reject enforcement and apply-authority wording", () => {
+  const manifest = fixtureManifest();
+  manifest.hints[0].summary = "This convention must-edit the file";
+
+  assert.throws(
+    () => parseRepoOwnedConventionHintsManifest(manifest),
+    /enforcement or apply-authority wording/,
+  );
+
+  const enforced = fixtureManifest();
+  enforced.hints[0].enforcement = "warning";
+  assert.throws(
+    () => parseRepoOwnedConventionHintsManifest(enforced),
+    /enforcement must be none/,
+  );
+
+  const publicConfig = fixtureManifest();
+  publicConfig.hints[0].publicConfig = true;
+  assert.throws(
+    () => parseRepoOwnedConventionHintsManifest(publicConfig),
+    /publicConfig must be false/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add an internal fixture-backed repo-owned convention-hints schema/parser.
- Surface matching advisory convention hints on full React Web issue cards and text reports.
- Keep summary JSON compact and document that tracked `.fooks` config / CLI / CI enforcement are future work.

## Boundaries
- No public CLI or tracked `.fooks` config.
- No CI/merge enforcement.
- No apply, auto-fix, codemod, or must-edit authority.
- Hints remain advisory inspect-first context only.

Closes #744

## Tests
- `npm run build && node --test test/repo-owned-convention-hints.test.mjs test/react-web-issue-report.test.mjs`
- `npm test`
