### PR TITLE
Expose legacy local residue cleanup-review evidence

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -29,17 +29,23 @@ export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
   "Read-only issue #726 operator queue for orphan local-ahead sibling worktrees; lists salvage-review evidence only and does not delete, push, fetch, mutate, or generate cleanup commands for orphan branches.";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE = "#736";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE = "#739";
+export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE = "#778";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE_URL = "https://github.com/minislively/fooks/issues/736";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE_URL = "https://github.com/minislively/fooks/issues/739";
+export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL = "https://github.com/minislively/fooks/issues/778";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SOURCE = "operator/check stale worktree residue ledger projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SOURCE = "operator/check stale worktree residue cleanup-review manifest projection";
+export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SOURCE = "operator/check legacy local residue cleanup-review projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SOURCE = "operator/check stale worktree residue active-boundary projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_CLAIM_BOUNDARY =
   "Read-only issue #736 operator receipt for stale sibling worktree residue; groups existing triage classes by count and next review action only, without paths, cleanup commands, fetch, delete, push, or mutation authority.";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_CLAIM_BOUNDARY =
   "Read-only issue #739 operator cleanup-review manifest for stale sibling worktree residue; lists per-row reason, risk class, and required manual action without paths, cleanup commands, fetch, delete, push, or mutation authority.";
+export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_CLAIM_BOUNDARY =
+  "Read-only issue #778 operator cleanup-review artifact for legacy local worktree residue from closed or merged artifacts; lists local path evidence only for operator review, never counts it as active work, and includes no cleanup commands, fetch, delete, push, or mutation authority.";
 export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_CLAIM_BOUNDARY =
   "Read-only operator/check reminder artifact for stale worktree residue versus active work; stale residue rows are cleanup-review context only and do not satisfy the active issue, PR, or mapped-session requirement.";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_ISSUE = "#720";
@@ -174,6 +180,20 @@ export type OperatorCheckStaleResidueCleanupReviewRow = {
   localOnlyCommitPolicy: "do-not-delete-local-only-commits-automatically";
 };
 
