### PR TITLE
Add React Web dry-run projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use fooks when you want frontend change intelligence for a supported React Web f
 
 - **Product direction:** frontend work cost reduction through source facts, evidence gates, actionable reports, and bounded preview guidance.
 - **First wedge:** React Web `.tsx` / `.jsx`; repeated same-file Codex context reuse is the strongest current workflow.
-- **First surface/problem:** `fooks inspect react-web-issues <file> [--json]` reports narrow native-control form/accessibility issue cards, with read-only safe previews only for deterministic native label/control associations.
+- **First surface/problem:** `fooks inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]` reports narrow native-control form/accessibility issue cards, compact first-minute handoffs, or dry-run-only migration candidates, with read-only safe previews only for deterministic native label/control associations.
 - **Supporting mechanism:** context reduction and caching help avoid rediscovering the same source facts, but they are not the whole product positioning.
 - **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
 - **Roadmap asks, not current support:** React Native/WebView, TUI / React CLI promotion beyond candidate / evidence-only status, Vue/SFC, broader TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity.
@@ -48,7 +48,7 @@ Use fooks when you want frontend change intelligence for a supported React Web f
 
 ## Quick start and local proof
 
-The first-minute path above is the shortest setup/proof loop: install the CLI, activate the current repo with `fooks setup`, check readiness with `fooks doctor`, then run `fooks inspect react-web-issues <supported-file>` for actionable React Web issue cards. Agents and tools that only need the compact work-order handoff should use `fooks inspect react-web-issues <supported-file> --summary-json`, read `firstMinuteSummary.items[0]`, and treat the result as advisory inspect-first input rather than edit authority. `fooks compare <supported-file>` is supporting local source-vs-payload evidence, not the whole product proof.
+The first-minute path above is the shortest setup/proof loop: install the CLI, activate the current repo with `fooks setup`, check readiness with `fooks doctor`, then run `fooks inspect react-web-issues <supported-file>` for actionable React Web issue cards. Agents and tools that only need the compact work-order handoff should use `fooks inspect react-web-issues <supported-file> --summary-json`, read `firstMinuteSummary.items[0]`, and treat the result as advisory inspect-first input rather than edit authority. Migration planners that need candidate rows can use `--dry-run-json`; it remains read-only and dry-run-only. `fooks compare <supported-file>` is supporting local source-vs-payload evidence, not the whole product proof.
 
 `fooks doctor` is the read-only health check for setup/hook readiness; its default output starts with status, why, first blocker, and next action so a new user can recover without reading JSON. `fooks inspect react-web-issues` is the first actionable report surface for narrow native-control form/accessibility findings. `fooks compare` defaults to a concise verdict/next-action summary for one supported file; add `--json` for exact local byte counts, exclusions, and claim boundary text.
 

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -50,6 +50,14 @@ fooks inspect react-web-issues src/components/Form.tsx --summary-json
 
 `--summary-json` is intentionally smaller than full `--json`: it keeps the first-minute summary, rollup IDs, read-only flags, and claim boundary, while omitting detailed card fields such as source snippets, preview details, context packets, and suggested actions.
 
