### PR TITLE
Expose live-artifact handoff evidence for clean sessions

### DIFF
--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -66,9 +66,12 @@ or mutation authority.
 
 - `fooks check --json` exposes the operator/check projection. The idle case is
   `verdict: "idleRequiresActiveArtifact"` with
-  `requiredActiveArtifact.required: true`; the acceptable active artifacts are
-  an open GitHub issue, an open GitHub pull request, or a mapped fooks tmux
-  session.
+  `requiredActiveArtifact.required: true`; `requiredActiveArtifact.dogfoodHandoff`
+  must expose `status: "requires-live-artifact"`,
+  `requiredBeforeNextDevelopmentAction: true`, and the
+  `ci-echo-and-stale-residue-are-not-active-work` evidence boundary. The
+  acceptable active artifacts are an open GitHub issue, an open GitHub pull
+  request, or a mapped fooks tmux session.
 - `fooks status activity --include-remote-counts --json` exposes
   `currentRunEvidence`. The non-active echo case is only
   `classification: "mainEchoNonActive"` with `mainEchoEvidence: true` and

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -80,6 +80,12 @@ export type OperatorCheckRequiredActiveArtifact = {
   required: boolean;
   acceptableArtifacts: ["open GitHub issue", "open GitHub pull request", "mapped fooks tmux session"];
   message: string;
+  dogfoodHandoff: {
+    status: "requires-live-artifact" | "satisfied" | "blocked";
+    requiredBeforeNextDevelopmentAction: boolean;
+    evidenceBoundary: "ci-echo-and-stale-residue-are-not-active-work";
+    nextAction: string;
+  };
 };
 
 export type OperatorCheckActiveWorkReceiptIdentifiers = {
@@ -839,13 +845,27 @@ function activeArtifactsFrom(activity: OperatorActivitySnapshot): OperatorCheckA
   return artifacts;
 }
 
-function requiredActiveArtifact(required: boolean): OperatorCheckRequiredActiveArtifact {
+function requiredActiveArtifact(state: { blocked: boolean; hasActiveArtifact: boolean }): OperatorCheckRequiredActiveArtifact {
+  const required = !state.blocked && !state.hasActiveArtifact;
+  const status = state.blocked ? "blocked" : required ? "requires-live-artifact" : "satisfied";
   return {
     required,
     acceptableArtifacts: ["open GitHub issue", "open GitHub pull request", "mapped fooks tmux session"],
-    message: required
-      ? "No concrete active issue, PR, or mapped fooks session is present; create or link one before treating post-merge main echoes as active work."
-      : "A concrete active issue, PR, or mapped fooks session is present, so the snapshot is not idle echo-only evidence.",
+    message: state.blocked
+      ? "Operator check is blocked; resolve blockers before deciding whether an active issue, PR, or mapped fooks session is required."
+      : required
+        ? "No concrete active issue, PR, or mapped fooks session is present; create or link one before treating post-merge main echoes as active work."
+        : "A concrete active issue, PR, or mapped fooks session is present, so the snapshot is not idle echo-only evidence.",
+    dogfoodHandoff: {
+      status,
+      requiredBeforeNextDevelopmentAction: required,
+      evidenceBoundary: "ci-echo-and-stale-residue-are-not-active-work",
+      nextAction: state.blocked
+        ? "Resolve operator-check blockers before using this snapshot for session-whip handoff."
+        : required
+          ? "Create or link an open issue, open PR, or mapped fooks tmux session before reporting this clean post-merge snapshot as active work."
+          : "Continue using the concrete active artifact already present in this snapshot.",
+    },
   };
 }
 
@@ -884,7 +904,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
     activeArtifacts,
     activeWorkReceipts,
-    requiredActiveArtifact: requiredActiveArtifact(!blocked && !hasActiveArtifact),
+    requiredActiveArtifact: requiredActiveArtifact({ blocked, hasActiveArtifact }),
     activity,
     blockers,
   };

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -57,6 +57,9 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
   assert.match(boundaryDoc, /create\/adopt one active artifact/);
   assert.match(boundaryDoc, /issue, branch, session, or PR/);
