### PR TITLE
Lock React Web first-minute golden outputs

### DIFF
--- a/test/fixtures/react-web-issues-golden/form-controls.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/form-controls.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "fixtures/compressed/FormControls.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 5,
+    "affectedFiles": [
+      "fixtures/compressed/FormControls.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 5
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "fixtures/compressed/FormControls.tsx",
+    "migrationCandidate": "human-reviewed-native-control-name",
+    "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/form-controls.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/form-controls.summary.selected.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "fixtures/compressed/FormControls.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 5,
+    "safePreviewCount": 0,
+    "manualReviewCount": 5,
+    "unsafeToAutoApplyCount": 5
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-4",
+      "react-web-label-5",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-4",
+      "react-web-label-5"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-4",
+      "react-web-label-5"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-4",
+      "react-web-label-5",
+      "react-web-label-2",
+      "react-web-label-3"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-4",
+      "react-web-label-5"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "human-reviewed-native-control-name",
+      "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
+      "nextAction": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/form-controls.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/form-controls.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: human-reviewed-native-control-name; first inspect: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.
+  - next action: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -17,6 +17,18 @@ import { cleanupMetricSessions } from "./metric-cleanup.mjs";
 const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
 const require = createRequire(import.meta.url);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readReactWebIssueGoldenText(name) {
+  return fs.readFileSync(path.join(repoRoot, "test", "fixtures", "react-web-issues-golden", name), "utf8").trimEnd();
+}
+
+function readReactWebIssueGoldenJson(name) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, "test", "fixtures", "react-web-issues-golden", name), "utf8"));
+}
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
 const {
   DESIGN_REVIEW_METADATA_ITEM_CAPS,
@@ -5066,6 +5078,21 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.match(demo, /No billing proof/);
   assert.doesNotMatch(demo, /Auto-apply: yes|must-edit|automatically edits files/i);
   assert.doesNotMatch(demo, /React Native support is available|WebView support is available|TUI support is available/i);
+});
+
+
+test("React Web issue-card public demo keeps selected golden handoff strings", () => {
+  const demo = fs.readFileSync(path.join(repoRoot, "docs", "demo", "react-web-issues.md"), "utf8");
+  const summaryGolden = readReactWebIssueGoldenJson("form-controls.summary.selected.json");
+  const dryRunGolden = readReactWebIssueGoldenJson("form-controls.dry-run.selected.json");
+  const firstItem = summaryGolden.firstMinuteSummary.firstItem;
+
+  assert.match(demo, new RegExp(escapeRegExp(firstItem.firstInspectStep)));
+  assert.match(demo, new RegExp(escapeRegExp(firstItem.nextAction)));
+  assert.match(demo, new RegExp(escapeRegExp(firstItem.humanDecisionNeeded[0])));
+  assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[0])));
+  assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[2])));
+  assert.match(demo, new RegExp(escapeRegExp(String(dryRunGolden.firstCandidate.dryRunOnly))));
 });
 
 test("package release surface keeps internal docs out of the npm tarball", () => {

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -60,6 +60,89 @@ function parseIssues(file) {
   return JSON.parse(cli.stdout);
 }
 
+function readGoldenJson(name) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, "test", "fixtures", "react-web-issues-golden", name), "utf8"));
+}
+
+function readGoldenText(name) {
+  return fs.readFileSync(path.join(repoRoot, "test", "fixtures", "react-web-issues-golden", name), "utf8").trimEnd();
+}
+
+function projectSummaryGolden(summary) {
+  const firstItem = summary.firstMinuteSummary.items[0];
+  return {
+    schemaVersion: summary.schemaVersion,
+    projection: summary.projection,
+    filePath: summary.filePath,
+    readOnly: summary.readOnly,
+    autoApply: summary.autoApply,
+    summary: summary.summary,
+    triageTopIds: summary.triageTopIds,
+    firstMinuteSummary: {
+      sourceTopIssueIds: summary.firstMinuteSummary.sourceTopIssueIds,
+      firstItem: {
+        issueId: firstItem.issueId,
+        fixShape: firstItem.fixShape,
+        firstInspectStep: firstItem.firstInspectStep,
+        nextAction: firstItem.nextAction,
+        humanDecisionNeeded: firstItem.humanDecisionNeeded,
+        doNotDo: firstItem.doNotDo,
+        fixShapeGuidance: firstItem.fixShapeGuidance,
+        decision: {
+          state: firstItem.decision.state,
+          allowedActions: firstItem.decision.allowedActions,
+          humanReviewRequired: firstItem.decision.humanReviewRequired,
+          autoApply: firstItem.decision.autoApply,
+        },
+      },
+    },
+  };
+}
+
+function projectDryRunGolden(dryRun) {
+  const firstCandidate = dryRun.candidates[0];
+  return {
+    schemaVersion: dryRun.schemaVersion,
+    projection: dryRun.projection,
+    filePath: dryRun.filePath,
+    readOnly: dryRun.readOnly,
+    dryRunOnly: dryRun.dryRunOnly,
+    autoApply: dryRun.autoApply,
+    summary: dryRun.summary,
+    firstCandidate: {
+      issueId: firstCandidate.issueId,
+      affectedFile: firstCandidate.affectedFile,
+      migrationCandidate: firstCandidate.migrationCandidate,
+      firstInspectStep: firstCandidate.firstInspectStep,
+      previewAvailable: firstCandidate.previewAvailable,
+      humanReviewRequired: firstCandidate.humanReviewRequired,
+      autoApply: firstCandidate.autoApply,
+      dryRunOnly: firstCandidate.dryRunOnly,
+      riskNotes: firstCandidate.riskNotes,
+      decision: {
+        state: firstCandidate.decision.state,
+        allowedActions: firstCandidate.decision.allowedActions,
+        humanReviewRequired: firstCandidate.decision.humanReviewRequired,
+        autoApply: firstCandidate.decision.autoApply,
+      },
+    },
+  };
+}
+
+function projectTextGolden(text) {
+  const lines = text.split("\n");
+  const summaryIndex = lines.findIndex((line) => line === "## First-minute summary");
+  assert.ok(summaryIndex >= 0, "expected first-minute summary heading in text output");
+  const summaryLines = lines.slice(summaryIndex, lines.findIndex((line, index) => index > summaryIndex && line.startsWith("## Issue 1:")));
+  return [
+    "## First-minute summary",
+    summaryLines.find((line) => line.startsWith("- react-web-label-1: human-reviewed-native-control-name;")),
+    summaryLines.find((line) => line.trimStart().startsWith("- next action:")),
+    summaryLines.find((line) => line.trimStart().startsWith("- human decision needed:")),
+    summaryLines.find((line) => line.trimStart().startsWith("- do not do:")),
+  ].join("\n").trimEnd();
+}
+
 function hasNestedKey(value, key) {
   if (!value || typeof value !== "object") return false;
   if (Object.hasOwn(value, key)) return true;
@@ -865,6 +948,20 @@ test("React Web issue report summary JSON is compact first-minute data without d
   assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller/i);
 });
 
