### PR TITLE
Clarify stale local worktrees are not active work

### DIFF
--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -20,6 +20,16 @@ or a mapped fooks tmux session. Keep the echo receipt and the active artifact
 receipt separate in reminders so a successful `main` rerun cannot reopen work by
 itself.
 
+Legacy local `fooks.omx-worktrees` entries that remain after merges are inventory
+or cleanup-review receipts, not active work receipts. When they have local
+branch-archive evidence and no mapped tmux pane, `fooks check --json` may surface
+them under `activeWorkReceipts.legacyLocalResidueCleanupReview` so dogfood nudges
+can see the stale local inventory. That review block keeps
+`staleLocalResidueIsActiveWorkEvidence: false` and
+`satisfiesActiveArtifactRequirement: false`; it does not satisfy the active
+artifact requirement and does not add cleanup commands, runtime cleanup order,
+or mutation authority.
+
 ## Evidence surfaces
 
 - `fooks check --json` exposes the operator/check projection. The idle case is
@@ -47,6 +57,11 @@ itself.
   clean worktree, zero local tracking divergence, zero fooks-like tmux sessions,
   and opt-in GitHub open issue/PR counts of zero. If any proof is missing or a
   work signal exists, it remains `activeOrUnknown`.
+- Legacy local `fooks.omx-worktrees` residue can remain visible in inventory
+  after merges, but it is separated from active current-run evidence. Its
+  cleanup-review rows are advisory receipts only and require a separate open
+  issue, open PR, or mapped fooks tmux session before any nudge treats the
+  checkout as active work.
 - `npm run --silent ci:alerts -- --alerts <file> --branch main --json` marks a
   current completed `main` success as `verdict: "current-main-echo"`,
   `echo: true`, and `disposition: "verification-only"`.

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1184,6 +1184,11 @@ test("operator check surfaces legacy local residue as cleanup-review evidence on
   assert.equal(snapshot.postMergeMainEchoBoundary.mainEchoEvidence, true);
   assert.deepEqual(snapshot.activeArtifacts, []);
   assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.deepEqual(snapshot.requiredActiveArtifact.acceptableArtifacts, [
+    "open GitHub issue",
+    "open GitHub pull request",
+    "mapped fooks tmux session",
+  ]);
 
   const review = snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview;
   assert.equal(review.issue, "#778");
@@ -1196,6 +1201,16 @@ test("operator check surfaces legacy local residue as cleanup-review evidence on
   assert.match(snapshot.activeWorkReceipts.reportLine, /legacyLocalResidueCleanupReview=1\(#778\)/);
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 0);
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
+  assert.deepEqual(snapshot.activeWorkReceipts.staleResidueActiveBoundary.acceptableActiveArtifacts, [
+    "open GitHub issue",
+    "open GitHub pull request",
+    "mapped fooks tmux session",
+  ]);
+  assert.equal(
+    snapshot.activeWorkReceipts.receipts.some((receipt) => receipt.classification === "active"),
+    false,
+  );
 
   assert.deepEqual(review.rows, [
     {


### PR DESCRIPTION
## Summary
- Clarifies that stale local fooks worktree inventory is not active work by itself
- Keeps dogfood nudge evidence tied to active issue/branch/session/PR signals

## Test plan
- Generated by dogfood OMX worktree; CI validates the focused docs/test surface

Fixes #793
