### PR TITLE
Document React Web echo anchor for #823

### DIFF
--- a/docs/dogfood/post-merge-react-web-ci-echo-anchor-823.md
+++ b/docs/dogfood/post-merge-react-web-ci-echo-anchor-823.md
@@ -1,0 +1,35 @@
+# Post-merge React Web CI echo anchor (#823)
+
+This is a narrow read-only dogfood artifact for issue #823. It anchors the
+post-merge React Web CI/release-report echo nudge boundary without changing
+runtime/provider behavior, merge-gate policy, detector scope, React Web,
+React Native, TUI, WebView behavior, cleanup policy, performance claims, or
+product claims.
+
+## Echo-only seed
+
+At the start of this pass, the clean `main` seed had no open issue, no open PR,
+no mapped fooks tmux/proc session, and nine legacy local worktree entries. That
+state is echo-only evidence: clean React Web CI/release-report receipts and
+legacy local worktree inventory are not active development work by themselves.
+
+## Active-work anchor rule
+
+A post-merge React Web CI or release-report nudge must stay non-active unless a
+fresh active artifact exists. Acceptable anchors for the next development action
+are a fresh active issue, branch, session, or PR. If none exists, the nudge must
+say that the checkout cannot be treated as active development until one is
+created or linked; it must not reuse green CI, a successful release report, or
+legacy local worktree residue as the active-work reason.
+
+Issue #823 and this branch are the fresh active artifacts for this docs/test
+operator-boundary pass only. This artifact is not cleanup authority, does not
+reopen merged work, and does not authorize fetching, deleting, pushing unrelated
+branches, or changing operator/runtime behavior.
+
+## Verification boundary
+
+Use this artifact with `docs/post-merge-main-ci-echo-boundary.md` and the
+operator reminder tests only. It records the reminder boundary for React Web CI
+and release-report echoes; it does not expand detectors, change merge gates, or
+claim product/performance improvements.

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -53,6 +53,7 @@ function makeTempProject() {
 test("operator reminder docs require a blocker or active artifact after clean CI/React echoes", () => {
   const boundaryDoc = fs.readFileSync(path.join(repoRoot, "docs", "post-merge-main-ci-echo-boundary.md"), "utf8");
   const dogfoodDoc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-merge-reminder-action-803.md"), "utf8");
+  const issue823Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "post-merge-react-web-ci-echo-anchor-823.md"), "utf8");
 
   assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
   assert.match(boundaryDoc, /create\/adopt one active artifact/);
@@ -66,6 +67,11 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   assert.match(dogfoodDoc, /create or adopt one active issue, branch, session, or PR evidence artifact/);
   assert.match(dogfoodDoc, /Clean CI, clean React Web release-report echoes, and stale\s+local worktree inventory are verification or review receipts only/);
   assert.equal(/must repeat clean status as the next development action/.test(dogfoodDoc), false);
+  assert.match(issue823Doc, /issue #823/i);
+  assert.match(issue823Doc, /post-merge React Web CI or release-report nudge must stay non-active unless a\s+fresh active artifact exists/);
+  assert.match(issue823Doc, /fresh active issue, branch, session, or PR/);
+  assert.match(issue823Doc, /green CI, a successful release report, or\s+legacy local worktree residue as the active-work reason/);
+  assert.match(issue823Doc, /not cleanup authority/);
 });
 
 test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {


### PR DESCRIPTION
## Summary\n- add a narrow dogfood artifact for issue #823 anchoring post-merge React Web CI/release-report echoes as non-active without a fresh artifact\n- lock the operator reminder doc test to that issue #823 artifact\n\n## Verification\n- git diff --check\n- npm run build\n- node --test --test-name-pattern 'operator reminder docs require a blocker or active artifact after clean CI/React echoes' test/operator-activity.test.mjs\n\nCloses #823