### PR TITLE
Anchor clean-slate reminders to active evidence

### DIFF
--- a/docs/dogfood/clean-slate-development-reminder-857.md
+++ b/docs/dogfood/clean-slate-development-reminder-857.md
@@ -1,0 +1,57 @@
+# Clean-slate development reminder anchor (#857)
+
+This is a narrow read-only docs/test operator-boundary artifact for issue #857.
+It anchors clean-slate post-merge fooks development reminders to concrete active
+issue, branch, session, or PR evidence instead of letting clean CI or release
+report echoes become the reminder itself.
+
+## Live seed
+
+The issue seed is a clean post-merge state:
+
+- main head: `a5d9ba1`
+- dirty paths: `0`
+- open PR/issues: `0/0`
+- fooks tmux/proc sessions: `0/0`
+- legacy local worktree residue exists, but no live session/proc owns it
+
+Those facts are verification and inventory receipts only. They are not active
+fooks development evidence, and they do not replace a concrete next action.
+
+## Reminder rule
+
+A clean-slate development reminder must choose exactly one of these outcomes:
+
+1. **Blocker report:** name the blocker that prevents bounded development from
+   starting, then state the concrete next action required to unblock or create an
+   active issue, branch, session, or PR anchor.
+2. **No-blocker report:** create or adopt one concrete active issue, branch,
+   session, or PR anchor, then state the next development action against that
+   anchor.
+
+If neither outcome is available, the reminder must stop at the clean-slate
+boundary: it can preserve the clean CI/release-report echo as verification
+evidence, but it must say that no active issue/branch/session/PR is currently
+attached and that one must be created or linked before reporting active fooks
+development.
+
+Issue #857 and branch `er/clean-slate-reminder-857` are the active artifacts for
+this docs/test pass only. This artifact is not cleanup authority, does not reopen
+merged work, and does not authorize fetching, deleting, pushing unrelated
+branches, or changing runtime/provider behavior.
+
+## Focused verification
+
+Use this artifact with `docs/post-merge-main-ci-echo-boundary.md` and the
+operator reminder tests only. Focused verification for this boundary is:
+
+```sh
+npm run build
+node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs
+```
+
+The verification proves the docs/test reminder boundary mentions issue #857, the
+branch/session/PR/issue anchor requirement, the blocker/no-blocker next-action
+requirement, and the clean CI echo non-authority. It does not change provider
+behavior, merge gates, detector scope, frontend behavior, cleanup policy,
+performance claims, or product claims.

--- a/docs/post-merge-main-ci-echo-boundary.md
+++ b/docs/post-merge-main-ci-echo-boundary.md
@@ -41,10 +41,13 @@ an active development artifact.
 A development reminder must not end as a status-only idle report. After it names
 the clean-slate boundary, it must either report a real blocker that prevents
 starting bounded work or create/adopt one active artifact that can anchor the
-next action: an issue, branch, session, or PR. If none of those artifacts exists,
-the reminder should say that it cannot treat the checkout as active development
-until one is created or linked; it should not present clean `main` status, green
-CI, or stale local worktree inventory as the next development action.
+next action: an issue, branch, session, or PR. Blocker and no-blocker reports
+must both keep the concrete next action explicit: either the action required to
+unblock/create the anchor, or the next development action attached to the
+adopted anchor. If none of those artifacts exists, the reminder should say that
+it cannot treat the checkout as active development until one is created or
+linked; it should not present clean `main` status, green CI, or stale local
+worktree inventory as the next development action.
 
 Keep this reminder-anchor rule separate from the `fooks check` required-artifact
 contract. Branch-only evidence can be an active work receipt or reminder anchor,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -55,10 +55,12 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   const dogfoodDoc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-merge-reminder-action-803.md"), "utf8");
   const issue823Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "post-merge-react-web-ci-echo-anchor-823.md"), "utf8");
   const issue832Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "check-clean-main-ci-echo-832.md"), "utf8");
+  const issue857Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-slate-development-reminder-857.md"), "utf8");
 
   assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
   assert.match(boundaryDoc, /create\/adopt one active artifact/);
   assert.match(boundaryDoc, /issue, branch, session, or PR/);
+  assert.match(boundaryDoc, /Blocker and no-blocker reports\s+must both keep the concrete next action explicit/);
   assert.match(boundaryDoc, /requiredActiveArtifact\.dogfoodHandoff/);
   assert.match(boundaryDoc, /requires-live-artifact/);
   assert.match(boundaryDoc, /ci-echo-and-stale-residue-are-not-active-work/);
@@ -79,6 +81,15 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   assert.match(issue832Doc, /report only that artifact as the next development anchor/);
   assert.match(issue832Doc, /verification or inventory\s+receipts only/);
   assert.match(issue832Doc, /not change runtime\/provider behavior/);
+  assert.match(issue857Doc, /issue #857/i);
+  assert.match(issue857Doc, /main head: `a5d9ba1`/);
+  assert.match(issue857Doc, /open PR\/issues: `0\/0`/);
+  assert.match(issue857Doc, /Blocker report:[\s\S]*concrete next action required/);
+  assert.match(issue857Doc, /No-blocker report:[\s\S]*concrete active issue, branch,\s+session, or PR anchor/);
+  assert.match(issue857Doc, /no active issue\/branch\/session\/PR is currently\s+attached/);
+  assert.match(issue857Doc, /branch `er\/clean-slate-reminder-857`/);
+  assert.match(issue857Doc, /node --test test\/operator-activity\.test\.mjs test\/post-merge-main-ci-echo-boundary-doc\.test\.mjs/);
+  assert.match(issue857Doc, /does not change provider\s+behavior, merge gates, detector scope, frontend behavior, cleanup policy,\s+performance claims, or product claims/);
 });
 
 test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {


### PR DESCRIPTION
## Summary
- Adds a read-only #857 dogfood fixture for clean-slate post-merge fooks development reminders.
- Clarifies that blocker and no-blocker reminder reports must keep a concrete next action explicit.
- Extends the existing operator reminder doc test boundary to cover issue/branch/session/PR anchoring and focused verification.

Closes #857

## Verification
- `npm run build && node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs`

## Boundaries
- Docs/test operator-boundary only.
- No runtime/provider behavior, merge-gate policy, detector scope, React Web/RN/TUI/WebView behavior, cleanup policy, performance/token, or product claim changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
