### PR TITLE
Preserve live target evidence after final receipts

### DIFF
--- a/docs/dogfood/session-whip-final-receipt-artifact-875.md
+++ b/docs/dogfood/session-whip-final-receipt-artifact-875.md
@@ -1,0 +1,100 @@
+# Session whip final-receipt artifact boundary (#875)
+
+This is a narrow read-only dogfood docs/test artifact for issue #875. It covers
+the state after PR #874 merged and the final `main` CI receipts are green: a
+fooks session whip with idle forbidden must not answer with the just-verified
+receipt and must not report an empty state. It must immediately create or adopt
+one live issue/branch/session/PR target, then answer only with concrete live
+evidence for that target.
+
+## Session-whip rule
+
+When idle is forbidden and the latest available evidence is only a closed PR
+receipt, the session whip must first create or adopt exactly one bounded live
+artifact. The report is valid only when it contains concrete evidence for the
+current target:
+
+1. issue evidence for `#875`;
+2. non-`main` branch evidence for
+   `dogfood/issue-875-session-whip-final-receipt-artifact`;
+3. mapped OMX session evidence for this worktree;
+4. worktree evidence for the adopted target;
+5. `delta` evidence for the live target worktree;
+6. `ahead` evidence against `origin/main`;
+7. `proc` evidence for the running session process; and
+8. `pane` evidence for the attached tmux pane.
+
+The PR #874 final `main` CI receipts remain receipt-only closeout evidence. They
+may explain why the previous work is done, but they must not be reused as the
+answer to a fresh session whip, and they must not replace live target evidence
+with an empty state.
+
+## Captured read-only report shape
+
+```json
+{
+  "issue": "#875",
+  "readOnly": true,
+  "question": "session whip with idle forbidden after PR #874 final receipts",
+  "currentTargetEvidence": {
+    "adoptedIssue": {
+      "number": 875,
+      "isCurrentTargetEvidence": true
+    },
+    "adoptedBranch": {
+      "name": "dogfood/issue-875-session-whip-final-receipt-artifact",
+      "isMain": false,
+      "isCurrentTargetEvidence": true
+    },
+    "mappedOmxSession": {
+      "session": "fooks-dogfood-issue-875-session-whip-final-receipt-artifact",
+      "isCurrentTargetEvidence": true
+    },
+    "worktree": {
+      "path": "/home/bellman/Workspace/fooks.omx-worktrees/issue-875-session-whip-final-receipt-artifact",
+      "isCurrentTargetEvidence": true
+    },
+    "delta": {
+      "kind": "worktree-delta",
+      "required": true,
+      "evidence": "dogfood docs/test delta for issue #875; not a prior PR #874 receipt"
+    },
+    "ahead": {
+      "kind": "base-divergence",
+      "required": true,
+      "evidence": "git rev-list --left-right --count origin/main...HEAD reported 0 0 at target adoption before this artifact commit"
+    },
+    "proc": {
+      "kind": "mapped-process",
+      "required": true,
+      "evidence": "codex process observed in the adopted worktree session"
+    },
+    "pane": {
+      "kind": "tmux-pane",
+      "required": true,
+      "evidence": "TMUX_PANE=%2 in session fooks-dogfood-issue-875-session-whip-final-receipt-artifact:0.0"
+    }
+  },
+  "receiptOnlyEvidence": {
+    "mergedPullRequest": "#874",
+    "finalMainCiReceiptsGreen": true,
+    "priorReceiptIsCurrentTargetEvidence": false,
+    "emptyStateIsValidAnswer": false
+  },
+  "sessionWhipAnswerRule": "With idle forbidden after PR #874 final receipts, immediately create/adopt one live issue/branch/session/PR target and answer only with issue #875, branch, OMX session, worktree, delta, ahead, proc, and pane evidence. Do not answer with the PR #874 receipt or an empty state."
+}
+```
+
+## Non-goals
+
+This artifact does not change runtime/provider behavior, merge-gate policy,
+detector scope, React Web/RN/TUI/WebView behavior, performance claims, product
+claims, cleanup authority, release criteria, or the semantics of final `main` CI
+receipts. It documents and tests the session-whip final-receipt report boundary
+only.
+
+## Focused verification
+
+```sh
+node --test test/session-whip-final-receipt-artifact-doc.test.mjs test/post-success-nudge-replay-boundary-doc.test.mjs
+```

