### PR TITLE
Clarify worktree audit residue boundary

### DIFF
--- a/docs/dogfood/worktree-audit-scope-mismatch-879.md
+++ b/docs/dogfood/worktree-audit-scope-mismatch-879.md
@@ -1,0 +1,128 @@
+# Worktree audit scope mismatch boundary (#879)
+
+This is a narrow read-only dogfood docs/test artifact for issue #879. It covers
+an operator-boundary mismatch seen after the PR #878 cleanup: `fooks check` could
+look clean-slate, a duplicate guard could still count legacy local fooks
+worktree paths, and `worktree:audit` could report zero stale-review candidates
+because its entries were scoped to keep/root evidence. Operators must not merge
+those surfaces into one active-work signal.
+
+## Boundary rule
+
+Report these fields separately:
+
+1. **Raw git worktree inventory**: unscoped `git worktree list --porcelain`
+   counts and legacy local path counts. This is residue inventory only.
+2. **Audit scoped inventory**: `worktree:audit` entries, categories, and
+   `staleReviewCandidates`. This is the audit tool's scoped review surface only.
+3. **Runtime evidence**: tmux/session and `/proc` cwd/process evidence. This is
+   active only when it maps to a live issue/branch/session target.
+4. **Repository counts**: open PR and open issue counts. These counts remain
+   separate from raw local residue and from audit categories.
+
+Only live issue, branch, session, PR, or process evidence is active work. Raw
+legacy worktree paths and scoped audit keep/root entries are not active work by
+themselves.
+
+## Captured read-only report shape
+
+```json
+{
+  "issue": "#879",
+  "readOnly": true,
+  "question": "separate raw worktree residue from scoped audit and active-work evidence",
+  "observedAfterCleanup": "PR #878 cleanup",
+  "operatorBoundary": {
+    "separateFieldsRequired": [
+      "rawGitWorktreeInventory",
+      "auditScopedInventory",
+      "runtimeEvidence",
+      "repositoryCounts"
+    ],
+    "activeWorkEvidenceKinds": ["live-issue", "live-branch", "live-session", "live-pr", "live-proc"],
+    "residueIsActiveWork": false,
+    "auditKeepRootEntriesAreActiveWork": false
+  },
+  "rawGitWorktreeInventory": {
+    "source": "git worktree list --porcelain",
+    "totalWorktrees": 10,
+    "legacyLocalFooksWorktreePaths": 8,
+    "isScopedToAuditEntries": false,
+    "isActiveWorkEvidence": false,
+    "operatorMeaning": "local residue inventory; do not infer current work without live issue/branch/session/PR/proc evidence"
+  },
+  "auditScopedInventory": {
+    "source": "npm run --silent worktree:audit -- --json",
+    "staleReviewCandidates": 0,
+    "entries": {
+      "total": 1,
+      "categories": {
+        "keep": 1,
+        "safe-cleanup": 0,
+        "salvage-review": 0,
+        "manual-review-noise": 0
+      },
+      "scope": "keep/root"
+    },
+    "isActiveWorkEvidence": false,
+    "operatorMeaning": "scoped audit result; zero stale-review candidates does not erase raw local residue counts"
+  },
+  "runtimeEvidence": {
+    "tmux": {
+      "source": "tmux list-panes -a -F '#{session_name}\\t#{pane_current_path}'",
+      "mappedLiveFooksSessions": 0,
+      "isActiveWorkEvidence": false
+    },
+    "proc": {
+      "source": "/proc/*/cwd mapped to issue worktree",
+      "mappedLiveProcesses": 0,
+      "isActiveWorkEvidence": false
+    },
+    "operatorMeaning": "tmux/proc evidence becomes active only when it maps to a live issue, branch, session, PR, or process target"
+  },
+  "repositoryCounts": {
+    "openPullRequests": {
+      "source": "gh pr list --state open --json number --limit 200",
+      "count": 0,
+      "isActiveWorkEvidence": false
+    },
+    "openIssues": {
+      "source": "gh issue list --state open --json number --limit 200",
+      "count": 0,
+      "isActiveWorkEvidence": false
+    },
+    "operatorMeaning": "open PR/issue counts are not interchangeable with raw local worktree residue"
+  },
+  "activeWorkDecision": {
+    "isCleanSlateForActiveWork": true,
+    "activeEvidencePresent": false,
+    "reason": "no live issue, branch, session, PR, or proc evidence is present; raw worktree residue and audit keep/root entries remain separate non-active fields"
+  }
+}
+```
+
+## Operator reading order
+
+1. Read `repositoryCounts` for open GitHub work.
+2. Read `runtimeEvidence` for live mapped sessions/processes.
+3. Read `auditScopedInventory` for stale-review candidates within the audit
+   scope.
+4. Read `rawGitWorktreeInventory` last as local residue inventory.
+
+Do not reinterpret `rawGitWorktreeInventory.legacyLocalFooksWorktreePaths` as
+open work. Do not reinterpret `auditScopedInventory.staleReviewCandidates=0` as
+proof that no legacy local paths exist. The fields answer different questions.
+
+## Non-goals
+
+This artifact does not change runtime/provider behavior, merge-gate policy,
+detector scope, React Web/RN/TUI/WebView behavior, performance claims, product
+claims, duplicate-guard detection, `worktree:audit` scope, `fooks check` output,
+cleanup authority, or branch/worktree deletion policy. It documents and tests the
+operator reporting boundary only.
+
+## Focused verification
+
+```sh
+node --test test/worktree-audit-scope-mismatch-doc.test.mjs
+```

