### PR TITLE
Expose exact post-merge main CI evidence

### DIFF
--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -22,6 +22,18 @@ new recovery, cleanup, or implementation lane from the success echo alone.
   `currentRunEvidence`. The non-active echo case is only
   `classification: "mainEchoNonActive"` with `mainEchoEvidence: true` and
   `activeWorkEvidence: false`.
+- `fooks check --json` and `fooks status activity --include-remote-counts
+  --json` expose `postMergeMainCiEvidence`, a read-only exact-head summary for
+  local `origin/main`. It reports the local `origin/main` head SHA and the
+  latest `CI` plus `React Web Release Report` workflow conclusions for that
+  exact SHA only. The `mainHeadSource` is the local `origin/main` tracking ref
+  with no fetch performed, and `remoteFreshness` is not verified by this
+  read-only surface.
+- `postMergeMainCiEvidence.summary.allExactHeadConclusionsSuccessful` is true
+  only when both exact-head workflow runs completed with `success`. A missing
+  exact-head run is `status: "unknown"` and an incomplete exact-head run is
+  `status: "pending"`; stale pre-merge successes never satisfy the exact-head
+  success summary.
 - `currentRunEvidence` is intentionally narrow: it requires branch `main`, a
   clean worktree, zero local tracking divergence, zero fooks-like tmux sessions,
   and opt-in GitHub open issue/PR counts of zero. If any proof is missing or a

--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -28,12 +28,18 @@ export const OPERATOR_ACTIVITY_LEGACY_WORKTREE_ENTRY_LIMIT = 5;
 export const OPERATOR_ACTIVITY_CURRENT_RUN_SOURCE = "status activity current-run dogfood reminder";
 export const OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY =
   "Current-run operator reminder evidence only; read-only, bounded to this snapshot, and not cleanup authority or runtime/provider behavior.";
+export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE =
+  "GitHub Actions run list for exact local origin/main head; read-only and no fetch performed";
+export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY =
+  "Read-only post-merge main CI evidence for the exact local origin/main head only; missing exact-head workflow evidence stays unknown or pending and never becomes success.";
+export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS = ["CI", "React Web Release Report"] as const;
 
 export type OperatorActivityCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
 export type OperatorActivityPathExists = (targetPath: string) => boolean;
 
 export type OperatorActivityOptions = WorktreeEvidenceOptions & {
   includeRemoteCounts?: boolean;
+  includeRemoteWorkflowEvidence?: boolean;
   commandRunner?: OperatorActivityCommandRunner;
   pathExists?: OperatorActivityPathExists;
   now?: () => string;
@@ -147,6 +153,44 @@ export type OperatorActivityCurrentRunEvidence = {
   blockers: string[];
 };
 
+export type OperatorActivityPostMergeMainWorkflowEvidenceStatus = "success" | "failure" | "pending" | "unknown";
+
+export type OperatorActivityPostMergeMainWorkflowEvidence = {
+  workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number];
+  status: OperatorActivityPostMergeMainWorkflowEvidenceStatus;
+  conclusion?: string;
+  runStatus?: string;
+  runId?: number;
+  url?: string;
+  headSha?: string;
+  headBranch?: string;
+  event?: string;
+  updatedAt?: string;
+  reason: string;
+};
+
+export type OperatorActivityPostMergeMainCiEvidence = {
+  available: boolean;
+  source: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE;
+  claimBoundary: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY;
+  readOnly: true;
+  exactHeadRequired: true;
+  mainRef: "origin/main";
+  mainHeadSource: "local origin/main tracking ref; no fetch performed";
+  remoteFreshness: "not verified";
+  mainHead?: string;
+  workflowEvidence: OperatorActivityPostMergeMainWorkflowEvidence[];
+  summary: {
+    exactHeadWorkflowCount: number;
+    successCount: number;
+    pendingCount: number;
+    unknownCount: number;
+    failureCount: number;
+    allExactHeadConclusionsSuccessful: boolean;
+  };
+  blockers: string[];
+};
+
 export type OperatorActivitySnapshot = {
   schemaVersion: typeof OPERATOR_ACTIVITY_SCHEMA_VERSION;
   command: typeof OPERATOR_ACTIVITY_COMMAND;
@@ -159,6 +203,7 @@ export type OperatorActivitySnapshot = {
   optionalCounts: OperatorActivityRemoteCounts;
   legacyWorktreeEvidence: OperatorActivityLegacyWorktreeEvidence;
   currentRunEvidence: OperatorActivityCurrentRunEvidence;
+  postMergeMainCiEvidence: OperatorActivityPostMergeMainCiEvidence;
   blockers: string[];
 };
 
@@ -438,6 +483,206 @@ function readRemoteCounts(cwd: string, options: OperatorActivityOptions): Operat
   };
 }
 
