### PR TITLE
Add empty aria-label React Web issue cards

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -34,6 +34,7 @@ export type ReactWebRelatedContextQuality = "same-file-only" | "local-supporting
 type ReactWebIssueKind =
   | "react-web.missing-accessible-label"
   | "react-web.ambiguous-accessible-label"
+  | "react-web.empty-accessible-name"
   | "react-web.unassociated-nearby-label";
 
 export type ReactWebIssueTriageEvidence = {
@@ -335,6 +336,8 @@ function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return `Native ${finding.element} lacks recognized accessible-label evidence.`;
     case "ambiguous-accessible-label":
       return `Native ${finding.element} only has ambiguous accessible-label evidence.`;
+    case "empty-accessible-name":
+      return `Native ${finding.element} has empty accessible-name evidence.`;
     case "unassociated-nearby-label":
       return `Nearby label text is not explicitly associated with this native ${finding.element}.`;
   }
@@ -346,6 +349,8 @@ function whyItMattersFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return "Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.";
     case "ambiguous-accessible-label":
       return "Placeholder-only labeling can disappear during input and is weaker than an explicit accessible name.";
+    case "empty-accessible-name":
+      return "A blank aria-label creates accessible-name evidence that communicates no useful control name.";
     case "unassociated-nearby-label":
       return "Visible label text may not be programmatically connected to the native form control.";
   }
@@ -357,6 +362,8 @@ function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): strin
       return "Add an explicit accessible label with human-reviewed copy for the native control.";
     case "ambiguous-accessible-label":
       return "Replace placeholder-only labeling with explicit label evidence or human-reviewed aria-label copy.";
+    case "empty-accessible-name":
+      return "Replace the empty aria-label with human-reviewed accessible-name evidence.";
     case "unassociated-nearby-label":
       return "Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.";
   }
