### PR TITLE
Sharpen React Web agent handoff instructions

### DIFF
--- a/docs/demo/react-web-issues.md
+++ b/docs/demo/react-web-issues.md
@@ -90,15 +90,15 @@ Representative first item:
   "fixShape": "human-reviewed-native-control-name",
   "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
   "whyThisFirst": "Rank 1 high issue because label-preview confidence is high; high-confidence-manual-review remains human-reviewed.",
-  "nextAction": "Start by inspecting fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+  "nextAction": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.",
   "humanDecisionNeeded": [
-    "Review the final accessible label/name copy.",
+    "Confirm the final accessible label/name copy from current source context.",
     "Choose the label/name shape from local JSX evidence."
   ],
   "doNotDo": [
     "Do not apply patches automatically from this report.",
     "Do not infer custom-component semantics.",
-    "Do not generate accessible-name copy automatically."
+    "Do not generate final label/name copy automatically."
   ],
   "decision": {
     "state": "human-decision-required",

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -97,7 +97,7 @@ fooks inspect react-web-issues src/components/Form.tsx --summary-json
 The intended consumer flow is:
 
 1. Read `firstMinuteSummary.items` in `sourceTopIssueIds` order.
-2. Start with `items[0].firstInspectStep` and `items[0].nextAction`.
+2. Start with `items[0].firstInspectStep` and `items[0].nextAction`; inspect that source line first and confirm it still matches the reported evidence before suggesting changes.
 3. Keep `decision`, `humanDecisionNeeded`, `doNotDo`, `fixShapeGuidance.autoApply`, and `claimBoundary` in the agent prompt or task card.
 4. Treat `contextHints` as orienting evidence only; they may include source pointers or short advisory convention pointers, but they do not change rank, priority, bucket, or edit authority. Current source evidence wins over those hints and over historical memory.
 5. If `items` is empty, stop and inspect the top-level `inScope` / `skippedReason` values instead of inventing a React Web task.

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -563,14 +563,16 @@ function fixShapeInspectFirstFor(options: {
   const steps = [
     `Inspect ${options.filePath}:${options.finding.loc.startLine}-${options.finding.loc.endLine} (${options.finding.element}) before editing.`,
   ];
+  steps.push(`Confirm the current source still matches this native ${options.finding.element} evidence before suggesting changes.`);
   if (options.attributes.length > 0) {
-    steps.push(`Use existing attribute evidence as hints only: ${options.attributes.slice(0, 6).join(", ")}.`);
+    steps.push(`Use current attribute evidence as hints only: ${options.attributes.slice(0, 6).join(", ")}.`);
   }
   if (options.previewAvailable) {
     steps.push("Review the safe preview diff as a candidate shape; fooks still does not apply it.");
   } else {
-    steps.push("Select the final label/name text manually; fooks does not generate accessible-name copy.");
+    steps.push("Select the final label/name text manually; fooks does not generate final label/name copy.");
   }
+  steps.push("If this is a custom component or the evidence changed, stop and read the source normally.");
   for (const item of options.relatedContext.slice(0, 2)) {
     const location = `${item.file}${item.line ? `:${item.line}${item.endLine && item.endLine !== item.line ? `-${item.endLine}` : ""}` : ""}`;
     steps.push(`Inspect related ${item.kind} (${item.source}) at ${location}.`);
@@ -867,11 +869,14 @@ function whyThisFirstFor(issue: ReactWebIssueCard): string {
 }
 
 function nextActionFor(issue: ReactWebIssueCard): string {
-  return trimSummaryText(`Start by ${firstInspectStepFor(issue).replace(/^Inspect/u, "inspecting")}`, 180);
+  const target = firstInspectStepFor(issue)
+    .replace(/^Inspect\s+/u, "")
+    .replace(/\s+before editing\.$/u, "");
+  return trimSummaryText(`Inspect ${target} first; confirm current source still matches before suggesting changes.`, 180);
 }
 
 function humanDecisionNeededFor(issue: ReactWebIssueCard): string[] {
-  const decisions = ["Review the final accessible label/name copy."];
+  const decisions = ["Confirm the final accessible label/name copy from current source context."];
   if (issue.fixability === "safe-preview") {
     decisions.push("Confirm the htmlFor/id association before using the preview shape.");
   } else {
@@ -885,7 +890,7 @@ function doNotDoFor(): string[] {
     [
       "Do not apply patches automatically from this report.",
       "Do not infer custom-component semantics.",
-      "Do not generate accessible-name copy automatically.",
+      "Do not generate final label/name copy automatically.",
     ],
     3,
     120,

--- a/test/helpers/react-web-agent-handoff-dogfood.mjs
+++ b/test/helpers/react-web-agent-handoff-dogfood.mjs
@@ -81,6 +81,7 @@ function isSafeSummaryItem(item) {
     isObject(item) &&
     isNonEmptyString(item.issueId) &&
     isNonEmptyString(item.firstInspectStep) &&
+    isStringArray(item.inspectFirst) &&
     isNonEmptyString(item.nextAction) &&
     isStringArray(item.humanDecisionNeeded) &&
     isStringArray(item.doNotDo) &&
@@ -137,6 +138,7 @@ export function consumeReactWebSummaryForAgentTask(summary) {
     filePath: summary.filePath,
     claimBoundary: summary.claimBoundary,
     firstInspectStep: item.firstInspectStep,
+    inspectFirst: item.inspectFirst,
     nextAction: item.nextAction,
     whyThisFirst: item.whyThisFirst,
     humanDecisionNeeded: item.humanDecisionNeeded,

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -665,10 +665,10 @@ test("React Web issue report text mode prints per-card manual-review fix-shape g
   assert.equal(cli.status, 0, cli.stderr);
   assert.match(cli.stdout, /- top manual-review ids: react-web-label-1, react-web-label-4, react-web-label-5/);
   assert.match(cli.stdout, /- fix shape: human-reviewed-native-control-name/);
-  assert.match(cli.stdout, /Use existing attribute evidence as hints only: name=email, onChange, required, type=email/);
-  assert.match(cli.stdout, /Use existing attribute evidence as hints only: className, spread:field, type=text/);
-  assert.match(cli.stdout, /Use existing attribute evidence as hints only: className, spread:register\("email"\)/);
-  assert.match(cli.stdout, /Select the final label\/name text manually; fooks does not generate accessible-name copy/);
+  assert.match(cli.stdout, /Use current attribute evidence as hints only: name=email, onChange, required, type=email/);
+  assert.match(cli.stdout, /Use current attribute evidence as hints only: className, spread:field, type=text/);
+  assert.match(cli.stdout, /Use current attribute evidence as hints only: className, spread:register\("email"\)/);
+  assert.match(cli.stdout, /Select the final label\/name text manually; fooks does not generate final label\/name copy/);
   assert.match(cli.stdout, /- inspect first for fix shape:/);
   assert.doesNotMatch(cli.stdout, /must-edit|Auto-apply: yes|Controller/);
 });
@@ -749,7 +749,11 @@ test("React Web issue report JSON includes machine-readable first-minute summary
     assertCompactConventionContextHint(item);
     assertConventionDoesNotPolluteActionFields(item);
     assert.match(item.whyThisFirst, new RegExp(`Rank ${issue.triage.rank} ${issue.triage.priority} issue`));
-    assert.match(item.nextAction, /Start by inspecting/);
+    assert.match(item.nextAction, /^Inspect .* first; confirm current source still matches/);
+    assert.ok(item.inspectFirst.some((entry) => /current source still matches/.test(entry)));
+    assert.ok(item.inspectFirst.some((entry) => /custom component|evidence changed/.test(entry)));
+    assert.ok(item.humanDecisionNeeded.some((entry) => /current source context/.test(entry)));
+    assert.ok(item.doNotDo.some((entry) => /final label\/name copy/.test(entry)));
     assert.ok(item.contextHints.some((entry) => entry.includes(issue.evidence.element)));
     assert.equal(item.fixShapeGuidance.claimBoundary, issue.fixShapeGuidance.claimBoundary);
     assert.equal(item.fixShapeGuidance.humanReviewRequired, true);
@@ -1037,7 +1041,8 @@ test("React Web agent handoff dogfood consumes summary JSON as an inspect-first 
   const handoffText = JSON.stringify(task);
   assert.match(handoffText, /Read-only React Web issue report/);
   assert.match(handoffText, /does not auto-apply patches/);
-  assert.match(task.nextAction, /Start by inspecting/);
+  assert.match(task.nextAction, /^Inspect .* first; confirm current source still matches/);
+  assert.ok(task.inspectFirst.some((entry) => /custom component|evidence changed/.test(entry)));
   assert.ok(task.contextHints.some((hint) => /native|context|source|convention|preview/i.test(hint)));
   assert.doesNotMatch(handoffText, /must-edit|Auto-apply: yes|codemod|CI enforcement|merge gate/i);
 });


### PR DESCRIPTION
## Summary
- sharpen React Web `firstMinuteSummary` handoff text into an inspect-first, evidence-confirming action
- add explicit stop/read-source guidance when evidence changes or the target is a custom component
- keep human-reviewed label/name copy, no-auto-apply, and custom-component boundaries locked in tests/docs

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `node --test --test-name-pattern "React Web first-minute work-order docs stay discoverable" test/fooks.test.mjs`
- `npm run release:smoke`
- `git diff --check`

Closes #821