+Use the dry-run projection when an agent or migration planner needs read-only candidate rows instead of issue cards:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx --dry-run-json
+```
+
+`--dry-run-json` is still not an apply path. It projects existing ranked issue evidence into migration candidates with affected files, first inspect steps, preview availability, and risk notes. The projection stays dry-run-only: no patch application, generated accessible-name copy, custom-component semantic inference, or rank/priority/bucket changes.
+
 ## Agent/tool handoff
 
 Use `--summary-json` when an agent or tool needs a compact first-minute instruction packet instead of the full issue-card report:
@@ -66,7 +74,7 @@ The intended consumer flow is:
 4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority.
 5. If `items` is empty, stop and inspect the top-level `inScope` / `skippedReason` values instead of inventing a React Web task.
 
-The compact handoff is not an apply command. It should help an agent choose the first source location to inspect, not skip human review, invent accessible-name copy, treat custom components as native controls, or widen the report into a broader accessibility audit.
+The compact handoff is not an apply command. It should help an agent choose the first source location to inspect, not skip human review, invent accessible-name copy, treat custom components as native controls, or widen the report into a broader accessibility audit. If an agent needs candidate rows for a migration plan, use `--dry-run-json` and keep its `dryRunOnly`, `autoApply`, `humanReviewRequired`, and `riskNotes` fields attached to the task card.
 
 ## What the mini work order is allowed to say
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -649,7 +649,7 @@ Everyday commands:
   ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
-  ${displayCliName} inspect react-web-issues <file> [--json|--summary-json]
+  ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
@@ -714,10 +714,11 @@ function parseCompareArgs(args: string[]): { filePath: string; json: boolean } {
   return { filePath: requireFilePath(filePath), json };
 }
 
-function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode: "text" | "json" | "summary-json" } {
+function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode: "text" | "json" | "summary-json" | "dry-run-json" } {
   let filePath: string | undefined;
   let json = false;
   let summaryJson = false;
+  let dryRunJson = false;
 
   for (const arg of args) {
     if (arg === "--json") {
@@ -728,6 +729,10 @@ function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode
       summaryJson = true;
       continue;
     }
+    if (arg === "--dry-run-json") {
+      dryRunJson = true;
+      continue;
+    }
     if (!filePath) {
       filePath = arg;
       continue;
@@ -735,11 +740,14 @@ function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode
     throw new Error(`Unexpected react-web-issues argument: ${arg}`);
   }
 
-  if (json && summaryJson) {
-    throw new Error("inspect react-web-issues accepts either --json or --summary-json, not both");
+  if ([json, summaryJson, dryRunJson].filter(Boolean).length > 1) {
+    throw new Error("inspect react-web-issues accepts only one of --json, --summary-json, or --dry-run-json");
   }
 
-  return { filePath: requireFilePath(filePath), outputMode: summaryJson ? "summary-json" : json ? "json" : "text" };
+  return {
+    filePath: requireFilePath(filePath),
+    outputMode: dryRunJson ? "dry-run-json" : summaryJson ? "summary-json" : json ? "json" : "text",
+  };
 }
 
 function parseInspectEvidenceArgs(args: string[]): { id: string; json: boolean } {
@@ -1348,10 +1356,17 @@ async function run(): Promise<void> {
       }
       if (arg1 === "react-web-issues") {
         const { filePath: file, outputMode } = parseReactWebIssuesArgs(rest.slice(1));
-        const { buildReactWebIssueReport, buildReactWebIssueReportSummaryJson, renderReactWebIssueReportText } = await import("../core/react-web-issue-report.js");
+        const {
+          buildReactWebIssueReport,
+          buildReactWebIssueReportMigrationDryRunJson,
+          buildReactWebIssueReportSummaryJson,
+          renderReactWebIssueReportText,
+        } = await import("../core/react-web-issue-report.js");
         const report = buildReactWebIssueReport(file, process.cwd());
         if (outputMode === "summary-json") {
           print(buildReactWebIssueReportSummaryJson(report));
+        } else if (outputMode === "dry-run-json") {
+          print(buildReactWebIssueReportMigrationDryRunJson(report));
         } else if (outputMode === "json") {
           print(report);
         } else {

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -201,6 +201,38 @@ export type ReactWebIssueReportSummaryJson = {
   firstMinuteSummary: ReactWebIssueFirstMinuteSummary;
 };
 
+export type ReactWebIssueReportMigrationDryRunJson = {
+  schemaVersion: "react-web-issue-report-migration-dry-run.v1";
+  sourceReportSchemaVersion: typeof REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION;
+  command: typeof REACT_WEB_ISSUE_REPORT_COMMAND;
+  projection: "migration-dry-run-json";
+  profile: "react-web";
+  filePath: string;
+  readOnly: true;
+  dryRunOnly: true;
+  autoApply: false;
+  claimBoundary: typeof REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY;
+  inScope: boolean;
+  skippedReason?: string;
+  summary: {
+    candidateCount: number;
+    affectedFiles: string[];
+    safePreviewCandidateCount: number;
+    manualReviewCandidateCount: number;
+  };
+  candidates: {
+    issueId: string;
+    migrationCandidate: ReactWebIssueFixShape;
+    affectedFile: string;
+    firstInspectStep: string;
+    previewAvailable: boolean;
+    humanReviewRequired: true;
+    autoApply: false;
+    dryRunOnly: true;
+    riskNotes: string[];
+  }[];
+};
+
 function issueKindFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueKind {
   return `react-web.${finding.kind}` as ReactWebIssueKind;
 }
@@ -874,6 +906,56 @@ export function buildReactWebIssueReportSummaryJson(report: ReactWebIssueReport)
       manualReviewIssueIds: report.triageRollup.manualReviewIssueIds,
     },
     firstMinuteSummary: report.firstMinuteSummary,
+  };
+}
+
+function migrationRiskNotesFor(issue: ReactWebIssueCard): string[] {
+  const notes = [
+    issue.safetyRationale,
+    issue.fixability === "safe-preview"
+      ? "Safe preview is a read-only shape candidate and still requires human review before use."
+      : "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+    "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+    "Do not infer custom-component semantics.",
+  ];
+  return uniqueCompactStrings(notes, 4, 160);
+}
+
+export function buildReactWebIssueReportMigrationDryRunJson(
+  report: ReactWebIssueReport,
+): ReactWebIssueReportMigrationDryRunJson {
+  const rankedIssues = [...report.issues].sort((a, b) => a.triage.rank - b.triage.rank);
+  const candidates = rankedIssues.map((issue) => ({
+    issueId: issue.id,
+    migrationCandidate: issue.fixShapeGuidance.shape,
+    affectedFile: issue.whereToLook.filePath,
+    firstInspectStep: firstInspectStepFor(issue),
+    previewAvailable: issue.triage.evidence.safePreviewAvailable,
+    humanReviewRequired: true as const,
+    autoApply: false as const,
+    dryRunOnly: true as const,
+    riskNotes: migrationRiskNotesFor(issue),
+  }));
+  return {
+    schemaVersion: "react-web-issue-report-migration-dry-run.v1",
+    sourceReportSchemaVersion: report.schemaVersion,
+    command: report.command,
+    projection: "migration-dry-run-json",
+    profile: report.profile,
+    filePath: report.filePath,
+    readOnly: true,
+    dryRunOnly: true,
+    autoApply: false,
+    claimBoundary: report.claimBoundary,
+    inScope: report.inScope,
+    ...(report.skippedReason ? { skippedReason: report.skippedReason } : {}),
+    summary: {
+      candidateCount: candidates.length,
+      affectedFiles: [...new Set(candidates.map((candidate) => candidate.affectedFile))].sort(),
+      safePreviewCandidateCount: candidates.filter((candidate) => candidate.previewAvailable).length,
+      manualReviewCandidateCount: candidates.filter((candidate) => !candidate.previewAvailable).length,
+    },
+    candidates,
   };
 }
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3821,7 +3821,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect activation-mode <id> \[--json\]/);
   assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
   assert.match(help, /fooks inspect react-web-label-preview <file> \[--json\]/);
-  assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\]/);
+  assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\|--dry-run-json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\]/);

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -19,6 +19,7 @@ const { buildReactWebLabelPatchPreview } = require(path.join(repoRoot, "dist", "
 const {
   REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY,
   buildReactWebIssueReport,
+  buildReactWebIssueReportMigrationDryRunJson,
   buildReactWebIssueReportSummaryJson,
   renderReactWebIssueReportText,
 } = require(path.join(repoRoot, "dist", "core", "react-web-issue-report.js"));
@@ -875,8 +876,99 @@ test("React Web issue report summary JSON preserves skip boundaries without deta
   assert.deepEqual(Object.hasOwn(summary, "issues"), false);
 });
 
+test("React Web issue report migration dry-run JSON projects read-only candidates", () => {
+  const fullCli = runIssues(fixtures.formControls, "--json");
+  const dryRunCli = runIssues(fixtures.formControls, "--dry-run-json");
+  assert.equal(fullCli.status, 0, fullCli.stderr);
+  assert.equal(dryRunCli.status, 0, dryRunCli.stderr);
+
+  const fullReport = JSON.parse(fullCli.stdout);
+  const dryRun = JSON.parse(dryRunCli.stdout);
+  const projected = buildReactWebIssueReportMigrationDryRunJson(fullReport);
+
+  assert.equal(dryRun.schemaVersion, "react-web-issue-report-migration-dry-run.v1");
+  assert.equal(dryRun.sourceReportSchemaVersion, fullReport.schemaVersion);
+  assert.equal(dryRun.command, "inspect react-web-issues");
+  assert.equal(dryRun.projection, "migration-dry-run-json");
+  assert.equal(dryRun.profile, "react-web");
+  assert.equal(dryRun.filePath, fullReport.filePath);
+  assert.equal(dryRun.readOnly, true);
+  assert.equal(dryRun.dryRunOnly, true);
+  assert.equal(dryRun.autoApply, false);
+  assert.equal(dryRun.claimBoundary, REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY);
+  assert.deepEqual(dryRun, projected);
+  assert.deepEqual(
+    dryRun.candidates.map((candidate) => candidate.issueId),
+    fullReport.triageRollup.rankedIssueIds,
+  );
+  assert.deepEqual(dryRun.summary, {
+    candidateCount: 5,
+    affectedFiles: ["fixtures/compressed/FormControls.tsx"],
+    safePreviewCandidateCount: 0,
+    manualReviewCandidateCount: 5,
+  });
+
+  for (const candidate of dryRun.candidates) {
+    assert.match(candidate.issueId, /^react-web-label-/);
+    assert.match(candidate.migrationCandidate, /^human-reviewed-|^safe-preview-/);
+    assert.equal(candidate.affectedFile, "fixtures/compressed/FormControls.tsx");
+    assert.match(candidate.firstInspectStep, /^Inspect fixtures\/compressed\/FormControls\.tsx:\d+-\d+ \((input|select|textarea)\) before editing\.$/);
+    assert.equal(candidate.previewAvailable, false);
+    assert.equal(candidate.humanReviewRequired, true);
+    assert.equal(candidate.autoApply, false);
+    assert.equal(candidate.dryRunOnly, true);
+    assert.ok(candidate.riskNotes.length >= 3);
+    assert.ok(candidate.riskNotes.some((note) => /human review|human-reviewed/i.test(note)));
+    assert.ok(candidate.riskNotes.some((note) => /Do not apply patches automatically/i.test(note)));
+    assert.ok(candidate.riskNotes.every((note) => note.length <= 160));
+  }
+
+  const compactText = JSON.stringify(dryRun);
+  for (const detailedCardKey of ["issues", "contextPacket", "conventionHints", "relatedContext", "preview", "evidence", "sourceSignals", "suggestedAction", "whereToLook", "whyItMatters", "problem"]) {
+    assert.equal(hasNestedKey(dryRun, detailedCardKey), false, `dry-run-json should not include detailed key ${detailedCardKey}`);
+  }
+  assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller|policyBoundary|excludedInference/i);
+});
+
+test("React Web issue report migration dry-run JSON preserves empty and unsupported boundaries", () => {
+  const labelledCli = runIssues(fixtures.labelled, "--dry-run-json");
+  assert.equal(labelledCli.status, 0, labelledCli.stderr);
+  const labelled = JSON.parse(labelledCli.stdout);
+  assert.equal(labelled.inScope, true);
+  assert.equal(labelled.readOnly, true);
+  assert.equal(labelled.dryRunOnly, true);
+  assert.equal(labelled.autoApply, false);
+  assert.deepEqual(labelled.summary, {
+    candidateCount: 0,
+    affectedFiles: [],
+    safePreviewCandidateCount: 0,
+    manualReviewCandidateCount: 0,
+  });
+  assert.deepEqual(labelled.candidates, []);
+
+  const rnCli = runIssues(fixtures.rn, "--dry-run-json");
+  assert.equal(rnCli.status, 0, rnCli.stderr);
+  const rn = JSON.parse(rnCli.stdout);
+  assert.equal(rn.inScope, false);
+  assert.match(rn.skippedReason, /^domain-classification:react-native/);
+  assert.equal(rn.readOnly, true);
+  assert.equal(rn.dryRunOnly, true);
+  assert.equal(rn.autoApply, false);
+  assert.deepEqual(rn.summary, {
+    candidateCount: 0,
+    affectedFiles: [],
+    safePreviewCandidateCount: 0,
+    manualReviewCandidateCount: 0,
+  });
+  assert.deepEqual(rn.candidates, []);
+});
+
 test("React Web issue report rejects conflicting JSON output flags", () => {
   const cli = runIssues(fixtures.formControls, "--json", "--summary-json");
   assert.notEqual(cli.status, 0);
-  assert.match(cli.stderr, /either --json or --summary-json, not both/);
+  assert.match(cli.stderr, /only one of --json, --summary-json, or --dry-run-json/);
+
+  const dryRunCli = runIssues(fixtures.formControls, "--summary-json", "--dry-run-json");
+  assert.notEqual(dryRunCli.status, 0);
+  assert.match(dryRunCli.stderr, /only one of --json, --summary-json, or --dry-run-json/);
 });


### PR DESCRIPTION
## Summary
- Add `fooks inspect react-web-issues <file> --dry-run-json` as a read-only React Web migration candidate projection.
- Project existing ranked issue evidence into candidate rows with affected files, first inspect steps, preview availability, and risk notes.
- Keep the boundary explicit in docs/tests: dry-run-only, no auto-apply, no generated label/name copy, no custom-component semantics inference, and no rank/priority/bucket changes.

## Verification
- `npm ci && npm run build && node --test test/react-web-issue-report.test.mjs test/fooks.test.mjs`
- `npm test`
- `git diff --check`

Closes #758
