### PR TITLE
Lock source evidence as React Web decision authority

### DIFF
--- a/.omx/specs/deep-interview-agentmemory-decision-layer.md
+++ b/.omx/specs/deep-interview-agentmemory-decision-layer.md
@@ -1,0 +1,24 @@
+# Deep interview note — agentmemory lesson for React Web Decision Layer
+
+## Source-evidence authority principle
+
+Issue #782 only imports the useful boundary lesson from the `agentmemory` comparison. `agentmemory` can remember prior agent/session context; `fooks` decides current frontend work from current source evidence.
+
+For the current React Web Decision Layer:
+
+```text
+current source evidence > advisory context / repo convention / historical memory
+confidence high != apply authority
+```
+
+## Decision for this pass
+
+- Preserve the additive `react-web-decision.v1` contract.
+- Do not add authority/freshness schema fields such as `evidenceFreshness`, `decisionBasis`, or `contextAuthority`.
+- Keep repo-owned convention hints and compact `contextHints` advisory only.
+- Keep `allowedActions.applyPatch: false`, `allowedActions.generateCopy: false`, `autoApply: false`, and `humanReviewRequired: true` as hard boundaries.
+- Keep dry-run projections as inventory rows only, even when preview/context evidence exists.
+
+## Future-agent warning
+
+Do not promote memory, cached context, repo convention, or a high-confidence label into edit authority. If future work adds apply behavior, generated copy, broader policy gates, or freshness semantics, it needs a separate design, schema, and regression suite.

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -16,7 +16,7 @@ After #766, the same report carries a compact first-minute mini work order throu
 
 ```text
 source-derived React Web evidence
-  -> decision (allowedActions + stopConditions; confidence is not apply authority)
+  -> decision (allowedActions + stopConditions; source evidence outranks advisory context/memory; confidence is not apply authority)
   -> ranked issue cards
   -> firstMinuteSummary
        -> why this issue is first
@@ -71,7 +71,7 @@ Every full issue card now includes a `decision` object, and `--summary-json` / `
 - `incomplete`: in-scope inputs with no current issue/candidate evidence stop safely.
 - `malformed-stop`: agent handoff validation failed closed.
 
-The important invariant is structural: **confidence high is evidence quality, not apply authority**. Consumers should check `decision.allowedActions` and `decision.stopConditions`, not infer authority from `confidence`, `fixability`, `triage.bucket`, or preview availability. Current React Web decisions always keep `allowedActions.applyPatch: false`, `allowedActions.generateCopy: false`, `autoApply: false`, and `humanReviewRequired: true`.
+The important invariants are structural: **current source evidence outranks advisory context, repo convention hints, and historical memory**, and **confidence high is evidence quality, not apply authority**. Consumers should check `decision.allowedActions` and `decision.stopConditions`, not infer authority from `confidence`, `fixability`, `triage.bucket`, preview availability, `contextHints`, repo-owned convention hints, or remembered prior sessions. Current React Web decisions always keep `allowedActions.applyPatch: false`, `allowedActions.generateCopy: false`, `autoApply: false`, and `humanReviewRequired: true`. This pass intentionally does not add authority/freshness schema fields such as `evidenceFreshness`, `decisionBasis`, or `contextAuthority`; the existing decision object remains the authority surface.
 
 ## Agent/tool handoff
 
@@ -99,7 +99,7 @@ The intended consumer flow is:
 1. Read `firstMinuteSummary.items` in `sourceTopIssueIds` order.
 2. Start with `items[0].firstInspectStep` and `items[0].nextAction`.
 3. Keep `decision`, `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply`, and `claimBoundary` in the agent prompt or task card.
-4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority.
+4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority. Current source evidence wins over those hints and over historical memory.
 5. If `items` is empty, stop and inspect the top-level `inScope` / `skippedReason` values instead of inventing a React Web task.
 
 The compact handoff is not an apply command. It should help an agent choose the first source location to inspect, not skip human review, invent accessible-name copy, treat custom components as native controls, or widen the report into a broader accessibility audit. If an agent needs candidate rows for a migration plan, use `--dry-run-json` and keep its `dryRunOnly`, `autoApply`, `humanReviewRequired`, and `riskNotes` fields attached to the task card.
@@ -127,7 +127,7 @@ The intended dry-run consumer flow is:
 1. Read `candidates[]` in the returned order; each candidate is derived from the ranked issue evidence.
 2. Start each row from `candidate.firstInspectStep` and `candidate.affectedFile`.
 3. Keep `decision`, `dryRunOnly`, `autoApply`, `humanReviewRequired`, and `riskNotes` with every task card.
