### PR TITLE
Add missing htmlFor target issue cards

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -36,7 +36,8 @@ type ReactWebIssueKind =
   | "react-web.ambiguous-accessible-label"
   | "react-web.empty-accessible-name"
   | "react-web.unassociated-nearby-label"
-  | "react-web.duplicate-literal-id";
+  | "react-web.duplicate-literal-id"
+  | "react-web.missing-htmlFor-target";
 
 export type ReactWebIssueTriageEvidence = {
   safePreviewAvailable: boolean;
@@ -60,6 +61,7 @@ export type ReactWebIssueTriage = {
 type ReactWebIssueFixShape =
   | "safe-preview-htmlFor-association"
   | "human-reviewed-label-association"
+  | "human-reviewed-htmlFor-target"
   | "human-reviewed-placeholder-replacement"
   | "human-reviewed-button-name"
   | "human-reviewed-native-control-name"
@@ -344,6 +346,8 @@ function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return `Nearby label text is not explicitly associated with this native ${finding.element}.`;
     case "duplicate-literal-id":
       return `Native ${finding.element} has an ambiguous duplicate id association.`;
+    case "missing-htmlFor-target":
+      return `Native label htmlFor target is missing from same-file literal id evidence.`;
   }
 }
 
@@ -359,6 +363,8 @@ function whyItMattersFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return "Visible label text may not be programmatically connected to the native form control.";
     case "duplicate-literal-id":
       return "Duplicate literal id values can make htmlFor/control associations ambiguous for assistive technology and DOM lookup behavior.";
+    case "missing-htmlFor-target":
+      return "A native label with htmlFor must reference an existing control id; otherwise visible label text may not be programmatically connected to its intended control.";
   }
 }
 
@@ -374,6 +380,8 @@ function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): strin
       return "Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.";
     case "duplicate-literal-id":
       return "Inspect every same-file duplicate id occurrence and choose unique, human-reviewed id/htmlFor associations.";
+    case "missing-htmlFor-target":
+      return "Inspect the exact native label line, verify whether the target id should exist in this file, and manually choose a human-reviewed htmlFor/id association or stop if the target is intentionally external.";
   }
 }
 
@@ -399,6 +407,9 @@ function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
   if (finding.kind === "duplicate-literal-id") {
     return "Duplicate literal id associations require source inspection and coordinated id/htmlFor choices, so fooks reports the ambiguity and does not auto-apply it.";
   }
+  if (finding.kind === "missing-htmlFor-target") {
+    return "A missing htmlFor target may require adding or correcting an id, moving the label, or recognizing intentional cross-file/runtime wiring, so fooks reports the exact native label line for manual review and does not auto-apply it.";
+  }
   return "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.";
 }
 
@@ -408,6 +419,9 @@ function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
   }
   if (finding.kind === "duplicate-literal-id") {
     return "Preview skipped because duplicate literal id associations must be resolved by inspecting every same-file occurrence first.";
+  }
+  if (finding.kind === "missing-htmlFor-target") {
+    return "Preview skipped because the htmlFor target is absent from same-file literal id evidence; stop if source inspection shows the target is intentionally generated, external, or no longer missing.";
   }
   return "Preview skipped because generated accessible-name copy would require human review.";
 }
@@ -434,6 +448,7 @@ function nativeElementWeight(element: ReactWebLabelPatchPreviewFinding["element"
     case "textarea":
       return 2;
     case "button":
+    case "label":
       return 1;
   }
 }
