### PR TITLE
Measure React Web decisions by safe handoff quality

### DIFF
--- a/benchmarks/BENCHMARK_ARCHITECTURE.md
+++ b/benchmarks/BENCHMARK_ARCHITECTURE.md
@@ -41,7 +41,28 @@
 
 ---
 
-### Layer 2: Frontend Task Benchmark (미구현 - Phase 2)
+### Layer 2: Decision Handoff Benchmark (React Web first pass)
+
+**목적:** 실제 agent-facing work order가 첫 작업 판단을 안전하게 줄이는지 검증
+
+**비교군:**
+- **A. Raw source + generic prompt**
+- **B. Full fooks issue JSON**
+- **C. `--summary-json` decision handoff**
+- **D. `--dry-run-json` decision handoff**
+
+**1차 측정:**
+- **Decision Handoff Correctness** (`decision` 계약이 task/candidate에 보존되는가)
+- **First Inspect Target Presence** (`firstInspectStep`가 실제 `file:line`으로 존재하는가)
+- **Top-1 Issue Linkage** (`sourceTopIssueIds[0]`와 첫 task가 일치하는가)
+- **No-Auto-Apply Compliance** (`applyPatch:false`, `autoApply:false`)
+- **Human Review Boundary Retention** (`humanReviewRequired:true`)
+- **Unsupported/Malformed Stop Rate** (지원 불가/깨진 projection에서 fail-closed stop하는가)
+- **Projection Size Reduction** (full JSON 대비 summary/dry-run 크기 절감; 보조 지표)
+
+**claim boundary:** 이 Layer 2는 deterministic fixture-backed handoff evidence입니다. provider billing-token, runtime-token, latency, live-agent turn-count, 자동 patch apply 증거가 아닙니다.
+
+### Later Layer 3: Frontend Task Benchmark (future applied lane)
 
 **목적:** 실제 프론트 작업 성공성
 
@@ -79,10 +100,13 @@
 | Metric | Layer 1 | Layer 2 | 통합 |
 |--------|---------|---------|------|
 | **Token Savings** | ✅ 85.3% | - | baseline |
-| **Task Success** | - | ⏳ TBD | 핵심 |
-| **Edit Precision** | - | ⏳ TBD | 핵심 |
-| **Retry Count** | - | ⏳ TBD | 효율성 |
-| **Completion Latency** | - | ⏳ TBD | 속도 |
+| **Decision Handoff Correctness** | - | ✅ React Web first pass | 핵심 |
+| **No-Auto-Apply Compliance** | - | ✅ React Web first pass | 핵심 |
+| **Human Review Boundary Retention** | - | ✅ React Web first pass | 핵심 |
+| **Task Success** | - | ⏳ Layer 3 | 미래 applied lane |
+| **Edit Precision** | - | ⏳ Layer 3 | 미래 applied lane |
+| **Retry Count** | - | ⏳ Layer 3 | 효율성 |
+| **Completion Latency** | - | ⏳ Layer 3 | 속도 |
 
 **최종 질문:**
 > "이 서비스가 실제 프론트 복잡 작업에 유리한가?"

--- a/docs/benchmark-evidence.md
+++ b/docs/benchmark-evidence.md
@@ -24,7 +24,26 @@ benchmark harness.
 
 ## Validation ladder
 
