### PR TITLE
Guard React Web issue cards against quiet-control noise

### DIFF
--- a/test/fixtures/react-web-label-preview/quiet-native-evidence.tsx
+++ b/test/fixtures/react-web-label-preview/quiet-native-evidence.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+function DesignSystemTextInput(_props: { label: string; name: string }) {
+  return null;
+}
+
+export function QuietNativeEvidence() {
+  const imageAlt = "Search products";
+
+  return (
+    <form>
+      <button type="button">
+        <span>Open settings</span>
+      </button>
+      <input type="submit" value="Save profile" />
+      <input alt={imageAlt} type="image" src="/search.png" />
+      <span id="country-label">Country</span>
+      <select aria-labelledby="country-label" name="country">
+        <option value="kr">Korea</option>
+      </select>
+      <textarea aria-label="Support notes" name="notes" />
+      <label>
+        Confirm email
+        <input name="confirmEmail" />
+      </label>
+      <DesignSystemTextInput label="Display name" name="displayName" />
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -43,6 +43,7 @@ const fixtures = {
   relatedContext: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "related-context-form.tsx"),
   expandedNativeControls: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx"),
   emptyAriaLabel: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx"),
+  quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -691,6 +692,26 @@ test("React Web first-minute work-order quality gate keeps safety invariants str
   const humanReviewReport = cloneJson(baseReport);
   humanReviewReport.firstMinuteSummary.items[0].fixShapeGuidance.humanReviewRequired = false;
   assertOnlyWorkOrderRegressionClass(humanReviewReport, "missing-human-decision");
+});
+
+test("React Web issue report stays quiet for native name evidence and custom decoys", () => {
+  const report = parseIssues(fixtures.quietNativeEvidence);
+  const summary = buildReactWebIssueReportSummaryJson(report);
+  const dryRun = buildReactWebIssueReportMigrationDryRunJson(report);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.summary.issueCount, 0);
+  assert.equal(report.summary.manualReviewCount, 0);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 0);
+  assert.deepEqual(report.issues, []);
+  assert.deepEqual(report.firstMinuteSummary, { sourceTopIssueIds: [], items: [] });
+  assert.equal(summary.autoApply, false);
+  assert.deepEqual(summary.firstMinuteSummary, { sourceTopIssueIds: [], items: [] });
+  assert.equal(dryRun.autoApply, false);
+  assert.equal(dryRun.dryRunOnly, true);
+  assert.deepEqual(dryRun.candidates, []);
+  assert.doesNotMatch(JSON.stringify(report), /DesignSystemTextInput|displayName|TODO:/);
 });
 
 test("React Web issue report preserves skip and no unsupported custom-component inference boundaries", () => {

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -12,6 +12,7 @@ const associationFixture = path.join(repoRoot, "test", "fixtures", "react-web-la
 const unsafeAssociationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "label-association-unsafe.tsx");
 const expandedNativeControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx");
 const emptyAriaLabelFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx");
+const quietNativeEvidenceFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -65,6 +66,17 @@ test("React Web label preview stays quiet when native controls have narrow label
   assert.equal(preview.inScope, true);
   assert.deepEqual(preview.summary, { findingCount: 0, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
   assert.deepEqual(preview.findings, []);
+});
+
+test("React Web label preview stays quiet for native controls with sufficient name evidence and custom decoys", () => {
+  const cli = runPreview(quietNativeEvidenceFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  assert.deepEqual(preview.summary, { findingCount: 0, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
+  assert.deepEqual(preview.findings, []);
+  assert.doesNotMatch(JSON.stringify(preview), /DesignSystemTextInput|displayName|TODO:/);
 });
 
 test("React Web label preview suggests conservative nearby label associations", () => {


### PR DESCRIPTION
## Summary
- Add a quiet native-evidence fixture covering visible button text, submit/image input names, aria-labelledby, textarea aria-label, wrapped labels, and a custom-component decoy.
- Lock label-preview behavior so sufficient native accessible-name evidence produces zero findings and no TODO previews.
- Lock issue-report/summary/dry-run behavior so quiet evidence produces no issue cards, no work-order items, no candidates, and no auto-apply authority.

Closes #830

## Verification
- `npm run typecheck`
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs`
- `node --test --test-name-pattern "React Web first-minute work-order docs stay discoverable|React Web issue-card public demo keeps selected golden" test/fooks.test.mjs`
- `npm run release:smoke`
- `git diff --check`

## Claim boundary
This is a test-first false-positive/noise guard. It does not add detectors, change public JSON shape, rewrite docs/marketing, expand broad accessibility support, infer custom-component semantics, or add auto-apply/generated-copy authority.
