### PR TITLE
Expose duplicate PR cut evidence

### DIFF
--- a/docs/pr-alert-disambiguation.md
+++ b/docs/pr-alert-disambiguation.md
@@ -29,4 +29,24 @@ This invokes `gh api repos/<owner>/<repo>/issues/<number>` for each matching ale
 
 ## Post-merge duplicate reopen evidence
 
-When dogfood alerts mention a reopened duplicate PR after the linked issue has already been closed by a merged PR, attach saved PR-ish evidence with `--pr-evidence`. The guard remains read-only: `operator-close-candidate` means preserve the evidence and use the explicit operator close flow if appropriate. It never comments, closes, reopens, deletes branches, or weakens merge-gate checks.
+When dogfood alerts mention reopened duplicate PRs after the linked issue has already been closed by a merged PR, attach saved PR-ish evidence with `--pr-evidence`. The guard remains read-only: `operator-close-candidate` / `cut-duplicate-pr` means preserve the evidence and use the explicit operator close flow if appropriate. It never comments, closes, reopens, deletes branches, or weakens merge-gate checks.
+
+The markdown report includes an `Operator duplicate PR cut evidence` section for every PR with supplied duplicate evidence. For #768/#769-style duplicates, expect concise lines covering:
+
+- linked issue closed state;
+- closing PR number and merged state;
+- same-title and/or overlapping-file duplicate signals;
+- dirty/not-mergeable current PR head;
+- the read-only action boundary.
+
+Example dogfood command shape:
+
+```sh
+npm run --silent pr:alerts -- \
+  --repo minislively/fooks \
+  --alerts /tmp/fooks-duplicate-alerts.txt \
+  --events /tmp/fooks-issues-768-769.json \
+  --pr-evidence /tmp/fooks-pr-768-769-evidence.json
+```
+
+Treat `cut-duplicate-pr` as a conservative operator recommendation, not an automated mutation. Treat `do-not-cut` as insufficient evidence and continue normal PR triage.

--- a/scripts/guard-pr-alerts.mjs
+++ b/scripts/guard-pr-alerts.mjs
@@ -134,6 +134,12 @@ function closingPullNumber(evidence) {
   return Number.isInteger(number) ? number : Number.parseInt(String(number ?? ""), 10);
 }
 
+function linkedIssueNumber(evidence) {
+  const linkedIssue = evidence?.linkedIssue ?? evidence?.linked_issue;
+  const number = linkedIssue?.number ?? linkedIssue?.issueNumber ?? linkedIssue?.issue_number;
+  return Number.isInteger(number) ? number : Number.parseInt(String(number ?? ""), 10);
+}
+
 function headIsDirty(evidence) {
   const head = evidence?.head ?? {};
   const dirtyState = head.mergeableState ?? head.mergeable_state ?? evidence?.mergeableState ?? evidence?.mergeable_state;
@@ -197,11 +203,28 @@ function classifyPostMergeDuplicatePr(evidence) {
   else reasons.push("current PR head is not known dirty");
 
   const isPostMergeDuplicate = linkedIssueIsClosed(evidence) && closingCandidateIsMerged && Number.isInteger(closingNumber) && duplicateSignals.length > 0 && headIsDirty(evidence);
+  const linkedNumber = linkedIssueNumber(evidence);
+  const evidenceLines = [
+    Number.isInteger(linkedNumber)
+      ? `linked issue #${linkedNumber}: ${linkedIssueIsClosed(evidence) ? "closed" : "not known closed"}`
+      : `linked issue: ${linkedIssueIsClosed(evidence) ? "closed" : "not known closed"}`,
+    Number.isInteger(closingNumber)
+      ? `closing PR #${closingNumber}: ${closingCandidateIsMerged ? "merged" : closingCandidate ? "not known merged" : "evidence missing"}`
+      : "closing PR: unknown",
+    duplicateSignals.length > 0
+      ? `duplicate signals: ${duplicateSignals.join("; ")}`
+      : "duplicate signals: no same-title or overlapping-file signal supplied",
+    `current PR head: ${headIsDirty(evidence) ? "dirty/not mergeable" : "not known dirty"}`,
+    "action boundary: read-only evidence only; no close/comment/delete/branch cleanup performed",
+  ];
+
   return {
     classification: isPostMergeDuplicate ? "duplicate-post-merge" : "insufficient-duplicate-post-merge-evidence",
     recommendation: isPostMergeDuplicate ? "operator-close-candidate" : "continue-normal-pr-triage",
+    cutRecommendation: isPostMergeDuplicate ? "cut-duplicate-pr" : "do-not-cut",
     mergeRecovery: isPostMergeDuplicate ? "do-not-start-merge-recovery" : "not-ruled-out",
     destructiveAction: "none-read-only",
+    evidenceLines,
     reasons,
   };
 }
@@ -341,6 +364,22 @@ function renderMarkdown(result) {
     const duplicateGuard = row.postMergeDuplicate ? `${row.postMergeDuplicate.classification}/${row.postMergeDuplicate.recommendation}` : "-";
     lines.push(`| ${row.prHandling} | ${escapeMarkdown(duplicateGuard)} | ${row.kind} | ${ref} | ${escapeMarkdown(row.state)} | ${escapeMarkdown(row.title || "-")} | ${escapeMarkdown(row.reason)} |`);
   }
+
+  const duplicateRows = result.rows.filter((row) => row.postMergeDuplicate?.evidenceLines?.length > 0);
+  if (duplicateRows.length > 0) {
+    lines.push("", "## Operator duplicate PR cut evidence", "");
+    lines.push("Read-only recommendation lines for operator review; the script does not mutate GitHub state.", "");
+    for (const row of duplicateRows) {
+      lines.push(`### ${escapeMarkdown(row.repo)}#${row.number}: ${escapeMarkdown(row.postMergeDuplicate.cutRecommendation)}`);
+      lines.push(`- classification: ${escapeMarkdown(row.postMergeDuplicate.classification)}`);
+      lines.push(`- recommendation: ${escapeMarkdown(row.postMergeDuplicate.recommendation)}`);
+      for (const evidenceLine of row.postMergeDuplicate.evidenceLines) {
+        lines.push(`- evidence: ${escapeMarkdown(evidenceLine)}`);
+      }
+      lines.push("");
+    }
+  }
+
   return `${lines.join("\n")}\n`;
 }
 

