### PR TITLE
Anchor fooks check after clean main CI echo

### DIFF
--- a/docs/dogfood/check-clean-main-ci-echo-832.md
+++ b/docs/dogfood/check-clean-main-ci-echo-832.md
@@ -1,0 +1,23 @@
+# Check clean main CI echo artifact handoff (#832)
+
+This is a narrow docs/test operator-boundary artifact for issue #832. It keeps
+`fooks check` from treating a clean post-merge `main` CI/React echo as the final
+answer when no active dogfood artifact exists.
+
+## Rule
+
+After clean `main` CI or React Web release-report echoes, `fooks check` must not
+end as a status recap. If the run has no active issue, branch, session, or PR to
+report, the operator handoff must create or adopt exactly one bounded active
+artifact first, then report only that artifact as the next development anchor.
+
+Clean CI, clean React echoes, zero open issue/PR counts, zero mapped fooks
+sessions, and legacy local worktree inventory remain verification or inventory
+receipts only. They are not the artifact that satisfies the handoff.
+
+## Current adoption
+
+Issue #832 and this non-`main` branch are the active artifacts for this pass. This
+artifact is read-only evidence; it does not change runtime/provider behavior,
+merge-gate policy, detector scope, cleanup authority, React Web, React Native,
+TUI, WebView behavior, performance claims, or product claims.

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -54,6 +54,7 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   const boundaryDoc = fs.readFileSync(path.join(repoRoot, "docs", "post-merge-main-ci-echo-boundary.md"), "utf8");
   const dogfoodDoc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-merge-reminder-action-803.md"), "utf8");
   const issue823Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "post-merge-react-web-ci-echo-anchor-823.md"), "utf8");
+  const issue832Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "check-clean-main-ci-echo-832.md"), "utf8");
 
   assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
   assert.match(boundaryDoc, /create\/adopt one active artifact/);
@@ -72,6 +73,12 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   assert.match(issue823Doc, /fresh active issue, branch, session, or PR/);
   assert.match(issue823Doc, /green CI, a successful release report, or\s+legacy local worktree residue as the active-work reason/);
   assert.match(issue823Doc, /not cleanup authority/);
+  assert.match(issue832Doc, /issue #832/i);
+  assert.match(issue832Doc, /`fooks check` must not\s+end as a status recap/);
+  assert.match(issue832Doc, /create or adopt exactly one bounded active\s+artifact first/);
+  assert.match(issue832Doc, /report only that artifact as the next development anchor/);
+  assert.match(issue832Doc, /verification or inventory\s+receipts only/);
+  assert.match(issue832Doc, /not change runtime\/provider behavior/);
 });
 
 test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {


### PR DESCRIPTION
Closes #832.

## Summary
- Add a narrow dogfood docs artifact for the clean-main CI/React echo handoff boundary.
- Lock the operator docs test so `fooks check` must anchor on a concrete active artifact instead of ending with status-only receipts.

## Verification
- npm run build
- node --test test/operator-activity.test.mjs
- git diff --check

## Scope
Docs/test/operator boundary only; no runtime/provider behavior, merge-gate policy, detector scope, React Web/RN/TUI/WebView behavior, product claim, or performance claim change.