### PR TITLE
Lock frontend-family PRD claim boundaries

### DIFF
--- a/docs/frontend-domain-contract.md
+++ b/docs/frontend-domain-contract.md
@@ -17,6 +17,8 @@ Architecture shorthand:
 
 This shorthand describes the intended separation of responsibilities for future implementation work. It does not add runtime behavior, setup eligibility, compact payload reuse, domain support wording, or team/worktree launch authorization.
 
+For issue #796 planning, [Frontend-family behavior-neutral PRD](frontend-family-prd.md) is the docs-only roadmap lock that maps existing domain-profile, payload-policy, runtime, and evidence seams without changing those contracts.
+
 ## Domain vs concern boundary
 
 The frontend-domain contract separates **where code runs** from **what task-relevant library/dataflow evidence is present**.

--- a/docs/frontend-domain-profiles.md
+++ b/docs/frontend-domain-profiles.md
@@ -3,6 +3,7 @@
 This document promotes the RN/WebView/TUI domain-profile plan into tracked project docs. It does **not** add runtime support. The current strongest fooks path remains repeated same-file React web `.tsx` / `.jsx` work in Codex, plus the documented same-file `.ts` / `.js` beta when module signals are strong enough.
 
 For the canonical cross-domain taxonomy, outcome vocabulary, claim boundaries, and shard triggers, see [Frontend domain contract](frontend-domain-contract.md).
+Issue #796 adds the [Frontend-family behavior-neutral PRD](frontend-family-prd.md) as the docs-only roadmap lock for current code seams, promotion order, and claim wording.
 
 ## Design rule
 

