### PR TITLE
Keep metric cleanup verification bounded

### DIFF
--- a/test/metric-cleanup.mjs
+++ b/test/metric-cleanup.mjs
@@ -29,12 +29,22 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
     }
   }
 
+  const remainingSessionEntries = fs.readdirSync(root, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+  if (remainingSessionEntries.length === 0) {
+    fs.rmSync(sessionsSummaryPath(repoRoot), { force: true });
+    fs.rmSync(root, { recursive: true, force: true });
+    return;
+  }
+
+  const rebuildLimit = Number.parseInt(process.env.FOOKS_TEST_METRIC_CLEANUP_REBUILD_LIMIT ?? "200", 10);
+  if (Number.isFinite(rebuildLimit) && rebuildLimit >= 0 && remainingSessionEntries.length > rebuildLimit) {
+    // Test helpers should not make verification time scale with a developer's accumulated local telemetry.
+    // Large stores keep their existing aggregate summary and can be rebuilt by metric-writing code later.
+    return;
+  }
+
   fs.rmSync(sessionsSummaryPath(repoRoot), { force: true });
-  let remainingSessionCount = 0;
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
+  for (const entry of remainingSessionEntries) {
     const summaryPath = path.join(root, entry.name, "summary.json");
     if (!fs.existsSync(summaryPath)) {
       continue;
@@ -42,13 +52,8 @@ export async function cleanupMetricSessions(repoRoot, prefixes) {
     try {
       const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
       refreshProjectMetricSummaryFromSession(repoRoot, summary.metricSessionKey ?? summary.sessionKey ?? entry.name);
-      remainingSessionCount += 1;
     } catch {
       // Test cleanup should not fail the suite when ignored telemetry is malformed.
     }
-  }
-
-  if (remainingSessionCount === 0) {
-    fs.rmSync(root, { recursive: true, force: true });
   }
 }

--- a/test/metric-cleanup.test.mjs
+++ b/test/metric-cleanup.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanupMetricSessions } from "./metric-cleanup.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const { sessionsDir, sessionsSummaryPath } = await import(path.join(repoRoot, "dist", "core", "paths.js"));
+
+test("metric cleanup keeps large local session stores on the bounded fast path", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-metric-cleanup-large-store-"));
+  const previousLimit = process.env.FOOKS_TEST_METRIC_CLEANUP_REBUILD_LIMIT;
+  try {
+    fs.symlinkSync(path.join(repoRoot, "dist"), path.join(tempDir, "dist"), "dir");
+    const root = sessionsDir(tempDir);
+    fs.mkdirSync(path.join(root, "target-session"), { recursive: true });
+    fs.mkdirSync(path.join(root, "kept-session"), { recursive: true });
+    fs.writeFileSync(sessionsSummaryPath(tempDir), JSON.stringify({ sentinel: "preserve-large-store-summary" }));
+
+    process.env.FOOKS_TEST_METRIC_CLEANUP_REBUILD_LIMIT = "0";
+    await cleanupMetricSessions(tempDir, ["target-"]);
+
+    assert.equal(fs.existsSync(path.join(root, "target-session")), false);
+    assert.equal(fs.existsSync(path.join(root, "kept-session")), true);
+    assert.deepEqual(JSON.parse(fs.readFileSync(sessionsSummaryPath(tempDir), "utf8")), {
+      sentinel: "preserve-large-store-summary",
+    });
+  } finally {
+    if (previousLimit === undefined) {
+      delete process.env.FOOKS_TEST_METRIC_CLEANUP_REBUILD_LIMIT;
+    } else {
+      process.env.FOOKS_TEST_METRIC_CLEANUP_REBUILD_LIMIT = previousLimit;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Fixes #807.
- Bounds the test-only metric cleanup rebuild so runtime verification no longer scales with thousands of unrelated local `.fooks/sessions` entries.
- Adds a regression test for the large-store fast path while preserving full rebuild behavior for small stores.

## Verification
- `npm run build && node --test test/metric-cleanup.test.mjs test/domain-profiles.test.mjs test/payload-policy-registry.test.mjs test/domain-payload-policy-coverage.test.mjs test/claim-boundary-doc-audit.test.mjs test/runtime-bridge-contract.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT npm test`

## Boundaries
- Test helper only; no production metric aggregation or frontend-family payload policy changes.
- No RN/WebView/TUI support-claim expansion.