--- a/test/session-whip-final-receipt-artifact-doc.test.mjs
+++ b/test/session-whip-final-receipt-artifact-doc.test.mjs
@@ -1,0 +1,82 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "session-whip-final-receipt-artifact-875.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #875 dogfood artifact documents the idle-forbidden session-whip target shape", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#875");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.question, "session whip with idle forbidden after PR #874 final receipts");
+
+  assert.equal(report.currentTargetEvidence.adoptedIssue.number, 875);
+  assert.equal(report.currentTargetEvidence.adoptedIssue.isCurrentTargetEvidence, true);
+  assert.equal(report.currentTargetEvidence.adoptedBranch.name, "dogfood/issue-875-session-whip-final-receipt-artifact");
+  assert.equal(report.currentTargetEvidence.adoptedBranch.isMain, false);
+  assert.equal(report.currentTargetEvidence.adoptedBranch.isCurrentTargetEvidence, true);
+  assert.equal(report.currentTargetEvidence.mappedOmxSession.session, "fooks-dogfood-issue-875-session-whip-final-receipt-artifact");
+  assert.equal(report.currentTargetEvidence.mappedOmxSession.isCurrentTargetEvidence, true);
+  assert.equal(
+    report.currentTargetEvidence.worktree.path,
+    "/home/bellman/Workspace/fooks.omx-worktrees/issue-875-session-whip-final-receipt-artifact",
+  );
+  assert.equal(report.currentTargetEvidence.worktree.isCurrentTargetEvidence, true);
+
+  for (const field of ["delta", "ahead", "proc", "pane"]) {
+    assert.equal(report.currentTargetEvidence[field].required, true, `${field} must be required live target evidence`);
+    assert.match(report.currentTargetEvidence[field].evidence, /\S/u, `${field} must carry concrete evidence text`);
+  }
+
+  assert.equal(report.receiptOnlyEvidence.mergedPullRequest, "#874");
+  assert.equal(report.receiptOnlyEvidence.finalMainCiReceiptsGreen, true);
+  assert.equal(report.receiptOnlyEvidence.priorReceiptIsCurrentTargetEvidence, false);
+  assert.equal(report.receiptOnlyEvidence.emptyStateIsValidAnswer, false);
+  assert.match(report.sessionWhipAnswerRule, /idle forbidden/);
+  assert.match(report.sessionWhipAnswerRule, /create\/adopt one live issue\/branch\/session\/PR target/);
+  assert.match(report.sessionWhipAnswerRule, /issue #875, branch, OMX session, worktree, delta, ahead, proc, and pane/);
+  assert.match(report.sessionWhipAnswerRule, /Do not answer with the PR #874 receipt or an empty state/);
+});
+
+test("issue #875 dogfood artifact preserves session-whip non-goals", () => {
+  for (const required of [
+    "PR #874 merged",
+    "final `main` CI receipts are green",
+    "fooks session whip with idle forbidden",
+    "must not answer with the just-verified receipt",
+    "must not report an empty state",
+    "create or adopt exactly one bounded live artifact",
+    "issue evidence for `#875`",
+    "dogfood/issue-875-session-whip-final-receipt-artifact",
+    "mapped OMX session evidence",
+    "worktree evidence",
+    "`delta` evidence",
+    "`ahead` evidence",
+    "`proc` evidence",
+    "`pane` evidence",
+    "receipt-only closeout evidence",
+    "does not change runtime/provider behavior",
+    "merge-gate policy",
+    "detector scope",
+    "React Web/RN/TUI/WebView behavior",
+    "performance claims",
+    "product claims",
+    "session-whip final-receipt report boundary only",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #875 doc text: ${required}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a dogfood doc for Issue #875 that preserves live target evidence after final CI/release receipts during session whip.
- Add a focused doc test for the issue/branch/session/PR evidence contract.

## Scope
- docs/test/operator boundary only
- no runtime/provider behavior change
- no merge-gate policy change
- no detector/frontend behavior change
- no performance/product claim change

## Verification
- `git diff --check HEAD`
- `npm run typecheck -- --pretty false`
- `node --test test/session-whip-final-receipt-artifact-doc.test.mjs`
- `npm run build`

Closes #875