-The repo now treats token/cost evidence as four distinct layers with separate
+The repo separates size, runtime, billing, and decision-handoff evidence instead of treating one reduction number as the product claim. React Web Decision Layer work uses the decision-handoff lane below; source/payload size remains useful, but it is not the primary product KPI for agent-facing work orders.
+
+### Decision handoff lane
+
+For React Web work orders, the benchmark question is not "can fooks quote a larger context-reduction number?" The first-pass product question is:
+
+> Does the projection help an agent choose the first safe inspect action while preserving the no-apply and human-review boundaries?
+
+The deterministic Decision Handoff Benchmark compares these arms:
+
+| Arm | Input shape | What it measures |
+| --- | --- | --- |
+| A | raw source + generic prompt | baseline source-reading burden and first-target ambiguity |
+| B | full fooks issue JSON | detailed source-grounded report with all card evidence |
+| C | `--summary-json` decision handoff | compact first-minute inspect target plus decision authority |
+| D | `--dry-run-json` decision handoff | compact read-only migration candidate rows plus decision authority |
+
+Primary metrics are decision-handoff correctness, first inspect target presence, top-1 issue linkage, no-auto-apply compliance, human-review boundary retention, dry-run candidate safety, and unsupported/malformed fail-closed stop behavior. Projection byte/token reduction versus full JSON is secondary evidence only. This lane does not support provider billing-token, runtime-token, latency, live-agent turn-count, or automatic patch-apply claims.
+
+The repo also treats token/cost evidence as four distinct layers with separate
 claim boundaries:
 
 | Level | Evidence source | What it can support | What it cannot support yet |

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -6058,6 +6058,24 @@ test("docs keep bounded R4 rerun diagnostic reason tied to claimability failures
   assert.doesNotMatch(benchmarkEvidence, /diagnostic-only` because\s+the accepted-pair\s+denominator was missing/i);
 });
 
+
+test("benchmark docs center React Web decision handoff metrics before size claims", () => {
+  const benchmarkEvidence = fs.readFileSync(path.join(repoRoot, "docs", "benchmark-evidence.md"), "utf8");
+  const architecture = fs.readFileSync(path.join(repoRoot, "benchmarks", "BENCHMARK_ARCHITECTURE.md"), "utf8");
+  const combined = `${benchmarkEvidence}\n${architecture}`;
+
+  assert.match(combined, /Decision Handoff Benchmark/);
+  assert.match(combined, /raw source \+ generic prompt/i);
+  assert.match(combined, /full fooks issue JSON/i);
+  assert.match(combined, /`--summary-json` decision handoff/);
+  assert.match(combined, /`--dry-run-json` decision handoff/);
+  assert.match(combined, /Decision Handoff Correctness/);
+  assert.match(combined, /No-Auto-Apply Compliance/);
+  assert.match(combined, /Human Review Boundary Retention/);
+  assert.match(benchmarkEvidence, /Projection byte\/token reduction versus full JSON is secondary evidence only/);
+  assert.match(benchmarkEvidence, /does not support provider billing-token, runtime-token, latency, live-agent turn-count, or automatic patch-apply claims/);
+});
+
 test("docs keep direct runtime benchmark regressions out of public win claims", () => {
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
   const release = fs.readFileSync(path.join(repoRoot, "docs", "release.md"), "utf8");

--- a/test/helpers/react-web-decision-handoff-benchmark.mjs
+++ b/test/helpers/react-web-decision-handoff-benchmark.mjs
@@ -1,0 +1,154 @@
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function jsonByteLength(value) {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function reductionPercent(smaller, baseline) {
+  if (!Number.isFinite(baseline) || baseline <= 0) return 0;
+  return Number(((baseline - smaller) / baseline * 100).toFixed(1));
+}
+
+function hasSafeDecision(decision, options = {}) {
+  return (
+    isObject(decision) &&
+    decision.schemaVersion === "react-web-decision.v1" &&
+    isObject(decision.allowedActions) &&
+    decision.allowedActions.applyPatch === false &&
+    decision.allowedActions.generateCopy === false &&
+    decision.autoApply === false &&
+    decision.humanReviewRequired === true &&
+    (options.dryRunOnly === undefined || decision.dryRunOnly === options.dryRunOnly) &&
+    (options.states === undefined || options.states.includes(decision.state)) &&
+    Array.isArray(decision.stopConditions) &&
+    decision.stopConditions.length > 0
+  );
+}
+
+function isInspectFirstTaskSafe(task) {
+  return (
+    isObject(task) &&
+    task.kind === "inspect-first-task" &&
+    task.source === "summary-json" &&
+    typeof task.issueId === "string" &&
+    task.issueId.length > 0 &&
+    typeof task.firstInspectStep === "string" &&
+    /[^\s:]+:\d+(?:-\d+)?/u.test(task.firstInspectStep) &&
+    task.autoApply === false &&
+    task.humanReviewRequired === true &&
+    hasSafeDecision(task.decision, {
+      states: ["ready-for-agent-inspect", "human-decision-required"],
+      dryRunOnly: false,
+    })
+  );
+}
+
+function isDryRunCandidateSafe(candidate) {
+  return (
+    isObject(candidate) &&
+    typeof candidate.issueId === "string" &&
+    candidate.issueId.length > 0 &&
+    candidate.autoApply === false &&
+    candidate.humanReviewRequired === true &&
+    candidate.dryRunOnly === true &&
+    hasSafeDecision(candidate.decision, {
+      states: ["dry-run-candidate-only"],
+      dryRunOnly: true,
+    })
+  );
+}
+
+export function evaluateReactWebDecisionHandoffBenchmark({
+  fixture,
+  rawSource,
+  fullJson,
+  summaryJson,
+  dryRunJson,
+  summaryTask,
+  dryRunTasks,
+}) {
+  const rawSourceBytes = Buffer.byteLength(rawSource, "utf8");
+  const fullJsonBytes = jsonByteLength(fullJson);
+  const summaryJsonBytes = jsonByteLength(summaryJson);
+  const dryRunJsonBytes = jsonByteLength(dryRunJson);
+  const firstSummaryItem = summaryJson?.firstMinuteSummary?.items?.[0];
+  const sourceTopIssueId = summaryJson?.firstMinuteSummary?.sourceTopIssueIds?.[0];
+  const dryRunCandidates = Array.isArray(dryRunTasks?.candidates) ? dryRunTasks.candidates : [];
+
+  const firstInspectTargetPresent = isInspectFirstTaskSafe(summaryTask);
+  const top1IssueStartMatch = Boolean(
+    firstInspectTargetPresent &&
+      sourceTopIssueId &&
+      summaryTask.issueId === sourceTopIssueId &&
+      firstSummaryItem?.firstInspectStep === summaryTask.firstInspectStep,
+  );
+  const dryRunCandidateSafety = dryRunTasks?.kind === "dry-run-candidate-tasks" && dryRunCandidates.length > 0 && dryRunCandidates.every(isDryRunCandidateSafe);
+  const noAutoApplyCompliance = [summaryTask, dryRunTasks, ...dryRunCandidates]
+    .filter(Boolean)
+    .every((entry) => entry.autoApply === false && entry.decision?.allowedActions?.applyPatch !== true && entry.decision?.allowedActions?.generateCopy !== true);
+  const humanReviewBoundaryRetention = [summaryTask, ...dryRunCandidates]
+    .filter(Boolean)
+    .every((entry) => entry.humanReviewRequired === true && entry.decision?.humanReviewRequired === true);
+
+  return {
+    schemaVersion: "react-web-decision-handoff-benchmark.v1",
+    fixture,
+    comparisonArms: [
+      "raw-source-generic-prompt",
+      "full-fooks-issue-json",
+      "summary-json-decision-handoff",
+      "dry-run-json-decision-handoff",
+    ],
+    primaryMetrics: {
+      decisionHandoffCorrect: firstInspectTargetPresent && top1IssueStartMatch && dryRunCandidateSafety && noAutoApplyCompliance && humanReviewBoundaryRetention,
+      firstInspectTargetPresent,
+      top1IssueStartMatch,
+      noAutoApplyCompliance,
+      humanReviewBoundaryRetention,
+      dryRunCandidateSafety,
+    },
+    secondarySizeMetrics: {
+      rawSourceBytes,
+      fullJsonBytes,
+      summaryJsonBytes,
+      dryRunJsonBytes,
+      approxTokens: {
+        rawSource: Math.ceil(rawSourceBytes / 4),
+        fullJson: Math.ceil(fullJsonBytes / 4),
+        summaryJson: Math.ceil(summaryJsonBytes / 4),
+        dryRunJson: Math.ceil(dryRunJsonBytes / 4),
+      },
+      summaryVsFullReductionPct: reductionPercent(summaryJsonBytes, fullJsonBytes),
+      dryRunVsFullReductionPct: reductionPercent(dryRunJsonBytes, fullJsonBytes),
+      summaryVsRawReductionPct: reductionPercent(summaryJsonBytes, rawSourceBytes),
+      dryRunVsRawReductionPct: reductionPercent(dryRunJsonBytes, rawSourceBytes),
+    },
+    claimBoundary:
+      "Decision handoff benchmark evidence only: proves deterministic projection correctness, safety-boundary retention, and compactness for named React Web fixtures; it is not provider-token, billing, latency, live-agent turn-count, or automatic patch-apply evidence.",
+  };
+}
+
+export function evaluateReactWebDecisionStopBenchmark(stops) {
+  const entries = stops.map((stop) => ({
+    source: stop?.source,
+    reason: stop?.reason,
+    kind: stop?.kind,
+    state: stop?.stopDecision?.state,
+    inspectAllowed: stop?.stopDecision?.allowedActions?.inspect === true,
+    applyPatchAllowed: stop?.stopDecision?.allowedActions?.applyPatch === true,
+    generateCopyAllowed: stop?.stopDecision?.allowedActions?.generateCopy === true,
+    autoApply: stop?.autoApply === true || stop?.stopDecision?.autoApply === true,
+  }));
+  return {
+    schemaVersion: "react-web-decision-stop-benchmark.v1",
+    stopCount: entries.length,
+    entries,
+    unsupportedStopRate: entries.length === 0 ? 0 : entries.filter((entry) => entry.state === "unsupported").length / entries.length,
+    malformedStopRate: entries.length === 0 ? 0 : entries.filter((entry) => entry.state === "malformed-stop").length / entries.length,
+    allStopFailClosed: entries.every(
+      (entry) => entry.kind === "stop" && !entry.inspectAllowed && !entry.applyPatchAllowed && !entry.generateCopyAllowed && !entry.autoApply,
+    ),
+  };
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import {
@@ -15,6 +16,10 @@ import {
   consumeReactWebDryRunForAgentTasks,
   consumeReactWebSummaryForAgentTask,
 } from "./helpers/react-web-agent-handoff-dogfood.mjs";
+import {
+  evaluateReactWebDecisionHandoffBenchmark,
+  evaluateReactWebDecisionStopBenchmark,
+} from "./helpers/react-web-decision-handoff-benchmark.mjs";
 
 const repoRoot = process.cwd();
 const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
@@ -967,6 +972,44 @@ test("React Web issue report migration dry-run JSON preserves empty and unsuppor
   assert.deepEqual(rn.candidates, []);
 });
 
+
+
+test("React Web decision handoff benchmark treats correctness as primary and size as secondary", () => {
+  const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
+  const summary = buildReactWebIssueReportSummaryJson(report);
+  const dryRun = buildReactWebIssueReportMigrationDryRunJson(report);
+  const summaryTask = consumeReactWebSummaryForAgentTask(summary);
+  const dryRunTasks = consumeReactWebDryRunForAgentTasks(dryRun);
+  const benchmark = evaluateReactWebDecisionHandoffBenchmark({
+    fixture: "FormControls.tsx",
+    rawSource: fs.readFileSync(fixtures.formControls, "utf8"),
+    fullJson: report,
+    summaryJson: summary,
+    dryRunJson: dryRun,
+    summaryTask,
+    dryRunTasks,
+  });
+
+  assert.equal(benchmark.schemaVersion, "react-web-decision-handoff-benchmark.v1");
+  assert.deepEqual(benchmark.comparisonArms, [
+    "raw-source-generic-prompt",
+    "full-fooks-issue-json",
+    "summary-json-decision-handoff",
+    "dry-run-json-decision-handoff",
+  ]);
+  assert.equal(benchmark.primaryMetrics.decisionHandoffCorrect, true);
+  assert.equal(benchmark.primaryMetrics.firstInspectTargetPresent, true);
+  assert.equal(benchmark.primaryMetrics.top1IssueStartMatch, true);
+  assert.equal(benchmark.primaryMetrics.noAutoApplyCompliance, true);
+  assert.equal(benchmark.primaryMetrics.humanReviewBoundaryRetention, true);
+  assert.equal(benchmark.primaryMetrics.dryRunCandidateSafety, true);
+  assert.ok(benchmark.secondarySizeMetrics.summaryJsonBytes < benchmark.secondarySizeMetrics.fullJsonBytes);
+  assert.ok(benchmark.secondarySizeMetrics.dryRunJsonBytes < benchmark.secondarySizeMetrics.fullJsonBytes);
+  assert.ok(benchmark.secondarySizeMetrics.summaryVsFullReductionPct > 0);
+  assert.ok(benchmark.secondarySizeMetrics.dryRunVsFullReductionPct > 0);
+  assert.match(benchmark.claimBoundary, /not provider-token, billing, latency, live-agent turn-count/i);
+});
+
 test("React Web agent handoff dogfood consumes summary JSON as an inspect-first task", () => {
   const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
   const summary = buildReactWebIssueReportSummaryJson(report);
@@ -1133,6 +1176,41 @@ test("React Web agent handoff dogfood fails closed on malformed projections", ()
     assert.equal(Object.hasOwn(stop, "affectedFile"), false);
     assert.equal(Object.hasOwn(stop, "firstInspectStep"), false);
   }
+});
+
+
+
+test("React Web decision stop benchmark scores unsupported and malformed handoffs as fail-closed", () => {
+  const rnReport = buildReactWebIssueReport(fixtures.rn, repoRoot);
+  const rnSummaryStop = consumeReactWebSummaryForAgentTask(buildReactWebIssueReportSummaryJson(rnReport));
+  const rnDryRunStop = consumeReactWebDryRunForAgentTasks(buildReactWebIssueReportMigrationDryRunJson(rnReport));
+  const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
+  const malformedSummaryStop = consumeReactWebSummaryForAgentTask({
+    ...buildReactWebIssueReportSummaryJson(report),
+    firstMinuteSummary: { items: "not-an-array" },
+  });
+  const malformedDryRunStop = consumeReactWebDryRunForAgentTasks({
+    ...buildReactWebIssueReportMigrationDryRunJson(report),
+    candidates: "not-an-array",
+  });
+
+  const benchmark = evaluateReactWebDecisionStopBenchmark([
+    rnSummaryStop,
+    rnDryRunStop,
+    malformedSummaryStop,
+    malformedDryRunStop,
+  ]);
+
+  assert.equal(benchmark.schemaVersion, "react-web-decision-stop-benchmark.v1");
+  assert.equal(benchmark.stopCount, 4);
+  assert.equal(benchmark.allStopFailClosed, true);
+  assert.equal(benchmark.unsupportedStopRate, 0.5);
+  assert.equal(benchmark.malformedStopRate, 0.5);
+  assert.deepEqual(
+    benchmark.entries.map((entry) => entry.state),
+    ["unsupported", "unsupported", "malformed-stop", "malformed-stop"],
+  );
+  assert.ok(benchmark.entries.every((entry) => entry.applyPatchAllowed === false));
 });
 
 test("React Web decision layer contract keeps confidence separate from apply authority", () => {


### PR DESCRIPTION
## Summary
- Add a deterministic React Web Decision Handoff Benchmark helper that treats safe handoff correctness as the primary metric and size reduction as secondary evidence.
- Lock benchmark docs around the A/B/C/D comparison: raw source, full issue JSON, summary-json decision handoff, dry-run-json decision handoff.
- Add contract tests for first inspect target linkage, no-auto-apply compliance, human-review retention, dry-run candidate safety, and unsupported/malformed fail-closed stops.

Closes #780

## Tests
- `npm run build && node --test test/react-web-issue-report.test.mjs`
- `npm run typecheck`
- `env -u FOOKS_TARGET_ACCOUNT node --test --test-name-pattern "benchmark docs center|first-minute work-order docs" test/fooks.test.mjs`

## Claim boundary
This is deterministic fixture-backed handoff evidence only. It does not claim provider-token, billing, latency, live-agent turn-count, or automatic patch-apply wins.
