### PR TITLE
Keep post-merge main echoes from implying active work

### DIFF
--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -11,6 +11,15 @@ when the available surfaces all point at the already-merged `main` state and no
 current work signal is present. Record the echo as evidence, but do not start a
 new recovery, cleanup, or implementation lane from the success echo alone.
 
+## Durable boundary receipt
+
+A post-merge `main` CI or release-report success is an echo receipt only. It is
+not active work evidence unless one of these separate active artifacts is present:
+an open issue, an open pull request, a non-`main` active branch/worktree signal,
+or a mapped fooks tmux session. Keep the echo receipt and the active artifact
+receipt separate in reminders so a successful `main` rerun cannot reopen work by
+itself.
+
 ## Evidence surfaces
 
 - `fooks check --json` exposes the operator/check projection. The idle case is

--- a/test/post-merge-main-ci-echo-boundary-doc.test.mjs
+++ b/test/post-merge-main-ci-echo-boundary-doc.test.mjs
@@ -16,6 +16,9 @@ function assertDocIncludes(text) {
 
 test("post-merge main CI echo boundary doc names the read-only operator surfaces", () => {
   for (const required of [
+    "echo receipt only",
+    "open issue, an open pull request, a non-`main` active branch/worktree signal, or a mapped fooks tmux session",
+    "the echo receipt and the active artifact receipt separate",
     "fooks check --json",
     'verdict: "idleRequiresActiveArtifact"',
     "requiredActiveArtifact.required: true",


### PR DESCRIPTION
## Summary\n- Add a small operator-facing boundary receipt for post-merge main CI/release-report echoes.\n- Explicitly separates echo receipts from active issue, PR, branch/worktree, or mapped-session evidence.\n- Lock the wording with the existing focused doc guard.\n\n## Verification\n- git diff --check\n- node --test test/post-merge-main-ci-echo-boundary-doc.test.mjs\n\nCloses #791

Review gate receipt: qualifying maintainer/operator comment posted for current head.