### PR TITLE
Document React Web CI echo nudge for #823

### DIFF
--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -36,6 +36,16 @@ issue/branch/session/PR is currently attached. It may preserve the echo as
 verification evidence, but it must not imply that the merged CI echo is itself
 an active development artifact.
 
+### Issue #823 seed receipt
+
+For the #823 post-merge React Web echo nudge, the seed snapshot is verification
+or idle-inventory evidence only: `main` was at `421d3bf`, the worktree dirty
+count was `0`, open PR/issue counts were `0/0`, fooks tmux/process counts were
+`0/0`, and legacy local worktree count was `9`. Those counts are not a React Web
+assignment, release-report task, or cleanup authority. A clean-slate whip still
+needs a fresh issue, branch, session, or PR receipt before describing active
+work.
+
 ## Development reminder active-artifact rule
 
 A development reminder must not end as a status-only idle report. After it names


### PR DESCRIPTION
## Summary
- Add the #823 seed receipt to the post-merge main CI echo boundary doc.
- Clarify that main 421d3bf, dirty 0, open PR/issues 0/0, fooks tmux/proc 0/0, and legacy worktree count 9 are verification/idle-inventory evidence only.
- Keep the clean-slate whip requirement anchored on a fresh issue, branch, session, or PR receipt.

## Verification
- node inline doc assertion for the #823 receipt and counts
- git diff --check

Closes #823