### PR TITLE
Refresh React Web issue-card demo goldens

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ fooks doctor
 fooks inspect react-web-issues src/components/Form.tsx
 ```
 
-The issue-card output is read-only and actionable: each card explains `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`. High-confidence native label/control findings can include safe preview shape hints, but fooks does **not** auto-apply patches, invent final accessible-name copy, infer custom-component semantics, or claim a broad accessibility audit. Ambiguous cases stay as manual-review cards with stop reasons.
+The issue-card output is read-only and actionable: each card explains `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`. Current React Web cards can cover missing native label/name evidence, empty `aria-label` evidence, same-file missing `htmlFor` targets, high-confidence nearby label/control association previews, duplicate literal native ids, and conflicting native label associations. High-confidence native label/control findings can include safe preview shape hints, but fooks does **not** auto-apply patches, invent final accessible-name copy, infer custom-component semantics, or claim a broad accessibility audit. Ambiguous cases stay as manual-review cards with stop reasons.
 
-Want to see the product loop before installing it into a real repo? Start with the packaged golden demo: [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md). For the detailed first-minute handoff contract, including `--summary-json` and `--dry-run-json`, see [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md).
+Want to see the product loop before installing it into a real repo? Start with the packaged golden demo: [`docs/demo/react-web-issues.md`](docs/demo/react-web-issues.md). It is split into short representative examples rather than one kitchen-sink fixture, including duplicate-id and conflicting-label manual-review cards now proven by source/tests. For the detailed first-minute handoff contract, including `--summary-json` and `--dry-run-json`, see [`docs/react-web-first-minute-work-orders.md`](docs/react-web-first-minute-work-orders.md).
 
 Context reduction and caching are supporting mechanisms. In the strongest current Codex path, repeated work on the same React `.tsx` / `.jsx` file may reuse compact same-file context when the evidence gate says that is safe. `fooks compare` shows local source-vs-payload evidence for one supported file, but the launch-facing habit is simpler: **inspect first, then reuse context only when safe**.
 
@@ -39,7 +39,7 @@ Best fit: React Web `.tsx` / `.jsx` work where source-derived form and accessibi
 
 Use fooks when you want Codex to start React Web work with a compact, source-grounded issue card instead of rediscovering frontend facts from scratch.
 
-1. **Inspect first:** `fooks inspect react-web-issues <file>` ranks narrow native JSX label/control risks and tells the agent where to look before editing.
+1. **Inspect first:** `fooks inspect react-web-issues <file>` ranks narrow native JSX label/control risks—missing names, empty `aria-label`, missing same-file `htmlFor` targets, safe-preview association candidates, duplicate ids, and conflicting native label associations—and tells the agent where to look before editing.
 2. **Handoff safely:** `--summary-json` gives agents `firstMinuteSummary.items[0]`, `decision`, `humanDecisionNeeded`, and `doNotDo` boundaries as advisory inspect-first input rather than edit authority.
 3. **Preview only when safe:** `--dry-run-json` lists migration candidates and preview availability, but remains dry-run-only with `autoApply: false` and human review for final label/name choices.
 4. **Reuse when safe:** repeated same-file Codex work may reuse compact context after evidence gates pass; `fooks compare` is supporting local payload proof, not the headline.

--- a/docs/demo/react-web-issues.md
+++ b/docs/demo/react-web-issues.md
@@ -1,77 +1,172 @@
 # React Web issue-card golden demo
 
-This packaged demo is the short product-facing version of the detailed first-minute contract in [`../react-web-first-minute-work-orders.md`](../react-web-first-minute-work-orders.md). It uses the current `inspect react-web-issues` semantics: read-only React Web issue cards, compact first-minute handoff, and dry-run inventory rows. It is not a separate source of truth.
+This packaged demo is the short product-facing version of the detailed first-minute work-order contract in [`../react-web-first-minute-work-orders.md`](../react-web-first-minute-work-orders.md).
 
 Use it to understand the first fooks habit:
 
 ```bash
