### PR TITLE
Sharpen React Web first-minute README and golden demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # fooks
 
-Frontend change intelligence for lower-cost React Web work.
+Frontend change intelligence for Codex.
 
-`fooks` helps agents spend less time and context rediscovering the same React Web facts before feature work, migrations, refactors, and tests. The first wedge is React Web: source-fact extraction, evidence gates, and actionable issue cards point out narrow form/accessibility issues and, when confidence is high, show read-only safe preview candidates a human or agent can review. Ambiguous or risky cases stay as manual-review cards with skip reasons.
-
-Context reduction and caching remain supporting mechanisms. In the strongest current path, a Codex user mentions the same React `.tsx` / `.jsx` file more than once in one repo: the first eligible mention records compact context, and later same-file prompts may reuse a compact model-facing payload when safe. Claude and opencode are narrower helper paths, not Codex-equivalent automatic optimization.
+`fooks` gives Codex a frontend-aware first minute before React Web edits: it reads source facts, gates the evidence, turns narrow native-control form/accessibility findings into issue cards, and hands agents a compact inspect-first work order. The strongest path today is not “trust a token-savings claim”; it is **run `fooks inspect react-web-issues`, see where the frontend risk is, then edit with the current source open**.
 
 First-minute path:
+
+Run the first value path on a supported React Web file:
 
 ```bash
 npm install -g fxxk-frontend-hooks
@@ -14,37 +14,38 @@ cd your-supported-project
 fooks setup
 fooks doctor
 fooks inspect react-web-issues src/components/Form.tsx
+```
+
+The issue-card output is read-only and actionable: each card explains `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`. High-confidence native label/control findings can include safe preview shape hints, but fooks does **not** auto-apply patches, invent final accessible-name copy, infer custom-component semantics, or claim a broad accessibility audit. Ambiguous cases stay as manual-review cards with stop reasons.
+
+Want to see the product loop before installing it into a real repo? Start with the packaged golden demo: [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md). For the detailed first-minute handoff contract, including `--summary-json` and `--dry-run-json`, see [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md).
+
+Context reduction and caching are supporting mechanisms. In the strongest current Codex path, repeated work on the same React `.tsx` / `.jsx` file may reuse compact same-file context when the evidence gate says that is safe. `fooks compare` shows local source-vs-payload evidence for one supported file, but the launch-facing habit is simpler: **inspect first, then reuse context only when safe**.
+
+Then open Codex in that repo and work normally with the current source open. After the first issue-card pass, supporting local proof commands are:
+
+```bash
+fooks inspect react-web-issues src/components/Form.tsx --summary-json
+fooks inspect react-web-issues src/components/Form.tsx --dry-run-json
 fooks compare src/components/Button.tsx
 ```
 
-Then open Codex in that repo and work normally on the same supported file. `fooks setup` is explicit by design: installing the npm package alone does **not** edit Codex hooks, Claude files, or opencode project files. `fooks doctor` checks local setup/hook readiness, `fooks inspect react-web-issues` renders actionable React Web issue cards, and `fooks compare` shows source size versus the compact fooks model-facing payload for one supported file.
-
-To inspect the first frontend-change-intelligence wedge directly:
-
-```bash
-fooks inspect react-web-issues src/components/Form.tsx
-fooks inspect react-web-issues src/components/Form.tsx --json
-```
-
-Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibility facts can reduce frontend change cost. The current CLI surface is advisory and read-only: it emits issue cards with `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`; only deterministic high-confidence native label/control associations receive preview candidates, while ambiguous or risky findings receive manual-review skip reasons. There is also an experimental Codex-first `.ts` / `.js` same-file beta when module signals are strong enough. TUI / React CLI `.tsx` remains a candidate / evidence-only lane: syntax-level local evidence can exist, but terminal semantics or compact-reuse support are not current claims. The first-minute proof is local model-facing payload evidence and actionable report output, not provider billing or stable runtime-token proof. React Native/WebView, TUI / React CLI promotion, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap asks, not current support.
+Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibility facts can reduce frontend change risk before feature work, migrations, refactors, or tests. Experimental Codex-first `.ts` / `.js` same-file reuse remains narrow and signal-gated. React Native/WebView, TUI / React CLI promotion, Vue/SFC, broad TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity remain roadmap or boundary lanes, not current support.
 
 - Public npm package: `fxxk-frontend-hooks`
 - CLI command: `fooks`
 
 ## 30-second version
 
-Use fooks when you want frontend change intelligence for a supported React Web file: source-derived context that lowers the cost of repeated feature work, migrations, refactors, and tests, actionable issue cards before editing, conservative safe previews when confidence is high, and smaller model-facing context for repeated same-file Codex work.
+Use fooks when you want Codex to start React Web work with a compact, source-grounded issue card instead of rediscovering frontend facts from scratch.
 
