### PR TITLE
Expose convention hints in first-minute context hints

### DIFF
--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -59,7 +59,9 @@ A first-minute mini work order is an inspect-first handoff. It can point at the 
 - the next action shape, such as reviewing a native label/control association;
 - the human decision needed before choosing final copy or a fix;
 - do-not-do boundaries that keep the report advisory;
-- compact context hints from existing source attributes or nearby evidence.
+- compact context hints from existing source attributes, nearby evidence, or a matched repo-owned convention pointer.
+
+Repo-owned convention hints may appear here only as short advisory pointers, for example a reminder to inspect same-file native JSX first. The compact work order must not inline full convention packets, policy boundaries, excluded-inference lists, config details, or enforcement language.
 
 ## Boundaries that must stay explicit
 
@@ -71,5 +73,6 @@ The React Web first-minute work order is conservative by design:
 - **No broad accessibility audit:** it is a narrow native-control form/accessibility issue report, not a complete WCAG or design-system audit.
 - **No custom-component semantic inference:** custom components remain manual-review evidence unless native-control facts are explicit enough.
 - **No RN/TUI/WebView expansion:** React Native, TUI / React CLI, WebView, Vue/SFC, broad TS/JS, and multi-file refactor lanes remain outside this work-order claim unless future evidence and policy gates promote them.
+- **Convention hints stay advisory:** first-minute `contextHints` may include a short repo-owned convention pointer, but that pointer must not change rank, priority, bucket, first inspect action, next action, or edit authority.
 
 Keep future wording tied to the current inspect surfaces and these boundaries. If a future issue adds apply behavior, generated copy, broader accessibility coverage, custom-component semantics, or new runtime lanes, that should be documented as a separate capability with separate tests and evidence.

--- a/docs/repo-owned-convention-hints.md
+++ b/docs/repo-owned-convention-hints.md
@@ -7,13 +7,16 @@ Repo-owned convention hints are a first prototype for future team-owned fooks ch
 - Defines an internal convention-hints manifest schema.
 - Matches hints to React Web issue cards by profile, issue kind, native element, and file extension.
 - Projects matching hints into full React Web issue reports as advisory context.
-- Keeps compact summary output free of detailed convention-hint data.
+- Projects at most one matched hint into compact first-minute `contextHints` as a short advisory pointer.
+- Keeps compact summary output free of detailed convention-hint packets, policy/enforcement data, and public config claims.
 
 ## Boundaries
 
 This is not the future tracked config surface yet. The first pass does **not** add tracked `.fooks` policy/check files, a public CLI, CI enforcement, merge enforcement, codemod behavior, or edit authority.
 
 Convention hints should remain inspect-first context. They may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, or custom-component semantic inference.
+
+In first-minute summaries, convention hints are intentionally weaker than the ranked issue evidence. A matched hint can add a concise `contextHints` entry so an agent sees the team-context pointer, but it must not change ranking, priority, bucket assignment, `inspectFirst`, `nextAction`, or edit authority.
 
 ## Graduation path
 

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -760,19 +760,26 @@ function doNotDoFor(): string[] {
   );
 }
 
