### PR TITLE
Document summary JSON agent handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Use fooks when you want frontend change intelligence for a supported React Web f
 
 ## Quick start and local proof
 
-The first-minute path above is the shortest setup/proof loop: install the CLI, activate the current repo with `fooks setup`, check readiness with `fooks doctor`, then run `fooks inspect react-web-issues <supported-file>` for actionable React Web issue cards. `fooks compare <supported-file>` is supporting local source-vs-payload evidence, not the whole product proof.
+The first-minute path above is the shortest setup/proof loop: install the CLI, activate the current repo with `fooks setup`, check readiness with `fooks doctor`, then run `fooks inspect react-web-issues <supported-file>` for actionable React Web issue cards. Agents and tools that only need the compact work-order handoff should use `fooks inspect react-web-issues <supported-file> --summary-json`, read `firstMinuteSummary.items[0]`, and treat the result as advisory inspect-first input rather than edit authority. `fooks compare <supported-file>` is supporting local source-vs-payload evidence, not the whole product proof.
 
 `fooks doctor` is the read-only health check for setup/hook readiness; its default output starts with status, why, first blocker, and next action so a new user can recover without reading JSON. `fooks inspect react-web-issues` is the first actionable report surface for narrow native-control form/accessibility findings. `fooks compare` defaults to a concise verdict/next-action summary for one supported file; add `--json` for exact local byte counts, exclusions, and claim boundary text.
 
@@ -337,7 +337,7 @@ npm test
 Useful public docs:
 
 - Architecture boundaries for source facts, evidence gates, and reporting-vs-authorization separation: [`docs/architecture-boundaries.md`](docs/architecture-boundaries.md)
-- React Web first-minute work-order flow for human maintainers: [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md)
+- React Web first-minute work-order flow for human maintainers and agent/tool `--summary-json` handoffs: [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md)
 - Setup details: [`docs/setup.md`](docs/setup.md)
 - opencode support boundary: [`docs/opencode-read-interception.md`](docs/opencode-read-interception.md)
 - Release checklist: [`docs/release.md`](docs/release.md)

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -50,6 +50,24 @@ fooks inspect react-web-issues src/components/Form.tsx --summary-json
 
 `--summary-json` is intentionally smaller than full `--json`: it keeps the first-minute summary, rollup IDs, read-only flags, and claim boundary, while omitting detailed card fields such as source snippets, preview details, context packets, and suggested actions.
 
+## Agent/tool handoff
+
+Use `--summary-json` when an agent or tool needs a compact first-minute instruction packet instead of the full issue-card report:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx --summary-json
+```
+
+The intended consumer flow is:
+
+1. Read `firstMinuteSummary.items` in `sourceTopIssueIds` order.
+2. Start with `items[0].firstInspectStep` and `items[0].nextAction`.
+3. Keep `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply`, and `claimBoundary` in the agent prompt or task card.
+4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority.
+5. If `items` is empty, stop and inspect the top-level `inScope` / `skippedReason` values instead of inventing a React Web task.
+
+The compact handoff is not an apply command. It should help an agent choose the first source location to inspect, not skip human review, invent accessible-name copy, treat custom components as native controls, or widen the report into a broader accessibility audit.
+
 ## What the mini work order is allowed to say
 
 A first-minute mini work order is an inspect-first handoff. It can point at the top ranked React Web native-control issue and summarize:

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4973,11 +4973,20 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   const releaseSmoke = fs.readFileSync(path.join(repoRoot, "scripts", "release-smoke.mjs"), "utf8");
 
   assert.match(readme, /docs\/react-web-first-minute-work-orders\.md/);
+  assert.match(readme, /--summary-json/);
+  assert.match(readme, /firstMinuteSummary\.items\[0\]/);
+  assert.match(readme, /advisory inspect-first input rather than edit authority/);
   assert.ok(pkg.files.includes("docs/react-web-first-minute-work-orders.md"));
   assert.match(releaseSmoke, /docs\/react-web-first-minute-work-orders\.md/);
 
   assert.match(doc, /first-minute mini work order/i);
   assert.match(doc, /Before and after/);
+  assert.match(doc, /Agent\/tool handoff/);
+  assert.match(doc, /fooks inspect react-web-issues src\/components\/Form\.tsx --summary-json/);
+  assert.match(doc, /Read `firstMinuteSummary\.items` in `sourceTopIssueIds` order/);
+  assert.match(doc, /Start with `items\[0\]\.firstInspectStep` and `items\[0\]\.nextAction`/);
+  assert.match(doc, /fixShapeGuidance\.autoApply/);
+  assert.match(doc, /If `items` is empty, stop/);
   assert.match(doc, /ranked issue cards[\s\S]*firstMinuteSummary[\s\S]*--summary-json|firstMinuteSummary[\s\S]*compact first-minute/);
   assert.match(doc, /fooks inspect react-web-issues src\/components\/Form\.tsx/);
   assert.match(doc, /--json/);
@@ -4994,6 +5003,7 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.match(doc, /No broad accessibility audit:[\s\S]*not a complete WCAG or design-system audit/);
   assert.match(doc, /No custom-component semantic inference:[\s\S]*manual-review evidence/);
   assert.match(doc, /No RN\/TUI\/WebView expansion:[\s\S]*outside this work-order claim/);
+  assert.match(doc, /contextHints[\s\S]*do not change rank, priority, bucket, or edit authority/);
 
   assert.doesNotMatch(doc, /Auto-apply: yes|must-edit|automatically edits files/i);
   assert.doesNotMatch(doc, /generates? (?:final )?(?:label text|aria-label text|accessible-name copy)/i);


### PR DESCRIPTION
## Summary
- Documents `--summary-json` as the compact React Web first-minute handoff for agents/tools.
- Adds an agent/tool consumer flow that starts from `firstMinuteSummary.items[0]` and keeps guardrails in the task card.
- Locks README/doc discoverability and non-claims in tests.

## Verification
- `npm run build && node --test test/fooks.test.mjs test/react-web-issue-report.test.mjs`
- `npm test`
- `git diff --check`

Closes #756