--- a/test/worktree-audit-scope-mismatch-doc.test.mjs
+++ b/test/worktree-audit-scope-mismatch-doc.test.mjs
@@ -1,0 +1,95 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "worktree-audit-scope-mismatch-879.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #879 dogfood artifact keeps operator evidence surfaces separate", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#879");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.observedAfterCleanup, "PR #878 cleanup");
+  assert.deepEqual(report.operatorBoundary.separateFieldsRequired, [
+    "rawGitWorktreeInventory",
+    "auditScopedInventory",
+    "runtimeEvidence",
+    "repositoryCounts",
+  ]);
+  assert.deepEqual(report.operatorBoundary.activeWorkEvidenceKinds, ["live-issue", "live-branch", "live-session", "live-pr", "live-proc"]);
+  assert.equal(report.operatorBoundary.residueIsActiveWork, false);
+  assert.equal(report.operatorBoundary.auditKeepRootEntriesAreActiveWork, false);
+
+  assert.equal(report.rawGitWorktreeInventory.source, "git worktree list --porcelain");
+  assert.equal(report.rawGitWorktreeInventory.totalWorktrees, 10);
+  assert.equal(report.rawGitWorktreeInventory.legacyLocalFooksWorktreePaths, 8);
+  assert.equal(report.rawGitWorktreeInventory.isScopedToAuditEntries, false);
+  assert.equal(report.rawGitWorktreeInventory.isActiveWorkEvidence, false);
+
+  assert.equal(report.auditScopedInventory.source, "npm run --silent worktree:audit -- --json");
+  assert.equal(report.auditScopedInventory.staleReviewCandidates, 0);
+  assert.equal(report.auditScopedInventory.entries.total, 1);
+  assert.deepEqual(report.auditScopedInventory.entries.categories, {
+    keep: 1,
+    "safe-cleanup": 0,
+    "salvage-review": 0,
+    "manual-review-noise": 0,
+  });
+  assert.equal(report.auditScopedInventory.entries.scope, "keep/root");
+  assert.equal(report.auditScopedInventory.isActiveWorkEvidence, false);
+
+  assert.equal(report.runtimeEvidence.tmux.mappedLiveFooksSessions, 0);
+  assert.equal(report.runtimeEvidence.tmux.isActiveWorkEvidence, false);
+  assert.equal(report.runtimeEvidence.proc.mappedLiveProcesses, 0);
+  assert.equal(report.runtimeEvidence.proc.isActiveWorkEvidence, false);
+
+  assert.equal(report.repositoryCounts.openPullRequests.count, 0);
+  assert.equal(report.repositoryCounts.openPullRequests.isActiveWorkEvidence, false);
+  assert.equal(report.repositoryCounts.openIssues.count, 0);
+  assert.equal(report.repositoryCounts.openIssues.isActiveWorkEvidence, false);
+
+  assert.equal(report.activeWorkDecision.isCleanSlateForActiveWork, true);
+  assert.equal(report.activeWorkDecision.activeEvidencePresent, false);
+  assert.match(report.activeWorkDecision.reason, /no live issue, branch, session, PR, or proc evidence/);
+});
+
+test("issue #879 dogfood artifact preserves the requested narrow non-goals", () => {
+  for (const required of [
+    "narrow read-only dogfood docs/test artifact for issue #879",
+    "Raw git worktree inventory",
+    "Audit scoped inventory",
+    "Runtime evidence",
+    "Repository counts",
+    "Only live issue, branch, session, PR, or process evidence is active work",
+    "legacyLocalFooksWorktreePaths",
+    "staleReviewCandidates",
+    "keep/root",
+    "zero stale-review candidates does not erase raw local residue counts",
+    "local residue inventory; do not infer current work",
+    "does not change runtime/provider behavior",
+    "merge-gate policy",
+    "detector scope",
+    "React Web/RN/TUI/WebView behavior",
+    "performance claims",
+    "product claims",
+    "duplicate-guard detection",
+    "`worktree:audit` scope",
+    "`fooks check` output",
+    "operator reporting boundary only",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #879 doc text: ${required}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a dogfood doc for Issue #879 that separates raw legacy worktree residue counts from `worktree:audit` scoped stale-review candidates.
- Add a focused doc test for the residue/audit-scope boundary.

## Scope
- docs/test/operator boundary only
- no runtime/provider behavior change
- no merge-gate policy change
- no detector/frontend behavior change
- no performance/product claim change

## Verification
- `git diff --check HEAD`
- `npm run typecheck -- --pretty false`
- `node --test test/worktree-audit-scope-mismatch-doc.test.mjs`
- `npm run build`

Closes #879
