### PR TITLE
Clarify stale residue cannot satisfy active work

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -21,6 +21,7 @@ export const OPERATOR_CHECK_CLAIM_BOUNDARY =
   "Read-only operator/check artifact for the post-merge main echo versus active work boundary; it requires a concrete issue, PR, or mapped session artifact when the checkout is otherwise idle.";
 export const OPERATOR_CHECK_SOURCE = `status activity ${OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG} projection`;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
@@ -34,10 +35,13 @@ export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE_URL = "https://github.com
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE_URL = "https://github.com/minislively/fooks/issues/739";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SOURCE = "operator/check stale worktree residue ledger projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SOURCE = "operator/check stale worktree residue cleanup-review manifest projection";
+export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SOURCE = "operator/check stale worktree residue active-boundary projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_CLAIM_BOUNDARY =
   "Read-only issue #736 operator receipt for stale sibling worktree residue; groups existing triage classes by count and next review action only, without paths, cleanup commands, fetch, delete, push, or mutation authority.";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_CLAIM_BOUNDARY =
   "Read-only issue #739 operator cleanup-review manifest for stale sibling worktree residue; lists per-row reason, risk class, and required manual action without paths, cleanup commands, fetch, delete, push, or mutation authority.";
+export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_CLAIM_BOUNDARY =
+  "Read-only operator/check reminder artifact for stale worktree residue versus active work; stale residue rows are cleanup-review context only and do not satisfy the active issue, PR, or mapped-session requirement.";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_ISSUE = "#720";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_CLAIM_BOUNDARY =
   "Bounded local/static active-work receipt for fooks session-whip handling; aggregate issue/PR counts are not per-artifact identity, stale sibling worktree receipts are adoption classifiers only, and report lines omit paths and cleanup commands.";
@@ -182,6 +186,19 @@ export type OperatorCheckStaleResidueCleanupReviewManifest = {
   localOnlyCommitPolicy: "do-not-delete-local-only-commits-automatically";
 };
 
+export type OperatorCheckStaleResidueActiveBoundary = {
+  schemaVersion: typeof OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION;
+  source: typeof OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SOURCE;
+  claimBoundary: typeof OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_CLAIM_BOUNDARY;
+  readOnly: true;
+  staleResidueCount: number;
+  activeArtifactReceiptCount: number;
+  staleResidueIsActiveWorkEvidence: false;
+  satisfiesActiveArtifactRequirement: false;
+  acceptableActiveArtifacts: ["open GitHub issue", "open GitHub pull request", "mapped fooks tmux session"];
+  reminder: string;
+};
+
 export type OperatorCheckActiveWorkReceipt = {
   kind: OperatorCheckActiveWorkReceiptKind;
   classification: OperatorCheckActiveWorkReceiptClassification;
@@ -204,6 +221,7 @@ export type OperatorCheckActiveWorkReceipts = {
   salvageReviewQueue: OperatorCheckSalvageReviewQueue;
   staleResidueLedger: OperatorCheckStaleResidueLedger;
   cleanupReviewManifest: OperatorCheckStaleResidueCleanupReviewManifest;
+  staleResidueActiveBoundary: OperatorCheckStaleResidueActiveBoundary;
   blockers: string[];
 };
 
@@ -539,6 +557,26 @@ function buildCleanupReviewManifest(entries: OrphanLocalWorktreeEntry[]): Operat
   };
 }
 
+function buildStaleResidueActiveBoundary(
+  staleResidueCount: number,
+  activeArtifactReceiptCount: number,
+): OperatorCheckStaleResidueActiveBoundary {
+  return {
+    schemaVersion: OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION,
+    source: OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SOURCE,
+    claimBoundary: OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_CLAIM_BOUNDARY,
+    readOnly: true,
+    staleResidueCount,
+    activeArtifactReceiptCount,
+    staleResidueIsActiveWorkEvidence: false,
+    satisfiesActiveArtifactRequirement: false,
+    acceptableActiveArtifacts: ["open GitHub issue", "open GitHub pull request", "mapped fooks tmux session"],
+    reminder: staleResidueCount > 0
+      ? "Stale worktree residue is cleanup-review context only; require an open issue, open PR, or mapped fooks tmux session before treating this snapshot as active work."
+      : "No stale worktree residue was projected into this operator/check snapshot.",
+  };
+}
+
 function buildSalvageReviewQueue(entries: OrphanLocalWorktreeEntry[]): OperatorCheckSalvageReviewQueue {
   const items = entries
     .filter((entry) => !entry.current)
@@ -675,6 +713,10 @@ function buildActiveWorkReceipts(
     ...receipts.flatMap((receipt) => receipt.blockers),
   ]);
   const classification = overallReceiptClassification(receipts, blockers);