+fooks inspect react-web-issues <supported-react-web-file>
 fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
 ```
 
-## Before source
+The examples below are intentionally split into short golden slices instead of one kitchen-sink fixture. They show the current emitted card families that are safe to present in README-facing docs: missing native label/name evidence, empty `aria-label` evidence, same-file missing `htmlFor` targets, high-confidence read-only `htmlFor` association previews, duplicate literal native ids, and conflicting native label associations. Each full card still carries the stable human/agent fields `problem`, `whyItMatters`, `whereToLook`, `confidence`, and `suggestedAction`; the snippets show only the shortest representative lines.
 
-The demo source below is an excerpt from `fixtures/compressed/FormControls.tsx` around the native controls that trigger the issue cards. The full fixture also includes imports, form setup, a `Controller`, a registered input, and a submit button; the excerpt keeps the first-minute risk visible without pretending to be a separate fixture. The native controls have source facts that fooks can inspect, but the final accessible label/name copy still requires human judgment.
+## Demo 1: missing or empty native label/name evidence
+
+Baseline source excerpt from `fixtures/compressed/FormControls.tsx`:
 
 ```tsx
 export function FormControls() {
   return (
-    <form onSubmit={onSubmit} className="grid gap-4 rounded-lg border p-4">
-      <input name="email" type="email" required onChange={() => undefined} />
-      <select className="rounded border px-3 py-2" name="role" defaultValue="viewer">
-        <option value="viewer">Viewer</option>
-        <option value="admin">Admin</option>
-      </select>
-      <textarea className="rounded border px-3 py-2" name="notes" disabled defaultValue="" />
+    <form>
+      <input name="firstName" />
+      <select name="department" />
+      <textarea name="notes" />
     </form>
   );
 }
 ```
 
-## Command
-
 ```bash
 fooks inspect react-web-issues fixtures/compressed/FormControls.tsx
 ```
 
-Representative text output starts with the product boundary before any fix guidance:
+Representative output:
 
 ```text
-# React Web issue report
-
-Read-only React Web issue report for a narrow native JSX label/accessibility subset only: adapts label-preview findings into actionable issue cards, never edits files, does not auto-apply patches, does not claim broad accessibility coverage, and does not infer custom-component semantics.
-
-File: fixtures/compressed/FormControls.tsx
-Read-only: yes
-Auto-apply: no
-In scope: yes
 Issues: 5 (safe preview: 0, manual review: 5, unsafe to auto-apply: 5)
-```
 
-## Issue card shape
-
-A card tells the agent what risk exists and where to inspect first. The field names are stable enough for humans and agents to recognize; the exact ranking can change with source evidence.
-
-```text
 ## Issue 1: Native input lacks recognized accessible-label evidence.
-- why: Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.
+- first inspect: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.
+- next action: Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.
+- human decision needed: Confirm the final accessible label/name copy from current source context.
+- do not do: Do not apply patches automatically from this report.; Do not generate final label/name copy automatically.
 - where to look: fixtures/compressed/FormControls.tsx:23-23
