### PR TITLE
Protect source-grounded Decision Layer authority

### DIFF
--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -28,6 +28,20 @@ source-derived React Web evidence
 
 The goal is to make the first minute legible: a maintainer can see which native-control card to inspect first, why it was prioritized, and which decisions still require human review before any edit happens.
 
+After #766, these handoffs also carry an additive decision contract. The contract does not replace the legacy safety fields; it makes the same authority boundary explicit for agents and future workflow projections:
+
+```text
+source-derived React Web evidence
+  -> finding / issue card
+  -> decision
+       -> state
+       -> allowedActions
+       -> stopConditions
+  -> firstMinuteSummary / dry-run candidate / future workflow projection
+```
+
+The important product rule is unchanged: high confidence can make an issue ready for agent inspection, but it still does not authorize patch application.
+
 ## Current CLI surfaces
 
 Use the text report when a person wants the compact work order before the detailed cards:
@@ -66,9 +80,9 @@ An agent should choose the smallest inspect surface that answers the handoff que
 
 | Agent need | Use | First field to read | Keep attached |
 | --- | --- | --- | --- |
-| Decide the first source action for a supported React Web file | `--summary-json` | `firstMinuteSummary.items[0]` | `claimBoundary`, `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply` |
-| Build read-only migration candidate rows from ranked issue evidence | `--dry-run-json` | `candidates[]` | `dryRunOnly`, `autoApply`, `humanReviewRequired`, `riskNotes` |
-| Inspect detailed card evidence, context packets, or related local context | `--json` | `issues[]` plus `firstMinuteSummary` | `claimBoundary`, `contextPacket`, `relatedContext`, preview safety fields |
+| Decide the first source action for a supported React Web file | `--summary-json` | `firstMinuteSummary.items[0]` | `decision`, `claimBoundary`, `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply` |
+| Build read-only migration candidate rows from ranked issue evidence | `--dry-run-json` | `candidates[]` | `decision`, `dryRunOnly`, `autoApply`, `humanReviewRequired`, `riskNotes` |
+| Inspect detailed card evidence, context packets, or related local context | `--json` | `issues[]` plus `firstMinuteSummary` | `decision`, `claimBoundary`, `contextPacket`, `relatedContext`, preview safety fields |
 | A person wants a quick source-reading report | text mode | the first-minute summary before detailed cards | the printed boundaries and manual-review notes |
 
 Do not start with full `--json` when the agent only needs the first action, and do not use `--dry-run-json` as a codemod runner. These projections are task-shaping inputs: they choose where to inspect and what evidence to preserve, not whether an edit is allowed.
@@ -83,7 +97,7 @@ The intended consumer flow is:
 
 1. Read `firstMinuteSummary.items` in `sourceTopIssueIds` order.
 2. Start with `items[0].firstInspectStep` and `items[0].nextAction`.
-3. Keep `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply`, and `claimBoundary` in the agent prompt or task card.
+3. Keep `decision`, `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply`, and `claimBoundary` in the agent prompt or task card.
 4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority.
 5. If `items` is empty, stop and inspect the top-level `inScope` / `skippedReason` values instead of inventing a React Web task.
 
@@ -95,7 +109,7 @@ A compact first-minute agent task card should therefore retain the fields that p
 source: fooks inspect react-web-issues <file> --summary-json
 start: firstMinuteSummary.items[0].firstInspectStep
 next: firstMinuteSummary.items[0].nextAction
