### PR TITLE
Add read-only stale worktree audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bench:layer2:provider-cost:corrected-manifest": "npm run build && node benchmarks/layer2-frontend-task/build-provider-cost-corrected-manifest.js",
     "bench:layer2:billing-import": "node benchmarks/layer2-frontend-task/billing-import-evidence.js",
     "branch:audit": "node scripts/audit-remote-branches.mjs",
+    "worktree:audit": "node scripts/audit-stale-worktrees.mjs",
     "ci:alerts": "node scripts/triage-ci-alerts.mjs",
     "pr:alerts": "node scripts/guard-pr-alerts.mjs",
     "pr:merge-cleanup": "node scripts/classify-pr-merge-cleanup.mjs",

--- a/scripts/audit-stale-worktrees.mjs
+++ b/scripts/audit-stale-worktrees.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+
+function parseArgs(argv) {
+  const options = { cwd: repoRoot, format: "markdown" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--cwd") options.cwd = path.resolve(argv[++index] ?? "");
+    else if (arg === "--json") options.format = "json";
+    else if (arg === "--markdown") options.format = "markdown";
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.cwd) throw new Error("--cwd must be non-empty");
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/audit-stale-worktrees.mjs [options]\n\nRead-only stale worktree audit for fooks local worktree cleanup review.\nIt inspects local git worktrees, local remote-tracking refs, GitHub PR/issue\nevidence when gh is available, and tmux pane paths when tmux is available.\n\nOptions:\n  --cwd <path>      Project/worktree to audit (default: repository root)\n  --json            Emit machine-readable JSON\n  --markdown        Emit markdown (default)\n  -h, --help        Show this help\n\nBoundary:\n  This audit does not fetch, prune, remove worktrees, delete branches, push,\n  kill tmux sessions, write report files, or mutate runtime state. Any cleanup\n  command shown is a manual operator worksheet item only.`);
+}
+
+function inlineCode(value) {
+  return `\`${String(value ?? "").replaceAll("`", "\\`")}\``;
+}
+
+function markdownEscape(value) {
+  return String(value ?? "").replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function categoryLabel(category) {
+  if (category === "safe-cleanup") return "Safe cleanup candidates";
+  if (category === "salvage-review") return "Salvage review required";
+  if (category === "manual-review-noise") return "Manual review noise";
+  return "Keep / active or unknown";
+}
+
+function renderOpenIssue(openIssue) {
+  if (openIssue?.state === "open") return openIssue.issues.map((issue) => issue.number ? `#${issue.number}` : issue.url ?? "open").join(", ");
+  if (openIssue?.state === "none" && openIssue.checkedIssueNumbers?.length) return `none (${openIssue.checkedIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(", ")})`;
+  return openIssue?.state ?? "unknown";
+}
+
+function renderEntryTable(entries) {
+  if (!entries.length) return "No worktrees in this category.";
+  const header = "| Path | Branch | Dirty | Ahead | Remote | Open PR | Open issue | Tmux panes | Decision |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |";
+  const rows = entries.map((entry) => {
+    const openPr = entry.openPullRequest?.state === "open"
+      ? entry.openPullRequest.pullRequests.map((pullRequest) => pullRequest.number ? `#${pullRequest.number}` : pullRequest.url ?? "open").join(", ")
+      : entry.openPullRequest?.state ?? "unknown";
+    const candidateLabel = entry.staleReviewCandidate ? "stale-review-candidate" : entry.reasons[0] ?? "review evidence";
+    return [
+      inlineCode(entry.path),
+      inlineCode(entry.branch ?? "<detached>"),
+      markdownEscape(entry.dirty),
+      markdownEscape(entry.aheadOfBase ?? "unknown"),
+      markdownEscape(entry.remoteBranchExists),
+      markdownEscape(openPr),
+      markdownEscape(renderOpenIssue(entry.openIssue)),
+      markdownEscape(entry.activeTmuxPaneCount),
+      markdownEscape(candidateLabel),
+    ].join(" | ");
+  }).map((row) => `| ${row} |`);
+  return `${header}\n${rows.join("\n")}`;
+}
+
+export function renderStaleWorktreeAuditMarkdown(result) {
+  const counts = Object.fromEntries(Object.entries(result.triage.categories).map(([category, entries]) => [category, entries.length]));
+  const lines = [
+    "# Stale worktree audit",
+    "",
+    `Command: ${inlineCode("worktree:audit")}`,
+    `Linked issue: ${inlineCode("#854")}`,
+    `Generated: ${inlineCode(result.triage.generatedAt)}`,
+    `Audited cwd: ${inlineCode(result.triage.cwd)}`,
+    `Sibling root: ${inlineCode(result.triage.siblingRoot ?? "unknown")}`,
+    `Base ref: ${inlineCode(result.triage.baseRef ?? "unknown")}`,
+    `Stale review rule: ${inlineCode(result.staleReviewCandidateRule)}`,
+    "",
+    "## Read-only boundary",
+    "",
+    result.claimBoundary,
+    "",
+    "## Counts",
+    "",
+    `- Stale review candidates: ${result.staleReviewCandidates.length}`,
+    `- Safe cleanup candidates: ${counts["safe-cleanup"] ?? 0}`,
+    `- Salvage review required: ${counts["salvage-review"] ?? 0}`,
+    `- Manual review noise: ${counts["manual-review-noise"] ?? 0}`,
+    `- Keep / active or unknown: ${counts.keep ?? 0}`,
+    "",
+    "## Stale review candidates",
+    "",
+    renderEntryTable(result.entries.filter((entry) => entry.staleReviewCandidate)),
+    "",
+  ];
+
+  for (const category of ["salvage-review", "safe-cleanup", "manual-review-noise", "keep"]) {
+    lines.push(`## ${categoryLabel(category)}`, "", renderEntryTable(result.entries.filter((entry) => entry.category === category)), "");
+  }
+
+  lines.push("## Blockers", "");
+  if (result.blockers.length) {
+    for (const blocker of result.blockers) lines.push(`- ${blocker}`);
+  } else {
+    lines.push("No blockers recorded.");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function buildStaleWorktreeAudit(cwd, triageOrOptions = undefined) {
+  const { buildStaleWorktreeAudit: buildAudit } = require(path.join(repoRoot, "dist", "ops", "stale-worktree-audit.js"));
+  if (typeof triageOrOptions === "function") return buildAudit(cwd, { triage: triageOrOptions });
+  return buildAudit(cwd, triageOrOptions ?? {});
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const audit = buildStaleWorktreeAudit(options.cwd);
+  const output = options.format === "json" ? `${JSON.stringify(audit, null, 2)}\n` : renderStaleWorktreeAuditMarkdown(audit);
+  process.stdout.write(output);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -662,6 +662,7 @@ Everyday commands:
   ${displayCliName} status worktree
   ${displayCliName} status react-web [--json]
   ${displayCliName} status artifacts [--json]
+  ${displayCliName} status stale-worktrees [--json]
   ${displayCliName} status orphan-worktrees [--json]
   ${displayCliName} status activity [--include-remote-counts]
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
@@ -1474,6 +1475,17 @@ async function run(): Promise<void> {
         print(auditArtifacts(process.cwd()));
         return;
       }
+      if (arg1 === "stale-worktrees") {
+        const allowed = new Set(["--json"]);
+        for (const arg of rest.slice(1)) {
+          if (!allowed.has(arg)) {
+            throw new Error(`Unexpected status stale-worktrees argument: ${arg}`);
+          }
+        }
+        const { buildStaleWorktreeAudit } = await import("../ops/stale-worktree-audit.js");
+        print(buildStaleWorktreeAudit(process.cwd(), { command: "status stale-worktrees" }));
+        return;
+      }
       if (arg1 === "orphan-worktrees") {
         const allowed = new Set(["--json"]);
         for (const arg of rest.slice(1)) {
@@ -1496,7 +1508,7 @@ async function run(): Promise<void> {
         print(readOperatorActivitySnapshot(process.cwd(), { includeRemoteCounts: rest.includes("--include-remote-counts") }));
         return;
       }
-      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'react-web', 'artifacts', 'orphan-worktrees', or 'activity'");
+      throw new Error("status expects no argument, 'codex', 'claude', 'cache', 'worktree', 'react-web', 'artifacts', 'stale-worktrees', 'orphan-worktrees', or 'activity'");
     }
     case "codex-pre-read": {
       const { decideCodexPreRead } = await import("../adapters/codex-pre-read.js");

--- a/src/ops/stale-worktree-audit.ts
+++ b/src/ops/stale-worktree-audit.ts
@@ -1,0 +1,181 @@
+import { execFileSync } from "node:child_process";
+import type { OrphanLocalWorktreeEntry, OrphanLocalWorktreeTriageResult } from "./orphan-local-worktree-triage";
+import { triageOrphanLocalWorktrees } from "./orphan-local-worktree-triage";
+
+export const STALE_WORKTREE_AUDIT_SCHEMA_VERSION = 1;
+export const STALE_WORKTREE_AUDIT_COMMAND = "worktree:audit";
+export const STALE_WORKTREE_STATUS_COMMAND = "status stale-worktrees";
+export const STALE_WORKTREE_AUDIT_ISSUE = "#854";
+export const STALE_WORKTREE_AUDIT_ISSUE_URL = "https://github.com/minislively/fooks/issues/854";
+export const STALE_WORKTREE_AUDIT_CLAIM_BOUNDARY =
+  "Read-only stale worktree audit; does not fetch, prune, remove worktrees, delete branches, push, kill tmux sessions, write report files, or mutate runtime state. Cleanup commands in nested triage data are manual worksheet suggestions only.";
+export const STALE_WORKTREE_OPEN_ISSUE_SOURCE = "gh issue list --state open --json number,url,title --limit 200";
+export const STALE_WORKTREE_AUDIT_TIMEOUT_MS = 3000;
+
+export type StaleWorktreeAuditCommand = typeof STALE_WORKTREE_AUDIT_COMMAND | typeof STALE_WORKTREE_STATUS_COMMAND;
+export type StaleWorktreeAuditRunner = (command: string, args: string[], cwd: string) => string;
+
+export type StaleWorktreeOpenIssueEvidence =
+  | { state: "none"; source: typeof STALE_WORKTREE_OPEN_ISSUE_SOURCE; checkedIssueNumbers: number[] }
+  | { state: "open"; source: typeof STALE_WORKTREE_OPEN_ISSUE_SOURCE; checkedIssueNumbers: number[]; issues: { number: number; url?: string; title?: string }[] }
+  | { state: "unknown"; source: typeof STALE_WORKTREE_OPEN_ISSUE_SOURCE; checkedIssueNumbers: number[]; reason: string };
+
+export type StaleWorktreeCandidate = {
+  path: string;
+  branch?: string;
+  orphanCategory: OrphanLocalWorktreeEntry["category"];
+  dirty: OrphanLocalWorktreeEntry["dirty"];
+  aheadOfBase?: number;
+  behindBase?: number;
+  remoteBranchExists: OrphanLocalWorktreeEntry["remoteBranchExists"];
+  openPullRequest: OrphanLocalWorktreeEntry["openPullRequest"];
+  openIssue: StaleWorktreeOpenIssueEvidence;
+  diffEvidence: OrphanLocalWorktreeEntry["diffEvidence"];
+  decision: "stale-review-candidate";
+  decisionReason: string;
+};
+
+export type StaleWorktreeAuditResult = {
+  schemaVersion: typeof STALE_WORKTREE_AUDIT_SCHEMA_VERSION;
+  command: StaleWorktreeAuditCommand;
+  linkedIssue: typeof STALE_WORKTREE_AUDIT_ISSUE;
+  linkedIssueUrl: typeof STALE_WORKTREE_AUDIT_ISSUE_URL;
+  readOnly: true;
+  claimBoundary: typeof STALE_WORKTREE_AUDIT_CLAIM_BOUNDARY;
+  openIssueSource: typeof STALE_WORKTREE_OPEN_ISSUE_SOURCE;
+  staleReviewCandidateRule: "open PR=0 + open issue=0 + local diff check completed";
+  staleReviewCandidates: StaleWorktreeCandidate[];
+  entries: Array<OrphanLocalWorktreeEntry & { openIssue: StaleWorktreeOpenIssueEvidence; staleReviewCandidate: boolean }>;
+  triage: OrphanLocalWorktreeTriageResult;
+  blockers: string[];
+};
+
+export type StaleWorktreeAuditOptions = {
+  command?: StaleWorktreeAuditCommand;
+  runner?: StaleWorktreeAuditRunner;
+  triage?: OrphanLocalWorktreeTriageResult | ((cwd: string) => OrphanLocalWorktreeTriageResult);
+};
+
+function defaultRunner(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: STALE_WORKTREE_AUDIT_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+function errorDetail(error: unknown): string {
+  const maybeError = error && typeof error === "object" ? (error as { message?: unknown; stderr?: unknown; signal?: unknown; code?: unknown }) : {};
+  const stderr = maybeError.stderr;
+  const stderrText = Buffer.isBuffer(stderr) ? stderr.toString("utf8").trim() : typeof stderr === "string" ? stderr.trim() : "";
+  const message = typeof maybeError.message === "string" ? maybeError.message.trim() : String(error);
+  const status = maybeError.signal ? `signal ${String(maybeError.signal)}` : maybeError.code !== undefined ? `code ${String(maybeError.code)}` : "";
+  const detail = stderrText || message || "unknown error";
+  return status ? `${detail} (${status})` : detail;
+}
+
+function uniqueSortedNumbers(values: number[]): number[] {
+  return [...new Set(values)].sort((left, right) => left - right);
+}
+
+function uniqueSortedStrings(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+export function referencedIssueNumbers(entry: Pick<OrphanLocalWorktreeEntry, "path" | "branch">): number[] {
+  const haystack = [entry.branch, entry.path].filter(Boolean).join(" ");
+  const issueNumbers: number[] = [];
+  for (const match of haystack.matchAll(/(?:^|[^a-z0-9])(?:issue[-_/]?|#)(\d{1,6})(?=$|[^a-z0-9])/giu)) {
+    const issueNumber = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isFinite(issueNumber)) issueNumbers.push(issueNumber);
+  }
+  return uniqueSortedNumbers(issueNumbers);
+}
+
+function readOpenIssueIndex(runner: StaleWorktreeAuditRunner, cwd: string): { openIssuesByNumber: Map<number, { number: number; url?: string; title?: string }>; blocker?: string } {
+  try {
+    const output = runner("gh", ["issue", "list", "--state", "open", "--json", "number,url,title", "--limit", "200"], cwd);
+    const parsed = JSON.parse(output) as { number?: number; url?: string; title?: string }[];
+    const openIssuesByNumber = new Map<number, { number: number; url?: string; title?: string }>();
+    if (!Array.isArray(parsed)) return { openIssuesByNumber };
+    for (const issue of parsed) {
+      if (typeof issue.number !== "number") continue;
+      openIssuesByNumber.set(issue.number, { number: issue.number, url: issue.url, title: issue.title });
+    }
+    return { openIssuesByNumber };
+  } catch (error) {
+    return { openIssuesByNumber: new Map(), blocker: `gh open issue list unavailable: ${errorDetail(error)}` };
+  }
+}
+
+function openIssueEvidence(entry: OrphanLocalWorktreeEntry, issueIndex: ReturnType<typeof readOpenIssueIndex>): StaleWorktreeOpenIssueEvidence {
+  const checkedIssueNumbers = referencedIssueNumbers(entry);
+  if (issueIndex.blocker) {
+    return { state: "unknown", source: STALE_WORKTREE_OPEN_ISSUE_SOURCE, checkedIssueNumbers, reason: issueIndex.blocker };
+  }
+  const issues = checkedIssueNumbers.map((issueNumber) => issueIndex.openIssuesByNumber.get(issueNumber)).filter((issue): issue is { number: number; url?: string; title?: string } => Boolean(issue));
+  return issues.length > 0
+    ? { state: "open", source: STALE_WORKTREE_OPEN_ISSUE_SOURCE, checkedIssueNumbers, issues }
+    : { state: "none", source: STALE_WORKTREE_OPEN_ISSUE_SOURCE, checkedIssueNumbers };
+}
+
+function isStaleReviewCandidate(entry: OrphanLocalWorktreeEntry, openIssue: StaleWorktreeOpenIssueEvidence): boolean {
+  return !entry.current &&
+    entry.activeTmuxPaneCount === 0 &&
+    entry.openPullRequest.state === "none" &&
+    openIssue.state === "none" &&
+    entry.diffEvidence.changed !== "unknown" &&
+    entry.dirty !== "unknown";
+}
+
+export function buildStaleWorktreeAudit(cwd = process.cwd(), options: StaleWorktreeAuditOptions = {}): StaleWorktreeAuditResult {
+  const runner = options.runner ?? defaultRunner;
+  const triage = typeof options.triage === "function"
+    ? options.triage(cwd)
+    : options.triage ?? triageOrphanLocalWorktrees(cwd);
+  const issueIndex = readOpenIssueIndex(runner, cwd);
+  const blockers = [...triage.blockers];
+  if (issueIndex.blocker) blockers.push(issueIndex.blocker);
+
+  const entries = triage.entries.map((entry) => {
+    const openIssue = openIssueEvidence(entry, issueIndex);
+    return {
+      ...entry,
+      openIssue,
+      staleReviewCandidate: isStaleReviewCandidate(entry, openIssue),
+    };
+  });
+
+  const staleReviewCandidates = entries.filter((entry) => entry.staleReviewCandidate).map((entry) => ({
+    path: entry.path,
+    branch: entry.branch,
+    orphanCategory: entry.category,
+    dirty: entry.dirty,
+    aheadOfBase: entry.aheadOfBase,
+    behindBase: entry.behindBase,
+    remoteBranchExists: entry.remoteBranchExists,
+    openPullRequest: entry.openPullRequest,
+    openIssue: entry.openIssue,
+    diffEvidence: entry.diffEvidence,
+    decision: "stale-review-candidate" as const,
+    decisionReason: "open PR=0, open issue=0, and local diff evidence was checked before stale review classification",
+  }));
+
+  return {
+    schemaVersion: STALE_WORKTREE_AUDIT_SCHEMA_VERSION,
+    command: options.command ?? STALE_WORKTREE_AUDIT_COMMAND,
+    linkedIssue: STALE_WORKTREE_AUDIT_ISSUE,
+    linkedIssueUrl: STALE_WORKTREE_AUDIT_ISSUE_URL,
+    readOnly: true,
+    claimBoundary: STALE_WORKTREE_AUDIT_CLAIM_BOUNDARY,
+    openIssueSource: STALE_WORKTREE_OPEN_ISSUE_SOURCE,
+    staleReviewCandidateRule: "open PR=0 + open issue=0 + local diff check completed",
+    staleReviewCandidates,
+    entries,
+    triage,
+    blockers: uniqueSortedStrings(blockers),
+  };
+}

--- a/test/stale-worktree-audit.test.mjs
+++ b/test/stale-worktree-audit.test.mjs
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const auditScript = path.join(repoRoot, "scripts", "audit-stale-worktrees.mjs");
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function fakeTriage() {
+  return {
+    schemaVersion: 2,
+    command: "status orphan-worktrees",
+    linkedIssue: "#711",
+    linkedIssueUrl: "https://github.com/minislively/fooks/issues/711",
+    generatedAt: "2026-05-15T00:00:00.000Z",
+    cwd: "/work/fooks.omx-worktrees/current",
+    siblingRoot: "/work/fooks.omx-worktrees",
+    baseRef: "origin/main",
+    claimBoundary: "orphan local worktree triage boundary",
+    readOnly: true,
+    categories: {
+      "safe-cleanup": [],
+      "salvage-review": [],
+      "manual-review-noise": [],
+      keep: [],
+    },
+    entries: [],
+    decisionTable: [],
+    operatorWorksheet: {
+      issue: "#711",
+      readOnly: true,
+      requiredConfirmation: "manual confirmation required",
+      localOnlyCommitPolicy: "do-not-delete-local-only-commits-automatically",
+    },
+    blockers: [],
+  };
+}
+
+function fakeEntry(overrides) {
+  return {
+    path: "/work/fooks.omx-worktrees/fooks-issue-123-stale-merged",
+    branch: "fooks-issue-123-stale-merged",
+    head: "abc123",
+    current: false,
+    exists: true,
+    category: "safe-cleanup",
+    reasons: ["safe cleanup candidate"],
+    dirty: false,
+    changedPathCount: 0,
+    aheadOfBase: 0,
+    behindBase: 0,
+    baseRef: "origin/main",
+    diffEvidence: { source: "git diff --shortstat origin/main...HEAD", changed: false, summary: "no committed diff against base" },
+    remoteBranchExists: false,
+    openPullRequest: { state: "none", source: "gh pr list --state open --json number,url,headRefName --limit 200" },
+    closedPullRequest: { state: "none", source: "gh pr list --state closed --json number,url,headRefName,state,closedAt --limit 200" },
+    activeTmuxPaneCount: 0,
+    manualReviewCommands: [],
+    manualCleanupCommands: ["git worktree remove <path>"],
+    ...overrides,
+  };
+}
+
+function triageWithEntries(entries) {
+  const triage = fakeTriage();
+  triage.entries = entries;
+  triage.categories = {
+    "safe-cleanup": entries.filter((entry) => entry.category === "safe-cleanup"),
+    "salvage-review": entries.filter((entry) => entry.category === "salvage-review"),
+    "manual-review-noise": entries.filter((entry) => entry.category === "manual-review-noise"),
+    keep: entries.filter((entry) => entry.category === "keep"),
+  };
+  return triage;
+}
+
+function issueRunner(openIssues) {
+  return (command, args) => {
+    if (command === "gh" && args.join(" ") === "issue list --state open --json number,url,title --limit 200") {
+      return JSON.stringify(openIssues);
+    }
+    throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+  };
+}
+
+test("stale worktree audit helpers wrap issue 854 and render stale categories", async () => {
+  const { buildStaleWorktreeAudit, renderStaleWorktreeAuditMarkdown } = await import(auditScript);
+  const staleEntry = fakeEntry({
+    path: "/work/fooks.omx-worktrees/fooks-issue-123-stale-merged",
+    branch: "fooks-issue-123-stale-merged",
+  });
+  const openIssueEntry = fakeEntry({
+    path: "/work/fooks.omx-worktrees/fooks-issue-999-active-issue",
+    branch: "fooks-issue-999-active-issue",
+    category: "salvage-review",
+    aheadOfBase: 2,
+    diffEvidence: { source: "git diff --shortstat origin/main...HEAD", changed: true, summary: "1 file changed" },
+    reasons: ["local-only commits need review"],
+  });
+  const currentEntry = fakeEntry({
+    path: "/work/fooks.omx-worktrees/current",
+    branch: "current",
+    current: true,
+    category: "keep",
+    activeTmuxPaneCount: 1,
+    reasons: ["worktree is the current working directory"],
+  });
+  const triage = triageWithEntries([staleEntry, openIssueEntry, currentEntry]);
+
+  const result = buildStaleWorktreeAudit(triage.cwd, {
+    triage,
+    runner: issueRunner([{ number: 999, url: "https://github.com/minislively/fooks/issues/999", title: "active issue" }]),
+  });
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "worktree:audit");
+  assert.equal(result.linkedIssue, "#854");
+  assert.equal(result.readOnly, true);
+  assert.match(result.claimBoundary, /does not fetch, prune, remove worktrees, delete branches/);
+  assert.match(result.claimBoundary, /write report files/);
+  assert.equal(result.staleReviewCandidateRule, "open PR=0 + open issue=0 + local diff check completed");
+  assert.deepEqual(result.staleReviewCandidates.map((entry) => entry.branch), ["fooks-issue-123-stale-merged"]);
+  assert.equal(result.entries.find((entry) => entry.branch === "fooks-issue-999-active-issue").openIssue.state, "open");
+  assert.equal(result.entries.find((entry) => entry.branch === "fooks-issue-999-active-issue").staleReviewCandidate, false);
+
+  const markdown = renderStaleWorktreeAuditMarkdown(result);
+  assert.match(markdown, /# Stale worktree audit/);
+  assert.match(markdown, /Read-only boundary/);
+  assert.match(markdown, /Open issue/);
+  assert.match(markdown, /stale-review-candidate/);
+  assert.match(markdown, /Salvage review required/);
+  assert.match(markdown, /Safe cleanup candidates/);
+});
+
+test("stale worktree audit builder reads the current repo without mutation", async () => {
+  const { buildStaleWorktreeAudit } = await import(auditScript);
+  const result = buildStaleWorktreeAudit(repoRoot);
+  assert.equal(result.command, "worktree:audit");
+  assert.equal(result.linkedIssue, "#854");
+  assert.equal(result.readOnly, true);
+  assert.ok(Array.isArray(result.triage.entries));
+  assert.ok(Array.isArray(result.entries));
+  assert.ok(Array.isArray(result.staleReviewCandidates));
+});
+
+test("stale worktree audit script is stdout-only and rejects report file writes", () => {
+  const result = spawnSync(process.execPath, [auditScript, "--output", "audit.md"], { cwd: repoRoot, encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unknown argument: --output/);
+});
+
+test("status stale-worktrees emits issue 854 JSON and rejects unknown args", () => {
+  const output = execFileSync(process.execPath, [cliPath, "status", "stale-worktrees", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 10_000 });
+  const result = JSON.parse(output);
+  assert.equal(result.command, "status stale-worktrees");
+  assert.equal(result.linkedIssue, "#854");
+  assert.equal(result.readOnly, true);
+  assert.equal(result.staleReviewCandidateRule, "open PR=0 + open issue=0 + local diff check completed");
+  assert.ok(Array.isArray(result.entries));
+
+  const rejected = spawnSync(process.execPath, [cliPath, "status", "stale-worktrees", "--write"], { cwd: repoRoot, encoding: "utf8" });
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /Unexpected status stale-worktrees argument: --write/);
+});
+
+test("package exposes stdout-only stale worktree audit npm script", () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts["worktree:audit"], "node scripts/audit-stale-worktrees.mjs");
+});


### PR DESCRIPTION
## Summary
- Adds a read-only stale worktree audit/status surface for issue #854.
- Centralizes issue #854 metadata and stale-review-candidate rules in `src/ops/stale-worktree-audit.ts`.
- Exposes stdout-only `npm run worktree:audit -- --json` and `fooks status stale-worktrees --json` paths.
- Keeps cleanup suggestions as review evidence only; no worktree/branch deletion or write-capable report output.

## Verification
- `npm run build`
- `node --test test/stale-worktree-audit.test.mjs`
- `npm run worktree:audit -- --json`
- `node dist/cli/index.js status stale-worktrees --json`
- `npm test` (789/789)
- `git diff --check`

Closes #854
