### PR TITLE
Expand React Web issue-report fixture coverage

### DIFF
--- a/test/fixtures/react-web-label-preview/expanded-native-controls.tsx
+++ b/test/fixtures/react-web-label-preview/expanded-native-controls.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+
+function DesignSystemField(_props: { label: string; name: string }) {
+  return null;
+}
+
+export function ExpandedNativeControls() {
+  const [email, setEmail] = useState("");
+  const { register } = useForm<{ username: string }>();
+
+  return (
+    <form>
+      <section aria-label="native controlled fields">
+        <input type="email" name="email" value={email} onChange={(event) => setEmail(event.currentTarget.value)} required />
+      </section>
+
+      <section aria-label="react hook form fields">
+        <input className="field" {...register("username")} />
+      </section>
+
+      <section aria-label="disabled and readonly fields">
+        <input name="disabledEmail" disabled />
+        <textarea name="readonlyNotes" readOnly />
+      </section>
+
+      <section aria-label="custom wrapper boundary">
+        <DesignSystemField label="Billing account" name="billingAccount" />
+      </section>
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -29,6 +29,7 @@ const fixtures = {
   association: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-candidates.tsx"),
   unsafeAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx"),
   relatedContext: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "related-context-form.tsx"),
+  expandedNativeControls: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -361,6 +362,38 @@ test("React Web issue report includes nearby same-basename tests when not displa
   assert.ok(allEntries.some((entry) => entry.kind === "nearby-test" && entry.file.endsWith("/related-context-form.test.tsx")));
 });
 
+test("React Web issue report covers expanded native control fixture boundaries", () => {
+  const report = parseIssues(fixtures.expandedNativeControls);
+  const preview = buildReactWebLabelPatchPreview(fixtures.expandedNativeControls, repoRoot);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.summary.issueCount, 4);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.manualReviewCount, 4);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 4);
+  assert.equal(report.summary.issueCount, preview.summary.findingCount);
+  assert.ok(report.issues.every((issue) => issue.kind === "react-web.missing-accessible-label"));
+  assert.ok(report.issues.every((issue) => issue.fixability === "manual-review"));
+  assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
+  assert.deepEqual(report.issues.map((issue) => issue.fixShapeGuidance.localEvidence.attributes), [
+    ["name=email", "onChange", "required", "type=email", "value"],
+    ["className", 'spread:register("username")'],
+    ["disabled", "name=disabledEmail"],
+    ["name=readonlyNotes", "readOnly"],
+  ]);
+  assert.deepEqual(report.triageRollup.topIssueIds, [
+    "react-web-label-1",
+    "react-web-label-2",
+    "react-web-label-3",
+  ]);
+  assert.deepEqual(report.firstMinuteSummary.sourceTopIssueIds, report.triageRollup.topIssueIds);
+  assertReactWebWorkOrderQuality(parseReactWebWorkOrderQuality({ fixture: "expanded-native-controls.tsx", report }));
+
+  const serialized = JSON.stringify(report);
+  assert.doesNotMatch(serialized, /DesignSystemField|Billing account|billingAccount/);
+  assert.doesNotMatch(serialized, /must-edit|Auto-apply: yes/i);
+});
+
 test("React Web issue report fixture usefulness gate records accepted cards, noise, plausibility, and parity", () => {
   const cases = [
     {
@@ -380,6 +413,15 @@ test("React Web issue report fixture usefulness gate records accepted cards, noi
       expectedSafePreviewCount: 1,
       expectedManualReviewCount: 2,
       suggestionPlausibility: "High-confidence native nearby label/control htmlFor/id previews are deterministic and read-only; medium-confidence associations stay manual review.",
+    },
+    {
+      name: "expanded-native-controls.tsx",
+      file: fixtures.expandedNativeControls,
+      expectedCards: 4,
+      acceptedCards: 4,
+      expectedSafePreviewCount: 0,
+      expectedManualReviewCount: 4,
+      suggestionPlausibility: "Controlled, react-hook-form/register, disabled, and readOnly native controls stay manual-review; custom wrapper props are not inferred as native issue cards.",
     },
     {
       name: "labelled-controls.tsx",
@@ -418,7 +460,7 @@ test("React Web issue report fixture usefulness gate records accepted cards, noi
   );
 
   for (const entry of matrix) assertReactWebIssueFixtureUsefulness(entry);
-  assert.deepEqual(matrix.map((entry) => entry.verdict), ["pass", "pass", "pass", "pass"]);
+  assert.deepEqual(matrix.map((entry) => entry.verdict), ["pass", "pass", "pass", "pass", "pass"]);
   assert.ok(matrix.every((entry) => entry.parityWithPreviewFindings));
   assert.ok(matrix.every((entry) => entry.noiseNotes.length === 0));
   assert.ok(matrix.some((entry) => entry.expectedUnsupported === true && entry.unsupported === true));

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -10,6 +10,7 @@ const negativeFixture = path.join(repoRoot, "test", "fixtures", "react-web-label
 const rnFixture = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx");
 const associationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-candidates.tsx");
 const unsafeAssociationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx");
+const expandedNativeControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -83,6 +84,27 @@ test("React Web label preview suggests conservative nearby label associations", 
   assert.match(preview.findings[1].suggestedPatch.preview, /<label htmlFor="department">/);
   assert.match(preview.findings[1].suggestedPatch.preview, /<select name="department" id="department">/);
   assert.match(preview.findings[2].suggestedPatch.preview, /<textarea name="notes" id="notes" \/>/);
+  assert.ok(preview.findings.every((finding) => finding.suggestedPatch.readOnly === true));
+});
+
+test("React Web label preview covers expanded native control fixture boundaries", () => {
+  const cli = runPreview(expandedNativeControlsFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  assert.deepEqual(preview.summary, { findingCount: 4, missingCount: 4, ambiguousCount: 0, associationCount: 0 });
+  assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence, finding.suggestedPatch.attribute]), [
+    ["missing-accessible-label", "input", "high", "aria-label"],
+    ["missing-accessible-label", "input", "high", "aria-label"],
+    ["missing-accessible-label", "input", "high", "aria-label"],
+    ["missing-accessible-label", "textarea", "high", "aria-label"],
+  ]);
+  assert.ok(preview.findings.some((finding) => /value=\{email\}|onChange/.test(finding.context)));
+  assert.ok(preview.findings.some((finding) => /register\("username"\)/.test(finding.context)));
+  assert.ok(preview.findings.some((finding) => /disabled/.test(finding.context)));
+  assert.ok(preview.findings.some((finding) => /readOnly/.test(finding.context)));
+  assert.doesNotMatch(JSON.stringify(preview), /DesignSystemField|Billing account|billingAccount/);
   assert.ok(preview.findings.every((finding) => finding.suggestedPatch.readOnly === true));
 });
 


### PR DESCRIPTION
## Summary
- Closes #752.
- Adds `expanded-native-controls.tsx` to cover controlled input, react-hook-form/register spread, disabled input, readOnly textarea, and a custom wrapper boundary.
- Extends label-preview and issue-report tests so the expanded native controls stay manual-review/read-only and the custom wrapper is not inferred as a native issue card.
- Keeps this PR fixture/test-only: no runtime output, CLI, schema, ranking, auto-apply, or non-web lane changes.

## Validation
- `npm run build && node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs` — 27/27 pass
- `npm test` — 744/744 pass

## Merge gate
- Linked issue: closes #752
- Self-check: fixture expansion remains React Web native-control only; custom wrapper semantics stay excluded.