+
+test("React Web issue report summary JSON matches selected golden contract", () => {
+  const summaryCli = runIssues(fixtures.formControls, "--summary-json");
+  assert.equal(summaryCli.status, 0, summaryCli.stderr);
+  const summary = JSON.parse(summaryCli.stdout);
+  const selected = projectSummaryGolden(summary);
+
+  assert.deepEqual(selected, readGoldenJson("form-controls.summary.selected.json"));
+  assert.equal(selected.firstMinuteSummary.firstItem.decision.allowedActions.applyPatch, false);
+  assert.equal(selected.firstMinuteSummary.firstItem.decision.allowedActions.generateCopy, false);
+  assert.equal(selected.firstMinuteSummary.firstItem.fixShapeGuidance.autoApply, false);
+  assert.match(selected.firstMinuteSummary.firstItem.nextAction, /confirm current source still matches/);
+});
+
 test("React Web issue report summary JSON preserves skip boundaries without detailed cards", () => {
   const rnCli = runIssues(fixtures.rn, "--summary-json");
   assert.equal(rnCli.status, 0, rnCli.stderr);
@@ -943,6 +1040,27 @@ test("React Web issue report migration dry-run JSON projects read-only candidate
     assert.equal(hasNestedKey(dryRun, detailedCardKey), false, `dry-run-json should not include detailed key ${detailedCardKey}`);
   }
   assert.doesNotMatch(compactText, /must-edit|Auto-apply: yes|Controller|policyBoundary|excludedInference/i);
+});
+
+
+test("React Web issue report dry-run JSON matches selected golden contract", () => {
+  const dryRunCli = runIssues(fixtures.formControls, "--dry-run-json");
+  assert.equal(dryRunCli.status, 0, dryRunCli.stderr);
+  const dryRun = JSON.parse(dryRunCli.stdout);
+  const selected = projectDryRunGolden(dryRun);
+
+  assert.deepEqual(selected, readGoldenJson("form-controls.dry-run.selected.json"));
+  assert.equal(selected.dryRunOnly, true);
+  assert.equal(selected.firstCandidate.decision.allowedActions.applyPatch, false);
+  assert.equal(selected.firstCandidate.decision.allowedActions.generateCopy, false);
+  assert.equal(selected.firstCandidate.autoApply, false);
+});
+
+test("React Web issue report text output matches selected golden excerpt", () => {
+  const cli = runIssues(fixtures.formControls);
+  assert.equal(cli.status, 0, cli.stderr);
+
+  assert.equal(projectTextGolden(cli.stdout), readGoldenText("form-controls.text.excerpt.txt"));
 });
 
 test("React Web issue report migration dry-run JSON preserves empty and unsupported boundaries", () => {


### PR DESCRIPTION
## Summary
- add selected-field React Web issue golden fixtures for summary, dry-run, and text handoff output
- compare actual `fooks inspect react-web-issues` projections against those stable goldens
- add a public demo drift guard for golden-critical handoff/safety strings

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/react-web-issue-report.test.mjs`
- `node --test --test-name-pattern "React Web first-minute work-order docs stay discoverable|React Web issue-card public demo keeps selected golden" test/fooks.test.mjs`
- `npm run release:smoke`
- `git diff --check`

Closes #826