-- element: input
 - confidence: high
 - fixability: manual-review
 - auto-fix safety: unsafe-to-auto-apply
 - suggested action: Add an explicit accessible label with human-reviewed copy for the native control.
 ```
 
-JSON consumers should preserve the same issue-card meaning:
+### Empty `aria-label` evidence
 
-```json
-{
-  "problem": "Native input lacks recognized accessible-label evidence.",
-  "whyItMatters": "Users of assistive technology may not get a meaningful control name, making the control hard to understand or operate.",
-  "whereToLook": "fixtures/compressed/FormControls.tsx:23-23",
-  "confidence": "high",
-  "suggestedAction": "Add an explicit accessible label with human-reviewed copy for the native control."
+Empty accessible-name evidence is a different manual-review card from a missing label. The source already has accessible-name evidence, but the value is blank or whitespace-only.
+
+```tsx
+function EmptyAriaLabels() {
+  return (
+    <form>
+      <input aria-label="" name="email" type="email" />
+      <button aria-label=" ">Save</button>
+      <textarea aria-label="" name="notes" />
+    </form>
+  );
 }
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/empty-aria-labels.tsx
+```
+
+Representative output:
+
+```text
+Issues: 3 (safe preview: 0, manual review: 3, unsafe to auto-apply: 3)
+
+## Issue 1: Native input has empty accessible-name evidence.
+- why: A blank aria-label creates accessible-name evidence that communicates no useful control name.
+- where to look: test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4
+- fix shape: human-reviewed-accessible-name — Choose a human-reviewed accessible-name shape for this native input from local JSX context.
+- suggested action: Replace the empty aria-label with human-reviewed accessible-name evidence.
+```
+
+## Demo 2: `htmlFor` wiring cards
+
+`htmlFor` support has two distinct current shapes: missing target cards are manual-review, while high-confidence nearby native label/control associations can include a read-only preview.
+
+### Missing `htmlFor` target
+
+```tsx
+function MissingHtmlForTargetOnly() {
+  return (
+    <form>
+      <label htmlFor="missing-email">Email address</label>
+      <input id="email" name="email" aria-label="Email address" />
+    </form>
+  );
+}
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx
+```
+
+Representative output:
+
+```text
+Issues: 1 (safe preview: 0, manual review: 1, unsafe to auto-apply: 1)
+
+## Issue 1: Native label htmlFor target is missing from same-file literal id evidence.
+- issue kind: react-web.missing-htmlFor-target
+- where to look: test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4
+- fix shape: human-reviewed-htmlFor-target — Inspect the native label htmlFor literal and same-file id evidence before choosing any htmlFor/id target fix.
+- suggested action: Inspect the exact native label line, verify whether the target id should exist in this file, and manually choose a human-reviewed htmlFor/id association or stop if the target is intentionally external.
+```
+
+### Safe-preview nearby association
+
+```tsx
+function LabelAssociationCandidates() {
+  return (
+    <form>
+      <label>Email</label>
+      <input id="email" name="email" />
+    </form>
+  );
+}
+```
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/label-association-candidates.tsx
+```
+
+Representative output:
+
+```text
+Issues: 3 (safe preview: 1, manual review: 2, unsafe to auto-apply: 2)
+
+## Issue 1: Nearby label text is not explicitly associated with this native input.
+- fixability: safe-preview
+- auto-fix safety: not-auto-applied
+- fix shape: safe-preview-htmlFor-association — Inspect the read-only htmlFor/id association preview for this native input; use only after human review.
+- suggested action: Connect the nearby native label/control pair with htmlFor/id when the preview evidence remains valid.
+```
+
+## Demo 3: duplicate id and conflicting label intent
+
+These are now emitted issue cards too, but they remain manual-review-only because fooks cannot choose replacement ids or merge label intent.
+
+```bash
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/duplicate-id-controls.tsx
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/conflicting-label-association.tsx
+```
+
+Representative duplicate-id output:
+
+```text
+## Issue 1: Native input has an ambiguous duplicate id association.
+- issue kind: react-web.duplicate-literal-id
+- fix shape: human-reviewed-duplicate-id-association — Inspect duplicate same-file id evidence for this native input and choose unique id/htmlFor associations manually.
+- suggested action: Inspect every same-file duplicate id occurrence and choose unique, human-reviewed id/htmlFor associations.
+```
+
+Representative conflicting-label output:
+
+```text
+## Issue 1: Multiple native labels target the same native input id.
+- issue kind: react-web.conflicting-label-association
+- fix shape: human-reviewed-conflicting-label-association — Inspect every same-file native label targeting this control id and decide the intended accessible-name relationship manually.
+- suggested action: Inspect the exact native label and control lines, then decide whether the multiple label associations are intentional or need a human-reviewed source change.
 ```
 
 ## First-minute handoff (`--summary-json`)
@@ -79,7 +174,7 @@ JSON consumers should preserve the same issue-card meaning:
 Agents that only need the compact work order should read the first summary item, then inspect the current source before suggesting anything.
 
 ```bash
-fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --summary-json
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/empty-aria-labels.tsx --summary-json
 ```
 
 Representative first item:
@@ -87,10 +182,9 @@ Representative first item:
 ```json
 {
   "issueId": "react-web-label-1",
-  "fixShape": "human-reviewed-native-control-name",
-  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
-  "whyThisFirst": "Rank 1 high issue because label-preview confidence is high; high-confidence-manual-review remains human-reviewed.",
-  "nextAction": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) first; confirm current source still matches before suggesting changes.",
+  "fixShape": "human-reviewed-accessible-name",
+  "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+  "nextAction": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.",
   "humanDecisionNeeded": [
     "Confirm the final accessible label/name copy from current source context.",
     "Choose the label/name shape from local JSX evidence."
@@ -99,33 +193,24 @@ Representative first item:
     "Do not apply patches automatically from this report.",
     "Do not infer custom-component semantics.",
     "Do not generate final label/name copy automatically."
-  ],
-  "decision": {
-    "state": "human-decision-required",
-    "allowedActions": {
-      "inspect": true,
-      "suggestPatch": false,
-      "applyPatch": false,
-      "generateCopy": false
-    }
-  }
+  ]
 }
 ```
 
 Agent handoff:
 
-1. Inspect `fixtures/compressed/FormControls.tsx:23` first.
+1. Inspect `firstInspectStep` first.
 2. Confirm the current source still matches the issue evidence.
-3. Look for existing visible label, nearby native label/control structure, or source-observed naming hints.
+3. Look for existing visible label, nearby native label/control structure, same-file `htmlFor`/`id` evidence, duplicate id evidence, conflicting native label evidence, or source-observed naming hints.
 4. Do **not** generate final label copy automatically.
 5. If the target is a custom component or the source no longer matches, stop and read the file normally.
 
-## Dry-run and safe-preview split (`--dry-run-json`)
+## Migration inventory (`--dry-run-json`)
 
 Migration planners can request candidate rows, but the projection is still dry-run-only.
 
 ```bash