@@ -525,6 +532,7 @@ function fixShapeFor(options: {
   if (options.finding.kind === "ambiguous-accessible-label" && hasAttributeSignal(options.attributes, "placeholder")) {
     return "human-reviewed-placeholder-replacement";
   }
+  if (options.finding.kind === "empty-accessible-name") return "human-reviewed-accessible-name";
   if (options.finding.element === "button") return "human-reviewed-button-name";
   if (
     hasAttributeSignal(options.attributes, "name") ||

--- a/src/core/react-web-label-preview.ts
+++ b/src/core/react-web-label-preview.ts
@@ -6,9 +6,9 @@ import type { SourceRange } from "./schema";
 
 export const REACT_WEB_LABEL_PATCH_PREVIEW_SCHEMA_VERSION = "react-web-label-patch-preview.v1" as const;
 export const REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY =
-  "Read-only React Web JSX label preview only: detects a narrow set of native interactive elements with missing or ambiguous accessible-label evidence and suggests deterministic patch fragments without editing files or claiming full accessibility coverage." as const;
+  "Read-only React Web JSX label preview only: detects a narrow set of native interactive elements with missing, ambiguous, or empty accessible-label evidence and suggests read-only patch fragments without editing files or claiming full accessibility coverage." as const;
 
-type ReactWebLabelFindingKind = "missing-accessible-label" | "ambiguous-accessible-label" | "unassociated-nearby-label";
+type ReactWebLabelFindingKind = "missing-accessible-label" | "ambiguous-accessible-label" | "empty-accessible-name" | "unassociated-nearby-label";
 type ReactWebLabelConfidence = "high" | "medium";
 type ReactWebInteractiveElement = "button" | "input" | "select" | "textarea";
 
@@ -43,6 +43,7 @@ export type ReactWebLabelPatchPreview = {
     findingCount: number;
     missingCount: number;
     ambiguousCount: number;
+    emptyAccessibleNameCount: number;
     associationCount: number;
   };
   findings: ReactWebLabelPatchPreviewFinding[];
@@ -101,6 +102,14 @@ function stringLiteralAttributeValue(node: JsxInteractiveNode | ts.JsxOpeningEle
     return undefined;
   }
   return undefined;
+}
+
+function hasEmptyStringLiteralAttribute(node: JsxInteractiveNode | ts.JsxOpeningElement, attrName: string): boolean {
+  for (const property of node.attributes.properties) {
+    if (!ts.isJsxAttribute(property) || property.name.getText() !== attrName) continue;
+    return Boolean(property.initializer && ts.isStringLiteral(property.initializer) && property.initializer.text.trim() === "");
+  }
+  return false;
 }
 
 function tagNameOf(node: JsxInteractiveNode | ts.JsxOpeningElement): string {
@@ -331,6 +340,16 @@ function classifyLabelEvidence(options: {
 
   if (tag === "input" && values.get("type")?.toLowerCase() === "hidden") return undefined;
 
+  if (hasEmptyStringLiteralAttribute(node, "aria-label")) {
+    return {
+      labelled: false,
+      kind: "empty-accessible-name",
+      confidence: "high",
+      reason: `Native ${tag} has an empty aria-label string literal, so the accessible name evidence is present but blank and must be replaced with human-reviewed copy.`,
+      evidence: [...evidence, `jsx.${tag}.aria-label.empty`],
+    };
+  }
+
   if (hasNonEmptyAttr(values, "aria-label")) return { labelled: true, evidence: [...evidence, `jsx.${tag}.aria-label`] };
   if (hasNonEmptyAttr(values, "aria-labelledby")) return { labelled: true, evidence: [...evidence, `jsx.${tag}.aria-labelledby`] };
   if (hasNonEmptyAttr(values, "title")) return { labelled: true, evidence: [...evidence, `jsx.${tag}.title`] };
@@ -397,7 +416,7 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
       ...base,
       inScope: false,
       skippedReason: `domain-classification:${detection.classification}`,
-      summary: { findingCount: 0, missingCount: 0, ambiguousCount: 0, associationCount: 0 },
+      summary: { findingCount: 0, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 },
       findings: [],
     };
   }
@@ -482,6 +501,7 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
       findingCount: findings.length,
       missingCount: findings.filter((finding) => finding.kind === "missing-accessible-label").length,
       ambiguousCount: findings.filter((finding) => finding.kind === "ambiguous-accessible-label").length,
+      emptyAccessibleNameCount: findings.filter((finding) => finding.kind === "empty-accessible-name").length,
       associationCount: findings.filter((finding) => finding.kind === "unassociated-nearby-label").length,
     },
     findings,
@@ -497,7 +517,7 @@ export function renderReactWebLabelPatchPreviewText(preview: ReactWebLabelPatchP
     `File: ${preview.filePath}`,
     `Read-only: ${preview.readOnly ? "yes" : "no"}`,
     `In scope: ${preview.inScope ? "yes" : "no"}`,
-    `Findings: ${preview.summary.findingCount} (missing: ${preview.summary.missingCount}, ambiguous: ${preview.summary.ambiguousCount}, associations: ${preview.summary.associationCount})`,
+    `Findings: ${preview.summary.findingCount} (missing: ${preview.summary.missingCount}, ambiguous: ${preview.summary.ambiguousCount}, empty names: ${preview.summary.emptyAccessibleNameCount}, associations: ${preview.summary.associationCount})`,
   ];
   if (preview.skippedReason) lines.push(`Skipped: ${preview.skippedReason}`);
   if (preview.findings.length === 0) return `${lines.join("\n")}\n`;

--- a/test/fixtures/react-web-label-preview/empty-aria-labels.tsx
+++ b/test/fixtures/react-web-label-preview/empty-aria-labels.tsx
@@ -1,0 +1,12 @@
+export function EmptyAriaLabelControls() {
+  return (
+    <form>
+      <input aria-label="" name="email" type="email" />
+      <button aria-label=" ">
+        <svg aria-hidden="true" />
+      </button>
+      <textarea aria-label="" name="notes" />
+      <input aria-label="Search" name="query" />
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -42,6 +42,7 @@ const fixtures = {
   unsafeAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx"),
   relatedContext: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "related-context-form.tsx"),
   expandedNativeControls: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx"),
+  emptyAriaLabel: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -314,6 +315,37 @@ test("React Web issue report emits actionable issue cards over label preview fin
     assert.doesNotMatch(JSON.stringify(issue.relatedContext), /must-edit|auto-apply/i);
     assert.equal(issue.preview, undefined);
   }
+});
+
+test("React Web issue report emits manual-review cards for empty native aria-labels", () => {
+  const report = parseIssues(fixtures.emptyAriaLabel);
+  const preview = buildReactWebLabelPatchPreview(fixtures.emptyAriaLabel, repoRoot);
+
+  assert.equal(report.summary.issueCount, 3);
+  assert.equal(report.summary.manualReviewCount, 3);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 3);
+  assert.equal(report.summary.issueCount, preview.summary.findingCount);
+  assert.equal(preview.summary.emptyAccessibleNameCount, 3);
+  assert.ok(report.issues.every((issue) => issue.kind === "react-web.empty-accessible-name"));
+  assert.deepEqual(report.issues.map((issue) => [issue.evidence.element, issue.confidence, issue.fixability, issue.autoFixSafety, Boolean(issue.preview)]), [
+    ["input", "high", "manual-review", "unsafe-to-auto-apply", false],
+    ["button", "high", "manual-review", "unsafe-to-auto-apply", false],
+    ["textarea", "high", "manual-review", "unsafe-to-auto-apply", false],
+  ]);
+
+  const first = report.issues[0];
+  assert.match(first.problem, /empty accessible-name evidence/);
+  assert.match(first.whyItMatters, /blank aria-label/);
+  assert.match(first.suggestedAction, /Replace the empty aria-label/);
+  assert.match(first.contextPacket.relatedPattern, /react-web\.empty-accessible-name/);
+  assert.equal(first.decision.allowedActions.inspect, true);
+  assert.equal(first.decision.allowedActions.applyPatch, false);
+  assert.equal(first.decision.allowedActions.generateCopy, false);
+  assert.equal(first.decision.autoApply, false);
+  assert.equal(first.decision.humanReviewRequired, true);
+  assert.ok(first.fixShapeGuidance.inspectFirst.some((entry) => /does not generate final label\/name copy/.test(entry)));
+  assert.doesNotMatch(JSON.stringify(report), /Auto-apply: yes|must-edit/i);
 });
 
 test("React Web issue report turns nearby native associations into safe preview cards", () => {

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -11,6 +11,7 @@ const rnFixture = path.join(repoRoot, "test", "fixtures", "frontend-domain-expec
 const associationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-candidates.tsx");
 const unsafeAssociationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx");
 const expandedNativeControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx");
+const emptyAriaLabelFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -34,6 +35,7 @@ test("React Web label preview reports deterministic read-only patches for missin
   assert.equal(preview.summary.findingCount, 5);
   assert.equal(preview.summary.missingCount, 3);
   assert.equal(preview.summary.ambiguousCount, 2);
+  assert.equal(preview.summary.emptyAccessibleNameCount, 0);
   assert.equal(preview.summary.associationCount, 0);
 
   assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence]), [
@@ -61,7 +63,7 @@ test("React Web label preview stays quiet when native controls have narrow label
   const preview = JSON.parse(cli.stdout);
 
   assert.equal(preview.inScope, true);
-  assert.deepEqual(preview.summary, { findingCount: 0, missingCount: 0, ambiguousCount: 0, associationCount: 0 });
+  assert.deepEqual(preview.summary, { findingCount: 0, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
   assert.deepEqual(preview.findings, []);
 });
 
@@ -75,6 +77,7 @@ test("React Web label preview suggests conservative nearby label associations", 
   assert.equal(preview.summary.associationCount, 3);
   assert.equal(preview.summary.missingCount, 0);
   assert.equal(preview.summary.ambiguousCount, 0);
+  assert.equal(preview.summary.emptyAccessibleNameCount, 0);
   assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence, finding.suggestedPatch.attribute]), [
     ["unassociated-nearby-label", "input", "high", "htmlFor"],
     ["unassociated-nearby-label", "select", "medium", "id/htmlFor"],
@@ -93,7 +96,7 @@ test("React Web label preview covers expanded native control fixture boundaries"
   const preview = JSON.parse(cli.stdout);
 
   assert.equal(preview.inScope, true);
-  assert.deepEqual(preview.summary, { findingCount: 4, missingCount: 4, ambiguousCount: 0, associationCount: 0 });
+  assert.deepEqual(preview.summary, { findingCount: 4, missingCount: 4, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
   assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence, finding.suggestedPatch.attribute]), [
     ["missing-accessible-label", "input", "high", "aria-label"],
     ["missing-accessible-label", "input", "high", "aria-label"],
@@ -115,9 +118,33 @@ test("React Web label preview avoids unsafe nearby label associations", () => {
 
   assert.equal(preview.inScope, true);
   assert.equal(preview.summary.associationCount, 0);
+  assert.equal(preview.summary.emptyAccessibleNameCount, 0);
   assert.ok(preview.summary.missingCount > 0);
   assert.ok(preview.findings.every((finding) => finding.suggestedPatch.attribute === "aria-label"));
   assert.doesNotMatch(cli.stdout, /htmlFor=/);
+});
+
+test("React Web label preview reports empty aria-label native controls as manual-review findings", () => {
+  const cli = runPreview(emptyAriaLabelFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  assert.deepEqual(preview.summary, {
+    findingCount: 3,
+    missingCount: 0,
+    ambiguousCount: 0,
+    emptyAccessibleNameCount: 3,
+    associationCount: 0,
+  });
+  assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence, finding.suggestedPatch.attribute]), [
+    ["empty-accessible-name", "input", "high", "aria-label"],
+    ["empty-accessible-name", "button", "high", "aria-label"],
+    ["empty-accessible-name", "textarea", "high", "aria-label"],
+  ]);
+  assert.ok(preview.findings.every((finding) => finding.reason.includes("empty aria-label")));
+  assert.ok(preview.findings.every((finding) => finding.suggestedPatch.readOnly === true));
+  assert.doesNotMatch(JSON.stringify(preview), /Search/);
 });
 
 test("React Web label preview text mode is explicit about read-only patch previews", () => {


### PR DESCRIPTION
## Summary
- Add a narrow React Web native-control finding for empty string-literal `aria-label` evidence.
- Surface the finding as `react-web.empty-accessible-name` manual-review issue cards with no auto-apply or generated copy authority.
- Lock the behavior with a fixture covering `input`, `button`, and `textarea`, while preserving non-empty `aria-label` as valid evidence.

Closes #828

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs`
- `node --test --test-name-pattern "React Web first-minute work-order docs stay discoverable|React Web issue-card public demo keeps selected golden" test/fooks.test.mjs`
- `npm run release:smoke`
- `git diff --check`

## Claim boundary
This remains a read-only React Web native JSX label/accessibility subset. It does not claim broad accessibility coverage, custom-component semantics, React Native/WebView/TUI support, generated accessible-name copy, or auto-apply safety.