-- **Product direction:** frontend work cost reduction through source facts, evidence gates, actionable reports, and bounded preview guidance.
-- **First wedge:** React Web `.tsx` / `.jsx`; repeated same-file Codex context reuse is the strongest current workflow.
-- **First surface/problem:** `fooks inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]` reports narrow native-control form/accessibility issue cards, compact first-minute handoffs, or dry-run-only migration candidates, with a shared decision layer and read-only safe previews only for deterministic native label/control associations. High confidence is evidence quality, not apply authority.
-- **Supporting mechanism:** context reduction and caching help avoid rediscovering the same source facts, but they are not the whole product positioning.
-- **Experimental beta:** Codex + repeated same-file `.ts` / `.js` module work when module signals are strong enough.
-- **Roadmap asks, not current support:** React Native/WebView, TUI / React CLI promotion beyond candidate / evidence-only status, Vue/SFC, broader TS/JS coverage, multi-file refactors, read interception, LSP semantics, and Claude/opencode parity.
-- **Local proof:** `fooks inspect react-web-issues` shows actionable React Web issue cards, and `fooks compare` shows the original source size versus the compact fooks model-facing payload for one supported file.
-- **Benchmark impact:** the latest launch-grade evidence is estimate-scoped API cost, not billing proof: the corrected 2026-04-22 Codex OAuth campaign accepted 15/15 matched pairs and reduced median estimated OpenAI API cost by 4.171% under recorded pricing assumptions; larger Next.js and Tailwind profiles reported 26.492% and 38.238% median estimated API-cost reductions.
-- **Evidence boundary:** fooks supports prompt-size/context-load estimates and estimate-scoped API-cost evidence under explicit assumptions; it does not prove provider invoices, billing-grade charges, stable runtime-token wins, or Claude/opencode automatic savings.
-- **Usage-log boundary:** fooks is not a `ccusage` replacement and does not parse private usage logs by default; see [`docs/usage-log-boundary.md`](docs/usage-log-boundary.md).
+1. **Inspect first:** `fooks inspect react-web-issues <file>` ranks narrow native JSX label/control risks and tells the agent where to look before editing.
+2. **Handoff safely:** `--summary-json` gives agents `firstMinuteSummary.items[0]`, `decision`, `humanDecisionNeeded`, and `doNotDo` boundaries as advisory inspect-first input rather than edit authority.
+3. **Preview only when safe:** `--dry-run-json` lists migration candidates and preview availability, but remains dry-run-only with `autoApply: false` and human review for final label/name choices.
+4. **Reuse when safe:** repeated same-file Codex work may reuse compact context after evidence gates pass; `fooks compare` is supporting local payload proof, not the headline.
+5. **Prove narrowly:** benchmark and cost numbers are estimate-scoped supporting evidence, not provider invoice, billing-token, stable runtime-token, or Claude/opencode automatic-savings proof.
+
+See the example source, command output, summary handoff, and dry-run boundary in [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md).
 
 ## Quick start and local proof
 