-preserve: claimBoundary, humanDecisionNeeded, doNotDo, fixShapeGuidance.autoApply
+preserve: decision, claimBoundary, humanDecisionNeeded, doNotDo, fixShapeGuidance.autoApply
 stop: if firstMinuteSummary.items is empty, inspect inScope/skippedReason instead of inventing a task
 ```
 
@@ -111,7 +125,7 @@ The intended dry-run consumer flow is:
 
 1. Read `candidates[]` in the returned order; each candidate is derived from the ranked issue evidence.
 2. Start each row from `candidate.firstInspectStep` and `candidate.affectedFile`.
-3. Keep `dryRunOnly`, `autoApply`, `humanReviewRequired`, and `riskNotes` with every task card.
+3. Keep `decision`, `dryRunOnly`, `autoApply`, `humanReviewRequired`, and `riskNotes` with every task card.
 4. Treat `previewAvailable` as a hint about whether a read-only preview shape exists, not as permission to change source.
 5. If `candidates` is empty, stop and inspect `inScope` / `skippedReason` instead of creating a migration task.
 
@@ -122,7 +136,7 @@ source: fooks inspect react-web-issues <file> --dry-run-json
 row: candidates[n].issueId
 inspect: candidates[n].firstInspectStep
 file: candidates[n].affectedFile
-preserve: dryRunOnly, autoApply, humanReviewRequired, riskNotes
+preserve: decision, dryRunOnly, autoApply, humanReviewRequired, riskNotes
 stop: if candidates is empty or inScope is false, do not create a migration candidate
 ```
 

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -40,7 +40,7 @@ source-derived React Web evidence
   -> firstMinuteSummary / dry-run candidate / future workflow projection
 ```
 
-The important product rule is unchanged: high confidence can make an issue ready for agent inspection, but it still does not authorize patch application.
+The important product rule is unchanged: high confidence can make an issue ready for agent inspection, but it still does not authorize patch application. Current source evidence is the authority boundary: advisory context, repo-owned convention hints, and historical memory-like context may explain why to inspect something, but they must not outrank source evidence or grant apply authority.
 
 ## Current CLI surfaces
 

--- a/docs/repo-owned-convention-hints.md
+++ b/docs/repo-owned-convention-hints.md
@@ -14,9 +14,9 @@ Repo-owned convention hints are a first prototype for future team-owned fooks ch
 
 This is not the future tracked config surface yet. The first pass does **not** add tracked `.fooks` policy/check files, a public CLI, CI enforcement, merge enforcement, codemod behavior, or edit authority.
 
-Convention hints should remain inspect-first context. They may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, or custom-component semantic inference.
+Convention hints should remain inspect-first context. They may say what local evidence to inspect, but they must not imply mandatory edits, generated accessible-name copy, broad accessibility coverage, or custom-component semantic inference. Current source evidence remains stronger than any advisory convention, stale context, or historical memory-like hint.
 
-In first-minute summaries, convention hints are intentionally weaker than the ranked issue evidence. A matched hint can add a concise `contextHints` entry so an agent sees the team-context pointer, but it must not change ranking, priority, bucket assignment, `inspectFirst`, `nextAction`, or edit authority.
+In first-minute summaries, convention hints are intentionally weaker than the ranked issue evidence. A matched hint can add a concise `contextHints` entry so an agent sees the team-context pointer, but it must not change ranking, priority, bucket assignment, `inspectFirst`, `nextAction`, or edit authority. High confidence and helpful convention context still do not authorize patch application.
 
 ## Graduation path
 

--- a/src/core/react-web-decision.ts
+++ b/src/core/react-web-decision.ts
@@ -1,0 +1,178 @@
+export type ReactWebDecisionLevel = "blocker" | "warning" | "info";
+export type ReactWebDecisionConfidence = "high" | "medium" | "low";
+export type ReactWebDecisionState =
+  | "ready-for-agent-inspect"
+  | "human-decision-required"
+  | "dry-run-candidate-only"
+  | "unsupported"
+  | "incomplete"
+  | "malformed-stop";
+
+export type ReactWebDecisionAllowedActions = {
+  inspect: boolean;
+  suggestPatch: boolean;
+  applyPatch: false;
+  generateCopy: false;
+};
+
+export type ReactWebDecision = {
+  findingId: string;
+  ruleId: string;
+  level: ReactWebDecisionLevel;
+  confidence: ReactWebDecisionConfidence;
+  state: ReactWebDecisionState;
+  allowedActions: ReactWebDecisionAllowedActions;
+  reason: string;
+  requiredEvidence: string[];
+  stopConditions: string[];
+};
+
+export type ReactWebDecisionSummary = Pick<
+  ReactWebDecision,
+  "state" | "level" | "confidence" | "allowedActions" | "stopConditions"
+>;
+
+export type BuildReactWebIssueDecisionInput = {
+  findingId: string;
+  ruleId: string;
+  confidence: ReactWebDecisionConfidence;
+  previewAvailable: boolean;
+  manualReviewReason?: string;
+};
+
+const READ_ONLY_ALLOWED_ACTIONS: ReactWebDecisionAllowedActions = {
+  inspect: true,
+  suggestPatch: false,
+  applyPatch: false,
+  generateCopy: false,
+};
+
+function allowedActions(options: { inspect?: boolean; suggestPatch?: boolean } = {}): ReactWebDecisionAllowedActions {
+  return {
+    inspect: options.inspect ?? true,
+    suggestPatch: options.suggestPatch ?? false,
+    applyPatch: false,
+    generateCopy: false,
+  };
+}
+
+export function summarizeReactWebDecision(decision: ReactWebDecision): ReactWebDecisionSummary {
+  return {
+    state: decision.state,
+    level: decision.level,
+    confidence: decision.confidence,
+    allowedActions: { ...decision.allowedActions },
+    stopConditions: [...decision.stopConditions],
+  };
+}
+
+function uniqueStopConditions(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function buildReactWebIssueDecision(input: BuildReactWebIssueDecisionInput): ReactWebDecision {
+  if (input.previewAvailable && input.confidence === "high") {
+    return {
+      findingId: input.findingId,
+      ruleId: input.ruleId,
+      level: "warning",
+      confidence: input.confidence,
+      state: "ready-for-agent-inspect",
+      allowedActions: allowedActions({ suggestPatch: true }),
+      reason:
+        "High-confidence native JSX evidence supports a read-only preview shape, but fooks does not grant patch-apply authority.",
+      requiredEvidence: [
+        "native JSX element evidence",
+        "high-confidence label/control association evidence",
+        "read-only preview fragment",
+      ],
+      stopConditions: [
+        "Stop before editing files; this decision only authorizes inspection and patch suggestion.",
+        "Stop if the preview no longer matches local source evidence.",
+        "Stop if final accessible-name copy or semantic intent must be chosen.",
+      ],
+    };
+  }
+
+  return {
+    findingId: input.findingId,
+    ruleId: input.ruleId,
+    level: input.confidence === "high" ? "warning" : "info",
+    confidence: input.confidence,
+    state: "human-decision-required",
+    allowedActions: allowedActions(),
+    reason:
+      input.manualReviewReason ??
+      "The finding is reportable, but remediation requires human review before choosing label/name copy or association shape.",
+    requiredEvidence: [
+      "native JSX element evidence",
+      "local source context",
+      "human-reviewed remediation intent",
+    ],
+    stopConditions: [
+      "Stop before generating accessible-name copy.",
+      "Stop before applying patches automatically.",
+      "Stop before inferring custom-component semantics.",
+    ],
+  };
+}
+
+export function buildReactWebDryRunDecision(issueDecision: ReactWebDecision): ReactWebDecision {
+  return {
+    ...issueDecision,
+    state: "dry-run-candidate-only",
+    allowedActions: allowedActions({ suggestPatch: issueDecision.allowedActions.suggestPatch }),
+    reason: `Dry-run projection only: ${issueDecision.reason}`,
+    requiredEvidence: [...issueDecision.requiredEvidence, "dry-run projection boundary"],
+    stopConditions: uniqueStopConditions([
+      "Stop before any write path; dryRunOnly remains true.",
+      "Stop before applying patches automatically.",
+      ...issueDecision.stopConditions,
+    ]),
+  };
+}
+
+export function buildReactWebUnsupportedDecision(options: {
+  findingId?: string;
+  ruleId?: string;
+  reason: string;
+  skippedReason?: string;
+}): ReactWebDecision {
+  return {
+    findingId: options.findingId ?? "react-web-report",
+    ruleId: options.ruleId ?? "react-web.unsupported-boundary",
+    level: "info",
+    confidence: "low",
+    state: "unsupported",
+    allowedActions: { ...READ_ONLY_ALLOWED_ACTIONS },
+    reason: options.skippedReason ? `${options.reason}: ${options.skippedReason}` : options.reason,
+    requiredEvidence: ["supported React Web native JSX classification"],
+    stopConditions: [
+      "Stop because the source is outside the supported React Web native JSX lane.",
+      "Do not infer custom-component semantics.",
+      "Do not emit patch work orders.",
+    ],
+  };
+}
+
+export function buildReactWebMalformedDecision(options: {
+  findingId?: string;
+  ruleId?: string;
+  reason: string;
+}): ReactWebDecision {
+  return {
+    findingId: options.findingId ?? "react-web-projection",
+    ruleId: options.ruleId ?? "react-web.malformed-projection",
+    level: "blocker",
+    confidence: "low",
+    state: "malformed-stop",
+    allowedActions: allowedActions({ inspect: false }),
+    reason: options.reason,
+    requiredEvidence: ["well-formed React Web issue report projection"],
+    stopConditions: [
+      "Stop immediately because the projection is malformed.",
+      "Do not emit an agent work order.",
+      "Do not apply or suggest patches from malformed input.",
+    ],
+  };
+}

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -12,6 +12,13 @@ import {
   findRepoOwnedConventionHintsForIssue,
   type RepoOwnedConventionHintProjection,
 } from "./repo-owned-convention-hints";
+import {
+  buildReactWebDryRunDecision,
+  buildReactWebIssueDecision,
+  summarizeReactWebDecision,
+  type ReactWebDecision,
+  type ReactWebDecisionSummary,
+} from "./react-web-decision";
 
 export const REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION = "react-web-issue-report.v1" as const;
 export const REACT_WEB_ISSUE_REPORT_COMMAND = "inspect react-web-issues" as const;
@@ -112,6 +119,7 @@ export type ReactWebIssueCard = {
   conventionHints: RepoOwnedConventionHintProjection[];
   fixShapeGuidance: ReactWebIssueFixShapeGuidance;
   triage: ReactWebIssueTriage;
+  decision: ReactWebDecision;
   skipReason?: string;
   preview?: {
     type: "unified-diff-fragment";
@@ -130,6 +138,7 @@ export type ReactWebIssueFirstMinuteSummaryItem = {
   humanDecisionNeeded: string[];
   doNotDo: string[];
   contextHints: string[];
+  decision: ReactWebDecisionSummary;
   fixShapeGuidance: {
     claimBoundary: ReactWebIssueFixShapeGuidance["claimBoundary"];
     humanReviewRequired: true;
@@ -229,6 +238,7 @@ export type ReactWebIssueReportMigrationDryRunJson = {
     humanReviewRequired: true;
     autoApply: false;
     dryRunOnly: true;
+    decision: ReactWebDecisionSummary;
     riskNotes: string[];
   }[];
 };
@@ -661,6 +671,13 @@ function issueCardFor(
     }),
     conventionHints,
     fixShapeGuidance,
+    decision: buildReactWebIssueDecision({
+      findingId: `react-web-label-${index + 1}`,
+      ruleId: issueKindFor(finding),
+      confidence: finding.confidence,
+      previewAvailable: Boolean(preview),
+      manualReviewReason: safetyRationale,
+    }),
     ...(!isSafePreview ? { skipReason: skipReasonFor(finding) } : {}),
     ...(preview ? { preview } : {}),
   };
@@ -834,6 +851,7 @@ function buildFirstMinuteSummary(
       humanDecisionNeeded: humanDecisionNeededFor(issue),
       doNotDo: doNotDoFor(),
       contextHints: contextHintsFor(issue),
+      decision: summarizeReactWebDecision(issue.decision),
       fixShapeGuidance: {
         claimBoundary: issue.fixShapeGuidance.claimBoundary,
         humanReviewRequired: issue.fixShapeGuidance.humanReviewRequired,
@@ -934,6 +952,7 @@ export function buildReactWebIssueReportMigrationDryRunJson(
     humanReviewRequired: true as const,
     autoApply: false as const,
     dryRunOnly: true as const,
+    decision: summarizeReactWebDecision(buildReactWebDryRunDecision(issue.decision)),
     riskNotes: migrationRiskNotesFor(issue),
   }));
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,3 +217,19 @@ export type {
   ReactWebIssueTriageEvidence,
   ReactWebRelatedContextQuality,
 } from "./core/react-web-issue-report";
+export {
+  buildReactWebDryRunDecision,
+  buildReactWebIssueDecision,
+  buildReactWebMalformedDecision,
+  buildReactWebUnsupportedDecision,
+  summarizeReactWebDecision,
+} from "./core/react-web-decision";
+export type {
+  BuildReactWebIssueDecisionInput,
+  ReactWebDecision,
+  ReactWebDecisionAllowedActions,
+  ReactWebDecisionConfidence,
+  ReactWebDecisionLevel,
+  ReactWebDecisionState,
+  ReactWebDecisionSummary,
+} from "./core/react-web-decision";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4991,7 +4991,7 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.match(doc, /Read `firstMinuteSummary\.items` in `sourceTopIssueIds` order/);
   assert.match(doc, /Start with `items\[0\]\.firstInspectStep` and `items\[0\]\.nextAction`/);
   assert.match(doc, /source: fooks inspect react-web-issues <file> --summary-json/);
-  assert.match(doc, /preserve: claimBoundary, humanDecisionNeeded, doNotDo, fixShapeGuidance\.autoApply/);
+  assert.match(doc, /preserve: decision, claimBoundary, humanDecisionNeeded, doNotDo, fixShapeGuidance\.autoApply/);
   assert.match(doc, /fixShapeGuidance\.autoApply/);
   assert.match(doc, /If `items` is empty, stop/);
   assert.match(doc, /ranked issue cards[\s\S]*firstMinuteSummary[\s\S]*--summary-json|firstMinuteSummary[\s\S]*compact first-minute/);
@@ -5008,7 +5008,7 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.match(doc, /riskNotes/);
   assert.match(doc, /previewAvailable[\s\S]*read-only preview shape[\s\S]*not as permission to change source/);
   assert.match(doc, /source: fooks inspect react-web-issues <file> --dry-run-json/);
-  assert.match(doc, /preserve: dryRunOnly, autoApply, humanReviewRequired, riskNotes/);
+  assert.match(doc, /preserve: decision, dryRunOnly, autoApply, humanReviewRequired, riskNotes/);
   assert.match(doc, /if candidates is empty or inScope is false, do not create a migration candidate/);
   assert.match(doc, /first inspect step/i);
   assert.match(doc, /next action/i);

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -64,6 +64,51 @@ function hasNestedKey(value, key) {
 }
 
 
+function assertNoImmediateAuthorityLifecycleFields(value) {
+  assert.equal(hasNestedKey(value, "evidenceFreshness"), false);
+  assert.equal(hasNestedKey(value, "decisionBasis"), false);
+  assert.equal(hasNestedKey(value, "contextAuthority"), false);
+}
+
+function assertDecisionActionAuthority(decision) {
+  assert.deepEqual(Object.keys(decision.allowedActions).sort(), [
+    "applyPatch",
+    "generateCopy",
+    "inspect",
+    "suggestPatch",
+  ]);
+  assert.equal(decision.allowedActions.applyPatch, false);
+  assert.equal(decision.allowedActions.generateCopy, false);
+}
+
+function assertFullDecisionContract(decision) {
+  assert.deepEqual(Object.keys(decision).sort(), [
+    "allowedActions",
+    "confidence",
+    "findingId",
+    "level",
+    "reason",
+    "requiredEvidence",
+    "ruleId",
+    "state",
+    "stopConditions",
+  ]);
+  assertNoImmediateAuthorityLifecycleFields(decision);
+  assertDecisionActionAuthority(decision);
+}
+
+function assertSummaryDecisionContract(decision) {
+  assert.deepEqual(Object.keys(decision).sort(), [
+    "allowedActions",
+    "confidence",
+    "level",
+    "state",
+    "stopConditions",
+  ]);
+  assertNoImmediateAuthorityLifecycleFields(decision);
+  assertDecisionActionAuthority(decision);
+}
+
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -202,6 +247,7 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.equal(issue.conventionHints[0].source, "internal-prototype-fixture");
     assert.match(issue.conventionHints[0].policyBoundary, /Advisory convention hint only/);
     assert.doesNotMatch(JSON.stringify(issue.conventionHints), /must-edit|auto-apply|CI gate|merge gate/i);
+    assertFullDecisionContract(issue.decision);
     assert.match(issue.skipReason, /human review|accessible-name copy/);
     assert.ok(issue.triage.rank > 0);
     assert.ok(["high", "medium", "low"].includes(issue.triage.priority));
@@ -218,8 +264,7 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.equal(issue.decision.confidence, issue.confidence);
     assert.equal(issue.decision.allowedActions.inspect, true);
     assert.equal(issue.decision.allowedActions.suggestPatch, false);
-    assert.equal(issue.decision.allowedActions.applyPatch, false);
-    assert.equal(issue.decision.allowedActions.generateCopy, false);
+    assertDecisionActionAuthority(issue.decision);
     assert.ok(issue.decision.stopConditions.some((condition) => /generating accessible-name copy/i.test(condition)));
 
     assert.ok(Array.isArray(issue.relatedContext));
@@ -265,8 +310,7 @@ test("React Web issue report turns nearby native associations into safe preview 
   assert.equal(report.issues[0].decision.state, "ready-for-agent-inspect");
   assert.equal(report.issues[0].decision.allowedActions.inspect, true);
   assert.equal(report.issues[0].decision.allowedActions.suggestPatch, true);
-  assert.equal(report.issues[0].decision.allowedActions.applyPatch, false);
-  assert.equal(report.issues[0].decision.allowedActions.generateCopy, false);
+  assertFullDecisionContract(report.issues[0].decision);
   assert.ok(report.issues[0].decision.stopConditions.some((condition) => /Stop before editing files/i.test(condition)));
   assert.equal(report.issues[1].decision.state, "human-decision-required");
   assert.match(report.issues[0].contextPacket.relatedPattern, /safe-preview pattern/);
@@ -774,8 +818,7 @@ test("React Web issue report JSON includes machine-readable first-minute summary
       allowedActions: issue.decision.allowedActions,
       stopConditions: issue.decision.stopConditions,
     });
-    assert.equal(item.decision.allowedActions.applyPatch, false);
-    assert.equal(item.decision.allowedActions.generateCopy, false);
+    assertSummaryDecisionContract(item.decision);
   }
 
   assert.deepEqual(
@@ -951,8 +994,7 @@ test("React Web issue report migration dry-run JSON projects read-only candidate
     assert.equal(candidate.autoApply, false);
     assert.equal(candidate.dryRunOnly, true);
     assert.equal(candidate.decision.state, "dry-run-candidate-only");
-    assert.equal(candidate.decision.allowedActions.applyPatch, false);
-    assert.equal(candidate.decision.allowedActions.generateCopy, false);
+    assertSummaryDecisionContract(candidate.decision);
     assert.ok(candidate.decision.stopConditions.some((condition) => /dryRunOnly remains true/i.test(condition)));
     assert.ok(candidate.riskNotes.length >= 3);
     assert.ok(candidate.riskNotes.some((note) => /human review|human-reviewed/i.test(note)));

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -27,6 +27,10 @@ const {
   buildReactWebIssueReportSummaryJson,
   renderReactWebIssueReportText,
 } = require(path.join(repoRoot, "dist", "core", "react-web-issue-report.js"));
+const {
+  buildReactWebMalformedDecision,
+  buildReactWebUnsupportedDecision,
+} = require(path.join(repoRoot, "dist", "core", "react-web-decision.js"));
 
 const fixtures = {
   missing: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-labels.tsx"),
@@ -208,6 +212,15 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.equal(issue.triage.evidence.sameFileContextAvailable, true);
     assert.equal(issue.triage.evidence.relatedContextCount, issue.relatedContext.length);
     assert.ok(issue.triage.evidence.reasons.length > 0);
+    assert.equal(issue.decision.state, "human-decision-required");
+    assert.equal(issue.decision.ruleId, issue.kind);
+    assert.equal(issue.decision.findingId, issue.id);
+    assert.equal(issue.decision.confidence, issue.confidence);
+    assert.equal(issue.decision.allowedActions.inspect, true);
+    assert.equal(issue.decision.allowedActions.suggestPatch, false);
+    assert.equal(issue.decision.allowedActions.applyPatch, false);
+    assert.equal(issue.decision.allowedActions.generateCopy, false);
+    assert.ok(issue.decision.stopConditions.some((condition) => /generating accessible-name copy/i.test(condition)));
 
     assert.ok(Array.isArray(issue.relatedContext));
     assert.ok(issue.relatedContext.length > 0);
@@ -249,6 +262,13 @@ test("React Web issue report turns nearby native associations into safe preview 
   assert.equal(report.issues[0].triage.evidence.safePreviewAvailable, true);
   assert.equal(report.issues[0].triage.bucket, "safe-preview");
   assert.equal(report.issues[0].triage.rank, 1);
+  assert.equal(report.issues[0].decision.state, "ready-for-agent-inspect");
+  assert.equal(report.issues[0].decision.allowedActions.inspect, true);
+  assert.equal(report.issues[0].decision.allowedActions.suggestPatch, true);
+  assert.equal(report.issues[0].decision.allowedActions.applyPatch, false);
+  assert.equal(report.issues[0].decision.allowedActions.generateCopy, false);
+  assert.ok(report.issues[0].decision.stopConditions.some((condition) => /Stop before editing files/i.test(condition)));
+  assert.equal(report.issues[1].decision.state, "human-decision-required");
   assert.match(report.issues[0].contextPacket.relatedPattern, /safe-preview pattern/);
   assert.ok(report.issues[0].contextPacket.excludedInference.some((entry) => /candidate diff only/.test(entry)));
   assert.match(report.issues[0].preview.text, /htmlFor="email"/);
@@ -747,6 +767,15 @@ test("React Web issue report JSON includes machine-readable first-minute summary
     assert.equal(item.fixShapeGuidance.claimBoundary, issue.fixShapeGuidance.claimBoundary);
     assert.equal(item.fixShapeGuidance.humanReviewRequired, true);
     assert.equal(item.fixShapeGuidance.autoApply, false);
+    assert.deepEqual(item.decision, {
+      state: issue.decision.state,
+      level: issue.decision.level,
+      confidence: issue.decision.confidence,
+      allowedActions: issue.decision.allowedActions,
+      stopConditions: issue.decision.stopConditions,
+    });
+    assert.equal(item.decision.allowedActions.applyPatch, false);
+    assert.equal(item.decision.allowedActions.generateCopy, false);
   }
 
   assert.deepEqual(
@@ -921,6 +950,10 @@ test("React Web issue report migration dry-run JSON projects read-only candidate
     assert.equal(candidate.humanReviewRequired, true);
     assert.equal(candidate.autoApply, false);
     assert.equal(candidate.dryRunOnly, true);
+    assert.equal(candidate.decision.state, "dry-run-candidate-only");
+    assert.equal(candidate.decision.allowedActions.applyPatch, false);
+    assert.equal(candidate.decision.allowedActions.generateCopy, false);
+    assert.ok(candidate.decision.stopConditions.some((condition) => /dryRunOnly remains true/i.test(condition)));
     assert.ok(candidate.riskNotes.length >= 3);
     assert.ok(candidate.riskNotes.some((note) => /human review|human-reviewed/i.test(note)));
     assert.ok(candidate.riskNotes.some((note) => /Do not apply patches automatically/i.test(note)));
@@ -1130,6 +1163,31 @@ test("React Web agent handoff dogfood fails closed on malformed projections", ()
     assert.equal(Object.hasOwn(stop, "affectedFile"), false);
     assert.equal(Object.hasOwn(stop, "firstInspectStep"), false);
   }
+});
+
+test("React Web decision helpers encode unsupported and malformed stop states", () => {
+  const unsupported = buildReactWebUnsupportedDecision({
+    reason: "Custom component semantics are outside the supported native JSX lane",
+    skippedReason: "custom-component-boundary",
+  });
+  assert.equal(unsupported.state, "unsupported");
+  assert.equal(unsupported.allowedActions.inspect, true);
+  assert.equal(unsupported.allowedActions.suggestPatch, false);
+  assert.equal(unsupported.allowedActions.applyPatch, false);
+  assert.equal(unsupported.allowedActions.generateCopy, false);
+  assert.match(unsupported.reason, /custom-component-boundary/);
+  assert.ok(unsupported.stopConditions.some((condition) => /custom-component semantics/i.test(condition)));
+
+  const malformed = buildReactWebMalformedDecision({
+    reason: "firstMinuteSummary.items must be an array",
+  });
+  assert.equal(malformed.state, "malformed-stop");
+  assert.equal(malformed.level, "blocker");
+  assert.equal(malformed.allowedActions.inspect, false);
+  assert.equal(malformed.allowedActions.suggestPatch, false);
+  assert.equal(malformed.allowedActions.applyPatch, false);
+  assert.equal(malformed.allowedActions.generateCopy, false);
+  assert.ok(malformed.stopConditions.some((condition) => /Stop immediately/i.test(condition)));
 });
 
 test("React Web issue report rejects conflicting JSON output flags", () => {


### PR DESCRIPTION
## Summary
- Closes #782 by documenting source evidence as the React Web Decision Layer authority boundary
- Keeps repo convention/context/memory-like hints advisory only
- Strengthens regression tests by closing decision and allowedActions keysets across issue, summary, and dry-run projections

## Verification
- `npm run build && node --test test/react-web-issue-report.test.mjs && npm run typecheck && git diff --check`
- `$code-review`: APPROVE; architecture status CLEAR

## Known gap
- `npm test` did not complete locally within 300s; it surfaced an unrelated existing `test/fooks.test.mjs` `init creates config and cache contract` failure during the full-suite run. Targeted React Web issue-report coverage and typecheck pass.
