### PR TITLE
Add duplicate-id React Web issue cards

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -35,7 +35,8 @@ type ReactWebIssueKind =
   | "react-web.missing-accessible-label"
   | "react-web.ambiguous-accessible-label"
   | "react-web.empty-accessible-name"
-  | "react-web.unassociated-nearby-label";
+  | "react-web.unassociated-nearby-label"
+  | "react-web.duplicate-literal-id";
 
 export type ReactWebIssueTriageEvidence = {
   safePreviewAvailable: boolean;
@@ -62,7 +63,8 @@ type ReactWebIssueFixShape =
   | "human-reviewed-placeholder-replacement"
   | "human-reviewed-button-name"
   | "human-reviewed-native-control-name"
-  | "human-reviewed-accessible-name";
+  | "human-reviewed-accessible-name"
+  | "human-reviewed-duplicate-id-association";
 
 export type ReactWebIssueFixShapeGuidance = {
   claimBoundary: string;
@@ -340,6 +342,8 @@ function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return `Native ${finding.element} has empty accessible-name evidence.`;
     case "unassociated-nearby-label":
       return `Nearby label text is not explicitly associated with this native ${finding.element}.`;
+    case "duplicate-literal-id":
+      return `Native ${finding.element} has an ambiguous duplicate id association.`;
   }
 }
 
@@ -353,6 +357,8 @@ function whyItMattersFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return "A blank aria-label creates accessible-name evidence that communicates no useful control name.";
     case "unassociated-nearby-label":
       return "Visible label text may not be programmatically connected to the native form control.";
+    case "duplicate-literal-id":
+      return "Duplicate literal id values can make htmlFor/control associations ambiguous for assistive technology and DOM lookup behavior.";
   }
 }
 
@@ -366,6 +372,8 @@ function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): strin
       return "Replace the empty aria-label with human-reviewed accessible-name evidence.";
     case "unassociated-nearby-label":
       return "Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.";
+    case "duplicate-literal-id":
+      return "Inspect every same-file duplicate id occurrence and choose unique, human-reviewed id/htmlFor associations.";
   }
 }
 
@@ -388,12 +396,18 @@ function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
   if (finding.kind === "unassociated-nearby-label") {
     return "Nearby label/control evidence is not high-confidence enough for a safe preview, so fooks reports it for manual review and does not auto-apply it.";
   }
+  if (finding.kind === "duplicate-literal-id") {
+    return "Duplicate literal id associations require source inspection and coordinated id/htmlFor choices, so fooks reports the ambiguity and does not auto-apply it.";
+  }
   return "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.";
 }
 
 function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
   if (finding.kind === "unassociated-nearby-label") {
     return "Preview skipped because the nearby label/control association is not high-confidence deterministic evidence.";
+  }
+  if (finding.kind === "duplicate-literal-id") {
+    return "Preview skipped because duplicate literal id associations must be resolved by inspecting every same-file occurrence first.";
   }
   return "Preview skipped because generated accessible-name copy would require human review.";
 }