--- a/docs/demo/react-web-issues.md
+++ b/docs/demo/react-web-issues.md
@@ -1,0 +1,164 @@
+# React Web issue-card golden demo
+
+This packaged demo is the short product-facing version of the detailed first-minute contract in [`../react-web-first-minute-work-orders.md`](../react-web-first-minute-work-orders.md). It uses the current `inspect react-web-issues` semantics: read-only React Web issue cards, compact first-minute handoff, and dry-run inventory rows. It is not a separate source of truth.
+
+Use it to understand the first fooks habit:
+
+```bash
+fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
+```
+
+## Before source
+
+The demo source below is an excerpt from `fixtures/compressed/FormControls.tsx` around the native controls that trigger the issue cards. The full fixture also includes imports, form setup, a `Controller`, a registered input, and a submit button; the excerpt keeps the first-minute risk visible without pretending to be a separate fixture. The native controls have source facts that fooks can inspect, but the final accessible label/name copy still requires human judgment.
+
+```tsx
+export function FormControls() {
+  return (
+    <form onSubmit={onSubmit} className="grid gap-4 rounded-lg border p-4">
+      <input name="email" type="email" required onChange={() => undefined} />
+      <select className="rounded border px-3 py-2" name="role" defaultValue="viewer">
+        <option value="viewer">Viewer</option>
+        <option value="admin">Admin</option>
+      </select>
+      <textarea className="rounded border px-3 py-2" name="notes" disabled defaultValue="" />
+    </form>
+  );
+}
+```
+
+## Command
+
+```bash
+fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
+```
+
+Representative text output starts with the product boundary before any fix guidance:
+
+```text
+# React Web issue report
+
+Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics.
+
+File: fixtures/compressed/FormControls.tsx
+Read-only: yes
+Auto-apply: no
+In scope: yes
+Issues: 5 (safe preview: 0, manual review: 5, unsafe to auto-apply: 5)
+```
+
+## Issue card shape
+
+A card tells the agent what risk exists and where to inspect first. The field names are stable enough for humans and agents to recognize; the exact ranking can change with source evidence.
+
+```text
+## Issue 1: Native input lacks recognized accessible-label evidence.
+- why: Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.
+- where to look: fixtures/compressed/FormControls.tsx:23-23
+- element: input
+- confidence: high
+- fixability: manual-review
+- auto-fix safety: unsafe-to-auto-apply
+- suggested action: Add an explicit accessible label with human-reviewed copy for the native control.
+```
+
+JSON consumers should preserve the same issue-card meaning:
+
+```json
+{
+  "problem": "Native input lacks recognized accessible-label evidence.",
+  "whyItMatters": "Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.",
+  "whereToLook": "fixtures/compressed/FormControls.tsx:23-23",
+  "confidence": "high",
+  "suggestedAction": "Add an explicit accessible label with human-reviewed copy for the native control."
+}
+```
+
+## First-minute handoff (`--summary-json`)
+
+Agents that only need the compact work order should read the first summary item, then inspect the current source before suggesting anything.
+
+```bash
+fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --summary-json
+```
+
+Representative first item:
+
+```json
+{
+  "issueId": "react-web-label-1",
+  "fixShape": "human-reviewed-native-control-name",
+  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+  "whyThisFirst": "Rank 1 high issue because label-preview confidence is high; high-confidence-manual-review remains human-reviewed.",
+  "nextAction": "Start by inspecting fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+  "humanDecisionNeeded": [
+    "Review the final accessible label/name copy.",
+    "Choose the label/name shape from local JSX evidence."
+  ],
+  "doNotDo": [
+    "Do not apply patches automatically from this report.",
+    "Do not infer custom-component semantics.",
+    "Do not generate accessible-name copy automatically."
+  ],
+  "decision": {
+    "state": "human-decision-required",
+    "allowedActions": {
+      "inspect": true,
+      "suggestPatch": false,
+      "applyPatch": false,
+      "generateCopy": false
+    }
+  }
+}
+```
+
+Agent handoff:
+
+1. Inspect `fixtures/compressed/FormControls.tsx:23` first.
+2. Confirm the current source still matches the issue evidence.
+3. Look for existing visible label, nearby native label/control structure, or source-observed naming hints.
+4. Do **not** generate final label copy automatically.
+5. If the target is a custom component or the source no longer matches, stop and read the file normally.
+
+## Dry-run and safe-preview split (`--dry-run-json`)
+
+Migration planners can request candidate rows, but the projection is still dry-run-only.
+
+```bash
+fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --dry-run-json
+```
+
+Representative candidate:
+
+```json
+{
+  "issueId": "react-web-label-1",
+  "migrationCandidate": "human-reviewed-native-control-name",
+  "affectedFile": "fixtures/compressed/FormControls.tsx",
+  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+  "previewAvailable": false,
+  "humanReviewRequired": true,
+  "autoApply": false,
+  "dryRunOnly": true,
+  "riskNotes": [
+    "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
+    "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+    "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+    "Do not infer custom-component semantics."
+  ]
+}
+```
+
+If a future or different source file produces `previewAvailable: true`, treat the preview as a read-only review aid, not permission to edit. `autoApply` remains false unless a separate human/tool workflow explicitly decides to make a source change after reading the current file.
+
+## Boundary note
+
+This demo proves the first-minute React Web issue-card loop, not a broader product claim.
+
+- Read-only: `inspect react-web-issues` reports findings and handoff data; it does not edit files.
+- No auto-apply: safe previews are review aids, not patch authority.
+- No generated accessible-name copy: final label/name text stays human-reviewed.
+- No broad accessibility audit: this is a narrow native JSX label/control subset, not a complete WCAG or design-system audit.
+- No custom-component semantic inference: ambiguous/custom cases fall back to manual review or normal source reading.
+- No RN/WebView/TUI expansion: those lanes remain boundary/roadmap topics, not supported by this React Web demo.
+- No billing proof: benchmark/cost evidence elsewhere in the docs is estimate-scoped and does not prove provider invoices, provider billing tokens, or stable runtime-token savings.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "docs/release.md",
     "docs/roadmap.md",
     "docs/react-web-first-minute-work-orders.md",
