### PR TITLE
Anchor clean merge reminders to active evidence

### DIFF
--- a/docs/dogfood/clean-merge-reminder-action-803.md
+++ b/docs/dogfood/clean-merge-reminder-action-803.md
@@ -1,0 +1,37 @@
+# Clean-merge reminder action boundary (#803)
+
+This is a narrow read-only dogfood artifact for issue #803. It records the
+operator reminder rule for clean post-merge CI/React echoes without changing
+runtime/provider behavior, merge-gate policy, detector scope, React Web,
+React Native, TUI, WebView behavior, performance claims, or product claims.
+
+## Rule
+
+After clean `main` CI or React Web release-report echoes, a development reminder
+must not repeat clean status as the next development action. The reminder must
+either:
+
+1. report a real blocker that prevents bounded development from starting; or
+2. create or adopt one active issue, branch, session, or PR evidence artifact
+   that can anchor the next action.
+
+If neither condition is true, the reminder must say that the checkout cannot be
+treated as active development until an active issue, branch, session, or PR is
+created or linked. Clean CI, clean React Web release-report echoes, and stale
+local worktree inventory are verification or review receipts only.
+
+## Current dogfood adoption
+
+Issue #803 itself is the active issue artifact for this narrow reminder pass.
+The branch `dogfood/issue-803-clean-merge-reminder-action` is the active branch
+artifact for the docs/test follow-through. This artifact is read-only evidence;
+it does not authorize cleanup, fetching, deleting, pushing unrelated branches,
+reopening merged work, or changing operator runtime behavior.
+
+## Verification boundary
+
+Use this artifact with `docs/post-merge-main-ci-echo-boundary.md` and the
+operator reminder tests only. Passing CI/React echoes prove the merge result;
+they do not prove that future development work exists. Future reminder wording
+should stop at a concrete blocker or an adopted issue/branch/session/PR anchor,
+not at another clean-status summary.

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -50,6 +50,21 @@ function makeTempProject() {
   return tempDir;
 }
 
+test("operator reminder docs require a blocker or active artifact after clean CI/React echoes", () => {
+  const boundaryDoc = fs.readFileSync(path.join(repoRoot, "docs", "post-merge-main-ci-echo-boundary.md"), "utf8");
+  const dogfoodDoc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-merge-reminder-action-803.md"), "utf8");
+
+  assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
+  assert.match(boundaryDoc, /create\/adopt one active artifact/);
+  assert.match(boundaryDoc, /issue, branch, session, or PR/);
+  assert.match(dogfoodDoc, /issue #803/i);
+  assert.match(dogfoodDoc, /must not repeat clean status as the next development action/);
+  assert.match(dogfoodDoc, /report a real blocker/);
+  assert.match(dogfoodDoc, /create or adopt one active issue, branch, session, or PR evidence artifact/);
+  assert.match(dogfoodDoc, /Clean CI, clean React Web release-report echoes, and stale\s+local worktree inventory are verification or review receipts only/);
+  assert.equal(/must repeat clean status as the next development action/.test(dogfoodDoc), false);
+});
+
 test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {
   assert.deepEqual(parseOperatorActivityTmuxPanes("fooks-a\t/tmp/fooks\tzsh\nother\t/tmp/other\tnode\n"), [
     { session: "fooks-a", path: "/tmp/fooks", command: "zsh" },


### PR DESCRIPTION
## Summary
- Add a narrow read-only dogfood artifact for issue #803 that anchors clean CI/React merge reminders to a real blocker or active issue/branch/session/PR artifact.
- Add focused operator reminder doc coverage so the boundary cannot regress into repeating clean status as the next development action.
- Keep the change limited to docs/tests/operator reminder surfaces; no runtime/provider behavior, merge-gate policy, detector scope, React Web/RN/TUI/WebView behavior, performance claim, or product claim changes.

Fixes #803

## Review evidence
- Issue inspected: #803 Dogfood: bound clean-merge reminders to concrete next action.
- Focused: `npm run build && node --test test/operator-activity.test.mjs` (20/20 pass)
- Lint: `npm run lint` (pass)
- Typecheck: `npm run typecheck` (pass)
- Full test: `npm test` (767/767 pass)
- Whitespace: `git diff --check` (pass)
- Final cleanup: changed-file fallback/slop scan found no fallback-like findings; simplified the negative assertion before rerunning verification.
- Final review: code-reviewer APPROVE; architect CLEAR.

## Boundary
This PR creates a read-only dogfood artifact only. It does not authorize cleanup, fetching, deleting, pushing unrelated branches, reopening merged work, runtime/provider changes, merge-gate policy changes, detector expansion, React Web/RN/TUI/WebView behavior changes, or product/performance claims.