-4. Treat `previewAvailable` as a hint about whether a read-only preview shape exists, not as permission to change source.
+4. Treat `previewAvailable` as a hint about whether a read-only preview shape exists, not as permission to change source; dry-run rows remain dry-run-only even when preview/context evidence exists.
 5. If `candidates` is empty, stop and inspect `inScope` / `skippedReason` instead of creating a migration task.
 
 A dry-run agent task card should keep the dry-run boundary visible:
@@ -159,11 +159,11 @@ Repo-owned convention hints may appear here only as short advisory pointers, for
 The React Web first-minute work order is conservative by design:
 
 - **Read-only:** it reports source-derived evidence and does not edit files.
-- **No auto-apply:** it does not apply patches, trigger codemods, or authorize automatic changes; high confidence never changes this.
+- **No auto-apply:** it does not apply patches, trigger codemods, or authorize automatic changes; high confidence, preview availability, convention hints, context packets, and remembered history never change this.
 - **No generated accessible-name copy:** it does not invent final label text, aria-label text, or other accessible-name copy; a human or agent must choose copy from product context.
 - **No broad accessibility audit:** it is a narrow native-control form/accessibility issue report, not a complete WCAG or design-system audit.
 - **No custom-component semantic inference:** custom components remain manual-review evidence unless native-control facts are explicit enough.
 - **No RN/TUI/WebView expansion:** React Native, TUI / React CLI, WebView, Vue/SFC, broad TS/JS, and multi-file refactor lanes remain outside this work-order claim unless future evidence and policy gates promote them.
-- **Convention hints stay advisory:** first-minute `contextHints` may include a short repo-owned convention pointer, but that pointer must not change rank, priority, bucket, first inspect action, next action, or edit authority.
+- **Convention hints stay advisory:** first-minute `contextHints` may include a short repo-owned convention pointer, but that pointer must not change rank, priority, bucket, first inspect action, next action, or edit authority. Source evidence is the authority; convention/context/memory is only a pointer back to source inspection.
 
 Keep future wording tied to the current inspect surfaces and these boundaries. If a future issue adds apply behavior, generated copy, broader accessibility coverage, custom-component semantics, or new runtime lanes, that should be documented as a separate capability with separate tests and evidence.

--- a/docs/repo-owned-convention-hints.md
+++ b/docs/repo-owned-convention-hints.md
@@ -14,9 +14,9 @@ Repo-owned convention hints are a first prototype for future team-owned fooks ch
 
 This is not the future tracked config surface yet. The first pass does **not** add tracked `.fooks` policy/check files, a public CLI, CI enforcement, merge enforcement, codemod behavior, or edit authority.
 
-Convention hints should remain inspect-first context. They may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, or custom-component semantic inference.
+Convention hints should remain inspect-first context. Current source evidence has higher authority than advisory context, repo convention, or historical memory. Hints may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, custom-component semantic inference, or `applyPatch` / `generateCopy` authority.
 
-In first-minute summaries, convention hints are intentionally weaker than the ranked issue evidence. A matched hint can add a concise `contextHints` entry so an agent sees the team-context pointer, but it must not change ranking, priority, bucket assignment, `inspectFirst`, `nextAction`, or edit authority.
+In first-minute summaries, convention hints are intentionally weaker than the ranked issue evidence. A matched hint can add a concise `contextHints` entry so an agent sees the team-context pointer, but it must not change ranking, priority, bucket assignment, `inspectFirst`, `nextAction`, or edit authority. High confidence remains inspect/suggestion authority only, and this prototype must not add authority/freshness schema fields such as `evidenceFreshness`, `decisionBasis`, or `contextAuthority`.
 
 ## Graduation path
 

--- a/src/core/react-web-decision.ts
+++ b/src/core/react-web-decision.ts
@@ -46,6 +46,8 @@ export type BuildReactWebIssueDecisionOptions = {
 };
 
 const READ_ONLY_STOP_CONDITIONS = [
+  "Current source evidence outranks advisory context, repo convention, or historical memory.",
+  "Advisory context cannot grant applyPatch or generateCopy authority.",
   "Do not apply patches automatically.",
   "Do not generate accessible-name copy.",
   "Do not infer custom-component semantics.",

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -1274,6 +1274,56 @@ test("React Web decision layer marks manual review, dry-run, unsupported, and ma
   assert.equal(malformed.stopDecision.allowedActions.applyPatch, false);
 });
 