+  assert.match(boundaryDoc, /requiredActiveArtifact\.dogfoodHandoff/);
+  assert.match(boundaryDoc, /requires-live-artifact/);
+  assert.match(boundaryDoc, /ci-echo-and-stale-residue-are-not-active-work/);
   assert.match(dogfoodDoc, /issue #803/i);
   assert.match(dogfoodDoc, /must not repeat clean status as the next development action/);
   assert.match(dogfoodDoc, /report a real blocker/);
@@ -480,6 +483,13 @@ test("operator check forces a concrete active artifact when post-merge main echo
     "mapped fooks tmux session",
   ]);
   assert.match(snapshot.requiredActiveArtifact.message, /No concrete active issue, PR, or mapped fooks session/);
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.status, "requires-live-artifact");
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.requiredBeforeNextDevelopmentAction, true);
+  assert.equal(
+    snapshot.requiredActiveArtifact.dogfoodHandoff.evidenceBoundary,
+    "ci-echo-and-stale-residue-are-not-active-work",
+  );
+  assert.match(snapshot.requiredActiveArtifact.dogfoodHandoff.nextAction, /Create or link an open issue, open PR, or mapped fooks tmux session/);
   assert.equal(snapshot.activity.optionalCounts.enabled, true);
   assert.equal(snapshot.activity.currentRunEvidence.mainEchoEvidence, true);
   assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
@@ -540,6 +550,9 @@ test("operator check treats issue, PR, or mapped session as the concrete active 
 
   assert.equal(snapshot.verdict, "activeArtifactPresent");
   assert.equal(snapshot.requiredActiveArtifact.required, false);
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.status, "satisfied");
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.requiredBeforeNextDevelopmentAction, false);
+  assert.match(snapshot.requiredActiveArtifact.dogfoodHandoff.nextAction, /concrete active artifact already present/);
   assert.deepEqual(snapshot.activeArtifacts, [
     { kind: "issue", count: 1, source: OPERATOR_ACTIVITY_REMOTE_SOURCE },
     { kind: "pullRequest", count: 1, source: OPERATOR_ACTIVITY_REMOTE_SOURCE },
@@ -1204,6 +1217,12 @@ test("operator check surfaces legacy local residue as cleanup-review evidence on
     "open GitHub pull request",
     "mapped fooks tmux session",
   ]);
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.status, "requires-live-artifact");
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.requiredBeforeNextDevelopmentAction, true);
+  assert.equal(
+    snapshot.requiredActiveArtifact.dogfoodHandoff.evidenceBoundary,
+    "ci-echo-and-stale-residue-are-not-active-work",
+  );
 
   const review = snapshot.activeWorkReceipts.legacyLocalResidueCleanupReview;
   assert.equal(review.issue, "#778");


### PR DESCRIPTION
## Summary
- Expose `requiredActiveArtifact.dogfoodHandoff` in `fooks check --json` so clean post-merge/session-whip snapshots show whether a live artifact is still required.
- Preserve the existing `idleRequiresActiveArtifact` guard while making the handoff status machine-readable: `requires-live-artifact`, `satisfied`, or `blocked`.
- Document the CI echo/stale-residue boundary so stale cleanup receipts cannot be mistaken for active work.

## Scope boundary / non-goals
- No runtime/provider behavior changes.
- No merge-gate, detector, React/RN/TUI/WebView, or payload authorization changes.
- No stronger hard-blocking beyond the existing operator-check verdict.

## Verification
- `npm run build && node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT npm test`

Note: local raw `npm test` can inherit `FOOKS_TARGET_ACCOUNT`; the clean-env command above is the authoritative full-suite run for this PR.

Fixes #809