--- a/docs/frontend-family-prd.md
+++ b/docs/frontend-family-prd.md
@@ -1,0 +1,92 @@
+# Frontend-family behavior-neutral PRD
+
+Issue #796 locks the frontend-family roadmap as a docs-only product requirements baseline. It exists to prevent roadmap drift from turning syntax evidence, candidate lanes, or fallback boundaries into unsupported runtime/provider claims.
+
+This PRD does not change runtime behavior, provider behavior, setup eligibility, detector behavior, extractor output, payload schema, cache behavior, billing/cost claims, or public support scope. It is a shared wording and sequencing contract for later issues.
+
+## Decision summary
+
+| Lane | Product status for this PRD | Allowed wording | Stop condition |
+| --- | --- | --- | --- |
+| React Web | Current product lane for measured same-file `.tsx` / `.jsx` work, plus the documented Codex-first `.ts` / `.js` beta when normal gates allow it. | “Current React Web product lane” and “measured same-file React Web evidence.” | Stop if wording implies provider-token, billing-grade, runtime-token, multi-file, or cross-runtime parity proof. |
+| React Native | Narrow candidate lane only. The measured `F1` primitive/input gate and `rn-primitive-input-narrow-payload` name source-only evidence, not broad mobile support. | “Narrow RN candidate” and “source-only measured primitive/input evidence.” | Stop if wording claims mobile UI correctness, device/simulator execution, native component behavior, accessibility correctness, navigation success, list performance, or DOM/form equivalence. |
+| WebView | Boundary and safety fallback-first lane. WebView signals require normal source reading unless a later security/boundary gate explicitly narrows that rule. | “WebView boundary/fallback-first lane.” | Stop if wording claims WebView support, bridge safety, sandbox/security correctness, or default compact payload reuse. |
+| TUI / React CLI | Evidence-only lane. Ink/React CLI TSX may be useful syntax/payload evidence for future profiles, but it is not terminal UI product support. | “TUI/Ink evidence-only candidate.” | Stop if wording claims broad TUI support, terminal correctness, terminal UX safety, or default compact extraction. |
+
+## Existing file map
+
+The current repository already has the pieces needed for a behavior-neutral roadmap. Later implementation slices should cite these files instead of inventing new support language.
+
+| Surface | Current files | PRD reading |
+| --- | --- | --- |
+| Public product boundary | `README.md`, `docs/release.md`, `docs/roadmap.md`, `docs/benchmark-evidence.md` | React Web is the current product lane; future frontend-family lanes stay roadmap/evidence unless a measured gate says otherwise. |
+| Domain taxonomy and promotion contract | `docs/frontend-domain-contract.md`, `docs/frontend-domain-profiles.md`, `docs/frontend-scope-taxonomy.md`, `docs/frontend-domain-fixture-expectations.md` | Domain classification is evidence, not permission. Promotion stops at the first failed fixture, fallback, or wording gate. |
+| Payload policy boundary | `docs/domain-payload-architecture.md`, `test/domain-payload-policy-coverage.test.mjs`, `test/payload-policy-*.test.mjs`, `test/payload-policy-registry*.test.mjs` | Payload policy is the permission layer. Scanner/profile facts must not bypass compact/narrow/fallback/deferred policy decisions. |
+| Runtime and setup boundary | `docs/architecture-boundaries.md`, `docs/setup.md`, `docs/rn-webview-architecture.md`, `src/adapters/*runtime*`, `src/adapters/pre-read.ts` | Runtime adapters and pre-read fallback behavior are not changed by this PRD. WebView and broad RN/WebView boundaries remain fallback-first unless a later issue changes source behavior explicitly. |
+| Evidence and claim proof | `docs/benchmark-evidence.md`, `docs/provider-tokenizer-boundary.md`, `docs/react-native-source-only-guidance-report.md`, `scripts/react-*-evidence.mjs`, `test/claim-boundary-doc-audit.test.mjs` | Evidence wording must name its scope: local source/payload, estimate-scoped cost, measured fixture lane, or source-only RN evidence. |
+| Fixture and regression guardrails | `test/fixtures/frontend-domain-expectations/manifest.json`, `docs/frontend-fixture-boundary-regression-map.md`, `docs/rn-webview-fixture-candidates.md`, `docs/tui-fixture-candidates.md` | Fixtures can unlock future issue slices only when expected outcome, fallback reason, and claim boundary are recorded first. |
+
+## Behavior-neutral requirements
+
+1. Keep React Web as the only broad frontend product lane in public wording.
+2. Keep the RN `F1` primitive/input path narrow, measured, and source-only; do not widen it by implication.
+3. Keep WebView fallback-first and boundary/safety-oriented; do not describe bridge or sandbox correctness as proven.
+4. Keep TUI/Ink evidence-only; do not describe terminal rendering or interaction behavior as product support.
+5. Keep domain profiles separate from payload permission. A domain profile may observe signals, but a payload-policy decision must still choose compact, narrow, boundary-aware, fallback, or deferred behavior.
+6. Keep runtime/provider claims out of this docs slice. No hook behavior, provider savings, billing-grade cost, runtime-token, latency, cache, or setup-parity claim changes are authorized.
+7. Keep future work issue-sized. A later PR must name one slice, one owned surface, one verification command set, and one claim boundary.
+
+## Claim wording guard
+
+Use this checklist before editing README, release notes, roadmap, architecture docs, issue text, or PR descriptions:
+
+- Prefer “product lane” for React Web and “candidate,” “evidence,” “source-only,” “fallback-first,” or “boundary” for RN/WebView/TUI.
+- Name exact gates when they matter: measured `F1` RN primitive/input narrow pre-read payload gate and `rn-primitive-input-narrow-payload`.
+- Do not use “support,” “supported,” “available,” “enabled,” “stable,” “ready,” or “safe” near RN, WebView, or TUI unless the same sentence clearly negates or scopes the claim.
+- Do not describe WebView compact extraction as default, safe, available, or supported.
+- Do not describe TUI/Ink syntax evidence as terminal correctness, broad TUI support, or default compact reuse.
+- Do not describe RN primitives, handlers, styles, navigation, accessibility, lists, media, or platform branches as runtime-correct, device-tested, accessible, equivalent to DOM controls, or cross-file understood.
+- Do not imply that docs-only architecture work authorizes implementation worktrees, runtime source changes, setup changes, provider behavior changes, parser rewrites, or WebView compact paths.
+
+`test/claim-boundary-doc-audit.test.mjs` is the current automated guard for broad RN/WebView/TUI wording drift. This PRD is a human-facing companion to that test, not a replacement for it.
+
+## Next issue slices
+
+Each slice below must be filed and reviewed independently. None is authorized by this PRD to change runtime behavior by default.
+
+1. **Issue slice: domain-profile registry shell**
+   - Scope: introduce or refine profile/registry seams.
+   - Constraint: no support expansion, setup eligibility change, payload shape change, or runtime adapter change.
+   - Verification: existing React Web behavior tests plus claim-boundary doc audit.
+2. **Issue slice: React Web seam wrap**
+   - Scope: move current React Web product behavior behind the new seams first.
+   - Constraint: preserve current measured same-file behavior and public product wording.
+   - Verification: React Web payload/evidence tests and build/typecheck.
+3. **Issue slice: RN narrow candidate hardening**
+   - Scope: keep `F1` primitive/input and any listed RN concern evidence source-only and policy-scoped.
+   - Constraint: no broad RN support, no device/simulator/runtime correctness claim, no DOM/form equivalence.
+   - Verification: RN payload/readiness tests and claim-boundary audit.
+4. **Issue slice: WebView boundary fixture/fallback review**
+   - Scope: document WebView source, injection, and bridge boundary fixtures and fallback reasons.
+   - Constraint: fallback-first remains default; no compact payload reuse, bridge safety, or sandbox correctness claim.
+   - Verification: WebView payload-policy/fallback tests and wording audit.
+5. **Issue slice: TUI/Ink evidence baseline**
+   - Scope: track Ink/React CLI syntax/payload fixture evidence only.
+   - Constraint: no broad TUI product support, terminal correctness, terminal UX safety, or default compact reuse.
+   - Verification: TUI fixture docs/tests and claim-boundary audit.
+6. **Issue slice: payload-policy split**
+   - Scope: make compact/narrow/boundary/fallback/deferred permission explicit after profile evidence.
+   - Constraint: no scanner/profile fact may become permission by itself.
+   - Verification: payload-policy registry/coverage tests and focused docs audit.
+7. **Issue slice: final public wording pass**
+   - Scope: align README, release notes, roadmap, and benchmark docs after measured evidence changes.
+   - Constraint: wording must not exceed green fixtures, policy gates, or benchmark assumptions.
+   - Verification: `node --test test/claim-boundary-doc-audit.test.mjs` plus any lane-specific evidence command.
+
+## PR acceptance criteria for issue #796
+
+- This PRD maps current domain-profile, payload-policy, runtime, and evidence surfaces.
+- React Web, RN, WebView, and TUI statuses are locked using behavior-neutral wording.
+- Next issue slices are explicit and do not authorize broad implementation work.
+- Claim wording guard is documented and covered by the existing audit test surface.
+- The final diff contains no runtime/provider behavior change.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,8 @@
 
 This page frames common "does fooks support X?" questions as future support or evidence lanes. These items are **not required** for the current strongest workflow: Codex repeated same-file React `.tsx` / `.jsx` context reduction, with a narrower experimental Codex-first `.ts` / `.js` same-file beta.
 