+    "docs/demo/react-web-issues.md",
     "docs/rn-webview-architecture.md",
     "docs/usage-log-boundary.md",
     "docs/provider-tokenizer-boundary.md",

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -176,6 +176,7 @@ function assertPackedFiles(packEntry) {
     "docs/release.md",
     "docs/roadmap.md",
     "docs/react-web-first-minute-work-orders.md",
+    "docs/demo/react-web-issues.md",
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4970,14 +4970,23 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
   const docPath = path.join(repoRoot, "docs", "react-web-first-minute-work-orders.md");
   const doc = fs.readFileSync(docPath, "utf8");
+  const demoPath = path.join(repoRoot, "docs", "demo", "react-web-issues.md");
+  const demo = fs.readFileSync(demoPath, "utf8");
   const releaseSmoke = fs.readFileSync(path.join(repoRoot, "scripts", "release-smoke.mjs"), "utf8");
 
   assert.match(readme, /docs\/react-web-first-minute-work-orders\.md/);
+  assert.match(readme, /docs\/demo\/react-web-issues\.md/);
+  assert.match(readme, /frontend change intelligence/i);
+  assert.match(readme, /fooks inspect react-web-issues src\/components\/Form\.tsx/);
+  assert.match(readme, /advisory inspect-first input rather than edit authority/);
+  assert.match(readme, /estimate-scoped supporting evidence|estimate-scoped supporting proof|estimate-scoped/);
   assert.match(readme, /--summary-json/);
   assert.match(readme, /firstMinuteSummary\.items\[0\]/);
   assert.match(readme, /advisory inspect-first input rather than edit authority/);
   assert.ok(pkg.files.includes("docs/react-web-first-minute-work-orders.md"));
+  assert.ok(pkg.files.includes("docs/demo/react-web-issues.md"));
   assert.match(releaseSmoke, /docs\/react-web-first-minute-work-orders\.md/);
+  assert.match(releaseSmoke, /docs\/demo\/react-web-issues\.md/);
 
   assert.match(doc, /first-minute mini work order/i);
   assert.match(doc, /Before and after/);
@@ -5033,6 +5042,30 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.doesNotMatch(doc, /infers? custom-component semantics/i);
   assert.doesNotMatch(doc, /React Native support is available|WebView support is available|TUI support is available/i);
   assert.doesNotMatch(doc, /runs? (?:a )?codemod|codemod execution|CI enforcement|enforces in CI/i);
+
+  assert.match(demo, /React Web issue-card golden demo/);
+  assert.match(demo, /\.\.\/react-web-first-minute-work-orders\.md/);
+  assert.match(demo, /fooks inspect react-web-issues fixtures\/compressed\/FormControls\.tsx/);
+  assert.match(demo, /Before source/);
+  assert.match(demo, /problem/);
+  assert.match(demo, /whyItMatters/);
+  assert.match(demo, /whereToLook/);
+  assert.match(demo, /confidence/);
+  assert.match(demo, /suggestedAction/);
+  assert.match(demo, /--summary-json/);
+  assert.match(demo, /firstMinuteSummary|First-minute handoff/);
+  assert.match(demo, /--dry-run-json/);
+  assert.match(demo, /previewAvailable/);
+  assert.match(demo, /humanReviewRequired/);
+  assert.match(demo, /autoApply/);
+  assert.match(demo, /dryRunOnly/);
+  assert.match(demo, /read-only review aid/);
+  assert.match(demo, /Do \*\*not\*\* generate final label copy automatically/);
+  assert.match(demo, /No broad accessibility audit/);
+  assert.match(demo, /No RN\/WebView\/TUI expansion/);
+  assert.match(demo, /No billing proof/);
+  assert.doesNotMatch(demo, /Auto-apply: yes|must-edit|automatically edits files/i);
+  assert.doesNotMatch(demo, /React Native support is available|WebView support is available|TUI support is available/i);
 });
 
 test("package release surface keeps internal docs out of the npm tarball", () => {


### PR DESCRIPTION
## Summary
- Reframe the README first minute around React Web change intelligence and `fooks inspect react-web-issues`.
- Add a packaged public golden demo for React Web issue cards, summary handoff, dry-run/manual-review boundaries, and agent next steps.
- Extend package/release-smoke/test guards so the new demo ships and remains discoverable alongside the existing first-minute work-order contract.

Closes #819

## Verification
- `npm run typecheck`
- `node --test --test-name-pattern "React Web first-minute work-order docs stay discoverable|README smoke keeps first-minute" test/fooks.test.mjs`
- `npm run release:smoke`
- `$ai-slop-cleaner` scoped pass: no edits needed; fallback-like findings were pre-existing grounded fallback/test vocabulary outside changed prose semantics.
- `$code-review`: code-reviewer APPROVE; architect CLEAR after resolving the staged public-demo blocker.

## Notes
- Full `node --test test/fooks.test.mjs` was also attempted and currently has an environment-sensitive pre-existing init assertion (`targetAccount` resolves to `minislively` instead of `<your-github-org>` in this worktree). The targeted public-doc guard and release smoke passed.