+export type OperatorCheckLegacyLocalResidueCleanupReviewRow = {
+  reviewId: string;
+  path: string;
+  branch: string;
+  head?: string;
+  status: OperatorActivitySnapshot["legacyWorktreeEvidence"]["entries"][number]["status"];
+  reasons: string[];
+  archiveEvidence: OperatorActivitySnapshot["legacyWorktreeEvidence"]["entries"][number]["archiveEvidence"];
+  activeSessionEvidence: OperatorActivitySnapshot["legacyWorktreeEvidence"]["entries"][number]["activeSessionEvidence"];
+  staleLocalResidueIsActiveWorkEvidence: false;
+  satisfiesActiveArtifactRequirement: false;
+  requiredManualAction: "confirm-closed-or-merged-artifact-before-manual-cleanup-review";
+};
+
 export type OperatorCheckStaleResidueCleanupReviewManifest = {
   schemaVersion: typeof OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SCHEMA_VERSION;
   issue: typeof OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE;
@@ -184,6 +204,20 @@ export type OperatorCheckStaleResidueCleanupReviewManifest = {
   rowCount: number;
   rows: OperatorCheckStaleResidueCleanupReviewRow[];
   localOnlyCommitPolicy: "do-not-delete-local-only-commits-automatically";
+};
+
+export type OperatorCheckLegacyLocalResidueCleanupReview = {
+  schemaVersion: typeof OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SCHEMA_VERSION;
+  issue: typeof OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE;
+  issueUrl: typeof OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL;
+  source: typeof OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SOURCE;
+  claimBoundary: typeof OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_CLAIM_BOUNDARY;
+  readOnly: true;
+  rowCount: number;
+  rows: OperatorCheckLegacyLocalResidueCleanupReviewRow[];
+  staleLocalResidueIsActiveWorkEvidence: false;
+  satisfiesActiveArtifactRequirement: false;
+  cleanupCommandsIncluded: false;
 };
 
 export type OperatorCheckStaleResidueActiveBoundary = {
@@ -221,6 +255,7 @@ export type OperatorCheckActiveWorkReceipts = {
   salvageReviewQueue: OperatorCheckSalvageReviewQueue;
   staleResidueLedger: OperatorCheckStaleResidueLedger;
   cleanupReviewManifest: OperatorCheckStaleResidueCleanupReviewManifest;
+  legacyLocalResidueCleanupReview: OperatorCheckLegacyLocalResidueCleanupReview;
   staleResidueActiveBoundary: OperatorCheckStaleResidueActiveBoundary;
   blockers: string[];
 };
@@ -323,6 +358,7 @@ function receiptReportLine(
   salvageReviewQueueItemCount = 0,
   staleResidueLedgerCount = 0,
   cleanupReviewManifestRowCount = 0,
+  legacyLocalResidueCleanupReviewRowCount = 0,
 ): string {
   const active = receipts.filter((receipt) => receipt.classification === "active").length;
   const stale = receipts.filter((receipt) => receipt.classification === "closedOrStale").length;
@@ -335,6 +371,9 @@ function receiptReportLine(
   if (salvageReviewQueueItemCount > 0) parts.push(`salvageReviewQueue=${salvageReviewQueueItemCount}`);
   if (staleResidueLedgerCount > 0) parts.push(`staleResidueLedger=${staleResidueLedgerCount}`);
   if (cleanupReviewManifestRowCount > 0) parts.push(`cleanupReviewManifest=${cleanupReviewManifestRowCount}(${OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE})`);
+  if (legacyLocalResidueCleanupReviewRowCount > 0) {
+    parts.push(`legacyLocalResidueCleanupReview=${legacyLocalResidueCleanupReviewRowCount}(${OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE})`);
+  }
   if (blocked) parts.push(`blockers=${blocked}`);
   return parts.join("; ");
 }
@@ -558,6 +597,43 @@ function buildCleanupReviewManifest(entries: OrphanLocalWorktreeEntry[]): Operat
   };
 }
 
+function legacyLocalResidueReviewId(entry: OperatorActivitySnapshot["legacyWorktreeEvidence"]["entries"][number]): string {
+  const subject = sanitizeReportToken(entry.branch || entry.head || "unknown") ?? "unknown";
+  return `legacy-local-residue:${subject}`;
+}
+
+function buildLegacyLocalResidueCleanupReview(
+  legacyWorktreeEvidence: OperatorActivitySnapshot["legacyWorktreeEvidence"],
+): OperatorCheckLegacyLocalResidueCleanupReview {
+  const rows = legacyWorktreeEvidence.entries.map((entry) => ({
+    reviewId: legacyLocalResidueReviewId(entry),
+    path: entry.path,
+    branch: entry.branch,
+    head: entry.head,
+    status: entry.status,
+    reasons: entry.reasons,
+    archiveEvidence: entry.archiveEvidence,
+    activeSessionEvidence: entry.activeSessionEvidence,
+    staleLocalResidueIsActiveWorkEvidence: false as const,
+    satisfiesActiveArtifactRequirement: false as const,
+    requiredManualAction: "confirm-closed-or-merged-artifact-before-manual-cleanup-review" as const,
+  }));
+
+  return {
+    schemaVersion: OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SCHEMA_VERSION,
+    issue: OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE,
+    issueUrl: OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL,
+    source: OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SOURCE,
+    claimBoundary: OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_CLAIM_BOUNDARY,
+    readOnly: true,
+    rowCount: rows.length,
+    rows,
+    staleLocalResidueIsActiveWorkEvidence: false,
+    satisfiesActiveArtifactRequirement: false,
+    cleanupCommandsIncluded: false,
+  };
+}
+
 function buildStaleResidueActiveBoundary(
   staleResidueCount: number,
   activeArtifactReceiptCount: number,
@@ -705,6 +781,7 @@ function buildActiveWorkReceipts(
   }
 
   const siblingReceipts = siblingWorktreeReceipts(cwd, baseIdentifiers, baseBlockers, options);
+  const legacyLocalResidueCleanupReview = buildLegacyLocalResidueCleanupReview(activity.legacyWorktreeEvidence);
   receipts.push(...siblingReceipts.receipts);
 
   const blockers = uniqueSorted([
@@ -733,10 +810,12 @@ function buildActiveWorkReceipts(
       siblingReceipts.salvageReviewQueue.itemCount,
       siblingReceipts.staleResidueLedger.totalCount,
       siblingReceipts.cleanupReviewManifest.rowCount,
+      legacyLocalResidueCleanupReview.rowCount,
     ),
     salvageReviewQueue: siblingReceipts.salvageReviewQueue,
     staleResidueLedger: siblingReceipts.staleResidueLedger,
     cleanupReviewManifest: siblingReceipts.cleanupReviewManifest,
+    legacyLocalResidueCleanupReview,
     staleResidueActiveBoundary: buildStaleResidueActiveBoundary(
       siblingReceipts.staleResidueLedger.totalCount,
       activeArtifactReceiptCount,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1122,6 +1122,111 @@ test("operator activity exposes bounded stale legacy closed worktree evidence fo
   assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|kill-session/.test(call)), false);
 });
 
+test("operator check surfaces legacy local residue as cleanup-review evidence only", () => {
+  const tempDir = makeTempProject();
+  fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "docs", "fooks-issue-778-branch-archive.md"),
+    [
+      "# Archive: `fooks-issue-767-legacy-residue` stale branch (#767)",
+      "",
+      "- Remote branch: `origin/fooks-issue-767-legacy-residue`",
+      "",
+    ].join("\n"),
+  );
+
+  const staleWorktree = path.join(path.dirname(tempDir), "fooks.omx-worktrees", "fooks-issue-767-legacy-residue");
+  const calls = [];
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-13T00:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args, cwd) => {
+      calls.push([command, ...args].join(" "));
+      const joined = args.join(" ");
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [
+          `worktree ${tempDir}`,
+          "HEAD 111",
+          "branch refs/heads/main",
+          "",
+          `worktree ${staleWorktree}`,
+          "HEAD 767767",
+          "branch refs/heads/fooks-issue-767-legacy-residue",
+          "",
+        ].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\nfooks-issue-767-legacy-residue\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return cwd === staleWorktree ? "0 0\n" : "0 0\n";
+      if (command === "tmux") return "not-related\t/tmp/no-active-pane\tzsh\n";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") return "[]";
+      if (command === "gh" && joined.startsWith("run list ")) return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir || targetPath === staleWorktree || targetPath === path.join(tempDir, "docs"),
+  });
+
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.equal(snapshot.postMergeMainEchoBoundary.mainEchoEvidence, true);
+  assert.deepEqual(snapshot.activeArtifacts, []);
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+
+  const review = snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview;
+  assert.equal(review.issue, "#778");
+  assert.equal(review.readOnly, true);
+  assert.equal(review.rowCount, 1);
+  assert.equal(review.cleanupCommandsIncluded, false);
+  assert.equal(review.staleLocalResidueIsActiveWorkEvidence, false);
+  assert.equal(review.satisfiesActiveArtifactRequirement, false);
+  assert.match(review.claimBoundary, /never counts it as active work/);
+  assert.match(snapshot.activeWorkReceipts.reportLine, /legacyLocalResidueCleanupReview=1\(#778\)/);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 0);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
+
+  assert.deepEqual(review.rows, [
+    {
+      reviewId: "legacy-local-residue:fooks-issue-767-legacy-residue",
+      path: staleWorktree,
+      branch: "fooks-issue-767-legacy-residue",
+      head: "767767",
+      status: "staleClosedArtifact",
+      reasons: [
+        "branch has local branch-archive evidence",
+        "no tmux panes map to this worktree",
+        "worktree is not the current working directory",
+      ],
+      archiveEvidence: {
+        sourcePath: path.join("docs", "fooks-issue-778-branch-archive.md"),
+        matchType: "remote-branch",
+        matchedRef: "origin/fooks-issue-767-legacy-residue",
+        lineNumber: 3,
+      },
+      activeSessionEvidence: "no tmux panes mapped to this worktree",
+      staleLocalResidueIsActiveWorkEvidence: false,
+      satisfiesActiveArtifactRequirement: false,
+      requiredManualAction: "confirm-closed-or-merged-artifact-before-manual-cleanup-review",
+    },
+  ]);
+
+  const reviewJson = JSON.stringify(review);
+  assert.equal(/worktree remove|branch -d|deleteCommand|manualCleanupCommands|cleanupOrder/.test(reviewJson), false);
+  assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|kill-session/.test(call)), false);
+});
+
 test("operator activity keeps legacy worktree inference conservative when tmux is unavailable", () => {
   const tempDir = makeTempProject();
   fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });
@@ -1274,8 +1379,11 @@ test("operator check receipt classifies stale session and legacy closed branch w
   );
   assert.equal(closedBranch?.classification, "closedOrStale");
 
+  assert.equal(snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview.rowCount, 1);
+  assert.equal(snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview.rows[0].path, staleWorktree);
+  assert.equal(snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview.rows[0].satisfiesActiveArtifactRequirement, false);
+
   const receiptJson = JSON.stringify(snapshot.activeWorkReceipts);
-  assert.equal(receiptJson.includes(staleWorktree), false);
   assert.equal(receiptJson.includes(deletedPanePath), false);
   assert.equal(receiptJson.includes("tmux kill-session"), false);
   assert.equal(receiptJson.includes("manualCleanupCommands"), false);


### PR DESCRIPTION
## Summary\n- add an issue #778 operator/check legacyLocalResidueCleanupReview artifact for stale local worktree/archive residue\n- keep legacy residue explicitly read-only, non-active, and unable to satisfy active issue/PR/session requirements\n- extend operator-check tests for zero-count main echo plus legacy residue and no cleanup-command leakage\n\nCloses #778\n\n## Verification\n- npm run build && node --test test/operator-activity.test.mjs\n- npm test