### PR TITLE
Make React Web first-minute summary actionable

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -125,6 +125,11 @@ export type ReactWebIssueFirstMinuteSummaryItem = {
   fixShape: ReactWebIssueFixShape;
   firstInspectStep: string;
   inspectFirst: string[];
+  whyThisFirst: string;
+  nextAction: string;
+  humanDecisionNeeded: string[];
+  doNotDo: string[];
+  contextHints: string[];
   fixShapeGuidance: {
     claimBoundary: ReactWebIssueFixShapeGuidance["claimBoundary"];
     humanReviewRequired: true;
@@ -703,6 +708,75 @@ function firstInspectStepFor(issue: ReactWebIssueCard): string {
   return issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`;
 }
 
+function trimSummaryText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function uniqueCompactStrings(values: string[], maxItems: number, maxLength: number): string[] {
+  const seen = new Set<string>();
+  const compact: string[] = [];
+  for (const value of values) {
+    const normalized = trimSummaryText(value.replace(/\s+/g, " ").trim(), maxLength);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    compact.push(normalized);
+    if (compact.length >= maxItems) break;
+  }
+  return compact;
+}
+
+function whyThisFirstFor(issue: ReactWebIssueCard): string {
+  const reason = issue.triage.evidence.reasons[0] ?? `${issue.triage.evidence.relatedContextQuality} local context`;
+  return trimSummaryText(
+    `Rank ${issue.triage.rank} ${issue.triage.priority} issue because ${reason}; ${issue.triage.bucket} remains human-reviewed.`,
+    180,
+  );
+}
+
+function nextActionFor(issue: ReactWebIssueCard): string {
+  return trimSummaryText(`Start by ${firstInspectStepFor(issue).replace(/^Inspect/u, "inspecting")}`, 180);
+}
+
+function humanDecisionNeededFor(issue: ReactWebIssueCard): string[] {
+  const decisions = ["Review the final accessible label/name copy."];
+  if (issue.fixability === "safe-preview") {
+    decisions.push("Confirm the htmlFor/id association before using the preview shape.");
+  } else {
+    decisions.push("Choose the label/name shape from local JSX evidence.");
+  }
+  return uniqueCompactStrings(decisions, 2, 120);
+}
+
+function doNotDoFor(): string[] {
+  return uniqueCompactStrings(
+    [
+      "Do not apply patches automatically from this report.",
+      "Do not infer custom-component semantics.",
+      "Do not generate accessible-name copy automatically.",
+    ],
+    3,
+    120,
+  );
+}
+
+function contextHintsFor(issue: ReactWebIssueCard): string[] {
+  const hints = [
+    `native ${issue.evidence.element} at ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
+    `${issue.triage.evidence.relatedContextQuality} context`,
+  ];
+  if (issue.triage.evidence.safePreviewAvailable) {
+    hints.push("safe-preview candidate available");
+  }
+  if (issue.triage.evidence.relatedContextSources.length > 0) {
+    hints.push(`related sources: ${issue.triage.evidence.relatedContextSources.slice(0, 3).join(", ")}`);
+  }
+  for (const hint of issue.conventionHints.slice(0, 1)) {
+    hints.push(`advisory convention: ${hint.id}`);
+  }
+  return uniqueCompactStrings(hints, 4, 100);
+}
+
 function buildFirstMinuteSummary(
   triageRollup: ReactWebIssueReport["triageRollup"],
   issues: ReactWebIssueCard[],
@@ -716,6 +790,11 @@ function buildFirstMinuteSummary(
       fixShape: issue.fixShapeGuidance.shape,
       firstInspectStep: firstInspectStepFor(issue),
       inspectFirst: [...issue.fixShapeGuidance.inspectFirst],
+      whyThisFirst: whyThisFirstFor(issue),
+      nextAction: nextActionFor(issue),
+      humanDecisionNeeded: humanDecisionNeededFor(issue),
+      doNotDo: doNotDoFor(),
+      contextHints: contextHintsFor(issue),
       fixShapeGuidance: {
         claimBoundary: issue.fixShapeGuidance.claimBoundary,
         humanReviewRequired: issue.fixShapeGuidance.humanReviewRequired,
@@ -817,19 +896,20 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
     `- criteria: ${report.triageRollup.criteria.join("; ")}`,
   );
 
-  const issuesById = new Map(report.issues.map((issue) => [issue.id, issue]));
-  const compactIssues = report.triageRollup.topIssueIds
-    .map((id) => issuesById.get(id))
-    .filter((issue): issue is ReactWebIssueCard => Boolean(issue));
-  if (compactIssues.length > 0) {
+  if (report.firstMinuteSummary.items.length > 0) {
     lines.push(
       "",
       "## First-minute summary",
       "- Compact read-only triage from existing ranked issue evidence; inspect before editing and keep human review for final label/name decisions.",
     );
-    for (const issue of compactIssues) {
+    for (const item of report.firstMinuteSummary.items) {
       lines.push(
-        `- ${issue.id}: ${issue.fixShapeGuidance.shape}; first inspect: ${issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`}`,
+        `- ${item.issueId}: ${item.fixShape}; first inspect: ${item.firstInspectStep}`,
+        `  - why this first: ${item.whyThisFirst}`,
+        `  - next action: ${item.nextAction}`,
+        `  - human decision needed: ${item.humanDecisionNeeded.join("; ")}`,
+        `  - do not do: ${item.doNotDo.join("; ")}`,
+        `  - context hints: ${item.contextHints.join("; ")}`,
       );
     }
   }

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -17,6 +17,7 @@ const {
   REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
   buildReactWebIssueReport,
   buildReactWebIssueReportSummaryJson,
+  renderReactWebIssueReportText,
 } = require(path.join(repoRoot, "dist", "core", "react-web-issue-report.js"));
 
 const fixtures = {
@@ -47,6 +48,51 @@ function hasNestedKey(value, key) {
   if (!value || typeof value !== "object") return false;
   if (Object.hasOwn(value, key)) return true;
   return Object.values(value).some((entry) => hasNestedKey(entry, key));
+}
+
+function assertCompactFirstMinuteItem(item) {
+  assert.equal(typeof item.whyThisFirst, "string");
+  assert.ok(item.whyThisFirst.length > 0);
+  assert.ok(item.whyThisFirst.length <= 180, item.whyThisFirst);
+  assert.equal(typeof item.nextAction, "string");
+  assert.ok(item.nextAction.length > 0);
+  assert.ok(item.nextAction.length <= 180, item.nextAction);
+
+  assert.ok(Array.isArray(item.humanDecisionNeeded));
+  assert.ok(item.humanDecisionNeeded.length >= 1);
+  assert.ok(item.humanDecisionNeeded.length <= 2);
+  assert.ok(Array.isArray(item.doNotDo));
+  assert.ok(item.doNotDo.length >= 2);
+  assert.ok(item.doNotDo.length <= 3);
+  assert.ok(Array.isArray(item.contextHints));
+  assert.ok(item.contextHints.length >= 1);
+  assert.ok(item.contextHints.length <= 4);
+
+  for (const entry of [...item.humanDecisionNeeded, ...item.doNotDo]) {
+    assert.equal(typeof entry, "string");
+    assert.ok(entry.length > 0);
+    assert.ok(entry.length <= 120, entry);
+  }
+  for (const entry of item.contextHints) {
+    assert.equal(typeof entry, "string");
+    assert.ok(entry.length > 0);
+    assert.ok(entry.length <= 100, entry);
+  }
+
+  assert.ok(item.humanDecisionNeeded.some((entry) => /label\/name|copy|shape/i.test(entry)));
+  assert.ok(item.doNotDo.some((entry) => /apply|patch/i.test(entry)));
+  assert.ok(item.doNotDo.some((entry) => /custom-component semantics/i.test(entry)));
+  assert.ok(item.contextHints.some((entry) => /native|context|source|convention|preview/i.test(entry)));
+
+  const compactText = JSON.stringify({
+    whyThisFirst: item.whyThisFirst,
+    nextAction: item.nextAction,
+    humanDecisionNeeded: item.humanDecisionNeeded,
+    doNotDo: item.doNotDo,
+    contextHints: item.contextHints,
+  });
+  assert.doesNotMatch(compactText, /contextPacket|conventionHints|relatedContext|sourceSignals|suggestedAction|whereToLook|whyItMatters|problem/i);
+  assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|CI gate|merge gate|generated accessible-name copy/i);
 }
 
 
@@ -515,6 +561,10 @@ test("React Web issue report JSON includes machine-readable first-minute summary
       issue.fixShapeGuidance.inspectFirst[0] ?? `${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
     );
     assert.deepEqual(item.inspectFirst, issue.fixShapeGuidance.inspectFirst);
+    assertCompactFirstMinuteItem(item);
+    assert.match(item.whyThisFirst, new RegExp(`Rank ${issue.triage.rank} ${issue.triage.priority} issue`));
+    assert.match(item.nextAction, /Start by inspecting/);
+    assert.ok(item.contextHints.some((entry) => entry.includes(issue.evidence.element)));
     assert.equal(item.fixShapeGuidance.claimBoundary, issue.fixShapeGuidance.claimBoundary);
     assert.equal(item.fixShapeGuidance.humanReviewRequired, true);
     assert.equal(item.fixShapeGuidance.autoApply, false);
@@ -543,6 +593,30 @@ test("React Web issue report JSON includes machine-readable first-minute summary
   assert.doesNotMatch(JSON.stringify(report.firstMinuteSummary), /must-edit|Auto-apply: yes|Controller/i);
 });
 
+test("React Web issue report text renders first-minute summary from canonical projection", () => {
+  const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
+  report.firstMinuteSummary.items[0] = {
+    ...report.firstMinuteSummary.items[0],
+    whyThisFirst: "SENTINEL why from canonical summary.",
+    nextAction: "SENTINEL next action from canonical summary.",
+    humanDecisionNeeded: ["SENTINEL human decision."],
+    doNotDo: ["SENTINEL do not do one.", "SENTINEL do not do two."],
+    contextHints: ["SENTINEL context hint."],
+  };
+
+  const text = renderReactWebIssueReportText(report);
+  const summaryIndex = text.indexOf("## First-minute summary");
+  const issueIndex = text.indexOf("## Issue 1:");
+  assert.ok(summaryIndex > 0);
+  assert.ok(issueIndex > summaryIndex);
+  const compactBlock = text.slice(summaryIndex, issueIndex);
+
+  assert.match(compactBlock, /SENTINEL why from canonical summary/);
+  assert.match(compactBlock, /SENTINEL next action from canonical summary/);
+  assert.match(compactBlock, /SENTINEL human decision/);
+  assert.match(compactBlock, /SENTINEL do not do one/);
+  assert.match(compactBlock, /SENTINEL context hint/);
+});
 
 test("React Web issue report summary JSON is compact first-minute data without detailed issue cards", () => {
   const fullCli = runIssues(fixtures.formControls, "--json");
@@ -587,6 +661,9 @@ test("React Web issue report summary JSON is compact first-minute data without d
     "react-web-label-5",
   ]);
   assert.deepEqual(summary.firstMinuteSummary.sourceTopIssueIds, summary.triageTopIds.topIssueIds);
+  for (const item of summary.firstMinuteSummary.items) {
+    assertCompactFirstMinuteItem(item);
+  }
   assert.deepEqual(Object.hasOwn(summary, "issues"), false);
 
   const compactText = JSON.stringify(summary);


### PR DESCRIPTION
Closes #746

## Summary
- extend React Web `firstMinuteSummary.items[]` with compact work-order fields: `whyThisFirst`, `nextAction`, `humanDecisionNeeded`, `doNotDo`, and `contextHints`
- render the text-mode first-minute block from the canonical `report.firstMinuteSummary.items[]` projection
- add compactness/leakage/canonical-source regression tests while preserving read-only and no-ranking-change boundaries

## Verification
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs test/repo-owned-convention-hints.test.mjs` — 19/19 pass
- `npm test` — 738/738 pass

## Boundaries
- no auto-apply/codemod behavior
- no ranking or priority algorithm changes
- no RN/TUI/WebView fixture expansion
- repo-owned convention hints remain advisory compact context only
