### PR TITLE
Add conflicting label association React Web cards

### DIFF
--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -36,6 +36,7 @@ type ReactWebIssueKind =
   | "react-web.ambiguous-accessible-label"
   | "react-web.empty-accessible-name"
   | "react-web.unassociated-nearby-label"
+  | "react-web.conflicting-label-association"
   | "react-web.duplicate-literal-id"
   | "react-web.missing-htmlFor-target";
 
@@ -61,6 +62,7 @@ export type ReactWebIssueTriage = {
 type ReactWebIssueFixShape =
   | "safe-preview-htmlFor-association"
   | "human-reviewed-label-association"
+  | "human-reviewed-conflicting-label-association"
   | "human-reviewed-htmlFor-target"
   | "human-reviewed-placeholder-replacement"
   | "human-reviewed-button-name"
@@ -344,6 +346,8 @@ function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return `Native ${finding.element} has empty accessible-name evidence.`;
     case "unassociated-nearby-label":
       return `Nearby label text is not explicitly associated with this native ${finding.element}.`;
+    case "conflicting-label-association":
+      return `Multiple native labels target the same native ${finding.element} id.`;
     case "duplicate-literal-id":
       return `Native ${finding.element} has an ambiguous duplicate id association.`;
     case "missing-htmlFor-target":
@@ -361,6 +365,8 @@ function whyItMattersFor(finding: ReactWebLabelPatchPreviewFinding): string {
       return "A blank aria-label creates accessible-name evidence that communicates no useful control name.";
     case "unassociated-nearby-label":
       return "Visible label text may not be programmatically connected to the native form control.";
+    case "conflicting-label-association":
+      return "Multiple same-file native labels for one native control can create ambiguous accessible-name intent, especially when the labels describe different concepts.";
     case "duplicate-literal-id":
       return "Duplicate literal id values can make htmlFor/control associations ambiguous for assistive technology and DOM lookup behavior.";
     case "missing-htmlFor-target":
@@ -378,6 +384,8 @@ function suggestedFixIntentFor(finding: ReactWebLabelPatchPreviewFinding): strin
       return "Replace the empty aria-label with human-reviewed accessible-name evidence.";
     case "unassociated-nearby-label":
       return "Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.";
+    case "conflicting-label-association":
+      return "Inspect the exact native label and control lines, then manually choose whether the labels should be merged, separated, or left unchanged; stop if the source changed or the association is intentional.";
     case "duplicate-literal-id":
       return "Inspect every same-file duplicate id occurrence and choose unique, human-reviewed id/htmlFor associations.";
     case "missing-htmlFor-target":
@@ -404,6 +412,9 @@ function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
   if (finding.kind === "unassociated-nearby-label") {
     return "Nearby label/control evidence is not high-confidence enough for a safe preview, so fooks reports it for manual review and does not auto-apply it.";
   }
+  if (finding.kind === "conflicting-label-association") {
+    return "Conflicting native label associations require source inspection and human intent, so fooks reports the ambiguity and does not auto-apply it.";
+  }
   if (finding.kind === "duplicate-literal-id") {
     return "Duplicate literal id associations require source inspection and coordinated id/htmlFor choices, so fooks reports the ambiguity and does not auto-apply it.";
   }
@@ -416,6 +427,9 @@ function safetyRationaleFor(finding: ReactWebLabelPatchPreviewFinding): string {
 function skipReasonFor(finding: ReactWebLabelPatchPreviewFinding): string {
   if (finding.kind === "unassociated-nearby-label") {
     return "Preview skipped because the nearby label/control association is not high-confidence deterministic evidence.";
+  }
+  if (finding.kind === "conflicting-label-association") {
+    return "Preview skipped because multiple native labels target the same native control id; stop if source inspection shows the association is intentional, already changed, or not a native label/control pair.";
   }
   if (finding.kind === "duplicate-literal-id") {
     return "Preview skipped because duplicate literal id associations must be resolved by inspecting every same-file occurrence first.";
@@ -562,6 +576,7 @@ function fixShapeFor(options: {
     return "human-reviewed-placeholder-replacement";
   }
   if (options.finding.kind === "empty-accessible-name") return "human-reviewed-accessible-name";
+  if (options.finding.kind === "conflicting-label-association") return "human-reviewed-conflicting-label-association";
   if (options.finding.kind === "duplicate-literal-id") return "human-reviewed-duplicate-id-association";
   if (options.finding.kind === "missing-htmlFor-target") return "human-reviewed-htmlFor-target";
   if (options.finding.element === "button") return "human-reviewed-button-name";
@@ -581,6 +596,8 @@ function fixShapeSummaryFor(shape: ReactWebIssueFixShape, element: ReactWebLabel
       return `Inspect the read-only htmlFor/id association preview for this native ${element}; use only after human review.`;
     case "human-reviewed-label-association":
       return `Inspect nearby same-file label/control JSX and choose a human-reviewed association shape for this native ${element}.`;
+    case "human-reviewed-conflicting-label-association":
+      return `Inspect every native label targeting this native ${element} before choosing any label/control association change.`;
     case "human-reviewed-htmlFor-target":
       return "Inspect the native label htmlFor literal and same-file id evidence before choosing any htmlFor/id target fix.";
     case "human-reviewed-placeholder-replacement":
@@ -609,6 +626,10 @@ function fixShapeInspectFirstFor(options: {
   steps.push(`Confirm the current source still matches this native ${options.finding.element} evidence before suggesting changes.`);
   if (options.attributes.length > 0) {
     steps.push(`Use current attribute evidence as hints only: ${options.attributes.slice(0, 6).join(", ")}.`);
+  }
+  if (options.finding.kind === "conflicting-label-association" && options.finding.conflictingLabelAssociation) {
+    steps.push(`Inspect native label lines: ${options.finding.conflictingLabelAssociation.labelLines.join(", ")} targeting id "${options.finding.conflictingLabelAssociation.value}" and native control line ${options.finding.conflictingLabelAssociation.controlLine}.`);
+    steps.push("Stop if the multiple labels are intentional, the source changed, any label/control is not native JSX, or the final accessible-name intent is unclear.");
   }
   if (options.finding.kind === "duplicate-literal-id" && options.finding.duplicateId) {
     steps.push(`Inspect duplicate id lines: ${options.finding.duplicateId.lines.join(", ")} for id "${options.finding.duplicateId.value}" before choosing replacement ids.`);
@@ -675,6 +696,10 @@ function contextPacketRelatedPatternFor(options: {
   if (options.previewAvailable) {
     return `${base}; safe-preview pattern because existing JSX provides deterministic nearby label/control association evidence.`;
   }
+  if (options.finding.kind === "conflicting-label-association") {
+    const lines = options.finding.conflictingLabelAssociation?.labelLines.join(",") ?? "unknown";
+    return `${base}; manual-review conflicting-label-association pattern because native label htmlFor literals on lines ${lines} target the same native control id.`;
+  }
   if (options.finding.kind === "duplicate-literal-id") {
     const lines = options.finding.duplicateId?.lines.join(",") ?? "unknown";
     return `${base}; manual-review duplicate-id pattern because same-file literal id evidence appears on lines ${lines}.`;
@@ -718,6 +743,10 @@ function excludedInferenceFor(options: {
   }
   if (options.finding.kind === "unassociated-nearby-label" && !options.previewAvailable) {
     excluded.push("Does not infer htmlFor/id association when nearby label evidence is not high-confidence deterministic.");
+  }
+  if (options.finding.kind === "conflicting-label-association") {
+    excluded.push("Does not merge, delete, reorder, or rewrite labels for conflicting label association cards.");
+    excluded.push("Does not flag custom label components, dynamic htmlFor/id expressions, missing targets, or duplicate-id cases as conflicting-label associations.");
   }
   if (options.finding.kind === "duplicate-literal-id") {
     excluded.push("Does not choose replacement ids or rewrite htmlFor associations for duplicate id cards.");

--- a/src/core/react-web-label-preview.ts
+++ b/src/core/react-web-label-preview.ts
@@ -13,6 +13,7 @@ type ReactWebLabelFindingKind =
   | "ambiguous-accessible-label"
   | "empty-accessible-name"
   | "unassociated-nearby-label"
+  | "conflicting-label-association"
   | "duplicate-literal-id"
   | "missing-htmlFor-target";
 type ReactWebLabelConfidence = "high" | "medium";
@@ -32,6 +33,11 @@ export type ReactWebLabelPatchPreviewFinding = {
   };
   missingHtmlForTarget?: {
     value: string;
+  };
+  conflictingLabelAssociation?: {
+    value: string;
+    labelLines: number[];
+    controlLine: number;
   };
   suggestedPatch: {
     type: "unified-diff-fragment";
@@ -162,23 +168,24 @@ function isWrappedByLabel(node: ts.Node): boolean {
   return false;
 }
 
-function collectHtmlForIds(sourceFile: ts.SourceFile): Set<string> {
-  const ids = new Set<string>();
+function collectHtmlForReferences(sourceFile: ts.SourceFile): Map<string, SourceRange[]> {
+  const references = new Map<string, SourceRange[]>();
   const visit = (node: ts.Node): void => {
     if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
       if (tagNameOf(node) === "label") {
         for (const property of node.attributes.properties) {
           if (!ts.isJsxAttribute(property) || property.name.getText() !== "htmlFor") continue;
           const value = stringLiteralAttributeValue(node, "htmlFor");
-          if (value) ids.add(value);
+          if (value) references.set(value, [...(references.get(value) ?? []), sourceRangeOf(sourceFile, node)]);
         }
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
-  return ids;
+  return references;
 }
+
 
 function collectMissingHtmlForTargetFindings(options: {
   sourceFile: ts.SourceFile;
@@ -494,7 +501,8 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
 
   const sourceFile = ts.createSourceFile(fullPath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const lines = sourceText.split(/\r?\n/);
-  const labelledIds = collectHtmlForIds(sourceFile);
+  const htmlForReferences = collectHtmlForReferences(sourceFile);
+  const labelledIds = new Set(htmlForReferences.keys());
   const literalIdCounts = countLiteralAttributeValues(sourceFile, "id");
   const literalIdLocations = literalAttributeLocations(sourceFile, "id");
   const literalIds = new Set(literalIdCounts.keys());
@@ -537,6 +545,38 @@ export function buildReactWebLabelPatchPreview(filePath: string, cwd = process.c
               preview: "",
             },
           });
+        } else if (literalId && (literalIdCounts.get(literalId) ?? 0) === 1) {
+          const htmlForReferenceLines = (htmlForReferences.get(literalId) ?? []).map((loc) => loc.startLine);
+          if (htmlForReferenceLines.length > 1) {
+            const loc = sourceRangeOf(sourceFile, node);
+            findings.push({
+              kind: "conflicting-label-association",
+              element,
+              loc,
+              context: lineContext(lines, loc),
+              confidence: "high",
+              reason: `Native ${element} id "${literalId}" is targeted by ${htmlForReferenceLines.length} same-file native label htmlFor literals, so the accessible-name intent is ambiguous and needs inspect-first manual review.`,
+              evidence: [
+                `jsx.${element}`,
+                `jsx.${element}.id=${literalId}`,
+                "jsx.label.htmlFor.multiple",
+                `same-file.native-label.lines=${htmlForReferenceLines.join(",")}`,
+                `same-file.native-control.line=${loc.startLine}`,
+              ],
+              conflictingLabelAssociation: {
+                value: literalId,
+                labelLines: htmlForReferenceLines,
+                controlLine: loc.startLine,
+              },
+              suggestedPatch: {
+                type: "unified-diff-fragment",
+                readOnly: true,
+                attribute: "id/htmlFor",
+                insertion: `manual-review conflicting labels for ${escapeAttribute(literalId)}`,
+                preview: "",
+              },
+            });
+          }
         }
         const labelEvidence = classifyLabelEvidence({ node, tag: element, attrs, labelledIds });
         if (labelEvidence && !labelEvidence.labelled) {

--- a/test/fixtures/react-web-label-preview/conflicting-label-association.tsx
+++ b/test/fixtures/react-web-label-preview/conflicting-label-association.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Label as FieldLabel } from "./Label";
+
+export function ConflictingLabelAssociation() {
+  const dynamicTarget = "runtime-email";
+  return (
+    <form>
+      <label htmlFor="email">Email</label>
+      <label htmlFor="email">Work inbox</label>
+      <input id="email" name="email" />
+
+      <label htmlFor="phone">Phone</label>
+      <input id="phone" name="phone" />
+
+      <FieldLabel htmlFor="custom-field">Custom wrapper label</FieldLabel>
+      <label htmlFor={dynamicTarget}>Dynamic target</label>
+      <label htmlFor="missing-field">Missing field</label>
+      <input id="duplicate" name="primaryDuplicate" />
+      <input id="duplicate" name="secondaryDuplicate" />
+      <label htmlFor="duplicate">Duplicate id label</label>
+      <input aria-label="" name="emptyName" />
+      <button type="button" aria-label="Open menu" />
+    </form>
+  );
+}

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -46,6 +46,7 @@ const fixtures = {
   quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
   duplicateIds: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx"),
   missingHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx"),
+  conflictingLabelAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "conflicting-label-association.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -380,6 +381,46 @@ test("React Web issue report emits manual-review cards for duplicate literal nat
   assert.equal(first.decision.autoApply, false);
   assert.equal(first.decision.humanReviewRequired, true);
   assert.doesNotMatch(JSON.stringify(report), /Auto-apply: yes|must-edit/i);
+});
+
+
+test("React Web issue report emits inspect-first manual-review cards for conflicting native label associations", () => {
+  const report = parseIssues(fixtures.conflictingLabelAssociation);
+
+  assert.equal(report.inScope, true);
+  const issue = report.issues.find((item) => item.kind === "react-web.conflicting-label-association");
+  assert.ok(issue);
+  assert.equal(issue.whereToLook.filePath, "test/fixtures/react-web-label-preview/conflicting-label-association.tsx");
+  assert.equal(issue.whereToLook.line, 10);
+  assert.equal(issue.evidence.element, "input");
+  assert.equal(issue.confidence, "high");
+  assert.equal(issue.fixability, "manual-review");
+  assert.equal(issue.autoFixSafety, "unsafe-to-auto-apply");
+  assert.equal(issue.preview, undefined);
+  assert.match(issue.problem, /Multiple native labels target the same native input id/);
+  assert.match(issue.whyItMatters, /ambiguous accessible-name intent/);
+  assert.match(issue.suggestedAction, /exact native label and control lines/);
+  assert.match(issue.skipReason, /multiple native labels target the same native control id/);
+  assert.deepEqual(issue.fixShapeGuidance.shape, "human-reviewed-conflicting-label-association");
+  assert.ok(issue.fixShapeGuidance.inspectFirst.some((entry) => /native label lines: 8, 9 targeting id "email" and native control line 10/.test(entry)));
+  assert.ok(issue.fixShapeGuidance.inspectFirst.some((entry) => /Stop if the multiple labels are intentional/.test(entry)));
+  assert.match(issue.contextPacket.relatedPattern, /native label htmlFor literals on lines 8,9 target the same native control id/);
+  assert.ok(issue.contextPacket.excludedInference.some((entry) => /Does not merge, delete, reorder, or rewrite labels/.test(entry)));
+  assert.ok(issue.contextPacket.excludedInference.some((entry) => /custom label components, dynamic htmlFor\/id expressions, missing targets, or duplicate-id cases/.test(entry)));
+  assert.deepEqual(issue.evidence.sourceSignals, [
+    "jsx.input",
+    "jsx.input.id=email",
+    "jsx.label.htmlFor.multiple",
+    "same-file.native-label.lines=8,9",
+    "same-file.native-control.line=10",
+  ]);
+  assert.equal(issue.decision.allowedActions.inspect, true);
+  assert.equal(issue.decision.allowedActions.applyPatch, false);
+  assert.equal(issue.decision.autoApply, false);
+  assert.equal(issue.decision.humanReviewRequired, true);
+  const conflicts = report.issues.filter((item) => item.kind === "react-web.conflicting-label-association");
+  assert.equal(conflicts.length, 1);
+  assert.doesNotMatch(JSON.stringify(conflicts.map((item) => item.evidence.sourceSignals)), /custom-field|runtime-email|missing-field|duplicate/);
 });
 
 test("React Web issue report emits manual-review cards for native label htmlFor literals without same-file targets", () => {

--- a/test/react-web-label-preview.test.mjs
+++ b/test/react-web-label-preview.test.mjs
@@ -16,6 +16,7 @@ const emptyAriaLabelFixture = path.join(repoRoot, "test", "fixtures", "react-web
 const quietNativeEvidenceFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx");
 const duplicateIdControlsFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx");
 const missingHtmlForTargetFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx");
+const conflictingLabelAssociationFixture = path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "conflicting-label-association.tsx");
 
 function runPreview(file, ...args) {
   return spawnSync(process.execPath, [cliPath, "inspect", "react-web-label-preview", file, ...args], {
@@ -98,6 +99,40 @@ test("React Web label preview reports duplicate literal ids on htmlFor-associate
   assert.deepEqual(preview.findings.map((finding) => finding.duplicateId.lines), [[7, 9], [7, 9]]);
   assert.ok(preview.findings.every((finding) => finding.reason.includes("referenced by htmlFor")));
   assert.doesNotMatch(JSON.stringify(preview), /phone.*duplicate-literal-id/);
+});
+
+
+test("React Web label preview reports multiple native labels targeting one native control id", () => {
+  const cli = runPreview(conflictingLabelAssociationFixture, "--json");
+  assert.equal(cli.status, 0, cli.stderr);
+  const preview = JSON.parse(cli.stdout);
+
+  assert.equal(preview.inScope, true);
+  const conflicts = preview.findings.filter((finding) => finding.kind === "conflicting-label-association");
+  assert.equal(conflicts.length, 1);
+  const conflict = conflicts[0];
+  assert.deepEqual([conflict.kind, conflict.element, conflict.loc.startLine, conflict.confidence, conflict.suggestedPatch.attribute], [
+    "conflicting-label-association",
+    "input",
+    10,
+    "high",
+    "id/htmlFor",
+  ]);
+  assert.deepEqual(conflict.conflictingLabelAssociation, { value: "email", labelLines: [8, 9], controlLine: 10 });
+  assert.match(conflict.reason, /targeted by 2 same-file native label htmlFor literals/);
+  assert.deepEqual(conflict.evidence, [
+    "jsx.input",
+    "jsx.input.id=email",
+    "jsx.label.htmlFor.multiple",
+    "same-file.native-label.lines=8,9",
+    "same-file.native-control.line=10",
+  ]);
+  assert.equal(conflict.suggestedPatch.readOnly, true);
+  assert.equal(conflict.suggestedPatch.preview, "");
+  assert.doesNotMatch(JSON.stringify(conflicts), /custom-field|runtime-email|missing-field|duplicate/);
+  assert.equal(preview.findings.filter((finding) => finding.kind === "missing-htmlFor-target").length, 1);
+  assert.equal(preview.findings.filter((finding) => finding.kind === "duplicate-literal-id").length, 2);
+  assert.equal(preview.findings.filter((finding) => finding.kind === "empty-accessible-name").length, 1);
 });
 
 test("React Web label preview reports native label htmlFor literals with missing same-file id targets", () => {


### PR DESCRIPTION
## Summary
- add a narrow React Web native JSX detector for multiple literal native labels targeting the same unique native control id
- emit read-only manual-review issue cards with exact label/control line evidence and stop conditions
- add focused fixture coverage for custom labels, dynamic htmlFor, missing targets, duplicate ids, empty aria-labels, and quiet controls

Closes #842.

## Verification
- npm run typecheck -- --pretty false
- npm run build
- node --test test/react-web-label-preview.test.mjs test/react-web-issue-report.test.mjs
- git diff --check --cached
- ai-slop-cleaner changed-files pass
- code-review APPROVE; architect CLEAR