@@ -533,6 +547,7 @@ function fixShapeFor(options: {
     return "human-reviewed-placeholder-replacement";
   }
   if (options.finding.kind === "empty-accessible-name") return "human-reviewed-accessible-name";
+  if (options.finding.kind === "duplicate-literal-id") return "human-reviewed-duplicate-id-association";
   if (options.finding.element === "button") return "human-reviewed-button-name";
   if (
     hasAttributeSignal(options.attributes, "name") ||
@@ -558,6 +573,8 @@ function fixShapeSummaryFor(shape: ReactWebIssueFixShape, element: ReactWebLabel
       return `Use local native ${element} attributes as hints for a human-reviewed accessible-name shape; do not generate copy automatically.`;
     case "human-reviewed-accessible-name":
       return `Choose a human-reviewed accessible-name shape for this native ${element} from local JSX context.`;
+    case "human-reviewed-duplicate-id-association":
+      return `Inspect duplicate same-file id evidence for this native ${element} and choose unique id/htmlFor associations manually.`;
   }
 }
 
@@ -574,6 +591,9 @@ function fixShapeInspectFirstFor(options: {
   steps.push(`Confirm the current source still matches this native ${options.finding.element} evidence before suggesting changes.`);
   if (options.attributes.length > 0) {
     steps.push(`Use current attribute evidence as hints only: ${options.attributes.slice(0, 6).join(", ")}.`);
+  }
+  if (options.finding.kind === "duplicate-literal-id" && options.finding.duplicateId) {
+    steps.push(`Inspect duplicate id lines: ${options.finding.duplicateId.lines.join(", ")} for id "${options.finding.duplicateId.value}" before choosing replacement ids.`);
   }
   if (options.previewAvailable) {
     steps.push("Review the safe preview diff as a candidate shape; fooks still does not apply it.");
@@ -633,6 +653,10 @@ function contextPacketRelatedPatternFor(options: {
   if (options.previewAvailable) {
     return `${base}; safe-preview pattern because existing JSX provides deterministic nearby label/control association evidence.`;
   }
+  if (options.finding.kind === "duplicate-literal-id") {
+    const lines = options.finding.duplicateId?.lines.join(",") ?? "unknown";
+    return `${base}; manual-review duplicate-id pattern because same-file literal id evidence appears on lines ${lines}.`;
+  }
   if (options.finding.kind === "unassociated-nearby-label") {
     return `${base}; manual-review association pattern because nearby label/control evidence is not deterministic enough for a safe preview.`;
   }
@@ -669,6 +693,9 @@ function excludedInferenceFor(options: {
   }
   if (options.finding.kind === "unassociated-nearby-label" && !options.previewAvailable) {
     excluded.push("Does not infer htmlFor/id association when nearby label evidence is not high-confidence deterministic.");
+  }
+  if (options.finding.kind === "duplicate-literal-id") {
+    excluded.push("Does not choose replacement ids or rewrite htmlFor associations for duplicate id cards.");
   }
   return excluded;
 }

--- a/src/core/react-web-label-preview.ts
+++ b/src/core/react-web-label-preview.ts
@@ -8,7 +8,12 @@ export const REACT_WEB_LABEL_PATCH_PREVIEW_SCHEMA_VERSION = "react-web-label-pat
 export const REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY =
   "Read-only React Web JSX label preview only: detects a narrow set of native interactive elements with missing, ambiguous, or empty accessible-label evidence and suggests read-only patch fragments without editing files or claiming full accessibility coverage." as const;
 
-type ReactWebLabelFindingKind = "missing-accessible-label" | "ambiguous-accessible-label" | "empty-accessible-name" | "unassociated-nearby-label";
+type ReactWebLabelFindingKind =
+  | "missing-accessible-label"
+  | "ambiguous-accessible-label"
+  | "empty-accessible-name"
+  | "unassociated-nearby-label"
+  | "duplicate-literal-id";
 type ReactWebLabelConfidence = "high" | "medium";
 type ReactWebInteractiveElement = "button" | "input" | "select" | "textarea";
 
@@ -20,6 +25,10 @@ export type ReactWebLabelPatchPreviewFinding = {
   confidence: ReactWebLabelConfidence;
   reason: string;
   evidence: string[];
+  duplicateId?: {
+    value: string;
+    lines: number[];
+  };
   suggestedPatch: {
     type: "unified-diff-fragment";
     readOnly: true;
@@ -224,6 +233,19 @@ function countLiteralAttributeValues(sourceFile: ts.SourceFile, attrName: string
   return counts;
 }
 
+function literalAttributeLocations(sourceFile: ts.SourceFile, attrName: string): Map<string, SourceRange[]> {
+  const locations = new Map<string, SourceRange[]>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const value = stringLiteralAttributeValue(node, attrName);
+      if (value) locations.set(value, [...(locations.get(value) ?? []), sourceRangeOf(sourceFile, node)]);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return locations;
+}
+
 function labelContainsNativeControl(labelElement: ts.JsxElement): boolean {
   let contains = false;
   const visit = (node: ts.Node): void => {
@@ -425,6 +447,7 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
   const lines = sourceText.split(/\r?\n/);
   const labelledIds = collectHtmlForIds(sourceFile);
   const literalIdCounts = countLiteralAttributeValues(sourceFile, "id");
+  const literalIdLocations = literalAttributeLocations(sourceFile, "id");
   const literalIds = new Set(literalIdCounts.keys());
   const controlNameCounts = countLiteralAttributeValues(sourceFile, "name");
   const findings: ReactWebLabelPatchPreviewFinding[] = [];
@@ -435,6 +458,36 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
       if (INTERACTIVE_TAGS.has(tag as ReactWebInteractiveElement)) {
         const element = tag as ReactWebInteractiveElement;
         const attrs = attributesOf(node);
+        const literalId = stringLiteralAttributeValue(node, "id");
+        const duplicateIdLines = literalId ? (literalIdLocations.get(literalId) ?? []).map((loc) => loc.startLine) : [];
+        if (literalId && labelledIds.has(literalId) && duplicateIdLines.length > 1) {
+          const loc = sourceRangeOf(sourceFile, node);
+          findings.push({
+            kind: "duplicate-literal-id",
+            element,
+            loc,
+            context: lineContext(lines, loc),
+            confidence: "high",
+            reason: `Native ${element} id "${literalId}" is referenced by htmlFor but the same literal id appears ${duplicateIdLines.length} times in this file, so the label/control association is ambiguous and needs manual review.`,
+            evidence: [
+              `jsx.${element}`,
+              `jsx.${element}.id.duplicate=${literalId}`,
+              "jsx.label.htmlFor",
+              `same-file.literal-id.lines=${duplicateIdLines.join(",")}`,
+            ],
+            duplicateId: {
+              value: literalId,
+              lines: duplicateIdLines,
+            },
+            suggestedPatch: {
+              type: "unified-diff-fragment",
+              readOnly: true,
+              attribute: "id/htmlFor",
+              insertion: `manual-review duplicate id ${escapeAttribute(literalId)}`,
+              preview: "",
+            },
+          });
+        }
         const labelEvidence = classifyLabelEvidence({ node, tag: element, attrs, labelledIds });
         if (labelEvidence && !labelEvidence.labelled) {
           const loc = sourceRangeOf(sourceFile, node);

--- a/test/fixtures/react-web-label-preview/duplicate-id-controls.tsx
+++ b/test/fixtures/react-web-label-preview/duplicate-id-controls.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export function DuplicateIdControls() {
+  return (
+    <form>
+      <label htmlFor="email">Email</label>
+      <input id="email" name="primaryEmail" />
+      <label htmlFor="email">Confirm email</label>
+      <input id="email" name="confirmEmail" />
+      <label htmlFor="phone">Phone</label>
+      <input id="phone" name="phone" />
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -44,6 +44,7 @@ const fixtures = {
   expandedNativeControls: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx"),
   emptyAriaLabel: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx"),
   quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
+  duplicateIds: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -346,6 +347,37 @@ test("React Web issue report emits manual-review cards for empty native aria-lab
   assert.equal(first.decision.autoApply, false);
   assert.equal(first.decision.humanReviewRequired, true);
   assert.ok(first.fixShapeGuidance.inspectFirst.some((entry) => /does not generate final label\/name copy/.test(entry)));
+  assert.doesNotMatch(JSON.stringify(report), /Auto-apply: yes|must-edit/i);
+});
+
+
+test("React Web issue report emits manual-review cards for duplicate literal native ids", () => {
+  const report = parseIssues(fixtures.duplicateIds);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.summary.issueCount, 2);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.manualReviewCount, 2);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 2);
+  assert.ok(report.issues.every((issue) => issue.kind === "react-web.duplicate-literal-id"));
+  assert.ok(report.issues.every((issue) => issue.fixability === "manual-review"));
+  assert.ok(report.issues.every((issue) => issue.autoFixSafety === "unsafe-to-auto-apply"));
+
+  const first = report.issues[0];
+  assert.equal(first.whereToLook.filePath, "test/fixtures/react-web-label-preview/duplicate-id-controls.tsx");
+  assert.deepEqual(report.issues.map((issue) => issue.whereToLook.line), [7, 9]);
+  assert.match(first.problem, /ambiguous duplicate id association/);
+  assert.match(first.whyItMatters, /Duplicate literal id values/);
+  assert.match(first.suggestedAction, /Inspect every same-file duplicate id occurrence/);
+  assert.match(first.skipReason, /inspecting every same-file occurrence/);
+  assert.deepEqual(first.fixShapeGuidance.shape, "human-reviewed-duplicate-id-association");
+  assert.ok(first.fixShapeGuidance.inspectFirst.some((entry) => /duplicate id lines: 7, 9/.test(entry)));
+  assert.ok(first.contextPacket.excludedInference.some((entry) => /Does not choose replacement ids/.test(entry)));
+  assert.ok(first.evidence.sourceSignals.some((entry) => entry === "same-file.literal-id.lines=7,9"));
+  assert.equal(first.decision.allowedActions.inspect, true);
+  assert.equal(first.decision.allowedActions.applyPatch, false);
+  assert.equal(first.decision.autoApply, false);
+  assert.equal(first.decision.humanReviewRequired, true);
   assert.doesNotMatch(JSON.stringify(report), /Auto-apply: yes|must-edit/i);
 });
 

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -13,6 +13,7 @@ const unsafeAssociationFixture = path.join(repoRoot, "test", "fixtures", "react-
 const expandedNativeControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx");
 const emptyAriaLabelFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx");
 const quietNativeEvidenceFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx");
+const duplicateIdControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -77,6 +78,24 @@ test("React Web label preview stays quiet for native controls with sufficient na
   assert.deepEqual(preview.summary, { findingCount: 0, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
   assert.deepEqual(preview.findings, []);
   assert.doesNotMatch(JSON.stringify(preview), /DesignSystemTextInput|displayName|TODO:/);
+});
+
+
+test("React Web label preview reports duplicate literal ids on htmlFor-associated native controls", () => {
+  const cli = runPreview(duplicateIdControlsFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  assert.deepEqual(preview.summary, { findingCount: 2, missingCount: 0, ambiguousCount: 0, emptyAccessibleNameCount: 0, associationCount: 0 });
+  assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.confidence, finding.suggestedPatch.attribute]), [
+    ["duplicate-literal-id", "input", "high", "id/htmlFor"],
+    ["duplicate-literal-id", "input", "high", "id/htmlFor"],
+  ]);
+  assert.ok(preview.findings.every((finding) => finding.duplicateId.value === "email"));
+  assert.deepEqual(preview.findings.map((finding) => finding.duplicateId.lines), [[7, 9], [7, 9]]);
+  assert.ok(preview.findings.every((finding) => finding.reason.includes("referenced by htmlFor")));
+  assert.doesNotMatch(JSON.stringify(preview), /phone.*duplicate-literal-id/);
 });
 
 test("React Web label preview suggests conservative nearby label associations", () => {


### PR DESCRIPTION
## Summary
- detect same-file duplicate literal `id` values on htmlFor-associated native React Web controls
- emit manual-review duplicate-id issue cards with exact source lines, duplicate-id evidence, and stop conditions
- add focused React Web fixtures/tests while preserving the quiet native-control false-positive guard

## Verification
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs` (51 passing)
- `git diff --check`

Closes #833