+type GhRunListEntry = {
+  databaseId?: number;
+  status?: string;
+  conclusion?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  headBranch?: string;
+  headSha?: string;
+  event?: string;
+  name?: string;
+  workflowName?: string;
+  url?: string;
+};
+
+function readLocalOriginMainHead(cwd: string, options: OperatorActivityOptions): { head?: string; blockers: string[] } {
+  const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
+  try {
+    const head = runner("git", ["rev-parse", "--verify", "origin/main"], cwd, DEFAULT_OPERATOR_ACTIVITY_TIMEOUT_MS).trim();
+    return head ? { head, blockers: [] } : { blockers: ["origin/main head unavailable: git rev-parse returned empty output"] };
+  } catch (error) {
+    return { blockers: [`origin/main head unavailable: ${errorDetail(error)}`] };
+  }
+}
+
+function parseGhRunList(output: string): { runs: GhRunListEntry[]; blocker?: string } {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    if (!Array.isArray(parsed)) return { runs: [], blocker: "GitHub Actions run list unavailable: gh returned non-array JSON" };
+    return { runs: parsed.filter((item): item is GhRunListEntry => Boolean(item) && typeof item === "object") as GhRunListEntry[] };
+  } catch (error) {
+    return { runs: [], blocker: `GitHub Actions run list unavailable: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function workflowNameOf(run: GhRunListEntry): string {
+  return run.workflowName || run.name || "";
+}
+
+function latestRunForWorkflow(runs: GhRunListEntry[], workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number], mainHead: string): GhRunListEntry | undefined {
+  return runs
+    .filter((run) => run.headSha === mainHead)
+    .filter((run) => run.headBranch === "main")
+    .filter((run) => workflowNameOf(run) === workflow)
+    .sort((left, right) => String(right.updatedAt ?? right.createdAt ?? "").localeCompare(String(left.updatedAt ?? left.createdAt ?? "")))[0];
+}
+
+function workflowEvidenceFromRun(
+  workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number],
+  mainHead: string | undefined,
+  run: GhRunListEntry | undefined,
+): OperatorActivityPostMergeMainWorkflowEvidence {
+  if (!mainHead) {
+    return {
+      workflow,
+      status: "unknown",
+      reason: "origin/main head is unavailable; exact-head workflow evidence cannot be evaluated",
+    };
+  }
+  if (!run) {
+    return {
+      workflow,
+      status: "unknown",
+      headSha: mainHead,
+      reason: `no ${workflow} run was found for the exact origin/main head`,
+    };
+  }
+
+  const runStatus = run.status;
+  const conclusion = run.conclusion;
+  const base = {
+    workflow,
+    conclusion,
+    runStatus,
+    runId: run.databaseId,
+    url: run.url,
+    headSha: run.headSha,
+    headBranch: run.headBranch,
+    event: run.event,
+    updatedAt: run.updatedAt,
+  };
+  if (runStatus !== "completed") {
+    return {
+      ...base,
+      status: "pending",
+      reason: `${workflow} run for the exact origin/main head is ${runStatus ?? "not completed"}`,
+    };
+  }
+  if (conclusion === "success") {
+    return {
+      ...base,
+      status: "success",
+      reason: `${workflow} run completed successfully for the exact origin/main head`,
+    };
+  }
+  if (conclusion) {
+    return {
+      ...base,
+      status: "failure",
+      reason: `${workflow} run for the exact origin/main head completed with conclusion ${conclusion}`,
+    };
+  }
+  return {
+    ...base,
+    status: "unknown",
+    reason: `${workflow} run for the exact origin/main head is completed but has no conclusion`,
+  };
+}
+
+function summarizePostMergeMainCiEvidence(
+  workflowEvidence: OperatorActivityPostMergeMainWorkflowEvidence[],
+): OperatorActivityPostMergeMainCiEvidence["summary"] {
+  const successCount = workflowEvidence.filter((item) => item.status === "success").length;
+  const pendingCount = workflowEvidence.filter((item) => item.status === "pending").length;
+  const unknownCount = workflowEvidence.filter((item) => item.status === "unknown").length;
+  const failureCount = workflowEvidence.filter((item) => item.status === "failure").length;
+  return {
+    exactHeadWorkflowCount: workflowEvidence.filter((item) => Boolean(item.runId)).length,
+    successCount,
+    pendingCount,
+    unknownCount,
+    failureCount,
+    allExactHeadConclusionsSuccessful:
+      workflowEvidence.length === OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.length
+      && successCount === OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.length,
+  };
+}
+
+function remoteWorkflowEvidenceEnabled(options: OperatorActivityOptions): boolean {
+  return options.includeRemoteWorkflowEvidence ?? options.includeRemoteCounts ?? false;
+}
+
+function readPostMergeMainCiEvidence(cwd: string, options: OperatorActivityOptions): OperatorActivityPostMergeMainCiEvidence {
+  if (!remoteWorkflowEvidenceEnabled(options)) {
+    const workflowEvidence = OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.map((workflow) =>
+      workflowEvidenceFromRun(workflow, undefined, undefined)
+    );
+    const blockers = ["remote workflow evidence disabled; pass --include-remote-counts to inspect exact-head post-merge main CI evidence"];
+    return {
+      available: false,
+      source: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE,
+      claimBoundary: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY,
+      readOnly: true,
+      exactHeadRequired: true,
+      mainRef: "origin/main",
+      mainHeadSource: "local origin/main tracking ref; no fetch performed",
+      remoteFreshness: "not verified",
+      workflowEvidence,
+      summary: summarizePostMergeMainCiEvidence(workflowEvidence),
+      blockers,
+    };
+  }
+
+  const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
+  const mainHeadResult = readLocalOriginMainHead(cwd, options);
+  const blockers = [...mainHeadResult.blockers];
+  let runs: GhRunListEntry[] = [];
+
+  try {
+    const output = runner(
+      "gh",
+      [
+        "run",
+        "list",
+        "--branch",
+        "main",
+        "--limit",
+        "50",
+        "--json",
+        "databaseId,status,conclusion,createdAt,updatedAt,headBranch,headSha,event,name,workflowName,url",
+      ],
+      cwd,
+      DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS,
+    );
+    const parsed = parseGhRunList(output);
+    runs = parsed.runs;
+    if (parsed.blocker) blockers.push(parsed.blocker);
+  } catch (error) {
+    blockers.push(`GitHub Actions run list unavailable: ${errorDetail(error)}`);
+  }
+
+  const workflowEvidence = OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.map((workflow) =>
+    workflowEvidenceFromRun(workflow, mainHeadResult.head, mainHeadResult.head ? latestRunForWorkflow(runs, workflow, mainHeadResult.head) : undefined)
+  );
+
+  return {
+    available: blockers.length === 0,
+    source: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE,
+    claimBoundary: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY,
+    readOnly: true,
+    exactHeadRequired: true,
+    mainRef: "origin/main",
+    mainHeadSource: "local origin/main tracking ref; no fetch performed",
+    remoteFreshness: "not verified",
+    mainHead: mainHeadResult.head,
+    workflowEvidence,
+    summary: summarizePostMergeMainCiEvidence(workflowEvidence),
+    blockers: uniqueSorted(blockers),
+  };
+}
+
 function buildCurrentRunEvidence(
   worktree: OperatorActivityWorktree,
   tmux: OperatorActivityTmux,
@@ -515,6 +760,7 @@ export function readOperatorActivitySnapshot(cwd = process.cwd(), options: Opera
   const optionalCounts = readRemoteCounts(cwd, options);
   const legacyWorktreeEvidence = readLegacyWorktreeEvidence(cwd, options, generatedAt);
   const currentRunEvidence = buildCurrentRunEvidence(worktree, tmux, optionalCounts, legacyWorktreeEvidence);
+  const postMergeMainCiEvidence = readPostMergeMainCiEvidence(cwd, options);
   const optionalCountBlockers = optionalCounts.enabled ? optionalCounts.blockers : [];
 
   return {
@@ -529,6 +775,7 @@ export function readOperatorActivitySnapshot(cwd = process.cwd(), options: Opera
     optionalCounts,
     legacyWorktreeEvidence,
     currentRunEvidence,
+    postMergeMainCiEvidence,
     blockers: uniqueSorted([...worktree.blockers, ...tmux.blockers, ...optionalCountBlockers]),
   };
 }

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -242,6 +242,7 @@ export type OperatorCheckSnapshot = {
     echoOnly: boolean;
     reasons: string[];
   };
+  postMergeMainCiEvidence: OperatorActivitySnapshot["postMergeMainCiEvidence"];
   activeArtifacts: OperatorCheckActiveArtifact[];
   activeWorkReceipts: OperatorCheckActiveWorkReceipts;
   requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
@@ -801,6 +802,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
       echoOnly,
       reasons: activity.currentRunEvidence.reasons,
     },
+    postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
     activeArtifacts,
     activeWorkReceipts,
     requiredActiveArtifact: requiredActiveArtifact(!blocked && !hasActiveArtifact),

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -18,6 +18,8 @@ const {
   OPERATOR_ACTIVITY_COMMAND,
   OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
   OPERATOR_ACTIVITY_CURRENT_RUN_SOURCE,
+  OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY,
+  OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE,
   OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG,
   OPERATOR_ACTIVITY_REMOTE_SOURCE,
   OPERATOR_ACTIVITY_TMUX_COMMAND,
@@ -184,8 +186,176 @@ test("idle activity snapshot remains zero and read-only with opt-in remote count
     blockers: [],
   });
   assert.deepEqual(snapshot.blockers, []);
-  assert.equal(commandCalls.filter((call) => call.startsWith("gh ")).length, 2);
+  assert.equal(commandCalls.filter((call) => call.startsWith("gh ")).length, 3);
   assert.equal(gitCalls.some((call) => call.includes("fetch")), false);
+});
+
+test("operator activity reports exact-head post-merge main CI and release-report conclusions", () => {
+  const tempDir = makeTempProject();
+  const mainHead = "abc123main";
+  const calls = [];
+  const runs = [
+    {
+      databaseId: 101,
+      status: "completed",
+      conclusion: "success",
+      updatedAt: "2026-05-12T10:00:00Z",
+      headBranch: "main",
+      headSha: mainHead,
+      event: "push",
+      workflowName: "CI",
+      url: "https://github.com/minislively/fooks/actions/runs/101",
+    },
+    {
+      databaseId: 102,
+      status: "completed",
+      conclusion: "success",
+      updatedAt: "2026-05-12T10:05:00Z",
+      headBranch: "main",
+      headSha: mainHead,
+      event: "push",
+      workflowName: "React Web Release Report",
+      url: "https://github.com/minislively/fooks/actions/runs/102",
+    },
+    {
+      databaseId: 99,
+      status: "completed",
+      conclusion: "success",
+      updatedAt: "2026-05-12T09:00:00Z",
+      headBranch: "main",
+      headSha: "stale-premerge",
+      event: "push",
+      workflowName: "CI",
+      url: "https://github.com/minislively/fooks/actions/runs/99",
+    },
+  ];
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-12T10:10:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      calls.push([command, ...args].join(" "));
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return JSON.stringify(runs);
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${mainHead}`, "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return `${mainHead}\n`;
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.postMergeMainCiEvidence.available, true);
+  assert.equal(snapshot.postMergeMainCiEvidence.source, OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE);
+  assert.equal(snapshot.postMergeMainCiEvidence.claimBoundary, OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY);
+  assert.equal(snapshot.postMergeMainCiEvidence.readOnly, true);
+  assert.equal(snapshot.postMergeMainCiEvidence.exactHeadRequired, true);
+  assert.equal(snapshot.postMergeMainCiEvidence.mainRef, "origin/main");
+  assert.equal(snapshot.postMergeMainCiEvidence.mainHeadSource, "local origin/main tracking ref; no fetch performed");
+  assert.equal(snapshot.postMergeMainCiEvidence.remoteFreshness, "not verified");
+  assert.equal(snapshot.postMergeMainCiEvidence.mainHead, mainHead);
+  assert.deepEqual(snapshot.postMergeMainCiEvidence.summary, {
+    exactHeadWorkflowCount: 2,
+    successCount: 2,
+    pendingCount: 0,
+    unknownCount: 0,
+    failureCount: 0,
+    allExactHeadConclusionsSuccessful: true,
+  });
+  assert.deepEqual(snapshot.postMergeMainCiEvidence.workflowEvidence.map((item) => [item.workflow, item.status, item.headSha]), [
+    ["CI", "success", mainHead],
+    ["React Web Release Report", "success", mainHead],
+  ]);
+  assert.equal(calls.some((call) => /fetch|delete/.test(call)), false);
+});
+
+test("operator check keeps missing exact-head workflow evidence unknown instead of success", () => {
+  const tempDir = makeTempProject();
+  const mainHead = "new-main-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-12T11:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "rev-parse --verify origin/main") return `${mainHead}\n`;
+      if (command === "gh" && args[0] === "run") {
+        return JSON.stringify([
+          {
+            databaseId: 201,
+            status: "completed",
+            conclusion: "success",
+            updatedAt: "2026-05-12T10:30:00Z",
+            headBranch: "main",
+            headSha: "old-main-head",
+            event: "push",
+            workflowName: "CI",
+            url: "https://github.com/minislively/fooks/actions/runs/201",
+          },
+          {
+            databaseId: 202,
+            status: "in_progress",
+            conclusion: "",
+            updatedAt: "2026-05-12T10:35:00Z",
+            headBranch: "main",
+            headSha: mainHead,
+            event: "push",
+            workflowName: "React Web Release Report",
+            url: "https://github.com/minislively/fooks/actions/runs/202",
+          },
+        ]);
+      }
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${mainHead}`, "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.postMergeMainCiEvidence.mainHead, mainHead);
+  assert.deepEqual(snapshot.postMergeMainCiEvidence.workflowEvidence.map((item) => [item.workflow, item.status]), [
+    ["CI", "unknown"],
+    ["React Web Release Report", "pending"],
+  ]);
+  assert.equal(snapshot.postMergeMainCiEvidence.summary.successCount, 0);
+  assert.equal(snapshot.postMergeMainCiEvidence.summary.unknownCount, 1);
+  assert.equal(snapshot.postMergeMainCiEvidence.summary.pendingCount, 1);
+  assert.equal(snapshot.postMergeMainCiEvidence.summary.allExactHeadConclusionsSuccessful, false);
+  assert.equal(snapshot.activity.postMergeMainCiEvidence, snapshot.postMergeMainCiEvidence);
 });
 
 test("operator activity marks clean current main with zero counts and no sessions as non-active main echo evidence", () => {


### PR DESCRIPTION
## Summary
- Add `postMergeMainCiEvidence` to `fooks status activity --include-remote-counts --json` and `fooks check --json`.
- Report local `origin/main` head plus exact-head `CI` and `React Web Release Report` workflow conclusions only.
- Keep missing exact-head runs as `unknown` and incomplete exact-head runs as `pending`; stale pre-merge successes cannot satisfy the success summary.
- Preserve read-only/no-fetch semantics and keep CI evidence out of merge-gate/active-work verdict decisions.

Closes #776

## Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs`
- `git diff --check`
- Diff inspection for read-only/no merge/fetch/delete/push behavior
- Final review: code-reviewer APPROVE, architect CLEAR

## Notes
- The evidence intentionally uses the local `origin/main` tracking ref (`mainHeadSource: local origin/main tracking ref; no fetch performed`) and reports `remoteFreshness: not verified`.
- Live GitHub Actions lookup beyond mocked `gh run list` fixtures was not performed locally.
