### PR TITLE
Fail closed on malformed React Web handoff inputs

### DIFF
--- a/test/helpers/react-web-agent-handoff-dogfood.mjs
+++ b/test/helpers/react-web-agent-handoff-dogfood.mjs
@@ -23,14 +23,71 @@ function emptyStop(source, reason, projection) {
   };
 }
 
+function malformedStop(source, reason, projection) {
+  return {
+    ...emptyStop(source, reason, projection),
+    malformed: true,
+  };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isStringArray(value) {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isSafeSummaryItem(item) {
+  return (
+    isObject(item) &&
+    isNonEmptyString(item.issueId) &&
+    isNonEmptyString(item.firstInspectStep) &&
+    isNonEmptyString(item.nextAction) &&
+    isStringArray(item.humanDecisionNeeded) &&
+    isStringArray(item.doNotDo) &&
+    isStringArray(item.contextHints) &&
+    isObject(item.fixShapeGuidance) &&
+    item.fixShapeGuidance.autoApply === false &&
+    item.fixShapeGuidance.humanReviewRequired === true
+  );
+}
+
+function isSafeDryRunCandidate(candidate) {
+  return (
+    isObject(candidate) &&
+    isNonEmptyString(candidate.issueId) &&
+    isNonEmptyString(candidate.affectedFile) &&
+    isNonEmptyString(candidate.migrationCandidate) &&
+    isNonEmptyString(candidate.firstInspectStep) &&
+    typeof candidate.previewAvailable === "boolean" &&
+    candidate.humanReviewRequired === true &&
+    candidate.autoApply === false &&
+    candidate.dryRunOnly === true &&
+    isStringArray(candidate.riskNotes)
+  );
+}
+
 export function consumeReactWebSummaryForAgentTask(summary) {
   if (!isObject(summary) || summary.inScope === false) {
     return unsupportedStop("summary-json", summary);
   }
 
-  const item = summary.firstMinuteSummary?.items?.[0];
+  if (summary.firstMinuteSummary !== undefined && !isObject(summary.firstMinuteSummary)) {
+    return malformedStop("summary-json", "malformed-first-minute-summary", summary);
+  }
+
+  const items = summary.firstMinuteSummary?.items;
+  if (items !== undefined && !Array.isArray(items)) {
+    return malformedStop("summary-json", "malformed-first-minute-items", summary);
+  }
+
+  const item = items?.[0];
   if (!item) {
     return emptyStop("summary-json", "no-first-minute-items", summary);
+  }
+  if (!isSafeSummaryItem(item)) {
+    return malformedStop("summary-json", "malformed-first-minute-item", summary);
   }
 
   return {
@@ -57,10 +114,25 @@ export function consumeReactWebDryRunForAgentTasks(dryRun) {
     return unsupportedStop("dry-run-json", dryRun);
   }
 
-  const candidates = Array.isArray(dryRun.candidates) ? dryRun.candidates : [];
+  if (dryRun.candidates !== undefined && !Array.isArray(dryRun.candidates)) {
+    return {
+      ...malformedStop("dry-run-json", "malformed-dry-run-candidates", dryRun),
+      dryRunOnly: dryRun.dryRunOnly,
+      candidates: [],
+    };
+  }
+
+  const candidates = dryRun.candidates ?? [];
   if (candidates.length === 0) {
     return {
       ...emptyStop("dry-run-json", "no-dry-run-candidates", dryRun),
+      dryRunOnly: dryRun.dryRunOnly,
+      candidates: [],
+    };
+  }
+  if (!candidates.every(isSafeDryRunCandidate)) {
+    return {
+      ...malformedStop("dry-run-json", "malformed-dry-run-candidate", dryRun),
       dryRunOnly: dryRun.dryRunOnly,
       candidates: [],
     };

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -1071,6 +1071,67 @@ test("React Web agent handoff dogfood stops on empty and unsupported projections
   assert.match(rnDryRunStop.skippedReason, /^domain-classification:react-native/);
 });
 
+test("React Web agent handoff dogfood fails closed on malformed projections", () => {
+  const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
+  const summary = buildReactWebIssueReportSummaryJson(report);
+  const dryRun = buildReactWebIssueReportMigrationDryRunJson(report);
+
+  const malformedSummaryStops = [
+    consumeReactWebSummaryForAgentTask({
+      ...summary,
+      firstMinuteSummary: { ...summary.firstMinuteSummary, items: "not-an-array" },
+    }),
+    consumeReactWebSummaryForAgentTask({
+      ...summary,
+      firstMinuteSummary: {
+        ...summary.firstMinuteSummary,
+        items: [{ ...summary.firstMinuteSummary.items[0], firstInspectStep: undefined }],
+      },
+    }),
+    consumeReactWebSummaryForAgentTask({
+      ...summary,
+      firstMinuteSummary: {
+        ...summary.firstMinuteSummary,
+        items: [{ ...summary.firstMinuteSummary.items[0], fixShapeGuidance: { autoApply: true } }],
+      },
+    }),
+  ];
+
+  for (const stop of malformedSummaryStops) {
+    assert.equal(stop.kind, "stop");
+    assert.equal(stop.source, "summary-json");
+    assert.equal(stop.malformed, true);
+    assert.match(stop.reason, /^malformed-/);
+    assert.equal(Object.hasOwn(stop, "issueId"), false);
+    assert.equal(Object.hasOwn(stop, "firstInspectStep"), false);
+    assert.equal(Object.hasOwn(stop, "nextAction"), false);
+    assert.equal(Object.hasOwn(stop, "fixShapeGuidance"), false);
+  }
+
+  const malformedDryRunStops = [
+    consumeReactWebDryRunForAgentTasks({ ...dryRun, candidates: "not-an-array" }),
+    consumeReactWebDryRunForAgentTasks({
+      ...dryRun,
+      candidates: [{ ...dryRun.candidates[0], affectedFile: undefined }],
+    }),
+    consumeReactWebDryRunForAgentTasks({
+      ...dryRun,
+      candidates: [{ ...dryRun.candidates[0], autoApply: true }],
+    }),
+  ];
+
+  for (const stop of malformedDryRunStops) {
+    assert.equal(stop.kind, "stop");
+    assert.equal(stop.source, "dry-run-json");
+    assert.equal(stop.malformed, true);
+    assert.match(stop.reason, /^malformed-/);
+    assert.deepEqual(stop.candidates, []);
+    assert.equal(Object.hasOwn(stop, "issueId"), false);
+    assert.equal(Object.hasOwn(stop, "affectedFile"), false);
+    assert.equal(Object.hasOwn(stop, "firstInspectStep"), false);
+  }
+});
+
 test("React Web issue report rejects conflicting JSON output flags", () => {
   const cli = runIssues(fixtures.formControls, "--json", "--summary-json");
   assert.notEqual(cli.status, 0);


### PR DESCRIPTION
## Summary
- Makes the test-only React Web agent handoff dogfood consumer fail closed on malformed summary/dry-run shaped inputs.
- Adds malformed summary cases for wrong-typed items, missing inspect evidence, and unsafe fix guidance.
- Adds malformed dry-run cases for wrong-typed candidates, missing affected file, and unsafe apply authority.

## Boundaries
- Helper/test-only change.
- No README, CLI, `src/`, runtime, schema, provider, hook, CI gate, auto-apply, or codemod changes.
- Does not generate accessible-name copy or infer custom-component semantics.

## Verification
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `npm test`
- `git diff --check`

Closes #764