+function conventionContextHintFor(hint: RepoOwnedConventionHintProjection): string {
+  const inspectPointer = hint.inspectFirst[0]
+    ?.replace(/^Inspect/u, "inspect")
+    .replace(/\.$/u, "") ?? hint.summary;
+  return trimSummaryText(`advisory convention ${hint.id}: ${inspectPointer}`, 100);
+}
+
 function contextHintsFor(issue: ReactWebIssueCard): string[] {
   const hints = [
     `native ${issue.evidence.element} at ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
     `${issue.triage.evidence.relatedContextQuality} context`,
   ];
+  for (const hint of issue.conventionHints.slice(0, 1)) {
+    hints.push(conventionContextHintFor(hint));
+  }
   if (issue.triage.evidence.safePreviewAvailable) {
     hints.push("safe-preview candidate available");
   }
   if (issue.triage.evidence.relatedContextSources.length > 0) {
     hints.push(`related sources: ${issue.triage.evidence.relatedContextSources.slice(0, 3).join(", ")}`);
-  }
-  for (const hint of issue.conventionHints.slice(0, 1)) {
-    hints.push(`advisory convention: ${hint.id}`);
   }
   return uniqueCompactStrings(hints, 4, 100);
 }

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -110,6 +110,26 @@ function assertCompactFirstMinuteItem(item) {
   assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|CI gate|merge gate|generated accessible-name copy/i);
 }
 
+function assertCompactConventionContextHint(item) {
+  const conventionHints = item.contextHints.filter((entry) => /advisory convention react-web\.native-label-context/.test(entry));
+  assert.equal(conventionHints.length, 1);
+  assert.ok(conventionHints[0].length <= 100, conventionHints[0]);
+  assert.match(conventionHints[0], /inspect same-file JSX/);
+  assert.doesNotMatch(conventionHints[0], /policyBoundary|excludedInference|public config|CI gate|merge gate|auto-apply|must-edit/i);
+}
+
+function assertConventionDoesNotPolluteActionFields(item) {
+  const actionText = JSON.stringify({
+    firstInspectStep: item.firstInspectStep,
+    inspectFirst: item.inspectFirst,
+    whyThisFirst: item.whyThisFirst,
+    nextAction: item.nextAction,
+    humanDecisionNeeded: item.humanDecisionNeeded,
+    doNotDo: item.doNotDo,
+  });
+  assert.doesNotMatch(actionText, /advisory convention|react-web\.native-label-context|repo-owned convention/i);
+}
+
 
 test("React Web issue report emits actionable issue cards over label preview findings", () => {
   const report = parseIssues(fixtures.missing);
@@ -680,6 +700,23 @@ test("React Web issue report JSON includes machine-readable first-minute summary
     "react-web-label-4",
     "react-web-label-5",
   ]);
+  assert.deepEqual(
+    report.issues.map((issue) => [
+      issue.id,
+      issue.triage.rank,
+      issue.triage.priority,
+      issue.triage.bucket,
+      issue.triage.evidence.score,
+    ]),
+    [
+      ["react-web-label-1", 1, "high", "high-confidence-manual-review", 8],
+      ["react-web-label-2", 4, "high", "high-confidence-manual-review", 8],
+      ["react-web-label-3", 5, "high", "high-confidence-manual-review", 8],
+      ["react-web-label-4", 2, "high", "high-confidence-manual-review", 8],
+      ["react-web-label-5", 3, "high", "high-confidence-manual-review", 8],
+    ],
+  );
+  assert.doesNotMatch(JSON.stringify(report.issues.map((issue) => issue.triage)), /convention|react-web\.native-label-context/i);
   assert.deepEqual(report.firstMinuteSummary.sourceTopIssueIds, report.triageRollup.topIssueIds);
   assert.deepEqual(
     report.firstMinuteSummary.items.map((item) => item.issueId),
@@ -697,6 +734,8 @@ test("React Web issue report JSON includes machine-readable first-minute summary
     );
     assert.deepEqual(item.inspectFirst, issue.fixShapeGuidance.inspectFirst);
     assertCompactFirstMinuteItem(item);
+    assertCompactConventionContextHint(item);
+    assertConventionDoesNotPolluteActionFields(item);
     assert.match(item.whyThisFirst, new RegExp(`Rank ${issue.triage.rank} ${issue.triage.priority} issue`));
     assert.match(item.nextAction, /Start by inspecting/);
     assert.ok(item.contextHints.some((entry) => entry.includes(issue.evidence.element)));
@@ -798,6 +837,8 @@ test("React Web issue report summary JSON is compact first-minute data without d
   assert.deepEqual(summary.firstMinuteSummary.sourceTopIssueIds, summary.triageTopIds.topIssueIds);
   for (const item of summary.firstMinuteSummary.items) {
     assertCompactFirstMinuteItem(item);
+    assertCompactConventionContextHint(item);
+    assertConventionDoesNotPolluteActionFields(item);
   }
   assert.deepEqual(Object.hasOwn(summary, "issues"), false);
 


### PR DESCRIPTION
## Summary
- Reserves a compact first-minute `contextHints` slot for the first matched repo-owned convention hint.
- Keeps convention hints out of `inspectFirst`, `nextAction`, and triage/ranking fields.
- Updates docs to clarify compact convention hints are advisory pointers only, not policy packets or config/enforcement surfaces.

## Verification
- `npm run build && node --test test/react-web-issue-report.test.mjs test/repo-owned-convention-hints.test.mjs`
- `npm test`
- `git diff --check`

Closes #754
