### PR TITLE
Prevent empty stop evidence from passing handoff scoring

### DIFF
--- a/src/core/react-web-decision-handoff-benchmark.ts
+++ b/src/core/react-web-decision-handoff-benchmark.ts
@@ -254,8 +254,10 @@ export function evaluateReactWebDecisionStopBenchmark(stops: ReactWebDecisionSto
     entries,
     unsupportedStopRate: entries.length === 0 ? 0 : entries.filter((entry) => entry.state === "unsupported").length / entries.length,
     malformedStopRate: entries.length === 0 ? 0 : entries.filter((entry) => entry.state === "malformed-stop").length / entries.length,
-    allStopFailClosed: entries.every(
-      (entry) => entry.kind === "stop" && !entry.inspectAllowed && !entry.applyPatchAllowed && !entry.generateCopyAllowed && !entry.autoApply,
-    ),
+    allStopFailClosed:
+      entries.length > 0 &&
+      entries.every(
+        (entry) => entry.kind === "stop" && !entry.inspectAllowed && !entry.applyPatchAllowed && !entry.generateCopyAllowed && !entry.autoApply,
+      ),
   };
 }

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -1180,6 +1180,17 @@ test("React Web agent handoff dogfood fails closed on malformed projections", ()
 
 
 
+test("React Web decision stop benchmark does not claim fail-closed behavior without stop evidence", () => {
+  const benchmark = evaluateReactWebDecisionStopBenchmark([]);
+
+  assert.equal(benchmark.schemaVersion, "react-web-decision-stop-benchmark.v1");
+  assert.equal(benchmark.stopCount, 0);
+  assert.equal(benchmark.allStopFailClosed, false);
+  assert.equal(benchmark.unsupportedStopRate, 0);
+  assert.equal(benchmark.malformedStopRate, 0);
+  assert.deepEqual(benchmark.entries, []);
+});
+
 test("React Web decision stop benchmark scores unsupported and malformed handoffs as fail-closed", () => {
   const rnReport = buildReactWebIssueReport(fixtures.rn, repoRoot);
   const rnSummaryStop = consumeReactWebSummaryForAgentTask(buildReactWebIssueReportSummaryJson(rnReport));


### PR DESCRIPTION
## Summary
- Require at least one observed stop entry before React Web stop benchmark claims all stops fail closed
- Add a regression for empty stop benchmark inputs so no-evidence inputs stay non-claiming

## Tests
- npm run build && node --test test/react-web-issue-report.test.mjs
- npm test

## Review
- ai-slop-cleaner scoped pass: no-op, changed files only
- code-review: APPROVE
- architect status: CLEAR

Closes #787