+Issue #796 is locked by the [Frontend-family behavior-neutral PRD](frontend-family-prd.md), which maps the current domain-profile, payload-policy, runtime, and evidence seams before any future RN/WebView/TUI promotion work.
+
 If the answer you want sounds like “React Native?”, “WebView?”, “TUI/CLI?”, “Vue?”, “broader TS/JS?”, “multi-file?”, “read interception?”, “LSP rename/reference?”, or “provider parity?”, read that as a roadmap question unless another public doc explicitly says it already shipped.
 
 ## Current strongest workflow


### PR DESCRIPTION
## Summary
- Add a behavior-neutral frontend-family PRD for issue #796.
- Link the PRD from the frontend domain contract, domain profile roadmap, and roadmap.
- Lock React Web as the current product lane while keeping RN narrow/source-only, WebView fallback-first, and TUI evidence-only.

## Claim boundary
- Docs-only PR; no runtime/provider code changed.
- No support expansion, parser rewrite, setup eligibility change, WebView compact path, or provider/runtime behavior claim.
- Future work is split into issue-sized slices with explicit verification and claim boundaries.

## Verification
- `node --test test/claim-boundary-doc-audit.test.mjs`
- `npm run build`
- `git diff --check`

Fixes #796

Review gate receipt: qualifying maintainer/operator comment posted for current head.