### PR TITLE
Guard post-merge duplicate PR reopens

### DIFF
--- a/docs/pr-alert-disambiguation.md
+++ b/docs/pr-alert-disambiguation.md
@@ -5,6 +5,7 @@ Clawhip/relay-style alert text can describe a `fooks#NNN` close/comment as PR wo
 - `pull_request` present: safe to continue PR-specific handling.
 - `pull_request` absent: stop PR recovery and treat it as an issue event.
 - Alert says `PR fooks#NNN <new> -> merged` and GitHub already reports the PR as merged: treat it as a verification-only echo, not fresh actionable PR recovery.
+- Optional `--pr-evidence` rows can mark an open PR as `duplicate-post-merge` only when the linked issue is already closed by another PR, same-title or overlapping-file evidence is supplied, and the current head is dirty/not mergeable. Treat that as operator cut/close guidance, not automatic close authority or merge recovery.
 
 The guard is read-only. It never comments, closes, reopens, deletes branches, or changes worktrees.
 
@@ -25,3 +26,7 @@ npm run --silent pr:alerts -- --repo minislively/fooks --alerts /tmp/alerts.txt
 ```
 
 This invokes `gh api repos/<owner>/<repo>/issues/<number>` for each matching alert reference and prints a small markdown report. Use rows with `prHandling=skip` as a hard stop before any PR recovery workflow. Use `prHandling=echo` rows only to verify the already-merged GitHub state; do not start fresh PR recovery from that alert.
+
+## Post-merge duplicate reopen evidence
+
+When dogfood alerts mention a reopened duplicate PR after the linked issue has already been closed by a merged PR, attach saved PR-ish evidence with `--pr-evidence`. The guard remains read-only: `operator-close-candidate` means preserve the evidence and use the explicit operator close flow if appropriate. It never comments, closes, reopens, deletes branches, or weakens merge-gate checks.

--- a/scripts/guard-pr-alerts.mjs
+++ b/scripts/guard-pr-alerts.mjs
@@ -10,6 +10,7 @@ function parseArgs(argv) {
   const options = {
     alertsInput: "",
     eventsInput: "",
+    prEvidenceInput: "",
     output: "",
     repo: "",
     format: "markdown",
@@ -19,6 +20,7 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (arg === "--alerts") options.alertsInput = argv[++index];
     else if (arg === "--events") options.eventsInput = argv[++index];
+    else if (arg === "--pr-evidence") options.prEvidenceInput = argv[++index];
     else if (arg === "--repo") options.repo = normalizeRepo(argv[++index]);
     else if (arg === "--output") options.output = argv[++index];
     else if (arg === "--json") options.format = "json";
@@ -38,7 +40,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Usage: node scripts/guard-pr-alerts.mjs --repo <owner/repo> --alerts <path|-> [options]\n\nRead-only guard for alert buffers that mention issue/PR numbers before any PR-specific\nrecovery handling. It resolves refs through GitHub's issues API shape: pull requests\ninclude a pull_request field, while ordinary issues do not.\n\nOptions:\n  --alerts <path|->   Read alert text from a file or stdin\n  --events <path>     Use saved GitHub issue API JSON instead of invoking gh api\n  --repo <owner/repo> Repository to resolve shorthand refs against\n  --json              Emit machine-readable JSON\n  --markdown          Emit markdown (default)\n  --output <path>     Write output to a file instead of stdout\n  -h, --help          Show this help\n\nOffline usage:\n  gh api repos/minislively/fooks/issues/226 > /tmp/fooks-226.json\n  printf 'clawhip/relay: fooks#226 closed/commented' > /tmp/alerts.txt\n  node scripts/guard-pr-alerts.mjs --repo minislively/fooks --alerts /tmp/alerts.txt --events /tmp/fooks-226.json --json\n\nLive usage (read-only):\n  node scripts/guard-pr-alerts.mjs --repo minislively/fooks --alerts /tmp/alerts.txt`);
+  console.log(`Usage: node scripts/guard-pr-alerts.mjs --repo <owner/repo> --alerts <path|-> [options]\n\nRead-only guard for alert buffers that mention issue/PR numbers before any PR-specific\nrecovery handling. It resolves refs through GitHub's issues API shape: pull requests\ninclude a pull_request field, while ordinary issues do not.\n\nOptions:\n  --alerts <path|->   Read alert text from a file or stdin\n  --events <path>     Use saved GitHub issue API JSON instead of invoking gh api\n  --pr-evidence <path>\n                     Use saved PR-ish duplicate evidence keyed by PR number\n  --repo <owner/repo> Repository to resolve shorthand refs against\n  --json              Emit machine-readable JSON\n  --markdown          Emit markdown (default)\n  --output <path>     Write output to a file instead of stdout\n  -h, --help          Show this help\n\nOffline usage:\n  gh api repos/minislively/fooks/issues/226 > /tmp/fooks-226.json\n  printf 'clawhip/relay: fooks#226 closed/commented' > /tmp/alerts.txt\n  node scripts/guard-pr-alerts.mjs --repo minislively/fooks --alerts /tmp/alerts.txt --events /tmp/fooks-226.json --json\n\nLive usage (read-only):\n  node scripts/guard-pr-alerts.mjs --repo minislively/fooks --alerts /tmp/alerts.txt`);
 }
 
 function normalizeRepo(value) {
@@ -95,6 +97,115 @@ function readEvents(eventsInput) {
   return new Map(items.map((item) => [String(item.number), item]));
 }
 
+
+function readPrEvidence(prEvidenceInput) {
+  if (!prEvidenceInput) return new Map();
+  const raw = JSON.parse(fs.readFileSync(path.resolve(repoRoot, prEvidenceInput), "utf8"));
+  const items = Array.isArray(raw) ? raw : raw?.pullRequests ?? raw?.prs ?? [raw];
+  return new Map(items.filter(Boolean).map((item) => [String(item.number), item]));
+}
+
+function normalizeText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/#\d+/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function normalizeFiles(files) {
+  if (!Array.isArray(files)) return [];
+  return files
+    .map((file) => typeof file === "string" ? file : file?.filename ?? file?.path ?? file?.file)
+    .filter((file) => typeof file === "string" && file.trim())
+    .map((file) => file.trim());
+}
+
+function linkedIssueIsClosed(evidence) {
+  const linkedIssue = evidence?.linkedIssue ?? evidence?.linked_issue;
+  return linkedIssue?.state === "closed" || Boolean(linkedIssue?.closedAt ?? linkedIssue?.closed_at);
+}
+
+function closingPullNumber(evidence) {
+  const linkedIssue = evidence?.linkedIssue ?? evidence?.linked_issue;
+  const closer = linkedIssue?.closedByPullRequest ?? linkedIssue?.closed_by_pull_request;
+  const number = closer?.number ?? linkedIssue?.closedByPullRequestNumber ?? linkedIssue?.closed_by_pull_request_number;
+  return Number.isInteger(number) ? number : Number.parseInt(String(number ?? ""), 10);
+}
+
+function headIsDirty(evidence) {
+  const head = evidence?.head ?? {};
+  const dirtyState = head.mergeableState ?? head.mergeable_state ?? evidence?.mergeableState ?? evidence?.mergeable_state;
+  if (["dirty", "conflicting"].includes(String(dirtyState ?? "").toLowerCase())) return true;
+  if (head.isDirty === true || head.dirty === true || evidence?.dirtyHead === true || evidence?.dirty_head === true) return true;
+  if (evidence?.mergeable === false || head.mergeable === false) return true;
+  return false;
+}
+
+function titleDuplicateSignal(evidence, relatedPulls) {
+  const title = normalizeText(evidence?.title);
+  if (!title) return null;
+  return relatedPulls.find((candidate) => normalizeText(candidate?.title) === title) ?? null;
+}
+
+function fileOverlapSignal(evidence, relatedPulls) {
+  const currentFiles = new Set(normalizeFiles(evidence?.files));
+  if (currentFiles.size === 0) return { candidate: null, files: [] };
+  for (const candidate of relatedPulls) {
+    const overlap = normalizeFiles(candidate?.files).filter((file) => currentFiles.has(file));
+    if (overlap.length > 0) return { candidate, files: overlap };
+  }
+  return { candidate: null, files: [] };
+}
+
+function classifyPostMergeDuplicatePr(evidence) {
+  if (!evidence || typeof evidence !== "object") {
+    return { classification: "not-evaluated", recommendation: "no-duplicate-evidence", reasons: ["No PR duplicate evidence was supplied."] };
+  }
+
+  const relatedPulls = Array.isArray(evidence.relatedPullRequests) ? evidence.relatedPullRequests
+    : Array.isArray(evidence.related_pull_requests) ? evidence.related_pull_requests
+      : [];
+  const closingNumber = closingPullNumber(evidence);
+  const closingCandidate = Number.isInteger(closingNumber)
+    ? relatedPulls.find((candidate) => Number(candidate?.number) === closingNumber)
+    : null;
+  const closingCandidateIsMerged = Boolean(closingCandidate?.mergedAt || closingCandidate?.merged_at || closingCandidate?.merged === true);
+  const duplicateCandidates = closingCandidate ? [closingCandidate] : [];
+  const titleMatch = titleDuplicateSignal(evidence, duplicateCandidates);
+  const fileOverlap = fileOverlapSignal(evidence, duplicateCandidates);
+  const duplicateSignals = [];
+  if (titleMatch) duplicateSignals.push(`title matches closing PR #${titleMatch.number}`);
+  if (fileOverlap.files.length > 0) duplicateSignals.push(`files overlap closing PR #${fileOverlap.candidate?.number ?? "unknown"}: ${fileOverlap.files.join(", ")}`);
+
+  const reasons = [];
+  if (linkedIssueIsClosed(evidence)) reasons.push("linked issue is already closed");
+  else reasons.push("linked issue is not known closed");
+
+  if (Number.isInteger(closingNumber)) reasons.push(`linked issue was closed by PR #${closingNumber}`);
+  else reasons.push("linked issue closer PR is unknown");
+
+  if (closingCandidateIsMerged) reasons.push(`closing PR #${closingCandidate.number} is merged`);
+  else if (closingCandidate) reasons.push(`closing PR #${closingCandidate.number} is related but not known merged`);
+  else if (Number.isInteger(closingNumber)) reasons.push(`closing PR #${closingNumber} evidence was not supplied`);
+
+  if (duplicateSignals.length > 0) reasons.push(...duplicateSignals);
+  else reasons.push("no same-title or overlapping-file duplicate signal supplied");
+
+  if (headIsDirty(evidence)) reasons.push("current PR head is dirty or not mergeable");
+  else reasons.push("current PR head is not known dirty");
+
+  const isPostMergeDuplicate = linkedIssueIsClosed(evidence) && closingCandidateIsMerged && Number.isInteger(closingNumber) && duplicateSignals.length > 0 && headIsDirty(evidence);
+  return {
+    classification: isPostMergeDuplicate ? "duplicate-post-merge" : "insufficient-duplicate-post-merge-evidence",
+    recommendation: isPostMergeDuplicate ? "operator-close-candidate" : "continue-normal-pr-triage",
+    mergeRecovery: isPostMergeDuplicate ? "do-not-start-merge-recovery" : "not-ruled-out",
+    destructiveAction: "none-read-only",
+    reasons,
+  };
+}
+
 function fetchIssue(ref) {
   const stdout = execFileSync("gh", ["api", `repos/${ref.owner}/${ref.repo}/issues/${ref.number}`], {
     cwd: repoRoot,
@@ -135,11 +246,15 @@ function githubStateIsMerged(issue) {
   );
 }
 
-function classifyIssue(ref, issue, alertText) {
+function classifyIssue(ref, issue, alertText, duplicateEvidence = null) {
   const isPullRequest = Boolean(issue?.pull_request);
   const isMerged = isPullRequest && githubStateIsMerged(issue);
   const isNewToMergedEcho = isMerged && alertLooksLikeNewToMergedEcho(alertText, ref);
   const isPrunedDogfoodRuntimeCleanupEcho = isMerged && alertLooksLikePrunedDogfoodRuntimeCleanupEcho(alertText, ref);
+  const postMergeDuplicate = isPullRequest && duplicateEvidence ? classifyPostMergeDuplicatePr(duplicateEvidence) : null;
+  const prHandling = postMergeDuplicate?.classification === "duplicate-post-merge"
+    ? "cut"
+    : isNewToMergedEcho || isPrunedDogfoodRuntimeCleanupEcho ? "echo" : isPullRequest ? "allow" : "skip";
   return {
     repo: `${ref.owner}/${ref.repo}`,
     number: ref.number,
@@ -148,12 +263,13 @@ function classifyIssue(ref, issue, alertText) {
     state: issue?.state ?? "unknown",
     htmlUrl: issue?.html_url ?? `https://github.com/${ref.owner}/${ref.repo}/issues/${ref.number}`,
     kind: isPullRequest ? "pull_request" : "issue",
-    prHandling: isNewToMergedEcho || isPrunedDogfoodRuntimeCleanupEcho ? "echo" : isPullRequest ? "allow" : "skip",
+    prHandling,
     reason: isNewToMergedEcho
       ? "Alert reports <new> -> merged and GitHub state is already merged; verification-only echo"
       : isPrunedDogfoodRuntimeCleanupEcho
         ? "Alert reports merged dogfood stale runtime cleanup and GitHub state is already merged; no-action echo"
         : isPullRequest ? "GitHub issue API response includes pull_request" : "GitHub issue API response has no pull_request field",
+    ...(postMergeDuplicate ? { postMergeDuplicate } : {}),
   };
 }
 
@@ -161,14 +277,17 @@ function buildReport(options) {
   const alertText = readText(options.alertsInput);
   const refs = extractRefs(alertText, options.repo);
   const eventFixtures = readEvents(options.eventsInput);
+  const prEvidence = readPrEvidence(options.prEvidenceInput);
   const rows = refs.map((ref) => {
     const issue = eventFixtures.get(String(ref.number)) ?? fetchIssue(ref);
-    return classifyIssue(ref, issue, alertText);
+    return classifyIssue(ref, issue, alertText, prEvidence.get(String(ref.number)));
   });
 
   const counts = rows.reduce((acc, row) => {
     acc[row.kind] = (acc[row.kind] ?? 0) + 1;
     acc[row.prHandling] = (acc[row.prHandling] ?? 0) + 1;
+    const duplicateClass = row.postMergeDuplicate?.classification;
+    if (duplicateClass) acc[duplicateClass] = (acc[duplicateClass] ?? 0) + 1;
     return acc;
   }, {});
 
@@ -193,7 +312,7 @@ function renderMarkdown(result) {
     "",
     `Repository: \`${result.repository}\``,
     "",
-    "Use `prHandling=skip` rows as a hard stop for PR-specific recovery. The guard is read-only and classifies GitHub refs via the issues API `pull_request` field.",
+    "Use `prHandling=skip` rows as a hard stop for PR-specific recovery. Use `postMergeDuplicate.classification=duplicate-post-merge` as read-only cut/close guidance, not merge recovery. The guard is read-only and classifies GitHub refs via the issues API `pull_request` field.",
     "",
     "## Summary",
     "",
@@ -202,7 +321,9 @@ function renderMarkdown(result) {
     `- Issues: ${result.counts.issue ?? 0}`,
     `- PR handling allowed: ${result.counts.allow ?? 0}`,
     `- PR handling skipped: ${result.counts.skip ?? 0}`,
+    `- PR handling cut/close candidates: ${result.counts.cut ?? 0}`,
     `- Verification-only echoes: ${result.counts.echo ?? 0}`,
+    `- Duplicate post-merge close candidates: ${result.counts["duplicate-post-merge"] ?? 0}`,
     "",
     "## Rows",
     "",
@@ -213,11 +334,12 @@ function renderMarkdown(result) {
     return `${lines.join("\n")}\n`;
   }
 
-  lines.push("| PR handling | Kind | Ref | State | Title | Reason |");
-  lines.push("| --- | --- | --- | --- | --- | --- |");
+  lines.push("| PR handling | Duplicate guard | Kind | Ref | State | Title | Reason |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const row of result.rows) {
     const ref = row.htmlUrl ? `[${row.repo}#${row.number}](${row.htmlUrl})` : `\`${row.repo}#${row.number}\``;
-    lines.push(`| ${row.prHandling} | ${row.kind} | ${ref} | ${escapeMarkdown(row.state)} | ${escapeMarkdown(row.title || "-")} | ${escapeMarkdown(row.reason)} |`);
+    const duplicateGuard = row.postMergeDuplicate ? `${row.postMergeDuplicate.classification}/${row.postMergeDuplicate.recommendation}` : "-";
+    lines.push(`| ${row.prHandling} | ${escapeMarkdown(duplicateGuard)} | ${row.kind} | ${ref} | ${escapeMarkdown(row.state)} | ${escapeMarkdown(row.title || "-")} | ${escapeMarkdown(row.reason)} |`);
   }
   return `${lines.join("\n")}\n`;
 }

--- a/test/pr-alert-guard.test.mjs
+++ b/test/pr-alert-guard.test.mjs
@@ -187,6 +187,165 @@ test("PR alert guard treats already merged pruned dogfood runtime cleanup as no-
   }
 });
 
+
+test("PR alert guard marks dirty duplicate of already-closed linked issue as operator close candidate", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-duplicate-post-merge-"));
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const eventsPath = path.join(tempDir, "events.json");
+  const prEvidencePath = path.join(tempDir, "pr-evidence.json");
+
+  fs.writeFileSync(alertsPath, "relay: https://github.com/minislively/fooks/pull/769 reopened with dirty merge state after #767 merged");
+  fs.writeFileSync(eventsPath, JSON.stringify({
+    number: 769,
+    title: "React Web decision layer",
+    state: "open",
+    html_url: "https://github.com/minislively/fooks/pull/769",
+    pull_request: {
+      url: "https://api.github.com/repos/minislively/fooks/pulls/769",
+      html_url: "https://github.com/minislively/fooks/pull/769",
+    },
+  }));
+  fs.writeFileSync(prEvidencePath, JSON.stringify({
+    number: 769,
+    title: "React Web decision layer",
+    head: { mergeableState: "dirty" },
+    linkedIssue: {
+      number: 766,
+      state: "closed",
+      closedByPullRequestNumber: 767,
+    },
+    files: [
+      "src/reporting/react-web-evidence-artifact.ts",
+      "scripts/react-web-pr-gate-surface.mjs",
+    ],
+    relatedPullRequests: [
+      {
+        number: 767,
+        title: "React Web decision layer",
+        state: "closed",
+        mergedAt: "2026-05-11T12:00:00Z",
+        files: [
+          "src/reporting/react-web-evidence-artifact.ts",
+          "scripts/react-web-pr-gate-surface.mjs",
+        ],
+      },
+      {
+        number: 768,
+        title: "React Web decision layer",
+        state: "open",
+        files: ["scripts/react-web-pr-gate-surface.mjs"],
+      },
+    ],
+  }));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      guardScript,
+      "--repo",
+      "minislively/fooks",
+      "--alerts",
+      alertsPath,
+      "--events",
+      eventsPath,
+      "--pr-evidence",
+      prEvidencePath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const duplicate = result.rows[0].postMergeDuplicate;
+
+    assert.equal(result.totalRefs, 1);
+    assert.equal(result.counts.pull_request, 1);
+    assert.equal(result.counts.cut, 1);
+    assert.equal(result.counts.allow ?? 0, 0);
+    assert.equal(result.counts["duplicate-post-merge"], 1);
+    assert.equal(duplicate.classification, "duplicate-post-merge");
+    assert.equal(duplicate.recommendation, "operator-close-candidate");
+    assert.equal(duplicate.mergeRecovery, "do-not-start-merge-recovery");
+    assert.equal(duplicate.destructiveAction, "none-read-only");
+    assert.match(duplicate.reasons.join("\n"), /linked issue is already closed/);
+    assert.match(duplicate.reasons.join("\n"), /linked issue was closed by PR #767/);
+    assert.match(duplicate.reasons.join("\n"), /title matches closing PR #767/);
+    assert.match(duplicate.reasons.join("\n"), /files overlap closing PR #767/);
+    assert.match(duplicate.reasons.join("\n"), /current PR head is dirty or not mergeable/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+
+test("PR alert guard does not cut duplicate-looking PR when closing PR is not known merged", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-duplicate-not-merged-"));
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const eventsPath = path.join(tempDir, "events.json");
+  const prEvidencePath = path.join(tempDir, "pr-evidence.json");
+
+  fs.writeFileSync(alertsPath, "relay: https://github.com/minislively/fooks/pull/769 reopened with dirty merge state after #767 referenced");
+  fs.writeFileSync(eventsPath, JSON.stringify({
+    number: 769,
+    title: "React Web decision layer",
+    state: "open",
+    html_url: "https://github.com/minislively/fooks/pull/769",
+    pull_request: {
+      url: "https://api.github.com/repos/minislively/fooks/pulls/769",
+      html_url: "https://github.com/minislively/fooks/pull/769",
+    },
+  }));
+  fs.writeFileSync(prEvidencePath, JSON.stringify({
+    number: 769,
+    title: "React Web decision layer",
+    head: { mergeableState: "dirty" },
+    linkedIssue: {
+      number: 766,
+      state: "closed",
+      closedByPullRequestNumber: 767,
+    },
+    files: ["scripts/react-web-pr-gate-surface.mjs"],
+    relatedPullRequests: [{
+      number: 767,
+      title: "React Web decision layer",
+      state: "closed",
+      files: ["scripts/react-web-pr-gate-surface.mjs"],
+    }],
+  }));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      guardScript,
+      "--repo",
+      "minislively/fooks",
+      "--alerts",
+      alertsPath,
+      "--events",
+      eventsPath,
+      "--pr-evidence",
+      prEvidencePath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const duplicate = result.rows[0].postMergeDuplicate;
+
+    assert.equal(result.counts.cut ?? 0, 0);
+    assert.equal(result.counts.allow, 1);
+    assert.equal(result.counts["duplicate-post-merge"] ?? 0, 0);
+    assert.equal(duplicate.classification, "insufficient-duplicate-post-merge-evidence");
+    assert.equal(duplicate.recommendation, "continue-normal-pr-triage");
+    assert.equal(duplicate.mergeRecovery, "not-ruled-out");
+    assert.match(duplicate.reasons.join("\n"), /closing PR #767 is related but not known merged/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("PR alert disambiguation docs reference an existing package script", () => {
   const doc = fs.readFileSync(path.join(repoRoot, "docs", "pr-alert-disambiguation.md"), "utf8");
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));


### PR DESCRIPTION
## Summary
- add optional saved `--pr-evidence` support to the read-only PR alert guard
- classify dirty duplicate PR reopens as `duplicate-post-merge` / `operator-close-candidate` only when the linked issue is closed by an explicitly merged closing PR and title/files overlap that closing PR
- document that the guidance is evidence-only and does not close, reopen, delete, or weaken merge gates

Closes #770

## Verification
- `npm ci`
- `npm test` (754 passing)
- `npm run build`
- `npm run lint`
- `node --test test/pr-alert-guard.test.mjs` (7 passing)
- `git diff --check`
- final code review: APPROVE; architecture: CLEAR

## Safety boundaries
- Read-only classifier output only; no GitHub mutation or branch cleanup is introduced.
- Duplicate cut guidance requires explicit merged closing-PR evidence before suppressing merge recovery.
- Existing merge-gate policy files were not changed.