+  const activeArtifactReceiptCount = receipts.filter((receipt) =>
+    receipt.classification === "active"
+    && (receipt.kind === "issue" || receipt.kind === "pullRequest" || receipt.kind === "session")
+  ).length;
   return {
     schemaVersion: OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION,
     source: OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE,
@@ -694,6 +736,10 @@ function buildActiveWorkReceipts(
     salvageReviewQueue: siblingReceipts.salvageReviewQueue,
     staleResidueLedger: siblingReceipts.staleResidueLedger,
     cleanupReviewManifest: siblingReceipts.cleanupReviewManifest,
+    staleResidueActiveBoundary: buildStaleResidueActiveBoundary(
+      siblingReceipts.staleResidueLedger.totalCount,
+      activeArtifactReceiptCount,
+    ),
     blockers,
   };
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -312,6 +312,11 @@ test("operator check forces a concrete active artifact when post-merge main echo
   assert.equal(snapshot.activeWorkReceipts.cleanupReviewManifest.issue, "#739");
   assert.equal(snapshot.activeWorkReceipts.cleanupReviewManifest.readOnly, true);
   assert.equal(snapshot.activeWorkReceipts.cleanupReviewManifest.rowCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.readOnly, true);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
   assert.deepEqual(snapshot.blockers, []);
 });
 
@@ -379,6 +384,13 @@ test("operator check treats issue, PR, or mapped session as the concrete active 
   assert.equal(sessionReceipt?.classification, "active");
   assert.deepEqual(sessionReceipt?.identifiers.session, { name: "fooks-705", paneCount: 1 });
   assert.equal("number" in receiptsByKind.get("issue"), false);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 3);
+  assert.deepEqual(snapshot.activeWorkReceipts.staleResidueActiveBoundary.acceptableActiveArtifacts, [
+    "open GitHub issue",
+    "open GitHub pull request",
+    "mapped fooks tmux session",
+  ]);
 });
 
 
@@ -473,6 +485,11 @@ test("operator check projects sibling worktree adoption receipts without cleanup
   assert.equal(snapshot.activeWorkReceipts.cleanupReviewManifest.readOnly, true);
   assert.match(snapshot.activeWorkReceipts.cleanupReviewManifest.claimBoundary, /per-row reason, risk class, and required manual action/);
   assert.equal(snapshot.activeWorkReceipts.cleanupReviewManifest.rowCount, 2);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueCount, 2);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 1);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
+  assert.match(snapshot.activeWorkReceipts.staleResidueActiveBoundary.reminder, /require an open issue, open PR, or mapped fooks tmux session/);
   const byBranch = new Map(worktreeReceipts.map((receipt) => [receipt.identifiers.worktree.branch, receipt]));
   const manifestRowsByBranch = new Map(snapshot.activeWorkReceipts.cleanupReviewManifest.rows.map((row) => [row.branch, row]));
 
@@ -524,6 +541,7 @@ test("operator check projects sibling worktree adoption receipts without cleanup
     snapshot.activeWorkReceipts.salvageReviewQueue,
     snapshot.activeWorkReceipts.staleResidueLedger,
     snapshot.activeWorkReceipts.cleanupReviewManifest,
+    snapshot.activeWorkReceipts.staleResidueActiveBoundary,
   ]);
   assert.equal(receiptJson.includes(safeWorktree), false);
   assert.equal(receiptJson.includes(localAheadWorktree), false);
@@ -806,6 +824,9 @@ test("operator check stale residue ledger aggregates manual-review-noise and exc
   assert.equal(ledger.classes[2].nextReviewAction, "confirm-closed-pr-or-detached-review-context-before-ignoring");
   assert.match(snapshot.activeWorkReceipts.reportLine, /staleResidueLedger=2/);
   assert.match(snapshot.activeWorkReceipts.reportLine, /cleanupReviewManifest=2\(#739\)/);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueCount, 2);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
 
   const manifest = snapshot.activeWorkReceipts.cleanupReviewManifest;
   assert.equal(manifest.issue, "#739");


### PR DESCRIPTION
## Summary
- Adds a read-only `staleResidueActiveBoundary` projection to `fooks check` active-work receipts.
- Makes stale worktree residue explicitly cleanup-review context only: it never satisfies the active issue, PR, or mapped fooks tmux session requirement.
- Counts only active acceptable receipt rows (`issue`, `pullRequest`, `session`) via `activeArtifactReceiptCount`, excluding branch/worktree residue.

Closes #775.

## Related stale-session audit
- This worktree was behind `origin/main` by 8 with local modified `src/ops/operator-check.ts` and untracked `.fooks-session-task.txt`.
- No existing PR was found for `dogfood/stale-worktree-residue-active-boundary-20260512040058`.
- Related closed/merged context: #720/#736/#739 and PRs #722/#738/#740 already cover stale-worktree classification/ledger/manifest; this PR preserves the remaining useful active-boundary reminder slice.

## Boundaries
- Read-only operator/check receipt surface only.
- No cleanup, deletion, fetch, provider/runtime, merge-gate, detector, React Web/RN/TUI/WebView, performance, or product-claim behavior changes.
- `.fooks-session-task.txt` is local operational context and intentionally not committed.

## Verification
- `npm ci` (needed because this worktree initially had no `node_modules`)
- `npm run typecheck -- --pretty false`
- `npm run build && node --test test/operator-activity.test.mjs`
- `git diff --check`
- `npm test` (755 passing)
- Scoped ai-slop-cleaner pass: no fallback-like findings, no code changes needed after rename fix
- `$code-review`: code-reviewer APPROVE, architect CLEAR

## Review gate
- [x] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.

Fixes #775
