### PR TITLE
Anchor reminders away from final green receipts

### DIFF
--- a/docs/dogfood/green-receipt-next-anchor-863.md
+++ b/docs/dogfood/green-receipt-next-anchor-863.md
@@ -1,0 +1,58 @@
+# Green receipt next-development anchor (#863)
+
+This is a narrow read-only docs/test operator-boundary artifact for issue #863.
+It separates the final green post-merge `main` receipts from the next fooks
+development anchor so a reminder response cannot collapse into repeating the
+last successful CI/release-report evidence.
+
+## Final green receipt boundary
+
+After a merge chain finishes with both `main` CI and the React Web release-report
+green, those facts are final verification receipts only:
+
+- the exact-head `main` CI success receipt confirms the already-merged head;
+- the React Web release-report success receipt confirms the release-report
+  surface for that same completed state;
+- neither receipt is a concrete next-development anchor by itself.
+
+A reminder may preserve those receipts as evidence, but it must keep them
+separate from the active artifact that owns the next development action.
+
+## Reminder response rule
+
+A next development reminder must choose exactly one of these outcomes:
+
+1. **Adopt/create anchor:** create or adopt one concrete issue, branch, session,
+   or PR artifact, name it in the reminder response, and attach the next
+   development action to that artifact.
+2. **Concrete blocker:** report the concrete blocker that prevents creating or
+   adopting an issue, branch, session, or PR artifact, and name the specific next
+   action required to unblock the anchor.
+
+The reminder must not repeat the final green `main` CI receipt or React Web
+release-report receipt as the answer. It must not present green receipts, stale
+local worktree inventory, or clean checkout status as the next development
+anchor.
+
+Issue #863 and branch `dogfood/issue-863-green-receipt-next-anchor` are the
+active artifacts for this docs/test pass only. This artifact is not cleanup
+authority, does not reopen merged work, and does not authorize fetching,
+deleting, pushing unrelated branches, or changing runtime/provider behavior.
+
+## Focused verification
+
+Use this artifact with `docs/post-merge-main-ci-echo-boundary.md` and the
+operator reminder tests only. Focused verification for this boundary is:
+
+```sh
+npm run build
+node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs
+```
+
+The verification proves the docs/test reminder boundary mentions issue #863, the
+final green `main` CI plus React Web release-report receipt split, the concrete
+issue/branch/session/PR anchor requirement, the concrete blocker fallback, and
+the rule that final receipts are not the next development answer. It does not
+change runtime/provider behavior, merge-gate policy, detector scope, React Web
+behavior, React Native behavior, TUI behavior, WebView behavior, performance
+claims, or product claims.

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -56,6 +56,7 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   const issue823Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "post-merge-react-web-ci-echo-anchor-823.md"), "utf8");
   const issue832Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "check-clean-main-ci-echo-832.md"), "utf8");
   const issue857Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-slate-development-reminder-857.md"), "utf8");
+  const issue863Doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "green-receipt-next-anchor-863.md"), "utf8");
 
   assert.match(boundaryDoc, /A development reminder must not end as a status-only idle report/);
   assert.match(boundaryDoc, /create\/adopt one active artifact/);
@@ -90,6 +91,17 @@ test("operator reminder docs require a blocker or active artifact after clean CI
   assert.match(issue857Doc, /branch `er\/clean-slate-reminder-857`/);
   assert.match(issue857Doc, /node --test test\/operator-activity\.test\.mjs test\/post-merge-main-ci-echo-boundary-doc\.test\.mjs/);
   assert.match(issue857Doc, /does not change provider\s+behavior, merge gates, detector scope, frontend behavior, cleanup policy,\s+performance claims, or product claims/);
+  assert.match(issue863Doc, /issue #863/i);
+  assert.match(issue863Doc, /final green post-merge `main` receipts from the next fooks\s+development anchor/);
+  assert.match(issue863Doc, /both `main` CI and the React Web release-report\s+green/);
+  assert.match(issue863Doc, /final verification receipts only/);
+  assert.match(issue863Doc, /neither receipt is a concrete next-development anchor by itself/);
+  assert.match(issue863Doc, /create or adopt one concrete issue, branch, session,\s+or PR artifact/);
+  assert.match(issue863Doc, /report the concrete blocker that prevents creating or\s+adopting an issue, branch, session, or PR artifact/);
+  assert.match(issue863Doc, /must not repeat the final green `main` CI receipt or React Web\s+release-report receipt as the answer/);
+  assert.match(issue863Doc, /branch `dogfood\/issue-863-green-receipt-next-anchor`/);
+  assert.match(issue863Doc, /node --test test\/operator-activity\.test\.mjs test\/post-merge-main-ci-echo-boundary-doc\.test\.mjs/);
+  assert.match(issue863Doc, /does not\s+change runtime\/provider behavior, merge-gate policy, detector scope, React Web\s+behavior, React Native behavior, TUI behavior, WebView behavior, performance\s+claims, or product claims/);
 });
 
 test("parseOperatorActivityTmuxPanes parses tab-delimited session, path, and command", () => {


### PR DESCRIPTION
## Summary
- Adds a dogfood note separating final green main CI/release receipts from the next development anchor.
- Extends operator activity doc coverage so reminders create/adopt issue/branch/session/PR evidence or report a concrete blocker.
- Keeps scope to docs/test/operator boundary only.

## Verification
- `npm run build`
- `node --test test/operator-activity.test.mjs test/post-merge-main-ci-echo-boundary-doc.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check HEAD`

Closes #863
