### PR TITLE
Prevent absent tmux from blocking check projection

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -14,6 +14,7 @@ import {
   triageOrphanLocalWorktrees,
   type OrphanLocalWorktreeEntry,
 } from "./orphan-local-worktree-triage";
+import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -535,6 +536,10 @@ function baseReceiptIdentifiers(
 
 function withRepoBlockers(blockers: string[], repoBlockers: string[]): string[] {
   return uniqueSorted([...blockers, ...repoBlockers]);
+}
+
+function checkProjectionBlockers(blockers: string[]): string[] {
+  return blockers.filter((blocker) => !isTmuxActivityNoServerBlocker(blocker));
 }
 
 function receiptReportLine(
@@ -1181,12 +1186,12 @@ function buildActiveWorkReceipts(
   const legacyLocalResidueCleanupReview = buildLegacyLocalResidueCleanupReview(activity.legacyWorktreeEvidence);
   receipts.push(...siblingReceipts.receipts);
 
-  const blockers = uniqueSorted([
+  const blockers = checkProjectionBlockers(uniqueSorted([
     ...baseBlockers,
     ...activity.blockers,
     ...siblingReceipts.blockers,
     ...receipts.flatMap((receipt) => receipt.blockers),
-  ]);
+  ]));
   const classification = overallReceiptClassification(receipts, blockers);
   const activeArtifactReceiptCount = receipts.filter((receipt) =>
     receipt.classification === "active"
@@ -1273,7 +1278,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const activity = readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true });
   const activeArtifacts = activeArtifactsFrom(activity);
   const activeWorkReceipts = buildActiveWorkReceipts(cwd, activity, options);
-  const blockers = [...activity.blockers];
+  const blockers = checkProjectionBlockers([...activity.blockers]);
   const hasActiveArtifact = activeArtifacts.length > 0;
   const optionalCountBlockers = activity.optionalCounts.enabled ? activity.optionalCounts.blockers : [];
   const blocked = activity.currentRunEvidence.blockers.length > 0 || optionalCountBlockers.length > 0 || !activity.tmux.available;

--- a/src/ops/tmux-errors.ts
+++ b/src/ops/tmux-errors.ts
@@ -12,17 +12,34 @@ function errorTextParts(value: unknown, seen = new Set<unknown>()): string[] {
     stderr?: unknown;
     stdout?: unknown;
     output?: unknown;
+    shortMessage?: unknown;
+    originalMessage?: unknown;
+    all?: unknown;
     cause?: unknown;
   };
-  return [
+  const parts = [
     ...errorTextParts(record.stderr, seen),
     ...errorTextParts(record.stdout, seen),
     ...errorTextParts(record.output, seen),
+    ...errorTextParts(record.shortMessage, seen),
+    ...errorTextParts(record.originalMessage, seen),
+    ...errorTextParts(record.all, seen),
     ...errorTextParts(record.message, seen),
     ...errorTextParts(record.cause, seen),
   ];
+  try {
+    const rendered = String(value);
+    if (rendered && rendered !== "[object Object]") parts.push(rendered);
+  } catch {
+    // Ignore hostile error renderers; structured fields above remain the source of truth.
+  }
+  return parts;
 }
 
 export function isTmuxNoServerRunningError(error: unknown): boolean {
   return /no server running on\b/i.test(errorTextParts(error).join("\n"));
+}
+
+export function isTmuxActivityNoServerBlocker(blocker: string): boolean {
+  return blocker.startsWith("tmux activity unavailable:") && isTmuxNoServerRunningError(blocker);
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -764,7 +764,10 @@ test("CLI check and status activity treat absent tmux server as zero mapped sess
   assert.equal(check.requiredActiveArtifact.required, true);
   assert.equal(check.requiredActiveArtifact.dogfoodHandoff.status, "requires-live-artifact");
   assert.equal(check.activeWorkReceipts.classification, "mainEcho");
+  assert.deepEqual(check.activeWorkReceipts.blockers, []);
+  assert.equal(check.activeWorkReceipts.reportLine.includes("blocked"), false);
   assert.equal(check.activeWorkReceipts.localOnlyResidueActiveBoundary.activeRequirementEvidence.mappedFooksTmuxProcSessionCount, 0);
+  assert.equal(check.blockers.includes("tmux activity unavailable: no server running on /tmp/tmux-1000/default"), false);
   assert.equal(JSON.stringify(check).includes("tmux activity unavailable"), false);
   assert.equal(check.postMergeMainCiEvidence.summary.unknownCount, 2);
 
@@ -815,6 +818,51 @@ test("operator check suppresses no-server tmux output from top-level blockers", 
   assert.deepEqual(snapshot.blockers, []);
   assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
   assert.equal(snapshot.activeWorkReceipts.blockers.join("\n").includes("no server running"), false);
+  assert.equal(JSON.stringify(snapshot).includes("tmux activity unavailable: no server running"), false);
+});
+
+test("operator check suppresses no-server tmux failures from nonstandard error renderings", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-16T04:24:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") {
+        throw {
+          toString() {
+            return "tmux activity unavailable: no server running on /tmp/tmux-1000/default";
+          },
+        };
+      }
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD no-tmux-rendered-main", "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "no-tmux-rendered-main\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.deepEqual(snapshot.blockers, []);
+  assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
+  assert.deepEqual(snapshot.activeWorkReceipts.blockers, []);
   assert.equal(JSON.stringify(snapshot).includes("tmux activity unavailable: no server running"), false);
 });
 


### PR DESCRIPTION
## Summary
- harden tmux no-server detection across stderr/stdout/output/message and rendered error shapes
- filter only `tmux activity unavailable: no server running ...` projection leaks from `check.blockers` and `activeWorkReceipts.blockers`
- add CLI/check regression coverage proving absent tmux stays idle/mainEcho while true tmux errors and CI unknown remain separate

Closes #891

## Tests
- `npm run build`
- `node --test test/operator-activity.test.mjs`
- `npm test`
- `node dist/cli/index.js check --json` with real tmux
- `node dist/cli/index.js check --json` with fake tmux no-server shim

## Review
- code-reviewer: APPROVE
- architect: CLEAR
