### PR TITLE
Clarify React Web inspect-first scenario narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Frontend change intelligence for Codex.
 
 First-minute path:
 
+Scenario: a user asks Codex, “implement the `Form.tsx` feature.” Before editing, fooks should be the first inspect step, not a patch authority:
+
+```text
+user request
+  -> AI starts the task
+  -> fooks preflight on the supported React Web file
+  -> current source is read for JSX / TSX form-control evidence
+  -> issue cards + compact first-minute work order are handed to the AI
+  -> AI reopens or reruns against current source if freshness no longer matches
+  -> AI keeps the user's feature scope, then edits and verifies normally
+```
+
+Treat that handoff as advisory context: it tells the agent where to inspect first, what not to assume, and when a human decision is still needed. It is not auto-fix, not auto-apply, not codemod authority, and not permission to turn a feature request into a broad accessibility audit. Unsupported or ambiguous frontend lanes should fall back to normal source reading rather than a compact fooks payload.
+
 Run the first value path on a supported React Web file:
 
 ```bash

--- a/docs/react-web-first-minute-work-orders.md
+++ b/docs/react-web-first-minute-work-orders.md
@@ -75,6 +75,8 @@ The important invariants are structural: **current source evidence outranks advi
 
 ## Agent/tool handoff
 
+For a feature request such as “implement the `Form.tsx` feature,” this handoff should shape the agent's first minute, not replace source reading. Run the supported React Web inspect surface, keep the decision and do-not-do fields attached, confirm the current source still matches the reported evidence, then continue the requested feature work without widening it into an automatic fix or broad audit.
+
 ### Agent integration decision tree
 
 An agent should choose the smallest inspect surface that answers the handoff question:


### PR DESCRIPTION
## Summary
- add a README-first scenario for the `Form.tsx` feature-request flow
- clarify fooks as inspect-first React Web preflight/advisory context, not patch authority
- add a concise detailed-doc handoff sentence tying feature requests to source confirmation and scope boundaries

## Verification
- `git diff --check`
- `node --test --test-name-pattern "README smoke keeps first-minute compare path discoverable|React Web first-minute work-order docs stay discoverable and boundary-scoped" test/fooks.test.mjs`
- claim-boundary grep reviewed for auto-fix/auto-apply/codemod/provider/billing/RN/WebView/TUI/Vue/broad-audit wording
- ultragoal final gate: ai-slop-cleaner passed; code-review APPROVE/CLEAR

Closes #860
