### PR TITLE
Anchor orphan local-ahead queue to issue #843

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -26,7 +26,7 @@ export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
-  "Read-only issue #726 operator queue for orphan local-ahead sibling worktrees; lists salvage-review evidence only and does not delete, push, fetch, mutate, or generate cleanup commands for orphan branches.";
+  "Read-only issue #843 operator queue for orphan local-ahead sibling worktrees; lists salvage-review evidence only and does not delete, push, fetch, mutate, or generate cleanup commands for orphan branches.";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SCHEMA_VERSION = 1;

--- a/src/ops/orphan-local-worktree-triage.ts
+++ b/src/ops/orphan-local-worktree-triage.ts
@@ -7,8 +7,8 @@ export const ORPHAN_LOCAL_WORKTREE_TRIAGE_SCHEMA_VERSION = 2;
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_COMMAND = "status orphan-worktrees";
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE = "#711";
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL = "https://github.com/minislively/fooks/issues/711";
-export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE = "#726";
-export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE_URL = "https://github.com/minislively/fooks/issues/726";
+export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE = "#843";
+export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE_URL = "https://github.com/minislively/fooks/issues/843";
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY =
   "Read-only issue #711 local sibling worktree salvage/delete decision artifact; does not fetch, delete branches/worktrees, open PRs, auto-delete local-only commits, or change runtime/provider/merge-gate policy.";
 export const DEFAULT_ORPHAN_LOCAL_WORKTREE_TRIAGE_TIMEOUT_MS = 3000;

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -727,7 +727,7 @@ test("operator check projects sibling worktree adoption receipts without cleanup
   assert.equal(localAheadManifestRow?.evidence.aheadOfBase, 2);
   assert.equal(localAheadManifestRow?.evidence.remoteBranchExists, false);
 
-  assert.equal(snapshot.activeWorkReceipts.salvageReviewQueue.issue, "#726");
+  assert.equal(snapshot.activeWorkReceipts.salvageReviewQueue.issue, "#843");
   assert.equal(snapshot.activeWorkReceipts.salvageReviewQueue.readOnly, true);
   assert.equal(snapshot.activeWorkReceipts.salvageReviewQueue.itemCount, 1);
   assert.match(snapshot.activeWorkReceipts.salvageReviewQueue.claimBoundary, /does not delete, push, fetch, mutate/);


### PR DESCRIPTION
## Summary\n- point the read-only orphan local-ahead salvage-review queue receipt at issue #843\n- keep the queue boundary review-only: no fetch, push, delete, mutation, or cleanup command authority\n- update the operator receipt regression expectation\n\n## Verification\n- npm run build\n- node --test test/orphan-local-worktree-triage.test.mjs test/operator-activity.test.mjs\n- git diff --check\n- node dist/cli/index.js check --json\n\nCloses #843