+
+test("React Web decision authority stays with current source evidence over context and memory", () => {
+  const report = buildReactWebIssueReport(fixtures.formControls, repoRoot);
+  assert.ok(report.issues.length > 0);
+  assert.ok(report.issues.every((issue) => issue.conventionHints.length > 0));
+  assert.ok(report.firstMinuteSummary.items.every((item) => item.contextHints.some((hint) => /advisory convention/.test(hint))));
+
+  for (const issue of report.issues) {
+    assert.equal(issue.conventionHints[0].advisoryOnly, true);
+    assert.equal(issue.conventionHints[0].enforcement, "none");
+    assert.equal(issue.decision.allowedActions.applyPatch, false);
+    assert.equal(issue.decision.allowedActions.generateCopy, false);
+    assert.equal(issue.decision.autoApply, false);
+    assert.equal(issue.decision.humanReviewRequired, true);
+    assert.ok(issue.decision.stopConditions.some((condition) => /source evidence outranks advisory context/i.test(condition)));
+    assert.ok(issue.decision.stopConditions.some((condition) => /Advisory context cannot grant applyPatch or generateCopy authority/i.test(condition)));
+  }
+
+  const summary = buildReactWebIssueReportSummaryJson(report);
+  assert.equal(summary.decisionSummary.applyPatchAllowedCount, 0);
+  assert.equal(summary.decisionSummary.generateCopyAllowedCount, 0);
+  assert.equal(hasNestedKey(summary, "evidenceFreshness"), false);
+  assert.equal(hasNestedKey(summary, "decisionBasis"), false);
+  assert.equal(hasNestedKey(summary, "contextAuthority"), false);
+  assert.doesNotMatch(JSON.stringify(summary.firstMinuteSummary.items.map((item) => item.contextHints)), /must-edit|CI gate|merge gate/i);
+});
+
+test("React Web dry-run candidates remain dry-run-only with preview and context evidence", () => {
+  const report = buildReactWebIssueReport(fixtures.association, repoRoot);
+  const dryRun = buildReactWebIssueReportMigrationDryRunJson(report);
+  const previewCandidate = dryRun.candidates.find((candidate) => candidate.previewAvailable);
+  assert.ok(previewCandidate, "expected at least one preview-backed dry-run candidate");
+
+  assert.equal(dryRun.dryRunOnly, true);
+  assert.equal(dryRun.autoApply, false);
+  assert.equal(dryRun.decisionSummary.applyPatchAllowedCount, 0);
+  assert.equal(dryRun.decisionSummary.generateCopyAllowedCount, 0);
+  assert.equal(previewCandidate.dryRunOnly, true);
+  assert.equal(previewCandidate.autoApply, false);
+  assert.equal(previewCandidate.humanReviewRequired, true);
+  assert.equal(previewCandidate.decision.state, "dry-run-candidate-only");
+  assert.equal(previewCandidate.decision.allowedActions.applyPatch, false);
+  assert.equal(previewCandidate.decision.allowedActions.generateCopy, false);
+  assert.ok(previewCandidate.decision.stopConditions.some((condition) => /source evidence outranks advisory context/i.test(condition)));
+  assert.ok(previewCandidate.decision.stopConditions.some((condition) => /dry-run candidate is an inventory row only/i.test(condition)));
+  assert.equal(hasNestedKey(dryRun, "evidenceFreshness"), false);
+  assert.equal(hasNestedKey(dryRun, "decisionBasis"), false);
+  assert.equal(hasNestedKey(dryRun, "contextAuthority"), false);
+});
+
 test("React Web issue report rejects conflicting JSON output flags", () => {
   const cli = runIssues(fixtures.formControls, "--json", "--summary-json");
   assert.notEqual(cli.status, 0);


### PR DESCRIPTION
## Summary
- Locks the React Web Decision Layer rule that current source evidence outranks advisory context, repo convention hints, and historical memory.
- Keeps high confidence, preview availability, and convention/context hints separate from `applyPatch` / `generateCopy` authority.
- Adds the issue #782 source spec artifact plus focused regression coverage for advisory hints and preview-backed dry-run candidates.

## Verification
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `node --test test/fooks.test.mjs`
- `git diff --check`
- CLI summary-json stop-condition sample confirmed `applyPatch:false`, `generateCopy:false`, and source-evidence authority stop conditions.
.

Fixes #782