-fooks inspect react-web-issues fixtures/compressed/FormControls.tsx --dry-run-json
+fooks inspect react-web-issues test/fixtures/react-web-label-preview/label-association-candidates.tsx --dry-run-json
 ```
 
 Representative candidate:
@@ -133,32 +218,27 @@ Representative candidate:
 ```json
 {
   "issueId": "react-web-label-1",
-  "migrationCandidate": "human-reviewed-native-control-name",
-  "affectedFile": "fixtures/compressed/FormControls.tsx",
-  "firstInspectStep": "Inspect fixtures/compressed/FormControls.tsx:23-23 (input) before editing.",
-  "previewAvailable": false,
+  "migrationCandidate": "safe-preview-htmlFor-association",
+  "affectedFile": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+  "previewAvailable": true,
   "humanReviewRequired": true,
   "autoApply": false,
-  "dryRunOnly": true,
-  "riskNotes": [
-    "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
-    "No deterministic safe preview is available; choose the final label/name shape from local source context.",
-    "Do not apply patches automatically or generate accessible-name copy from this dry run.",
-    "Do not infer custom-component semantics."
-  ]
+  "dryRunOnly": true
 }
 ```
 
-If a future or different source file produces `previewAvailable: true`, treat the preview as a read-only review aid, not permission to edit. `autoApply` remains false unless a separate human/tool workflow explicitly decides to make a source change after reading the current file.
+If a source file produces `previewAvailable: true`, treat the preview as a read-only review aid, not permission to edit. `autoApply` remains false unless a separate human/tool workflow explicitly decides to make a source change after reading the current file.
 
 ## Boundary note
 
-This demo proves the first-minute React Web issue-card loop, not a broader product claim.
+This demo proves the first-minute React Web issue-card loop, not a broader product surface:
 
-- Read-only: `inspect react-web-issues` reports findings and handoff data; it does not edit files.
-- No auto-apply: safe previews are review aids, not patch authority.
+- Read-only only: `fooks inspect react-web-issues` never edits source.
+- No auto-apply: even safe previews are review aids, not applied patches.
 - No generated accessible-name copy: final label/name text stays human-reviewed.
 - No broad accessibility audit: this is a narrow native JSX label/control subset, not a complete WCAG or design-system audit.
 - No custom-component semantic inference: ambiguous/custom cases fall back to manual review or normal source reading.
+- No automatic duplicate/conflicting repair: duplicate-id and conflicting-label cards are emitted, but fooks does not choose replacement ids, merge labels, delete labels, or rewrite intent automatically.
 - No RN/WebView/TUI expansion: those lanes remain boundary/roadmap topics, not supported by this React Web demo.
 - No billing proof: benchmark/cost evidence elsewhere in the docs is estimate-scoped and does not prove provider invoices, provider billing tokens, or stable runtime-token savings.

--- a/test/fixtures/react-web-issues-golden/conflicting-label-association.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/conflicting-label-association.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/conflicting-label-association.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 5,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/conflicting-label-association.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 5
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-2",
+    "affectedFile": "test/fixtures/react-web-label-preview/conflicting-label-association.tsx",
+    "migrationCandidate": "human-reviewed-conflicting-label-association",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/conflicting-label-association.tsx:10-10 (input) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Conflicting native label associations require source inspection and human intent, so fooks reports the ambiguity and does not auto-apply it.",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/conflicting-label-association.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/conflicting-label-association.summary.selected.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/conflicting-label-association.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 5,
+    "safePreviewCount": 0,
+    "manualReviewCount": 5,
+    "unsafeToAutoApplyCount": 5
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3",
+      "react-web-label-4",
+      "react-web-label-5",
+      "react-web-label-1"
+    ],
+    "topIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3",
+      "react-web-label-4"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3",
+      "react-web-label-4"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3",
+      "react-web-label-4",
+      "react-web-label-5",
+      "react-web-label-1"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3",
+      "react-web-label-4"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-2",
+      "fixShape": "human-reviewed-conflicting-label-association",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/conflicting-label-association.tsx:10-10 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/conflicting-label-association.tsx:10-10 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/conflicting-label-association.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/conflicting-label-association.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-2: human-reviewed-conflicting-label-association; first inspect: Inspect test/fixtures/react-web-label-preview/conflicting-label-association.tsx:10-10 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/conflicting-label-association.tsx:10-10 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/duplicate-id-controls.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/duplicate-id-controls.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/duplicate-id-controls.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 2,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/duplicate-id-controls.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 2
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/duplicate-id-controls.tsx",
+    "migrationCandidate": "human-reviewed-duplicate-id-association",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/duplicate-id-controls.tsx:7-7 (input) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Duplicate literal id associations require source inspection and coordinated id/htmlFor choices, so fooks reports the ambiguity and does not auto-apply it.",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/duplicate-id-controls.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/duplicate-id-controls.summary.selected.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/duplicate-id-controls.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 2,
+    "safePreviewCount": 0,
+    "manualReviewCount": 2,
+    "unsafeToAutoApplyCount": 2
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "human-reviewed-duplicate-id-association",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/duplicate-id-controls.tsx:7-7 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/duplicate-id-controls.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/duplicate-id-controls.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/duplicate-id-controls.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: human-reviewed-duplicate-id-association; first inspect: Inspect test/fixtures/react-web-label-preview/duplicate-id-controls.tsx:7-7 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/duplicate-id-controls.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 3,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/empty-aria-labels.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 3
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+    "migrationCandidate": "human-reviewed-accessible-name",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "Correct user-facing accessible-name copy requires human review, so fooks reports the issue and does not auto-apply it.",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.summary.selected.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/empty-aria-labels.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 3,
+    "safePreviewCount": 0,
+    "manualReviewCount": 3,
+    "unsafeToAutoApplyCount": 3
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-3",
+      "react-web-label-2"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "human-reviewed-accessible-name",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/empty-aria-labels.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/empty-aria-labels.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: human-reviewed-accessible-name; first inspect: Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/empty-aria-labels.tsx:4-4 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 3,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/label-association-candidates.tsx"
+    ],
+    "safePreviewCandidateCount": 1,
+    "manualReviewCandidateCount": 2
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+    "migrationCandidate": "safe-preview-htmlFor-association",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+    "previewAvailable": true,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "The report can preview a high-confidence deterministic native htmlFor/id association from existing JSX evidence, but fooks remains read-only and does not apply…",
+      "Safe preview is a read-only shape candidate and still requires human review before use.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": true,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.summary.selected.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/label-association-candidates.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 3,
+    "safePreviewCount": 1,
+    "manualReviewCount": 2,
+    "unsafeToAutoApplyCount": 2
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "topIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "safePreviewIssueIds": [
+      "react-web-label-1"
+    ],
+    "manualReviewIssueIds": [
+      "react-web-label-2",
+      "react-web-label-3"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1",
+      "react-web-label-2",
+      "react-web-label-3"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "safe-preview-htmlFor-association",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Confirm the htmlFor/id association before using the preview shape."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "ready-for-agent-inspect",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": true,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/label-association-candidates.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/label-association-candidates.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: safe-preview-htmlFor-association; first inspect: Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/label-association-candidates.tsx:7-7 (input) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Confirm the htmlFor/id association before using the preview shape.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.dry-run.selected.json
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.dry-run.selected.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "react-web-issue-report-migration-dry-run.v1",
+  "projection": "migration-dry-run-json",
+  "filePath": "test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx",
+  "readOnly": true,
+  "dryRunOnly": true,
+  "autoApply": false,
+  "summary": {
+    "candidateCount": 1,
+    "affectedFiles": [
+      "test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx"
+    ],
+    "safePreviewCandidateCount": 0,
+    "manualReviewCandidateCount": 1
+  },
+  "firstCandidate": {
+    "issueId": "react-web-label-1",
+    "affectedFile": "test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx",
+    "migrationCandidate": "human-reviewed-htmlFor-target",
+    "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4 (label) before editing.",
+    "previewAvailable": false,
+    "humanReviewRequired": true,
+    "autoApply": false,
+    "dryRunOnly": true,
+    "riskNotes": [
+      "A missing htmlFor target may require adding or correcting an id, moving the label, or recognizing intentional cross-file/runtime wiring, so fooks reports the e…",
+      "No deterministic safe preview is available; choose the final label/name shape from local source context.",
+      "Do not apply patches automatically or generate accessible-name copy from this dry run.",
+      "Do not infer custom-component semantics."
+    ],
+    "decision": {
+      "state": "dry-run-candidate-only",
+      "allowedActions": {
+        "inspect": true,
+        "suggestPatch": false,
+        "applyPatch": false,
+        "generateCopy": false
+      },
+      "humanReviewRequired": true,
+      "autoApply": false
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.summary.selected.json
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.summary.selected.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "react-web-issue-report-summary.v1",
+  "projection": "summary-json",
+  "filePath": "test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx",
+  "readOnly": true,
+  "autoApply": false,
+  "summary": {
+    "issueCount": 1,
+    "safePreviewCount": 0,
+    "manualReviewCount": 1,
+    "unsafeToAutoApplyCount": 1
+  },
+  "triageTopIds": {
+    "rankedIssueIds": [
+      "react-web-label-1"
+    ],
+    "topIssueIds": [
+      "react-web-label-1"
+    ],
+    "topManualReviewIssueIds": [
+      "react-web-label-1"
+    ],
+    "safePreviewIssueIds": [],
+    "manualReviewIssueIds": [
+      "react-web-label-1"
+    ]
+  },
+  "firstMinuteSummary": {
+    "sourceTopIssueIds": [
+      "react-web-label-1"
+    ],
+    "firstItem": {
+      "issueId": "react-web-label-1",
+      "fixShape": "human-reviewed-htmlFor-target",
+      "firstInspectStep": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4 (label) before editing.",
+      "nextAction": "Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4 (label) first; confirm current source still matches before suggesting changes.",
+      "humanDecisionNeeded": [
+        "Confirm the final accessible label/name copy from current source context.",
+        "Choose the label/name shape from local JSX evidence."
+      ],
+      "doNotDo": [
+        "Do not apply patches automatically from this report.",
+        "Do not infer custom-component semantics.",
+        "Do not generate final label/name copy automatically."
+      ],
+      "fixShapeGuidance": {
+        "claimBoundary": "Local fix-shape guidance only: uses native element, same-file JSX attributes/context, safe-preview presence, and related-context entries; it is read-only, requires human review, and does not generate accessible-name copy or infer custom-component semantics.",
+        "humanReviewRequired": true,
+        "autoApply": false
+      },
+      "decision": {
+        "state": "human-decision-required",
+        "allowedActions": {
+          "inspect": true,
+          "suggestPatch": false,
+          "applyPatch": false,
+          "generateCopy": false
+        },
+        "humanReviewRequired": true,
+        "autoApply": false
+      }
+    }
+  }
+}

--- a/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.text.excerpt.txt
+++ b/test/fixtures/react-web-issues-golden/missing-htmlfor-target-only.text.excerpt.txt
@@ -1,0 +1,5 @@
+## First-minute summary
+- react-web-label-1: human-reviewed-htmlFor-target; first inspect: Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4 (label) before editing.
+  - next action: Inspect test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx:4-4 (label) first; confirm current source still matches before suggesting changes.
+  - human decision needed: Confirm the final accessible label/name copy from current source context.; Choose the label/name shape from local JSX evidence.
+  - do not do: Do not apply patches automatically from this report.; Do not infer custom-component semantics.; Do not generate final label/name copy automatically.

--- a/test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx
+++ b/test/fixtures/react-web-label-preview/missing-htmlfor-target-only.tsx
@@ -1,0 +1,8 @@
+export function MissingHtmlForTargetOnly() {
+  return (
+    <form>
+      <label htmlFor="missing-email">Email address</label>
+      <input id="email" name="email" aria-label="Email address" />
+    </form>
+  );
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -5057,13 +5057,25 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
 
   assert.match(demo, /React Web issue-card golden demo/);
   assert.match(demo, /\.\.\/react-web-first-minute-work-orders\.md/);
+  assert.match(demo, /short golden slices instead of one kitchen-sink fixture/);
   assert.match(demo, /fooks inspect react-web-issues fixtures\/compressed\/FormControls\.tsx/);
-  assert.match(demo, /Before source/);
+  assert.match(demo, /Demo 1: missing or empty native label\/name evidence/);
+  assert.match(demo, /Empty `aria-label` evidence/);
+  assert.match(demo, /Demo 2: `htmlFor` wiring cards/);
+  assert.match(demo, /Demo 3: duplicate id and conflicting label intent/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/empty-aria-labels\.tsx/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/missing-htmlfor-target-only\.tsx/);
+  assert.match(demo, /fooks inspect react-web-issues test\/fixtures\/react-web-label-preview\/label-association-candidates\.tsx/);
   assert.match(demo, /problem/);
   assert.match(demo, /whyItMatters/);
   assert.match(demo, /whereToLook/);
   assert.match(demo, /confidence/);
   assert.match(demo, /suggestedAction/);
+  assert.match(demo, /react-web\\.empty-accessible-name|Native input has empty accessible-name evidence/);
+  assert.match(demo, /react-web\\.missing-htmlFor-target|Native label htmlFor target is missing/);
+  assert.match(demo, /safe-preview-htmlFor-association/);
+  assert.match(demo, /human-reviewed-duplicate-id-association/);
+  assert.match(demo, /human-reviewed-conflicting-label-association/);
   assert.match(demo, /--summary-json/);
   assert.match(demo, /firstMinuteSummary|First-minute handoff/);
   assert.match(demo, /--dry-run-json/);
@@ -5085,13 +5097,31 @@ test("React Web issue-card public demo keeps selected golden handoff strings", (
   const demo = fs.readFileSync(path.join(repoRoot, "docs", "demo", "react-web-issues.md"), "utf8");
   const summaryGolden = readReactWebIssueGoldenJson("form-controls.summary.selected.json");
   const dryRunGolden = readReactWebIssueGoldenJson("form-controls.dry-run.selected.json");
+  const emptyAriaSummaryGolden = readReactWebIssueGoldenJson("empty-aria-labels.summary.selected.json");
+  const associationDryRunGolden = readReactWebIssueGoldenJson("label-association-candidates.dry-run.selected.json");
+  const missingHtmlForSummaryGolden = readReactWebIssueGoldenJson("missing-htmlfor-target-only.summary.selected.json");
+  const duplicateIdSummaryGolden = readReactWebIssueGoldenJson("duplicate-id-controls.summary.selected.json");
+  const conflictingLabelSummaryGolden = readReactWebIssueGoldenJson("conflicting-label-association.summary.selected.json");
   const firstItem = summaryGolden.firstMinuteSummary.firstItem;
+  const emptyAriaFirstItem = emptyAriaSummaryGolden.firstMinuteSummary.firstItem;
+  const associationCandidate = associationDryRunGolden.firstCandidate;
+  const missingHtmlForFirstItem = missingHtmlForSummaryGolden.firstMinuteSummary.firstItem;
+  const duplicateIdFirstItem = duplicateIdSummaryGolden.firstMinuteSummary.firstItem;
+  const conflictingLabelFirstItem = conflictingLabelSummaryGolden.firstMinuteSummary.firstItem;
 
   assert.match(demo, new RegExp(escapeRegExp(firstItem.firstInspectStep)));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.nextAction)));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.humanDecisionNeeded[0])));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[0])));
   assert.match(demo, new RegExp(escapeRegExp(firstItem.doNotDo[2])));
+  assert.match(demo, new RegExp(escapeRegExp(emptyAriaFirstItem.firstInspectStep)));
+  assert.match(demo, new RegExp(escapeRegExp(emptyAriaFirstItem.nextAction)));
+  assert.match(demo, new RegExp(escapeRegExp(missingHtmlForFirstItem.issueId)));
+  assert.match(demo, new RegExp(escapeRegExp(missingHtmlForFirstItem.fixShape)));
+  assert.match(demo, new RegExp(escapeRegExp(associationCandidate.migrationCandidate)));
+  assert.match(demo, new RegExp(escapeRegExp(duplicateIdFirstItem.fixShape)));
+  assert.match(demo, new RegExp(escapeRegExp(conflictingLabelFirstItem.fixShape)));
+  assert.match(demo, new RegExp(escapeRegExp(String(associationCandidate.previewAvailable))));
   assert.match(demo, new RegExp(escapeRegExp(String(dryRunGolden.firstCandidate.dryRunOnly))));
 });
 

--- a/test/react-web-issue-report.test.mjs
+++ b/test/react-web-issue-report.test.mjs
@@ -46,6 +46,7 @@ const fixtures = {
   quietNativeEvidence: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "quiet-native-evidence.tsx"),
   duplicateIds: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "duplicate-id-controls.tsx"),
   missingHtmlForTarget: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target.tsx"),
+  missingHtmlForTargetOnly: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "missing-htmlfor-target-only.tsx"),
   conflictingLabelAssociation: path.join(repoRoot, "test", "fixtures", "react-web-label-preview", "conflicting-label-association.tsx"),
   formControls: path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"),
   rn: path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations", "rn-accessibility-test-anchor.tsx"),
@@ -141,11 +142,25 @@ function projectTextGolden(text) {
   const summaryLines = lines.slice(summaryIndex, lines.findIndex((line, index) => index > summaryIndex && line.startsWith("## Issue 1:")));
   return [
     "## First-minute summary",
-    summaryLines.find((line) => line.startsWith("- react-web-label-1: human-reviewed-native-control-name;")),
+    summaryLines.find((line) => /^- react-web-(?:label|htmlfor-target)-\d+:/.test(line)),
     summaryLines.find((line) => line.trimStart().startsWith("- next action:")),
     summaryLines.find((line) => line.trimStart().startsWith("- human decision needed:")),
     summaryLines.find((line) => line.trimStart().startsWith("- do not do:")),
   ].join("\n").trimEnd();
+}
+
+function projectSummaryGoldenWithSource(summary) {
+  return {
+    ...projectSummaryGolden(summary),
+    sourceIssueCounts: summary.sourceIssueCounts,
+  };
+}
+
+function projectDryRunGoldenWithSource(dryRun) {
+  return {
+    ...projectDryRunGolden(dryRun),
+    sourceIssueCounts: dryRun.sourceIssueCounts,
+  };
 }
 
 function hasNestedKey(value, key) {
@@ -1226,6 +1241,64 @@ test("React Web issue report text output matches selected golden excerpt", () =>
   assert.equal(cli.status, 0, cli.stderr);
 
   assert.equal(projectTextGolden(cli.stdout), readGoldenText("form-controls.text.excerpt.txt"));
+});
+
+test("React Web issue report selected golden contracts cover current demo card families", () => {
+  const cases = [
+    {
+      fixture: fixtures.emptyAriaLabel,
+      prefix: "empty-aria-labels",
+      expectedKind: "react-web.empty-accessible-name",
+      expectedFixShape: "human-reviewed-accessible-name",
+    },
+    {
+      fixture: fixtures.missingHtmlForTargetOnly,
+      prefix: "missing-htmlfor-target-only",
+      expectedKind: "react-web.missing-htmlFor-target",
+      expectedFixShape: "human-reviewed-htmlFor-target",
+    },
+    {
+      fixture: fixtures.association,
+      prefix: "label-association-candidates",
+      expectedKind: "react-web.unassociated-nearby-label",
+      expectedFixShape: "safe-preview-htmlFor-association",
+    },
+    {
+      fixture: fixtures.duplicateIds,
+      prefix: "duplicate-id-controls",
+      expectedKind: "react-web.duplicate-literal-id",
+      expectedFixShape: "human-reviewed-duplicate-id-association",
+    },
+    {
+      fixture: fixtures.conflictingLabelAssociation,
+      prefix: "conflicting-label-association",
+      expectedKind: "react-web.conflicting-label-association",
+      expectedFixShape: "human-reviewed-conflicting-label-association",
+    },
+  ];
+
+  for (const entry of cases) {
+    const report = parseIssues(entry.fixture);
+    assert.ok(report.issues.some((issue) => issue.kind === entry.expectedKind));
+
+    const summaryCli = runIssues(entry.fixture, "--summary-json");
+    const dryRunCli = runIssues(entry.fixture, "--dry-run-json");
+    const textCli = runIssues(entry.fixture);
+    assert.equal(summaryCli.status, 0, summaryCli.stderr);
+    assert.equal(dryRunCli.status, 0, dryRunCli.stderr);
+    assert.equal(textCli.status, 0, textCli.stderr);
+
+    const summary = JSON.parse(summaryCli.stdout);
+    const dryRun = JSON.parse(dryRunCli.stdout);
+    assert.equal(summary.firstMinuteSummary.items[0].decision.issueKind, entry.expectedKind);
+    assert.equal(dryRun.candidates[0].decision.issueKind, entry.expectedKind);
+    assert.equal(summary.firstMinuteSummary.items[0].fixShape, entry.expectedFixShape);
+    assert.equal(dryRun.candidates[0].migrationCandidate, entry.expectedFixShape);
+
+    assert.deepEqual(projectSummaryGolden(summary), readGoldenJson(`${entry.prefix}.summary.selected.json`));
+    assert.deepEqual(projectDryRunGolden(dryRun), readGoldenJson(`${entry.prefix}.dry-run.selected.json`));
+    assert.equal(projectTextGolden(textCli.stdout), readGoldenText(`${entry.prefix}.text.excerpt.txt`));
+  }
 });
 
 test("React Web issue report migration dry-run JSON preserves empty and unsupported boundaries", () => {


### PR DESCRIPTION
## Summary
- recreate the demo/golden refresh from latest `origin/main` to avoid the stale/conflicting PR branch
- split the README-facing React Web issue-card demo into three short representative groups
- add selected goldens for empty `aria-label`, missing `htmlFor` target, safe-preview association, duplicate literal id, and conflicting label association cards
- update README/tests so duplicate-id and conflicting-label cards are shown as emitted manual-review cards, not future/boundary-only claims

Closes #849

## Validation
- npm run typecheck
- npm run build
- node --test --test-name-pattern "React Web issue report selected golden contracts cover current demo card families|React Web issue-card public demo|README smoke keeps first-minute compare path discoverable|React Web first-minute work-order docs stay discoverable" test/react-web-issue-report.test.mjs test/fooks.test.mjs
- git diff --check
- npm test: 783/784 pass; one local pre-existing environment-sensitive failure remains in `init creates config and cache contract` because this checkout resolves owner `minislively` instead of expected `<your-github-org>`

## Replacement note
This replaces closed stale PR #850, which was opened before pulling latest main and became conflicting.