### PR TITLE
Refresh React Web issue-card demo goldens

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ fooks doctor
 fooks inspect react-web-issues src/components/Form.tsx
 ```
 
-The issue-card output is read-only and actionable: each card explains `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`. High-confidence native label/control findings can include safe preview shape hints, but fooks does **not** auto-apply patches, invent final accessible-name copy, infer custom-component semantics, or claim a broad accessibility audit. Ambiguous cases stay as manual-review cards with stop reasons.
+The issue-card output is read-only and actionable: each card explains `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`. Current React Web cards can cover missing native label/name evidence, empty `aria-label` evidence, same-file missing `htmlFor` targets, and high-confidence nearby label/control association previews. High-confidence native label/control findings can include safe preview shape hints, but fooks does **not** auto-apply patches, invent final accessible-name copy, infer custom-component semantics, or claim a broad accessibility audit. Ambiguous cases stay as manual-review cards with stop reasons.
 
-Want to see the product loop before installing it into a real repo? Start with the packaged golden demo: [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md). For the detailed first-minute handoff contract, including `--summary-json` and `--dry-run-json`, see [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md).
+Want to see the product loop before installing it into a real repo? Start with the packaged golden demo: [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md). It is split into short representative examples rather than one kitchen-sink fixture. Duplicate-id or conflicting-label-looking evidence is not marketed as a standalone emitted card unless source/tests prove that behavior. For the detailed first-minute handoff contract, including `--summary-json` and `--dry-run-json`, see [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md).
 
 Context reduction and caching are supporting mechanisms. In the strongest current Codex path, repeated work on the same React `.tsx` / `.jsx` file may reuse compact same-file context when the evidence gate says that is safe. `fooks compare` shows local source-vs-payload evidence for one supported file, but the launch-facing habit is simpler: **inspect first, then reuse context only when safe**.
 
@@ -39,7 +39,7 @@ Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibi
 
 Use fooks when you want Codex to start React Web work with a compact, source-grounded issue card instead of rediscovering frontend facts from scratch.
 
-1. **Inspect first:** `fooks inspect react-web-issues <file>` ranks narrow native JSX label/control risks and tells the agent where to look before editing.
+1. **Inspect first:** `fooks inspect react-web-issues <file>` ranks narrow native JSX label/control risks—missing names, empty `aria-label`, missing same-file `htmlFor` targets, and safe-preview association candidates—and tells the agent where to look before editing.
 2. **Handoff safely:** `--summary-json` gives agents `firstMinuteSummary.items[0]`, `decision`, `humanDecisionNeeded`, and `doNotDo` boundaries as advisory inspect-first input rather than edit authority.
 3. **Preview only when safe:** `--dry-run-json` lists migration candidates and preview availability, but remains dry-run-only with `autoApply: false` and human review for final label/name choices.
 4. **Reuse when safe:** repeated same-file Codex work may reuse compact context after evidence gates pass; `fooks compare` is supporting local payload proof, not the headline.

--- a/docs/demo/react-web-issues.md
+++ b/docs/demo/react-web-issues.md
@@ -5,12 +5,14 @@ This packaged demo is the short product-facing version of the detailed first-min
 Use it to understand the first fooks habit:
 
 ```bash
-fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
+fooks inspect react-web-issues <supported-react-web-file>
 ```
 
-## Before source
+The examples below are intentionally split into short golden slices instead of one kitchen-sink fixture. They show the current emitted card families that are safe to present in README-facing docs: missing native label/name evidence, empty `aria-label` evidence, same-file missing `htmlFor` targets, and high-confidence read-only `htmlFor` association previews. Each full card still carries the stable human/agent fields `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`; the snippets show only the shortest representative lines.
 
-The demo source below is an excerpt from `fixtures/compressed/FormControls.tsx` around the native controls that trigger the issue cards. The full fixture also includes imports, form setup, a `Controller`, a registered input, and a submit button; the excerpt keeps the first-minute risk visible without pretending to be a separate fixture. The native controls have source facts that fooks can inspect, but the final accessible label/name copy still requires human judgment.
+## Demo 1: missing native label/name evidence
+
+Baseline source excerpt from `fixtures/compressed/FormControls.tsx`:
 
 ```tsx
 export function FormControls() {
@@ -27,51 +29,124 @@ export function FormControls() {
 }
 ```
 
-## Command
-
 ```bash
 fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
 ```
 
-Representative text output starts with the product boundary before any fix guidance:
+Representative output:
 
 ```text
-# React Web issue report
-
-Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics.
-
-File: fixtures/compressed/FormControls.tsx
-Read-only: yes
-Auto-apply: no
-In scope: yes
 Issues: 5 (safe preview: 0, manual review: 5, unsafe to auto-apply: 5)
-```
+Source issues: label-preview 5, htmlFor target-resolution 0
 
-## Issue card shape
-
-A card tells the agent what risk exists and where to inspect first. The field names are stable enough for humans and agents to recognize; the exact ranking can change with source evidence.
-
-```text
 ## Issue 1: Native input lacks recognized accessible-label evidence.
-- why: Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.
+- first inspect: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.
+- next action: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.
+- human decision needed: Confirm the final accessible label/name copy from current source context.
+- do not do: Do not apply patches automatically from this report.; Do not generate final label/name copy automatically.
 - where to look: fixtures/compressed/FormControls.tsx:23-23
-- element: input
 - confidence: high
 - fixability: manual-review
 - auto-fix safety: unsafe-to-auto-apply
 - suggested action: Add an explicit accessible label with human-reviewed copy for the native control.
 ```
 
-JSON consumers should preserve the same issue-card meaning:
+## Demo 2: empty `aria-label` evidence
 
-```json
-{
-  "problem": "Native input lacks recognized accessible-label evidence.",
-  "whyItMatters": "Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.",
-  "whereToLook": "fixtures/compressed/FormControls.tsx:23-23",
-  "confidence": "high",
-  "suggestedAction": "Add an explicit accessible label with human-reviewed copy for the native control."
+Empty accessible-name evidence is a different manual-review card from a missing label. The source already has accessible-name evidence, but the value is blank or whitespace-only.
+
+```tsx
+function EmptyAriaLabels() {
+  return (
+    <form>
+      <input aria-label="" name="email" type="email" />
+      <button aria-label=" ">Save</button>
+      <textarea aria-label="" name="notes" />
+    </form>
+  );
 }
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/empty-aria-labels.tsx
+```
+
+Representative output:
+
+```text
+Issues: 3 (safe preview: 0, manual review: 3, unsafe to auto-apply: 3)
+Source issues: label-preview 3, htmlFor target-resolution 0
+
+## Issue 1: Native input has empty accessible-name evidence.
+- why: A blank aria-label creates accessible-name evidence that communicates no useful control name.
+- where to look: test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4
+- fix shape: human-reviewed-accessible-name — Choose a human-reviewed accessible-name shape for this native input from local JSX context.
+- suggested action: Replace the empty aria-label with human-reviewed accessible-name evidence.
+```
+
+## Demo 3: `htmlFor` wiring cards
+
+`htmlFor` support has two distinct current shapes: missing target-resolution cards are manual-review, while high-confidence nearby native label/control associations can include a read-only preview.
+
+### Missing `htmlFor` target
+
+```tsx
+function MissingHtmlForTarget() {
+  return (
+    <form>
+      <label htmlFor="missing-email">Email address</label>
+      <input id="email" name="email" />
+    </form>
+  );
+}
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx
+```
+
+Representative output:
+
+```text
+Issues: 1 (safe preview: 0, manual review: 1, unsafe to auto-apply: 1)
+Source issues: label-preview 0, htmlFor target-resolution 1
+
+## Issue 1: Native label references htmlFor="missing-email" but no same-file literal id target was found.
+- issue id: react-web-htmlfor-target-1
+- where to look: test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6
+- source: htmlFor-target-resolution — Same-file literal target-resolution found a label htmlFor value without exactly one matching literal id.
+- fix shape: human-reviewed-htmlFor-target-resolution — Inspect the literal htmlFor target and choose a human-reviewed target-resolution shape; do not create ids automatically.
+- suggested action: Inspect label htmlFor="missing-email" and decide whether to correct the target id, add a matching native-control id, or remove stale label wiring.
+```
+
+### Safe-preview nearby association
+
+```tsx
+function LabelAssociationCandidates() {
+  return (
+    <form>
+      <label>Email</label>
+      <input id="email" name="email" />
+    </form>
+  );
+}
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/label-association-candidates.tsx
+```
+
+Representative output:
+
+```text
+Issues: 3 (safe preview: 1, manual review: 2, unsafe to auto-apply: 2)
+Source issues: label-preview 3, htmlFor target-resolution 0
+
+## Issue 1: Nearby label text is not explicitly associated with this native input.
+- fixability: safe-preview
+- auto-fix safety: not-auto-applied
+- fix shape: safe-preview-htmlFor-association — Inspect the read-only htmlFor/id association preview for this native input; use only after human review.
+- suggested action: Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.
 ```
 
 ## First-minute handoff (`--summary-json`)
@@ -79,7 +154,7 @@ JSON consumers should preserve the same issue-card meaning:
 Agents that only need the compact work order should read the first summary item, then inspect the current source before suggesting anything.
 
 ```bash
-fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --summary-json
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/empty-aria-labels.tsx --summary-json
 ```
 
 Representative first item:
@@ -87,10 +162,9 @@ Representative first item:
 ```json
 {
   "issueId": "react-web-label-1",
-  "fixShape": "human-reviewed-native-control-name",
-  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
-  "whyThisFirst": "Rank 1 high issue because label-preview confidence is high; high-confidence-manual-review remains human-reviewed.",
-  "nextAction": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.",
+  "fixShape": "human-reviewed-accessible-name",
+  "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+  "nextAction": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.",
   "humanDecisionNeeded": [
     "Confirm the final accessible label/name copy from current source context.",
     "Choose the label/name shape from local JSX evidence."
@@ -114,9 +188,9 @@ Representative first item:
 
 Agent handoff:
 
-1. Inspect `fixtures/compressed/FormControls.tsx:23` first.
+1. Inspect `firstInspectStep` first.
 2. Confirm the current source still matches the issue evidence.
-3. Look for existing visible label, nearby native label/control structure, or source-observed naming hints.
+3. Look for existing visible label, nearby native label/control structure, same-file `htmlFor`/`id` evidence, or source-observed naming hints.
 4. Do **not** generate final label copy automatically.
 5. If the target is a custom component or the source no longer matches, stop and read the file normally.
 
@@ -125,7 +199,7 @@ Agent handoff:
 Migration planners can request candidate rows, but the projection is still dry-run-only.
 
 ```bash
-fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --dry-run-json
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/label-association-candidates.tsx --dry-run-json
 ```
 
 Representative candidate:
@@ -133,23 +207,17 @@ Representative candidate:
 ```json
 {
   "issueId": "react-web-label-1",
-  "migrationCandidate": "human-reviewed-native-control-name",
-  "affectedFile": "fixtures/compressed/FormControls.tsx",
-  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
-  "previewAvailable": false,
+  "migrationCandidate": "safe-preview-htmlFor-association",
+  "affectedFile": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+  "previewAvailable": true,
   "humanReviewRequired": true,
   "autoApply": false,
-  "dryRunOnly": true,
-  "riskNotes": [
-    "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
-    "No deterministic safe preview is available; choose the final label/name shape from local source context.",
-    "Do not apply patches automatically or generate accessible-name copy from this dry run.",
-    "Do not infer custom-component semantics."
-  ]
+  "dryRunOnly": true
 }
 ```
 
-If a future or different source file produces `previewAvailable: true`, treat the preview as a read-only review aid, not permission to edit. `autoApply` remains false unless a separate human/tool workflow explicitly decides to make a source change after reading the current file.
+If a source file produces `previewAvailable: true`, treat the preview as a read-only review aid, not permission to edit. `autoApply` remains false unless a separate human/tool workflow explicitly decides to make a source change after reading the current file.
 
 ## Boundary note
 
@@ -160,5 +228,6 @@ This demo proves the first-minute React Web issue-card loop, not a broader produ
 - No generated accessible-name copy: final label/name text stays human-reviewed.
 - No broad accessibility audit: this is a narrow native JSX label/control subset, not a complete WCAG or design-system audit.
 - No custom-component semantic inference: ambiguous/custom cases fall back to manual review or normal source reading.
+- No duplicate-id/conflicting-label emitted-card claim: current duplicate-id or conflicting-label-looking evidence is treated as unsafe/boundary evidence unless source/tests prove a standalone emitted issue card.
 - No RN/WebView/TUI expansion: those lanes remain boundary/roadmap topics, not supported by this React Web demo.
 - No billing proof: benchmark/cost evidence elsewhere in the docs is estimate-scoped and does not prove provider invoices, provider billing tokens, or stable runtime-token savings.

--- a/src/core/react-web-issue-related-context.ts
+++ b/src/core/react-web-issue-related-context.ts
@@ -12,6 +12,7 @@ export type ReactWebRelatedContextConfidence = "high" | "medium" | "low";
 
 export type ReactWebRelatedContextSource =
   | "label-preview"
+  | "htmlFor-target-resolution"
   | "local-import"
   | "same-directory"
   | "nearby-test";

--- a/src/core/react-web-issue-report.ts
+++ b/src/core/react-web-issue-report.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
 import {
   buildReactWebLabelPatchPreview,
   REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY,
@@ -23,9 +27,12 @@ import {
 export const REACT_WEB_ISSUE_REPORT_SCHEMA_VERSION = "react-web-issue-report.v1" as const;
 export const REACT_WEB_ISSUE_REPORT_COMMAND = "inspect react-web-issues" as const;
 export const REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY =
-  "Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics." as const;
+  "Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings and same-file literal htmlFor target-resolution signals into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics." as const;
 
 type ReactWebIssueConfidence = "high" | "medium";
+type ReactWebIssueSourceKind = "label-preview" | "htmlFor-target-resolution";
+type ReactWebIssueElement = ReactWebLabelPatchPreviewFinding["element"] | "label";
+export type ReactWebIssueSourceCounts = Record<ReactWebIssueSourceKind, number> & { total: number };
 type ReactWebIssueFixability = "safe-preview" | "manual-review";
 type ReactWebIssueAutoFixSafety = "not-auto-applied" | "unsafe-to-auto-apply";
 export type ReactWebIssuePriority = "high" | "medium" | "low";
@@ -35,12 +42,13 @@ type ReactWebIssueKind =
   | "react-web.missing-accessible-label"
   | "react-web.ambiguous-accessible-label"
   | "react-web.empty-accessible-name"
-  | "react-web.unassociated-nearby-label";
+  | "react-web.unassociated-nearby-label"
+  | "react-web.missing-htmlfor-target";
 
 export type ReactWebIssueTriageEvidence = {
   safePreviewAvailable: boolean;
   confidence: ReactWebIssueConfidence;
-  nativeElement: ReactWebLabelPatchPreviewFinding["element"];
+  nativeElement: ReactWebIssueElement;
   sameFileContextAvailable: boolean;
   relatedContextCount: number;
   relatedContextSources: ReactWebIssueRelatedContext["source"][];
@@ -62,7 +70,8 @@ type ReactWebIssueFixShape =
   | "human-reviewed-placeholder-replacement"
   | "human-reviewed-button-name"
   | "human-reviewed-native-control-name"
-  | "human-reviewed-accessible-name";
+  | "human-reviewed-accessible-name"
+  | "human-reviewed-htmlFor-target-resolution";
 
 export type ReactWebIssueFixShapeGuidance = {
   claimBoundary: string;
@@ -70,7 +79,7 @@ export type ReactWebIssueFixShapeGuidance = {
   summary: string;
   inspectFirst: string[];
   localEvidence: {
-    element: ReactWebLabelPatchPreviewFinding["element"];
+    element: ReactWebIssueElement;
     attributes: string[];
     sameFileContextAvailable: boolean;
     safePreviewAvailable: boolean;
@@ -101,7 +110,12 @@ export type ReactWebIssueCard = {
     endLine: number;
     context: string;
     sourceSignals: string[];
-    element: ReactWebLabelPatchPreviewFinding["element"];
+    element: ReactWebIssueElement;
+  };
+  source: {
+    kind: ReactWebIssueSourceKind;
+    summary: string;
+    evidence: string[];
   };
   whereToLook: {
     filePath: string;
@@ -165,6 +179,7 @@ export type ReactWebIssueReport = {
     claimBoundary: typeof REACT_WEB_LABEL_PATCH_PREVIEW_CLAIM_BOUNDARY;
     findingCount: number;
   };
+  sourceIssueCounts: ReactWebIssueSourceCounts;
   inScope: boolean;
   skippedReason?: string;
   summary: {
@@ -202,6 +217,7 @@ export type ReactWebIssueReportSummaryJson = {
   claimBoundary: typeof REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY;
   inScope: boolean;
   skippedReason?: string;
+  sourceIssueCounts: ReactWebIssueSourceCounts;
   summary: ReactWebIssueReport["summary"];
   triageTopIds: {
     rankedIssueIds: string[];
@@ -228,6 +244,7 @@ export type ReactWebIssueReportMigrationDryRunJson = {
   claimBoundary: typeof REACT_WEB_ISSUE_REPORT_CLAIM_BOUNDARY;
   inScope: boolean;
   skippedReason?: string;
+  sourceIssueCounts: ReactWebIssueSourceCounts;
   summary: {
     candidateCount: number;
     affectedFiles: string[];
@@ -330,6 +347,125 @@ function issueKindFor(finding: ReactWebLabelPatchPreviewFinding): ReactWebIssueK
   return `react-web.${finding.kind}` as ReactWebIssueKind;
 }
 
+type ReactWebMissingHtmlForTargetSignal = {
+  targetId: string;
+  loc: {
+    startLine: number;
+    endLine: number;
+  };
+  context: string;
+  confidence: ReactWebIssueConfidence;
+  evidence: string[];
+};
+
+function absolutePathFor(filePath: string, cwd: string): string {
+  return path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+}
+
+function compactSourceLine(value: string, max = 180): string {
+  const compacted = value.replace(/\s+/g, " ").trim();
+  return compacted.length > max ? `${compacted.slice(0, Math.max(0, max - 1)).trimEnd()}…` : compacted;
+}
+
+function jsxTagNameText(tagName: ts.JsxTagNameExpression): string | undefined {
+  if (ts.isIdentifier(tagName)) return tagName.text;
+  if (ts.isJsxNamespacedName(tagName)) return `${tagName.namespace.text}:${tagName.name.text}`;
+  return undefined;
+}
+
+function stringLiteralAttributeValue(attributes: ts.JsxAttributes, name: string): string | undefined {
+  const property = attributes.properties.find((item): item is ts.JsxAttribute =>
+    ts.isJsxAttribute(item) && ts.isIdentifier(item.name) && item.name.text === name
+  );
+  if (!property?.initializer || !ts.isStringLiteral(property.initializer)) return undefined;
+  const value = property.initializer.text.trim();
+  return value || undefined;
+}
+
+function hasDynamicIdAttribute(attributes: ts.JsxAttributes): boolean {
+  return attributes.properties.some((item) =>
+    ts.isJsxAttribute(item) &&
+    ts.isIdentifier(item.name) &&
+    item.name.text === "id" &&
+    item.initializer !== undefined &&
+    !ts.isStringLiteral(item.initializer)
+  );
+}
+
+function findMissingHtmlForTargetSignals(filePath: string, cwd: string): ReactWebMissingHtmlForTargetSignal[] {
+  const absolutePath = absolutePathFor(filePath, cwd);
+  let source = "";
+  try {
+    source = fs.readFileSync(absolutePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  const sourceFile = ts.createSourceFile(absolutePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const lines = source.split(/\r?\n/);
+  const idCounts = new Map<string, number>();
+  let hasDynamicId = false;
+
+  function collectIds(node: ts.Node): void {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const literalId = stringLiteralAttributeValue(node.attributes, "id");
+      if (literalId) idCounts.set(literalId, (idCounts.get(literalId) ?? 0) + 1);
+      if (hasDynamicIdAttribute(node.attributes)) hasDynamicId = true;
+    }
+    ts.forEachChild(node, collectIds);
+  }
+  collectIds(sourceFile);
+
+  if (hasDynamicId) return [];
+
+  const signals: ReactWebMissingHtmlForTargetSignal[] = [];
+  function visitLabels(node: ts.Node): void {
+    if (ts.isJsxOpeningElement(node) && jsxTagNameText(node.tagName) === "label") {
+      const targetId = stringLiteralAttributeValue(node.attributes, "htmlFor");
+      if (targetId && (idCounts.get(targetId) ?? 0) === 0) {
+        const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        const end = sourceFile.getLineAndCharacterOfPosition(node.end);
+        const context = compactSourceLine(lines[start.line] ?? node.getText(sourceFile));
+        signals.push({
+          targetId,
+          loc: {
+            startLine: start.line + 1,
+            endLine: end.line + 1,
+          },
+          context,
+          confidence: "medium",
+          evidence: [
+            "jsx.label.htmlFor.literal",
+            "jsx.id.same-file-target.missing",
+            "dynamic-id-attributes.absent",
+          ],
+        });
+      }
+    }
+    ts.forEachChild(node, visitLabels);
+  }
+  visitLabels(sourceFile);
+
+  return signals;
+}
+
+function relatedContextForMissingHtmlForTarget(
+  filePath: string,
+  signal: ReactWebMissingHtmlForTargetSignal,
+): ReactWebIssueRelatedContext[] {
+  return [{
+    kind: "same-file-pattern",
+    file: filePath,
+    reason: `Inspect the same-file literal label htmlFor="${signal.targetId}" because no matching literal id target was found in this file.`,
+    confidence: signal.confidence,
+    source: "htmlFor-target-resolution",
+    action: "inspect-first",
+    line: signal.loc.startLine,
+    endLine: signal.loc.endLine,
+    context: signal.context,
+  }];
+}
+
 function problemFor(finding: ReactWebLabelPatchPreviewFinding): string {
   switch (finding.kind) {
     case "missing-accessible-label":
@@ -409,17 +545,18 @@ function relatedContextQualityFor(relatedContext: ReactWebIssueRelatedContext[])
   if (sources.has("local-import") || sources.has("nearby-test")) {
     return "local-supporting-context";
   }
-  if (sources.has("label-preview")) return "same-file-only";
+  if (sources.has("label-preview") || sources.has("htmlFor-target-resolution")) return "same-file-only";
   return "thin-local-context";
 }
 
-function nativeElementWeight(element: ReactWebLabelPatchPreviewFinding["element"]): number {
+function nativeElementWeight(element: ReactWebIssueElement): number {
   switch (element) {
     case "input":
     case "select":
     case "textarea":
       return 2;
     case "button":
+    case "label":
       return 1;
   }
 }
@@ -438,7 +575,9 @@ function priorityFor(score: number): ReactWebIssuePriority {
 function triageEvidenceFor(issue: Omit<ReactWebIssueCard, "triage">): ReactWebIssueTriageEvidence {
   const safePreviewAvailable = issue.fixability === "safe-preview" && Boolean(issue.preview);
   const sameFileContextAvailable = issue.relatedContext.some(
-    (item) => item.kind === "same-file-pattern" && item.source === "label-preview",
+    (item) =>
+      item.kind === "same-file-pattern" &&
+      (item.source === "label-preview" || item.source === "htmlFor-target-resolution"),
   );
   const relatedContextSources = uniqueRelatedContextSources(issue.relatedContext);
   const relatedContextQuality = relatedContextQualityFor(issue.relatedContext);
@@ -451,10 +590,10 @@ function triageEvidenceFor(issue: Omit<ReactWebIssueCard, "triage">): ReactWebIs
   }
   if (issue.confidence === "high") {
     score += 3;
-    reasons.push("label-preview confidence is high");
+    reasons.push(`${issue.source.kind} confidence is high`);
   } else {
     score += 1;
-    reasons.push("label-preview confidence is medium");
+    reasons.push(`${issue.source.kind} confidence is medium`);
   }
 
   const elementWeight = nativeElementWeight(issue.evidence.element);
@@ -558,6 +697,8 @@ function fixShapeSummaryFor(shape: ReactWebIssueFixShape, element: ReactWebLabel
       return `Use local native ${element} attributes as hints for a human-reviewed accessible-name shape; do not generate copy automatically.`;
     case "human-reviewed-accessible-name":
       return `Choose a human-reviewed accessible-name shape for this native ${element} from local JSX context.`;
+    case "human-reviewed-htmlFor-target-resolution":
+      return "Inspect the literal htmlFor target and choose a human-reviewed target-resolution shape; do not create ids automatically.";
   }
 }
 
@@ -740,6 +881,11 @@ function issueCardFor(
       sourceSignals: finding.evidence,
       element: finding.element,
     },
+    source: {
+      kind: "label-preview" as const,
+      summary: "Label-preview patch-preview detector produced this issue card from native JSX evidence.",
+      evidence: finding.evidence,
+    },
     whereToLook: {
       filePath,
       line: finding.loc.startLine,
@@ -786,6 +932,112 @@ function issueCardFor(
   };
 }
 
+function issueCardForMissingHtmlForTarget(
+  filePath: string,
+  signal: ReactWebMissingHtmlForTargetSignal,
+  index: number,
+): ReactWebIssueCard {
+  const relatedContext = relatedContextForMissingHtmlForTarget(filePath, signal);
+  const cardId = `react-web-htmlfor-target-${index + 1}`;
+  const skipReason =
+    "Preview skipped because same-file literal htmlFor target resolution needs manual review and may involve renamed, generated, or cross-file ids.";
+  const suggestedAction =
+    `Inspect label htmlFor="${signal.targetId}" and decide whether to correct the target id, add a matching native-control id, or remove stale label wiring.`;
+  const fixShapeGuidance: ReactWebIssueFixShapeGuidance = {
+    claimBoundary:
+      "Local htmlFor target-resolution guidance only: uses same-file literal label htmlFor/id evidence; it is read-only, requires human review, and does not create ids, generate copy, or infer custom-component semantics.",
+    shape: "human-reviewed-htmlFor-target-resolution",
+    summary:
+      "Inspect the literal htmlFor target and choose a human-reviewed target-resolution shape; do not create ids automatically.",
+    inspectFirst: [
+      `Inspect ${filePath}:${signal.loc.startLine}-${signal.loc.endLine} (label) before editing.`,
+      `Confirm whether htmlFor="${signal.targetId}" should point to an existing native control, a renamed id, or stale wiring.`,
+      "Search current same-file JSX for the intended target before suggesting id changes.",
+      "If target creation depends on generated, dynamic, cross-file, or custom-component semantics, stop and read the source normally.",
+    ],
+    localEvidence: {
+      element: "label",
+      attributes: [`htmlFor=${signal.targetId}`],
+      sameFileContextAvailable: true,
+      safePreviewAvailable: false,
+      relatedContextCount: relatedContext.length,
+      relatedContextSources: uniqueRelatedContextSources(relatedContext),
+    },
+    humanReviewRequired: true,
+    autoApply: false,
+  };
+  const issueWithoutTriage = {
+    id: cardId,
+    kind: "react-web.missing-htmlfor-target" as const,
+    problem: `Native label references htmlFor="${signal.targetId}" but no same-file literal id target was found.`,
+    whyItMatters:
+      "Visible label text may not be programmatically connected to its intended native control when htmlFor points at a missing id.",
+    evidence: {
+      filePath,
+      line: signal.loc.startLine,
+      endLine: signal.loc.endLine,
+      context: signal.context,
+      sourceSignals: signal.evidence,
+      element: "label" as const,
+    },
+    source: {
+      kind: "htmlFor-target-resolution" as const,
+      summary: "Same-file literal target-resolution found a label htmlFor value without exactly one matching literal id.",
+      evidence: signal.evidence,
+    },
+    whereToLook: {
+      filePath,
+      line: signal.loc.startLine,
+      endLine: signal.loc.endLine,
+      context: signal.context,
+    },
+    relatedContext,
+    confidence: signal.confidence,
+    fixability: "manual-review" as const,
+    autoFixSafety: "unsafe-to-auto-apply" as const,
+    safetyRationale:
+      "Correct target resolution may require renaming ids, creating missing ids, or understanding dynamic/cross-file behavior, so fooks reports it for manual review and does not auto-apply it.",
+    suggestedFixIntent: suggestedAction,
+    suggestedAction,
+    contextPacket: {
+      whyThisFile: `Same-file literal htmlFor target-resolution evidence in ${filePath}:${signal.loc.startLine}-${signal.loc.endLine} produced this native label issue card.`,
+      relatedPattern:
+        "react-web.missing-htmlfor-target on a native label; manual-review target-resolution pattern because no deterministic safe preview is available.",
+      nearbyPrecedent: contextPacketNearbyPrecedentFor(relatedContext),
+      confidence: signal.confidence,
+      excludedInference: [
+        "Does not infer custom-component semantics.",
+        "Does not claim broad accessibility coverage beyond the native JSX label subset.",
+        "Does not auto-apply patches or make files editable from this report.",
+        "Does not infer generated, dynamic, or cross-file id targets.",
+        "Does not create missing ids or rename existing ids automatically.",
+      ],
+      conventionHints: [],
+    },
+    conventionHints: [],
+    fixShapeGuidance,
+    decision: buildReactWebIssueDecision({
+      cardId,
+      issueKind: "react-web.missing-htmlfor-target",
+      confidence: signal.confidence,
+      fixability: "manual-review",
+      previewAvailable: false,
+      skipReason,
+    }),
+    skipReason,
+  };
+  const evidence = triageEvidenceFor(issueWithoutTriage);
+  return {
+    ...issueWithoutTriage,
+    triage: {
+      rank: index + 1,
+      priority: priorityFor(evidence.score),
+      bucket: triageBucketFor(issueWithoutTriage),
+      evidence,
+    },
+  };
+}
+
 function compareIssuePriority(a: ReactWebIssueCard, b: ReactWebIssueCard): number {
   return (
     b.triage.evidence.score - a.triage.evidence.score ||
@@ -816,7 +1068,7 @@ function buildTriageRollup(issues: ReactWebIssueCard[]): ReactWebIssueReport["tr
       "Conservative local triage only: ranks issue cards from existing report evidence and does not edit files, auto-apply patches, infer custom-component semantics, or claim a broad accessibility audit.",
     criteria: [
       "safe preview availability",
-      "label-preview confidence",
+      "source evidence confidence",
       "native element type",
       "same-file JSX context",
       "related-context count and source quality",
@@ -998,20 +1250,31 @@ function buildFirstMinuteSummary(
 
 export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()): ReactWebIssueReport {
   const preview = buildReactWebLabelPatchPreview(filePath, cwd);
-  const issues = withTriageRanks(preview.findings.map((finding, index) =>
+  const previewIssues = preview.findings.map((finding, index) =>
     issueCardFor(
       preview.filePath,
       finding,
       index,
       buildReactWebIssueRelatedContext(preview.filePath, finding, cwd),
     ),
-  ));
+  );
+  const missingHtmlForTargetIssues = preview.inScope && preview.findings.length === 0
+    ? findMissingHtmlForTargetSignals(preview.filePath, cwd).map((signal, index) =>
+        issueCardForMissingHtmlForTarget(preview.filePath, signal, previewIssues.length + index)
+      )
+    : [];
+  const issues = withTriageRanks([...previewIssues, ...missingHtmlForTargetIssues]);
+  const sourceIssueCounts: ReactWebIssueSourceCounts = {
+    "label-preview": previewIssues.length,
+    "htmlFor-target-resolution": missingHtmlForTargetIssues.length,
+    total: issues.length,
+  };
   const triageRollup = buildTriageRollup(issues);
   const stopDecision = issues.length === 0
     ? buildReactWebStopDecision({
         state: preview.inScope ? "incomplete" : "unsupported",
         reason: preview.inScope
-          ? "No React Web issue cards were produced from the current bounded label-preview evidence."
+          ? "No React Web issue cards were produced from the current bounded label-preview or htmlFor target-resolution evidence."
           : preview.skippedReason ?? "Unsupported React Web issue-report boundary.",
         projection: "issue-card",
         stopConditions: preview.inScope
@@ -1033,6 +1296,7 @@ export function buildReactWebIssueReport(filePath: string, cwd = process.cwd()):
       claimBoundary: preview.claimBoundary,
       findingCount: preview.summary.findingCount,
     },
+    sourceIssueCounts,
     inScope: preview.inScope,
     ...(preview.skippedReason ? { skippedReason: preview.skippedReason } : {}),
     summary: {
@@ -1084,6 +1348,7 @@ export function buildReactWebIssueReportSummaryJson(report: ReactWebIssueReport)
     claimBoundary: report.claimBoundary,
     inScope: report.inScope,
     ...(report.skippedReason ? { skippedReason: report.skippedReason } : {}),
+    sourceIssueCounts: report.sourceIssueCounts,
     summary: report.summary,
     decisionSummary: report.decisionSummary,
     ...(report.stopDecision ? { stopDecision: { ...report.stopDecision, source: { ...report.stopDecision.source, projection: "summary-json" } } } : {}),
@@ -1199,6 +1464,7 @@ export function buildReactWebIssueReportMigrationDryRunJson(
     claimBoundary: report.claimBoundary,
     inScope: report.inScope,
     ...(report.skippedReason ? { skippedReason: report.skippedReason } : {}),
+    sourceIssueCounts: report.sourceIssueCounts,
     summary: {
       candidateCount: candidates.length,
       affectedFiles: [...new Set(candidates.map((candidate) => candidate.affectedFile))].sort(),
@@ -1224,6 +1490,7 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
     `Auto-apply: ${report.autoApply ? "yes" : "no"}`,
     `In scope: ${report.inScope ? "yes" : "no"}`,
     `Issues: ${report.summary.issueCount} (safe preview: ${report.summary.safePreviewCount}, manual review: ${report.summary.manualReviewCount}, unsafe to auto-apply: ${report.summary.unsafeToAutoApplyCount})`,
+    `Source issues: label-preview ${report.sourceIssueCounts["label-preview"]}, htmlFor target-resolution ${report.sourceIssueCounts["htmlFor-target-resolution"]}`,
   ];
   if (report.skippedReason) lines.push(`Skipped: ${report.skippedReason}`);
   if (report.issues.length === 0) return `${lines.join("\n")}\n`;
@@ -1266,6 +1533,7 @@ export function renderReactWebIssueReportText(report: ReactWebIssueReport): stri
       `- why: ${issue.whyItMatters}`,
       `- where to look: ${issue.whereToLook.filePath}:${issue.whereToLook.line}-${issue.whereToLook.endLine}`,
       `- element: ${issue.evidence.element}`,
+      `- source: ${issue.source.kind} — ${issue.source.summary}`,
       `- confidence: ${issue.confidence}`,
       `- fixability: ${issue.fixability}`,
       `- auto-fix safety: ${issue.autoFixSafety}`,

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.dry-run.selected.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 3,
+    "htmlFor-target-resolution": 0,
+    "total": 3
+  },
+  "summary": {
+    "candidateCount": 3,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/empty-aria-labels.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 3
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+    "migrationCandidate": "human-reviewed-accessible-name",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.summary.selected.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 3,
+    "htmlFor-target-resolution": 0,
+    "total": 3
+  },
+  "summary": {
+    "issueCount": 3,
+    "safePreviewCount": 0,
+    "manualReviewCount": 3,
+    "unsafeToAutoApplyCount": 3
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "human-reviewed-accessible-name",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: human-reviewed-accessible-name; first inspect: Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.dry-run.selected.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 3,
+    "htmlFor-target-resolution": 0,
+    "total": 3
+  },
+  "summary": {
+    "candidateCount": 3,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/label-association-candidates.tsx"
+    ],
+    "safePreviewCandidateCount": 1,
+    "manualReviewCandidateCount": 2
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+    "migrationCandidate": "safe-preview-htmlFor-association",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+    "previewAvailable": true,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "The report can preview a high-confidence deterministic native htmlFor/id association from existing JSX evidence, but fooks remains read-only and does not apply…",
+      "Safe preview is a read-only shape candidate and still requires human review before use.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": true,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.summary.selected.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 3,
+    "htmlFor-target-resolution": 0,
+    "total": 3
+  },
+  "summary": {
+    "issueCount": 3,
+    "safePreviewCount": 1,
+    "manualReviewCount": 2,
+    "unsafeToAutoApplyCount": 2
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "safePreviewIssueIds": [
+      "react-web-label-1"
+    ],
+    "manualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "safe-preview-htmlFor-association",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Confirm the htmlFor/id association before using the preview shape."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "ready-for-agent-inspect",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": true,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: safe-preview-htmlFor-association; first inspect: Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Confirm the htmlFor/id association before using the preview shape.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target.dry-run.selected.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 0,
+    "htmlFor-target-resolution": 1,
+    "total": 1
+  },
+  "summary": {
+    "candidateCount": 1,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 1
+  },
+  "firstCandidate": {
+    "issueId": "react-web-htmlfor-target-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx",
+    "migrationCandidate": "human-reviewed-htmlFor-target-resolution",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6 (label) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Correct target resolution may require renaming ids, creating missing ids, or understanding dynamic/cross-file behavior, so fooks reports it for manual review a…",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target.summary.selected.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "sourceIssueCounts": {
+    "label-preview": 0,
+    "htmlFor-target-resolution": 1,
+    "total": 1
+  },
+  "summary": {
+    "issueCount": 1,
+    "safePreviewCount": 0,
+    "manualReviewCount": 1,
+    "unsafeToAutoApplyCount": 1
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-htmlfor-target-1"
+    ],
+    "topIssueIds": [
+      "react-web-htmlfor-target-1"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-htmlfor-target-1"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-htmlfor-target-1"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-htmlfor-target-1"
+    ],
+    "firstItem": {
+      "issueId": "react-web-htmlfor-target-1",
+      "fixShape": "human-reviewed-htmlFor-target-resolution",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6 (label) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6 (label) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local htmlFor target-resolution guidance only: uses same-file literal label htmlFor/id evidence; it is read-only, requires human review, and does not create ids, generate copy, or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-htmlfor-target-1: human-reviewed-htmlFor-target-resolution; first inspect: Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6 (label) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx:6-6 (label) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-label-preview/htmlfor-target-quiet.tsx
+++ b/test/fixtures/react-web-label-preview/htmlfor-target-quiet.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+const dynamicId = "dynamic-email";
+
+function FieldLabel(props: { htmlFor: string; children: React.ReactNode }) {
+  return <span data-for={props.htmlFor}>{props.children}</span>;
+}
+
+export function QuietHtmlForTargetForm() {
+  return (
+    <form>
+      <label htmlFor="present-email">Present email</label>
+      <input id="present-email" aria-label="Present email" />
+
+      <label htmlFor="duplicate-email">Duplicate email</label>
+      <input id="duplicate-email" aria-label="Duplicate email" />
+      <div id="duplicate-email" />
+
+      <label htmlFor={dynamicId}>Dynamic email</label>
+      <input id={dynamicId} aria-label="Dynamic email" />
+
+      <FieldLabel htmlFor="missing-custom">Custom field</FieldLabel>
+    </form>
+  );
+}

--- a/test/fixtures/react-web-label-preview/htmlfor-target-static-quiet.tsx
+++ b/test/fixtures/react-web-label-preview/htmlfor-target-static-quiet.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+function FieldLabel(props: { htmlFor: string; children: React.ReactNode }) {
+  return <span data-for={props.htmlFor}>{props.children}</span>;
+}
+
+export function StaticQuietHtmlForTargetForm() {
+  return (
+    <form>
+      <label htmlFor="present-email">Present email</label>
+      <input id="present-email" aria-label="Present email" />
+
+      <label htmlFor="duplicate-email">Duplicate email</label>
+      <input id="duplicate-email" aria-label="Duplicate email" />
+      <div id="duplicate-email" />
+
+      <FieldLabel htmlFor="missing-custom">Custom field</FieldLabel>
+    </form>
+  );
+}

--- a/test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx
+++ b/test/fixtures/react-web-label-preview/missing-htmlfor-target.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function MissingHtmlForTargetForm() {
+  return (
+    <form>
+      <label htmlFor="missing-email">Email address</label>
+      <p>Enter the email address used for notifications.</p>
+    </form>
+  );
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -5057,13 +5057,23 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
 
   assert.match(demo, /React Web issue-card golden demo/);
   assert.match(demo, /\.\.\/react-web-first-minute-work-orders\.md/);
+  assert.match(demo, /short golden slices instead of one kitchen-sink fixture/);
   assert.match(demo, /fooks inspect react-web-issues fixtures\/compressed\/FormControls\.tsx/);
-  assert.match(demo, /Before source/);
+  assert.match(demo, /Demo 1: missing native label\/name evidence/);
+  assert.match(demo, /Demo 2: empty `aria-label` evidence/);
+  assert.match(demo, /Demo 3: `htmlFor` wiring cards/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/empty-aria-labels\.tsx/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/missing-htmlfor-target\.tsx/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/label-association-candidates\.tsx/);
   assert.match(demo, /problem/);
   assert.match(demo, /whyItMatters/);
   assert.match(demo, /whereToLook/);
   assert.match(demo, /confidence/);
   assert.match(demo, /suggestedAction/);
+  assert.match(demo, /react-web\\.empty-accessible-name|Native input has empty accessible-name evidence/);
+  assert.match(demo, /react-web\\.missing-htmlfor-target|Native label references htmlFor="missing-email"/);
+  assert.match(demo, /safe-preview-htmlFor-association/);
+  assert.match(demo, /No duplicate-id\/conflicting-label emitted-card claim/);
   assert.match(demo, /--summary-json/);
   assert.match(demo, /firstMinuteSummary|First-minute handoff/);
   assert.match(demo, /--dry-run-json/);
@@ -5085,13 +5095,25 @@ test("React Web issue-card public demo keeps selected golden handoff strings", (
   const demo = fs.readFileSync(path.join(repoRoot, "docs", "demo", "react-web-issues.md"), "utf8");
   const summaryGolden = readReactWebIssueGoldenJson("form-controls.summary.selected.json");
   const dryRunGolden = readReactWebIssueGoldenJson("form-controls.dry-run.selected.json");
+  const emptyAriaSummaryGolden = readReactWebIssueGoldenJson("empty-aria-labels.summary.selected.json");
+  const associationDryRunGolden = readReactWebIssueGoldenJson("label-association-candidates.dry-run.selected.json");
+  const missingHtmlForSummaryGolden = readReactWebIssueGoldenJson("missing-htmlfor-target.summary.selected.json");
   const firstItem = summaryGolden.firstMinuteSummary.firstItem;
+  const emptyAriaFirstItem = emptyAriaSummaryGolden.firstMinuteSummary.firstItem;
+  const associationCandidate = associationDryRunGolden.firstCandidate;
+  const missingHtmlForFirstItem = missingHtmlForSummaryGolden.firstMinuteSummary.firstItem;
 
   assert.match(demo, new RegExp(escapeRegExp(firstItem.firstInspectStep)));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.nextAction)));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.humanDecisionNeeded[0])));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[0])));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[2])));
+  assert.match(demo, new RegExp(escapeRegExp(emptyAriaFirstItem.firstInspectStep)));
+  assert.match(demo, new RegExp(escapeRegExp(emptyAriaFirstItem.nextAction)));
+  assert.match(demo, new RegExp(escapeRegExp(missingHtmlForFirstItem.issueId)));
+  assert.match(demo, new RegExp(escapeRegExp(missingHtmlForFirstItem.fixShape)));
+  assert.match(demo, new RegExp(escapeRegExp(associationCandidate.migrationCandidate)));
+  assert.match(demo, new RegExp(escapeRegExp(String(associationCandidate.previewAvailable))));
   assert.match(demo, new RegExp(escapeRegExp(String(dryRunGolden.firstCandidate.dryRunOnly))));
 });
 

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -141,11 +141,25 @@ function projectTextGolden(text) {
   const summaryLines = lines.slice(summaryIndex, lines.findIndex((line, index) => index > summaryIndex && line.startsWith("## Issue 1:")));
   return [
     "## First-minute summary",
-    summaryLines.find((line) => line.startsWith("- react-web-label-1: human-reviewed-native-control-name;")),
+    summaryLines.find((line) => line.startsWith("- react-web-label-1:") || line.startsWith("- react-web-htmlfor-target-1:")),
     summaryLines.find((line) => line.trimStart().startsWith("- next action:")),
     summaryLines.find((line) => line.trimStart().startsWith("- human decision needed:")),
     summaryLines.find((line) => line.trimStart().startsWith("- do not do:")),
   ].join("\n").trimEnd();
+}
+
+function projectSummaryGoldenWithSource(summary) {
+  return {
+    ...projectSummaryGolden(summary),
+    sourceIssueCounts: summary.sourceIssueCounts,
+  };
+}
+
+function projectDryRunGoldenWithSource(dryRun) {
+  return {
+    ...projectDryRunGolden(dryRun),
+    sourceIssueCounts: dryRun.sourceIssueCounts,
+  };
 }
 
 function hasNestedKey(value, key) {
@@ -1178,6 +1192,55 @@ test("React Web issue report text output matches selected golden excerpt", () =>
   assert.equal(cli.status, 0, cli.stderr);
 
   assert.equal(projectTextGolden(cli.stdout), readGoldenText("form-controls.text.excerpt.txt"));
+});
+
+test("React Web issue report selected golden contracts cover current demo card families", () => {
+  const cases = [
+    {
+      fixture: fixtures.emptyAriaLabel,
+      prefix: "empty-aria-labels",
+      expectedKind: "react-web.empty-accessible-name",
+      expectedFixShape: "human-reviewed-accessible-name",
+      expectedSourceCounts: { "label-preview": 3, "htmlFor-target-resolution": 0, total: 3 },
+    },
+    {
+      fixture: fixtures.missingHtmlForTarget,
+      prefix: "missing-htmlfor-target",
+      expectedKind: "react-web.missing-htmlfor-target",
+      expectedFixShape: "human-reviewed-htmlFor-target-resolution",
+      expectedSourceCounts: { "label-preview": 0, "htmlFor-target-resolution": 1, total: 1 },
+    },
+    {
+      fixture: fixtures.association,
+      prefix: "label-association-candidates",
+      expectedKind: "react-web.unassociated-nearby-label",
+      expectedFixShape: "safe-preview-htmlFor-association",
+      expectedSourceCounts: { "label-preview": 3, "htmlFor-target-resolution": 0, total: 3 },
+    },
+  ];
+
+  for (const entry of cases) {
+    const report = parseIssues(entry.fixture);
+    assert.equal(report.issues[0].kind, entry.expectedKind);
+
+    const summaryCli = runIssues(entry.fixture, "--summary-json");
+    const dryRunCli = runIssues(entry.fixture, "--dry-run-json");
+    const textCli = runIssues(entry.fixture);
+    assert.equal(summaryCli.status, 0, summaryCli.stderr);
+    assert.equal(dryRunCli.status, 0, dryRunCli.stderr);
+    assert.equal(textCli.status, 0, textCli.stderr);
+
+    const summary = JSON.parse(summaryCli.stdout);
+    const dryRun = JSON.parse(dryRunCli.stdout);
+    assert.deepEqual(summary.sourceIssueCounts, entry.expectedSourceCounts);
+    assert.deepEqual(dryRun.sourceIssueCounts, entry.expectedSourceCounts);
+    assert.equal(summary.firstMinuteSummary.items[0].fixShape, entry.expectedFixShape);
+    assert.equal(dryRun.candidates[0].migrationCandidate, entry.expectedFixShape);
+
+    assert.deepEqual(projectSummaryGoldenWithSource(summary), readGoldenJson(`${entry.prefix}.summary.selected.json`));
+    assert.deepEqual(projectDryRunGoldenWithSource(dryRun), readGoldenJson(`${entry.prefix}.dry-run.selected.json`));
+    assert.equal(projectTextGolden(textCli.stdout), readGoldenText(`${entry.prefix}.text.excerpt.txt`));
+  }
 });
 
 test("React Web issue report migration dry-run JSON preserves empty and unsupported boundaries", () => {

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -44,6 +44,9 @@ const fixtures = {
   expandedNativeControls: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "expanded-native-controls.tsx"),
   emptyAriaLabel: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "empty-aria-labels.tsx"),
   quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
+  missingHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx"),
+  quietHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "htmlfor-target-quiet.tsx"),
+  staticQuietHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "htmlfor-target-static-quiet.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
   customComponent: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "react-web", "custom-form-shell.tsx"),
@@ -392,7 +395,7 @@ test("React Web issue report JSON includes conservative priority rollup for firs
   assert.match(report.triageRollup.claimBoundary, /does not.*infer custom-component semantics/);
   assert.deepEqual(report.triageRollup.criteria, [
     "safe preview availability",
-    "label-preview confidence",
+    "source evidence confidence",
     "native element type",
     "same-file JSX context",
     "related-context count and source quality",
@@ -761,6 +764,67 @@ test("React Web issue report avoids unsafe htmlFor inference and keeps fallback 
   assert.doesNotMatch(JSON.stringify(report), /htmlFor=/);
 });
 
+
+test("React Web issue report emits conservative manual-review card for missing htmlFor target", () => {
+  const report = parseIssues(fixtures.missingHtmlForTarget);
+  const summary = JSON.parse(runIssues(fixtures.missingHtmlForTarget, "--summary-json").stdout);
+  const dryRun = JSON.parse(runIssues(fixtures.missingHtmlForTarget, "--dry-run-json").stdout);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.sourcePreview.findingCount, 0);
+  assert.deepEqual(report.sourceIssueCounts, {
+    "label-preview": 0,
+    "htmlFor-target-resolution": 1,
+    total: 1,
+  });
+  assert.equal(report.summary.issueCount, 1);
+  assert.equal(report.summary.safePreviewCount, 0);
+  assert.equal(report.summary.manualReviewCount, 1);
+  assert.equal(report.summary.unsafeToAutoApplyCount, 1);
+
+  const issue = report.issues[0];
+  assert.equal(issue.kind, "react-web.missing-htmlfor-target");
+  assert.equal(issue.source.kind, "htmlFor-target-resolution");
+  assert.equal(issue.evidence.element, "label");
+  assert.equal(issue.confidence, "medium");
+  assert.equal(issue.fixability, "manual-review");
+  assert.equal(issue.autoFixSafety, "unsafe-to-auto-apply");
+  assert.equal(issue.preview, undefined);
+  assert.match(issue.problem, /missing-email/);
+  assert.match(issue.safetyRationale, /manual review/);
+  assert.match(issue.skipReason, /target resolution needs manual review/);
+  assert.deepEqual(issue.relatedContext.map((entry) => entry.source), ["htmlFor-target-resolution"]);
+  assert.equal(issue.fixShapeGuidance.shape, "human-reviewed-htmlFor-target-resolution");
+  assert.equal(issue.fixShapeGuidance.localEvidence.safePreviewAvailable, false);
+  assert.deepEqual(issue.fixShapeGuidance.localEvidence.relatedContextSources, ["htmlFor-target-resolution"]);
+  assert.doesNotMatch(issue.contextPacket.whyThisFile, /Direct label-preview evidence|label-preview confidence/);
+  assert.equal(issue.relatedContext.some((entry) => entry.source === "label-preview"), false);
+
+  assert.deepEqual(summary.sourceIssueCounts, report.sourceIssueCounts);
+  assert.deepEqual(dryRun.sourceIssueCounts, report.sourceIssueCounts);
+  assert.equal(dryRun.summary.candidateCount, 1);
+  assert.equal(dryRun.candidates[0].migrationCandidate, "human-reviewed-htmlFor-target-resolution");
+  assert.equal(dryRun.candidates[0].previewAvailable, false);
+});
+
+test("React Web issue report keeps htmlFor target-resolution quiet for matching, duplicate, and custom-component boundaries", () => {
+  const report = parseIssues(fixtures.staticQuietHtmlForTarget);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.sourceIssueCounts["htmlFor-target-resolution"], 0);
+  assert.equal(report.issues.some((issue) => issue.kind === "react-web.missing-htmlfor-target"), false);
+  assert.doesNotMatch(JSON.stringify(report), /missing-custom/);
+});
+
+test("React Web issue report keeps htmlFor target-resolution quiet for dynamic htmlFor and dynamic id boundaries", () => {
+  const report = parseIssues(fixtures.quietHtmlForTarget);
+
+  assert.equal(report.inScope, true);
+  assert.equal(report.sourceIssueCounts["htmlFor-target-resolution"], 0);
+  assert.equal(report.issues.some((issue) => issue.kind === "react-web.missing-htmlfor-target"), false);
+});
+
+
 test("React Web issue report text mode is issue-card-first and prints the claim boundary", () => {
   const cli = runIssues(fixtures.association);
   assert.equal(cli.status, 0, cli.stderr);
@@ -770,7 +834,7 @@ test("React Web issue report text mode is issue-card-first and prints the claim 
   assert.match(cli.stdout, /- priority counts:/);
   assert.match(cli.stdout, /- ranked issue ids:/);
   assert.match(cli.stdout, /- top manual-review ids:/);
-  assert.match(cli.stdout, /- criteria: safe preview availability; label-preview confidence; native element type; same-file JSX context; related-context count and source quality/);
+  assert.match(cli.stdout, /- criteria: safe preview availability; source evidence confidence; native element type; same-file JSX context; related-context count and source quality/);
   assert.match(cli.stdout, /## Issue 1:/);
   assert.match(cli.stdout, /- triage: rank 1, high priority, safe-preview, score \d+/);
   assert.match(cli.stdout, /- triage evidence: safe preview yes, same-file context yes, related context \d+ \(/);


### PR DESCRIPTION
## Summary
- refresh the README-facing React Web issue-card demo into short representative slices
- add selected goldens for empty `aria-label`, missing `htmlFor` target, and safe-preview label association cards
- update public docs/tests so duplicate-id/conflicting-label-looking evidence stays a boundary unless emitted-card behavior is source/test proven

Closes #849

## Validation
- npm run typecheck
- npm run build
- node --test --test-name-pattern "React Web issue report selected golden contracts cover current demo card families|React Web issue-card public demo|README smoke keeps first-minute compare path discoverable|React Web first-minute work-order docs stay discoverable" test/react-web-issue-report.test.mjs test/fooks.test.mjs
- git diff --check

## Notes
- The branch also contains the missing-htmlFor target card work from the current feature branch base, because the demo/golden refresh is validating that latest card family.
- Full unfiltered `test/fooks.test.mjs` still has a known pre-existing environment-sensitive init expectation in this checkout; changed-surface targeted tests pass.