@@ -548,6 +563,7 @@ function fixShapeFor(options: {
   }
   if (options.finding.kind === "empty-accessible-name") return "human-reviewed-accessible-name";
   if (options.finding.kind === "duplicate-literal-id") return "human-reviewed-duplicate-id-association";
+  if (options.finding.kind === "missing-htmlFor-target") return "human-reviewed-htmlFor-target";
   if (options.finding.element === "button") return "human-reviewed-button-name";
   if (
     hasAttributeSignal(options.attributes, "name") ||
@@ -565,6 +581,8 @@ function fixShapeSummaryFor(shape: ReactWebIssueFixShape, element: ReactWebLabel
       return `Inspect the read-only htmlFor/id association preview for this native ${element}; use only after human review.`;
     case "human-reviewed-label-association":
       return `Inspect nearby same-file label/control JSX and choose a human-reviewed association shape for this native ${element}.`;
+    case "human-reviewed-htmlFor-target":
+      return "Inspect the native label htmlFor literal and same-file id evidence before choosing any htmlFor/id target fix.";
     case "human-reviewed-placeholder-replacement":
       return `Replace placeholder-only evidence with a human-reviewed label shape for this native ${element}; do not reuse placeholder text automatically.`;
     case "human-reviewed-button-name":
@@ -594,6 +612,10 @@ function fixShapeInspectFirstFor(options: {
   }
   if (options.finding.kind === "duplicate-literal-id" && options.finding.duplicateId) {
     steps.push(`Inspect duplicate id lines: ${options.finding.duplicateId.lines.join(", ")} for id "${options.finding.duplicateId.value}" before choosing replacement ids.`);
+  }
+  if (options.finding.kind === "missing-htmlFor-target" && options.finding.missingHtmlForTarget) {
+    steps.push(`Inspect the native label htmlFor="${options.finding.missingHtmlForTarget.value}" line exactly; no same-file literal id target was found.`);
+    steps.push("Stop if the target id is intentionally generated at runtime, supplied from another file, or the source changed to include a same-file literal id.");
   }
   if (options.previewAvailable) {
     steps.push("Review the safe preview diff as a candidate shape; fooks still does not apply it.");
@@ -657,6 +679,9 @@ function contextPacketRelatedPatternFor(options: {
     const lines = options.finding.duplicateId?.lines.join(",") ?? "unknown";
     return `${base}; manual-review duplicate-id pattern because same-file literal id evidence appears on lines ${lines}.`;
   }
+  if (options.finding.kind === "missing-htmlFor-target") {
+    return `${base}; manual-review missing-htmlFor-target pattern because no same-file literal id matches the native label htmlFor value.`;
+  }
   if (options.finding.kind === "unassociated-nearby-label") {
     return `${base}; manual-review association pattern because nearby label/control evidence is not deterministic enough for a safe preview.`;
   }
@@ -696,6 +721,10 @@ function excludedInferenceFor(options: {
   }
   if (options.finding.kind === "duplicate-literal-id") {
     excluded.push("Does not choose replacement ids or rewrite htmlFor associations for duplicate id cards.");
+  }
+  if (options.finding.kind === "missing-htmlFor-target") {
+    excluded.push("Does not infer custom label component semantics or flag dynamic htmlFor expressions as missing literal targets.");
+    excluded.push("Does not choose a replacement id or rewrite htmlFor for missing-target cards.");
   }
   return excluded;
 }

--- a/src/core/react-web-label-preview.ts
+++ b/src/core/react-web-label-preview.ts
@@ -13,9 +13,10 @@ type ReactWebLabelFindingKind =
   | "ambiguous-accessible-label"
   | "empty-accessible-name"
   | "unassociated-nearby-label"
-  | "duplicate-literal-id";
+  | "duplicate-literal-id"
+  | "missing-htmlFor-target";
 type ReactWebLabelConfidence = "high" | "medium";
-type ReactWebInteractiveElement = "button" | "input" | "select" | "textarea";
+type ReactWebInteractiveElement = "button" | "input" | "select" | "textarea" | "label";
 
 export type ReactWebLabelPatchPreviewFinding = {
   kind: ReactWebLabelFindingKind;
@@ -28,6 +29,9 @@ export type ReactWebLabelPatchPreviewFinding = {
   duplicateId?: {
     value: string;
     lines: number[];
+  };
+  missingHtmlForTarget?: {
+    value: string;
   };
   suggestedPatch: {
     type: "unified-diff-fragment";
@@ -152,7 +156,7 @@ function hasNonEmptyAttr(values: Map<string, string>, ...names: string[]): boole
 function isWrappedByLabel(node: ts.Node): boolean {
   let current: ts.Node | undefined = node.parent;
   while (current) {
-    if (ts.isJsxElement(current) && tagNameOf(current.openingElement).toLowerCase() === "label") return true;
+    if (ts.isJsxElement(current) && tagNameOf(current.openingElement) === "label") return true;
     current = current.parent;
   }
   return false;
@@ -162,10 +166,10 @@ function collectHtmlForIds(sourceFile: ts.SourceFile): Set<string> {
   const ids = new Set<string>();
   const visit = (node: ts.Node): void => {
     if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
-      if (tagNameOf(node).toLowerCase() === "label") {
+      if (tagNameOf(node) === "label") {
         for (const property of node.attributes.properties) {
           if (!ts.isJsxAttribute(property) || property.name.getText() !== "htmlFor") continue;
-          const value = jsxAttributeText(property.initializer);
+          const value = stringLiteralAttributeValue(node, "htmlFor");
           if (value) ids.add(value);
         }
       }
@@ -174,6 +178,51 @@ function collectHtmlForIds(sourceFile: ts.SourceFile): Set<string> {
   };
   visit(sourceFile);
   return ids;
+}
+
+function collectMissingHtmlForTargetFindings(options: {
+  sourceFile: ts.SourceFile;
+  lines: string[];
+  literalIds: Set<string>;
+}): ReactWebLabelPatchPreviewFinding[] {
+  const findings: ReactWebLabelPatchPreviewFinding[] = [];
+  const visit = (node: ts.Node): void => {
+    if (findings.length >= FINDING_LIMIT) return;
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      if (tagNameOf(node) === "label") {
+        const htmlFor = stringLiteralAttributeValue(node, "htmlFor");
+        if (htmlFor && !options.literalIds.has(htmlFor)) {
+          const loc = sourceRangeOf(options.sourceFile, node);
+          findings.push({
+            kind: "missing-htmlFor-target",
+            element: "label",
+            loc,
+            context: lineContext(options.lines, loc),
+            confidence: "high",
+            reason: `Native label htmlFor "${htmlFor}" has no same-file literal id target, so the label/control association must be inspected manually before any change.`,
+            evidence: [
+              "jsx.label",
+              `jsx.label.htmlFor=${htmlFor}`,
+              "same-file.id-target.missing",
+            ],
+            missingHtmlForTarget: {
+              value: htmlFor,
+            },
+            suggestedPatch: {
+              type: "unified-diff-fragment",
+              readOnly: true,
+              attribute: "htmlFor",
+              insertion: `manual-review htmlFor target ${escapeAttribute(htmlFor)}`,
+              preview: "",
+            },
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(options.sourceFile);
+  return findings;
 }
 
 function escapeAttribute(value: string): string {
@@ -292,8 +341,8 @@ function findNearbyLabelAssociationCandidate(options: {
 
   const previousSibling = siblings[controlIndex - 1];
   const nextSibling = siblings[controlIndex + 1];
-  const previousLabel = previousSibling && ts.isJsxElement(previousSibling) && tagNameOf(previousSibling.openingElement).toLowerCase() === "label" ? previousSibling : undefined;
-  const nextLabel = nextSibling && ts.isJsxElement(nextSibling) && tagNameOf(nextSibling.openingElement).toLowerCase() === "label" ? nextSibling : undefined;
+  const previousLabel = previousSibling && ts.isJsxElement(previousSibling) && tagNameOf(previousSibling.openingElement) === "label" ? previousSibling : undefined;
+  const nextLabel = nextSibling && ts.isJsxElement(nextSibling) && tagNameOf(nextSibling.openingElement) === "label" ? nextSibling : undefined;
   const labelElement = previousLabel ?? nextLabel;
   if (!labelElement) return undefined;
   const labelAttrs = attributesOf(labelElement.openingElement).values;
@@ -450,6 +499,7 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
   const literalIdLocations = literalAttributeLocations(sourceFile, "id");
   const literalIds = new Set(literalIdCounts.keys());
   const controlNameCounts = countLiteralAttributeValues(sourceFile, "name");
+  const missingHtmlForTargetFindings = collectMissingHtmlForTargetFindings({ sourceFile, lines, literalIds });
   const findings: ReactWebLabelPatchPreviewFinding[] = [];
 
   const visit = (node: ts.Node): void => {
@@ -547,17 +597,23 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
   };
   visit(sourceFile);
 
+  const missingHtmlForTargetLimit = Math.max(0, FINDING_LIMIT - findings.length);
+  const cappedFindings = [
+    ...missingHtmlForTargetFindings.slice(0, missingHtmlForTargetLimit),
+    ...findings,
+  ].slice(0, FINDING_LIMIT);
+
   return {
     ...base,
     inScope: true,
     summary: {
-      findingCount: findings.length,
-      missingCount: findings.filter((finding) => finding.kind === "missing-accessible-label").length,
-      ambiguousCount: findings.filter((finding) => finding.kind === "ambiguous-accessible-label").length,
-      emptyAccessibleNameCount: findings.filter((finding) => finding.kind === "empty-accessible-name").length,
-      associationCount: findings.filter((finding) => finding.kind === "unassociated-nearby-label").length,
+      findingCount: cappedFindings.length,
+      missingCount: cappedFindings.filter((finding) => finding.kind === "missing-accessible-label").length,
+      ambiguousCount: cappedFindings.filter((finding) => finding.kind === "ambiguous-accessible-label").length,
+      emptyAccessibleNameCount: cappedFindings.filter((finding) => finding.kind === "empty-accessible-name").length,
+      associationCount: cappedFindings.filter((finding) => finding.kind === "unassociated-nearby-label").length,
     },
-    findings,
+    findings: cappedFindings,
   };
 }
 

--- a/test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx
+++ b/test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+function FieldLabel(_props: { htmlFor: string; children: React.ReactNode }) {
+  return null;
+}
+
+function Label(_props: { htmlFor: string; children: React.ReactNode }) {
+  return null;
+}
+
+export function MissingHtmlForTargetCard() {
+  const dynamicTarget = "runtime-field";
+
+  return (
+    <form className="space-y-4">
+      <label htmlFor="display-name">Display name</label>
+      <input aria-label="Profile name" id="profile-name" name="displayName" />
+
+      <label htmlFor={dynamicTarget}>Runtime generated field</label>
+      <input aria-label="Runtime field" id="runtime-field" name="runtime" />
+
+      <FieldLabel htmlFor="custom-field">Custom field</FieldLabel>
+      <input aria-label="Custom field" id="custom-field" name="custom" />
+
+      <Label htmlFor="design-system-field">Design system field</Label>
+      <input aria-label="Design system field" id="design-system-field" name="designSystem" />
+
+      <Label>Wrapped custom label
+        <input name="wrappedByCustomLabel" />
+      </Label>
+
+      <Label>Sibling custom label</Label>
+      <input name="siblingCustomLabel" />
+
+      <label htmlFor="email">Email</label>
+      <input id="email" name="email" />
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -45,6 +45,7 @@ const fixtures = {
   emptyAriaLabel: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx"),
   quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
   duplicateIds: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx"),
+  missingHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -379,6 +380,43 @@ test("React Web issue report emits manual-review cards for duplicate literal nat
   assert.equal(first.decision.autoApply, false);
   assert.equal(first.decision.humanReviewRequired, true);
   assert.doesNotMatch(JSON.stringify(report), /Auto-apply: yes|must-edit/i);
+});
+
+test("React Web issue report emits manual-review cards for native label htmlFor literals without same-file targets", () => {
+  const report = parseIssues(fixtures.missingHtmlForTarget);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.summary.issueCount, 3);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.manualReviewCount, 3);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 3);
+  const issue = report.issues.find((item) => item.kind === "react-web.missing-htmlFor-target");
+  assert.ok(issue);
+  assert.equal(issue.kind, "react-web.missing-htmlFor-target");
+  assert.equal(issue.whereToLook.filePath, "test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx");
+  assert.equal(issue.whereToLook.line, 16);
+  assert.equal(issue.evidence.element, "label");
+  assert.equal(issue.confidence, "high");
+  assert.equal(issue.fixability, "manual-review");
+  assert.equal(issue.autoFixSafety, "unsafe-to-auto-apply");
+  assert.equal(issue.preview, undefined);
+  assert.match(issue.problem, /htmlFor target is missing/);
+  assert.match(issue.whyItMatters, /must reference an existing control id/);
+  assert.match(issue.suggestedAction, /exact native label line/);
+  assert.match(issue.skipReason, /target is absent from same-file literal id evidence/);
+  assert.deepEqual(issue.fixShapeGuidance.shape, "human-reviewed-htmlFor-target");
+  assert.ok(issue.fixShapeGuidance.inspectFirst.some((entry) => /htmlFor="display-name"/.test(entry)));
+  assert.ok(issue.fixShapeGuidance.inspectFirst.some((entry) => /Stop if the target id is intentionally generated at runtime/.test(entry)));
+  assert.ok(issue.contextPacket.excludedInference.some((entry) => /dynamic htmlFor expressions/.test(entry)));
+  assert.ok(issue.contextPacket.excludedInference.some((entry) => /Does not choose a replacement id/.test(entry)));
+  assert.deepEqual(issue.evidence.sourceSignals, ["jsx.label", "jsx.label.htmlFor=display-name", "same-file.id-target.missing"]);
+  assert.equal(issue.decision.allowedActions.inspect, true);
+  assert.equal(issue.decision.allowedActions.applyPatch, false);
+  assert.equal(issue.decision.autoApply, false);
+  assert.equal(issue.decision.humanReviewRequired, true);
+  assert.ok(report.issues.some((item) => item.evidence.context.includes("wrappedByCustomLabel")));
+  assert.ok(report.issues.some((item) => item.evidence.context.includes("siblingCustomLabel")));
+  assert.doesNotMatch(JSON.stringify(report), /react-web\\.missing-htmlFor-target.*dynamicTarget|FieldLabel|design-system-field/s);
 });
 
 test("React Web issue report turns nearby native associations into safe preview cards", () => {
@@ -790,7 +828,8 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
   assert.ok(report.issues.every((issue) => issue.relatedContext.length <= 5));
   assert.ok(report.issues.every((issue) => issue.relatedContext.every((entry) => entry.action === "inspect-first")));
   assert.doesNotMatch(JSON.stringify(report.issues.flatMap((issue) => issue.relatedContext)), /must-edit|auto-apply/i);
-  assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
+  assert.equal(report.issues.filter((issue) => issue.kind === "react-web.missing-htmlFor-target").length, 1);
+  assert.doesNotMatch(JSON.stringify(report.issues.filter((issue) => issue.kind !== "react-web.missing-htmlFor-target")), /htmlFor=/);
 });
 
 test("React Web issue report text mode is issue-card-first and prints the claim boundary", () => {

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 
 const repoRoot = process.cwd();
@@ -14,6 +15,7 @@ const expandedNativeControlsFixture = path.join(repoRoot, "test", "fixtures", "r
 const emptyAriaLabelFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx");
 const quietNativeEvidenceFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx");
 const duplicateIdControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx");
+const missingHtmlForTargetFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -98,6 +100,56 @@ test("React Web label preview reports duplicate literal ids on htmlFor-associate
   assert.doesNotMatch(JSON.stringify(preview), /phone.*duplicate-literal-id/);
 });
 
+test("React Web label preview reports native label htmlFor literals with missing same-file id targets", () => {
+  const cli = runPreview(missingHtmlForTargetFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  assert.equal(preview.summary.findingCount, 3);
+  assert.deepEqual(preview.findings.map((finding) => [finding.kind, finding.element, finding.loc.startLine, finding.confidence, finding.suggestedPatch.attribute]), [
+    ["missing-htmlFor-target", "label", 16, "high", "htmlFor"],
+    ["missing-accessible-label", "input", 29, "high", "aria-label"],
+    ["missing-accessible-label", "input", 33, "high", "aria-label"],
+  ]);
+  const finding = preview.findings[0];
+  assert.equal(finding.missingHtmlForTarget.value, "display-name");
+  assert.match(finding.reason, /no same-file literal id target/);
+  assert.deepEqual(finding.evidence, ["jsx.label", "jsx.label.htmlFor=display-name", "same-file.id-target.missing"]);
+  assert.equal(finding.suggestedPatch.readOnly, true);
+  assert.equal(finding.suggestedPatch.preview, "");
+  assert.doesNotMatch(JSON.stringify(preview), /missing-htmlFor-target.*dynamicTarget|FieldLabel|custom-field|design-system-field/s);
+  assert.ok(preview.findings.some((item) => item.context.includes("wrappedByCustomLabel")));
+  assert.ok(preview.findings.some((item) => item.context.includes("siblingCustomLabel")));
+  assert.doesNotMatch(JSON.stringify(preview.findings), /unassociated-nearby-label.*siblingCustomLabel/s);
+});
+
+test("React Web label preview missing htmlFor targets do not starve existing native-control findings", () => {
+  const source = [
+    'import React from "react";',
+    'export function ManyMissingTargets() {',
+    "  return <form>",
+    ...Array.from({ length: 24 }, (_, index) => `    <label htmlFor="missing-${index}">Missing ${index}</label>`),
+    '    <input name="stillReported" />',
+    "  </form>;",
+    "}",
+    "",
+  ].join("\n");
+  const fixturePath = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "tmp-many-missing-htmlfor-targets.tsx");
+  fs.writeFileSync(fixturePath, source);
+  try {
+    const cli = runPreview(fixturePath, "--json");
+    assert.equal(cli.status, 0, cli.stderr);
+    const preview = JSON.parse(cli.stdout);
+
+    assert.equal(preview.summary.findingCount, 24);
+    assert.ok(preview.findings.some((finding) => finding.kind === "missing-accessible-label" && finding.context.includes('name="stillReported"')));
+    assert.equal(preview.findings.filter((finding) => finding.kind === "missing-htmlFor-target").length, 23);
+  } finally {
+    fs.rmSync(fixturePath, { force: true });
+  }
+});
+
 test("React Web label preview suggests conservative nearby label associations", () => {
   const cli = runPreview(associationFixture, "--json");
   assert.equal(cli.status, 0, cli.stderr);
@@ -151,8 +203,9 @@ test("React Web label preview avoids unsafe nearby label associations", () => {
   assert.equal(preview.summary.associationCount, 0);
   assert.equal(preview.summary.emptyAccessibleNameCount, 0);
   assert.ok(preview.summary.missingCount > 0);
-  assert.ok(preview.findings.every((finding) => finding.suggestedPatch.attribute === "aria-label"));
-  assert.doesNotMatch(cli.stdout, /htmlFor=/);
+  assert.equal(preview.findings.filter((finding) => finding.kind === "missing-htmlFor-target").length, 1);
+  assert.ok(preview.findings.filter((finding) => finding.kind !== "missing-htmlFor-target").every((finding) => finding.suggestedPatch.attribute === "aria-label"));
+  assert.doesNotMatch(JSON.stringify(preview.findings.filter((finding) => finding.kind !== "missing-htmlFor-target")), /htmlFor=/);
 });
 
 test("React Web label preview reports empty aria-label native controls as manual-review findings", () => {


### PR DESCRIPTION
## Summary
- add a narrow `missing-htmlFor-target` React Web label-preview finding for exact native `<label htmlFor="literal">` with no same-file literal `id`
- surface the finding as a read-only manual-review issue card with exact label line, missing target evidence, and stop conditions
- lock boundaries for dynamic `htmlFor`, custom label components (including `<Label>`), existing empty aria-label/duplicate-id/quiet-control guards, and finding-limit starvation

## Verification
- `npm run build`
- `node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs` (54/54 passing)
- `git diff --check`
- ai-slop-cleaner changed-files pass: no masking fallback/slop edits needed
- code-review: APPROVE; architect: CLEAR

Closes #838.