--- a/test/pr-alert-guard.test.mjs
+++ b/test/pr-alert-guard.test.mjs
@@ -140,7 +140,6 @@ test("PR alert guard treats new-to-merged alerts for already merged PRs as verif
   }
 });
 
-
 test("PR alert guard treats already merged pruned dogfood runtime cleanup as no-action echo", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-dogfood-runtime-"));
   const alertsPath = path.join(tempDir, "alerts.txt");
@@ -186,7 +185,6 @@ test("PR alert guard treats already merged pruned dogfood runtime cleanup as no-
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
-
 
 test("PR alert guard marks dirty duplicate of already-closed linked issue as operator close candidate", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-duplicate-post-merge-"));
@@ -265,6 +263,7 @@ test("PR alert guard marks dirty duplicate of already-closed linked issue as ope
     assert.equal(result.counts["duplicate-post-merge"], 1);
     assert.equal(duplicate.classification, "duplicate-post-merge");
     assert.equal(duplicate.recommendation, "operator-close-candidate");
+    assert.equal(duplicate.cutRecommendation, "cut-duplicate-pr");
     assert.equal(duplicate.mergeRecovery, "do-not-start-merge-recovery");
     assert.equal(duplicate.destructiveAction, "none-read-only");
     assert.match(duplicate.reasons.join("\n"), /linked issue is already closed/);
@@ -272,12 +271,17 @@ test("PR alert guard marks dirty duplicate of already-closed linked issue as ope
     assert.match(duplicate.reasons.join("\n"), /title matches closing PR #767/);
     assert.match(duplicate.reasons.join("\n"), /files overlap closing PR #767/);
     assert.match(duplicate.reasons.join("\n"), /current PR head is dirty or not mergeable/);
+    assert.deepEqual(duplicate.evidenceLines, [
+      "linked issue #766: closed",
+      "closing PR #767: merged",
+      "duplicate signals: title matches closing PR #767; files overlap closing PR #767: src/reporting/react-web-evidence-artifact.ts, scripts/react-web-pr-gate-surface.mjs",
+      "current PR head: dirty/not mergeable",
+      "action boundary: read-only evidence only; no close/comment/delete/branch cleanup performed",
+    ]);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
-
-
 
 test("PR alert guard does not cut duplicate-looking PR when closing PR is not known merged", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-duplicate-not-merged-"));
@@ -339,8 +343,93 @@ test("PR alert guard does not cut duplicate-looking PR when closing PR is not kn
     assert.equal(result.counts["duplicate-post-merge"] ?? 0, 0);
     assert.equal(duplicate.classification, "insufficient-duplicate-post-merge-evidence");
     assert.equal(duplicate.recommendation, "continue-normal-pr-triage");
+    assert.equal(duplicate.cutRecommendation, "do-not-cut");
     assert.equal(duplicate.mergeRecovery, "not-ruled-out");
     assert.match(duplicate.reasons.join("\n"), /closing PR #767 is related but not known merged/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("PR alert guard renders compact read-only cut evidence for #768/#769 duplicate candidates", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-pr-alert-guard-operator-cut-evidence-"));
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const eventsPath = path.join(tempDir, "events.json");
+  const prEvidencePath = path.join(tempDir, "pr-evidence.json");
+
+  fs.writeFileSync(alertsPath, [
+    "relay: https://github.com/minislively/fooks/pull/768 reopened after closing PR #767 merged",
+    "relay: https://github.com/minislively/fooks/pull/769 reopened dirty duplicate after issue #766 closed",
+  ].join("\n"));
+  fs.writeFileSync(eventsPath, JSON.stringify([
+    {
+      number: 768,
+      title: "React Web decision layer",
+      state: "open",
+      html_url: "https://github.com/minislively/fooks/pull/768",
+      pull_request: { html_url: "https://github.com/minislively/fooks/pull/768" },
+    },
+    {
+      number: 769,
+      title: "React Web decision layer",
+      state: "open",
+      html_url: "https://github.com/minislively/fooks/pull/769",
+      pull_request: { html_url: "https://github.com/minislively/fooks/pull/769" },
+    },
+  ]));
+  fs.writeFileSync(prEvidencePath, JSON.stringify({
+    pullRequests: [768, 769].map((number) => ({
+      number,
+      title: "React Web decision layer",
+      head: { mergeableState: "dirty" },
+      linkedIssue: {
+        number: 766,
+        state: "closed",
+        closedByPullRequestNumber: 767,
+      },
+      files: [
+        "src/reporting/react-web-evidence-artifact.ts",
+        "scripts/react-web-pr-gate-surface.mjs",
+      ],
+      relatedPullRequests: [{
+        number: 767,
+        title: "React Web decision layer",
+        state: "closed",
+        mergedAt: "2026-05-11T12:00:00Z",
+        files: [
+          "src/reporting/react-web-evidence-artifact.ts",
+          "scripts/react-web-pr-gate-surface.mjs",
+        ],
+      }],
+    })),
+  }));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      guardScript,
+      "--repo",
+      "minislively/fooks",
+      "--alerts",
+      alertsPath,
+      "--events",
+      eventsPath,
+      "--pr-evidence",
+      prEvidencePath,
+      "--markdown",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    assert.match(stdout, /## Operator duplicate PR cut evidence/);
+    assert.match(stdout, /### minislively\/fooks#768: cut-duplicate-pr/);
+    assert.match(stdout, /### minislively\/fooks#769: cut-duplicate-pr/);
+    assert.match(stdout, /- evidence: linked issue #766: closed/);
+    assert.match(stdout, /- evidence: closing PR #767: merged/);
+    assert.match(stdout, /- evidence: duplicate signals: title matches closing PR #767; files overlap closing PR #767:/);
+    assert.match(stdout, /- evidence: current PR head: dirty\/not mergeable/);
+    assert.match(stdout, /- evidence: action boundary: read-only evidence only; no close\/comment\/delete\/branch cleanup performed/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -351,7 +440,8 @@ test("PR alert disambiguation docs reference an existing package script", () => 
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   const referencedScripts = [...doc.matchAll(/npm run --silent ([^\s]+)/g)].map((match) => match[1]);
 
-  assert.deepEqual(referencedScripts, ["pr:alerts", "pr:alerts"]);
+  assert.ok(referencedScripts.length >= 2);
+  assert.ok(referencedScripts.every((script) => script === "pr:alerts"));
   for (const script of referencedScripts) {
     assert.ok(pkg.scripts[script], `docs reference missing npm script: ${script}`);
   }


### PR DESCRIPTION
Closes #772.

## Summary
- add advisory `cutRecommendation` and compact `evidenceLines` to duplicate-post-merge PR evidence
- render an `Operator duplicate PR cut evidence` markdown section in the existing read-only `pr:alerts` guard
- document the #768/#769-style dogfood command shape and add focused positive/negative guard coverage

## Safety
- read-only only: no close/comment/delete/branch cleanup behavior added
- merge-gate policy unchanged
- duplicate cut output remains operator guidance, not mutation authority

## Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `node --test test/pr-alert-guard.test.mjs`
- `npm test`
- `git diff --check`
