### PR TITLE
Document React Web first-minute work orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ npm test
 Useful public docs:
 
 - Architecture boundaries for source facts, evidence gates, and reporting-vs-authorization separation: [`docs/architecture-boundaries.md`](docs/architecture-boundaries.md)
+- React Web first-minute work-order flow for human maintainers: [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md)
 - Setup details: [`docs/setup.md`](docs/setup.md)
 - opencode support boundary: [`docs/opencode-read-interception.md`](docs/opencode-read-interception.md)
 - Release checklist: [`docs/release.md`](docs/release.md)

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -1,0 +1,75 @@
+# React Web first-minute work orders
+
+This note explains how a human maintainer should read the current React Web first-minute summary. It is documentation for the existing `fooks inspect react-web-issues` report surfaces, not a new apply path or a broader product claim.
+
+## Before and after
+
+Before #747, maintainers and agents had to interpret a longer issue report:
+
+```text
+source-derived React Web evidence
+  -> ranked issue cards with problem / why it matters / where to look / confidence
+  -> human or agent decides which card matters first, what to inspect, and what not to change
+```
+
+After #747, the same report also carries a compact first-minute mini work order:
+
+```text
+source-derived React Web evidence
+  -> ranked issue cards
+  -> firstMinuteSummary
+       -> why this issue is first
+       -> first inspect step
+       -> next action
+       -> human decision needed
+       -> do-not-do boundaries
+       -> compact context hints
+```
+
+The goal is to make the first minute legible: a maintainer can see which native-control card to inspect first, why it was prioritized, and which decisions still require human review before any edit happens.
+
+## Current CLI surfaces
+
+Use the text report when a person wants the compact work order before the detailed cards:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx
+```
+
+Use full JSON when another tool needs the complete issue cards plus `firstMinuteSummary`:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx --json
+```
+
+Use the compact projection when another tool only needs the first-minute work-order data and top IDs, without detailed issue cards:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx --summary-json
+```
+
+`--summary-json` is intentionally smaller than full `--json`: it keeps the first-minute summary, rollup IDs, read-only flags, and claim boundary, while omitting detailed card fields such as source snippets, preview details, context packets, and suggested actions.
+
+## What the mini work order is allowed to say
+
+A first-minute mini work order is an inspect-first handoff. It can point at the top ranked React Web native-control issue and summarize:
+
+- why this issue appears first in the ranked evidence;
+- the first inspect step to take in the source file;
+- the next action shape, such as reviewing a native label/control association;
+- the human decision needed before choosing final copy or a fix;
+- do-not-do boundaries that keep the report advisory;
+- compact context hints from existing source attributes or nearby evidence.
+
+## Boundaries that must stay explicit
+
+The React Web first-minute work order is conservative by design:
+
+- **Read-only:** it reports source-derived evidence and does not edit files.
+- **No auto-apply:** it does not apply patches, trigger codemods, or authorize automatic changes.
+- **No generated accessible-name copy:** it does not invent final label text, aria-label text, or other accessible-name copy; a human or agent must choose copy from product context.
+- **No broad accessibility audit:** it is a narrow native-control form/accessibility issue report, not a complete WCAG or design-system audit.
+- **No custom-component semantic inference:** custom components remain manual-review evidence unless native-control facts are explicit enough.
+- **No RN/TUI/WebView expansion:** React Native, TUI / React CLI, WebView, Vue/SFC, broad TS/JS, and multi-file refactor lanes remain outside this work-order claim unless future evidence and policy gates promote them.
+
+Keep future wording tied to the current inspect surfaces and these boundaries. If a future issue adds apply behavior, generated copy, broader accessibility coverage, custom-component semantics, or new runtime lanes, that should be documented as a separate capability with separate tests and evidence.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "docs/setup.md",
     "docs/release.md",
     "docs/roadmap.md",
+    "docs/react-web-first-minute-work-orders.md",
     "docs/rn-webview-architecture.md",
     "docs/usage-log-boundary.md",
     "docs/provider-tokenizer-boundary.md",

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -175,6 +175,7 @@ function assertPackedFiles(packEntry) {
     "docs/setup.md",
     "docs/release.md",
     "docs/roadmap.md",
+    "docs/react-web-first-minute-work-orders.md",
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4964,6 +4964,44 @@ test("docs describe opencode as manual custom-tool support without runtime savin
   assert.equal(releaseSmoke.includes('run("npm", ["publish"'), false);
 });
 
+
+test("React Web first-minute work-order docs stay discoverable and boundary-scoped", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  const docPath = path.join(repoRoot, "docs", "react-web-first-minute-work-orders.md");
+  const doc = fs.readFileSync(docPath, "utf8");
+  const releaseSmoke = fs.readFileSync(path.join(repoRoot, "scripts", "release-smoke.mjs"), "utf8");
+
+  assert.match(readme, /docs\/react-web-first-minute-work-orders\.md/);
+  assert.ok(pkg.files.includes("docs/react-web-first-minute-work-orders.md"));
+  assert.match(releaseSmoke, /docs\/react-web-first-minute-work-orders\.md/);
+
+  assert.match(doc, /first-minute mini work order/i);
+  assert.match(doc, /Before and after/);
+  assert.match(doc, /ranked issue cards[\s\S]*firstMinuteSummary[\s\S]*--summary-json|firstMinuteSummary[\s\S]*compact first-minute/);
+  assert.match(doc, /fooks inspect react-web-issues src\/components\/Form\.tsx/);
+  assert.match(doc, /--json/);
+  assert.match(doc, /--summary-json/);
+  assert.match(doc, /first inspect step/i);
+  assert.match(doc, /next action/i);
+  assert.match(doc, /human decision needed/i);
+  assert.match(doc, /do-not-do boundaries/i);
+  assert.match(doc, /compact context hints/i);
+
+  assert.match(doc, /Read-only:[\s\S]*does not edit files/);
+  assert.match(doc, /No auto-apply:[\s\S]*does not apply patches/);
+  assert.match(doc, /No generated accessible-name copy:[\s\S]*does not invent final label text/);
+  assert.match(doc, /No broad accessibility audit:[\s\S]*not a complete WCAG or design-system audit/);
+  assert.match(doc, /No custom-component semantic inference:[\s\S]*manual-review evidence/);
+  assert.match(doc, /No RN\/TUI\/WebView expansion:[\s\S]*outside this work-order claim/);
+
+  assert.doesNotMatch(doc, /Auto-apply: yes|must-edit|automatically edits files/i);
+  assert.doesNotMatch(doc, /generates? (?:final )?(?:label text|aria-label text|accessible-name copy)/i);
+  assert.doesNotMatch(doc, /complete WCAG audit|broad accessibility audit available/i);
+  assert.doesNotMatch(doc, /infers? custom-component semantics/i);
+  assert.doesNotMatch(doc, /React Native support is available|WebView support is available|TUI support is available/i);
+});
+
 test("package release surface keeps internal docs out of the npm tarball", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");


### PR DESCRIPTION
Closes #748

## Summary
- add a maintainer-facing React Web first-minute work-order doc with before/after text diagrams
- tie the explanation to `fooks inspect react-web-issues`, `--json`, and `--summary-json`
- link and package the doc, and add assertions so docs stay read-only and boundary-scoped

## Boundaries
- no runtime behavior changes
- no auto-apply/codemod behavior
- no generated accessible-name copy
- no broad accessibility audit
- no custom-component semantic inference
- no RN/TUI/WebView support expansion

## Verification
- `npm run build`
- `node --test test/fooks.test.mjs test/claim-boundary-doc-audit.test.mjs`
- `npm pack --dry-run --json` — confirmed `docs/react-web-first-minute-work-orders.md` is packed
- `npm test` — 739/739 pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
