### PR TITLE
Clarify React Web first-minute handoff for operators

### DIFF
--- a/docs/demo/react-web-issues.md
+++ b/docs/demo/react-web-issues.md
@@ -136,6 +136,19 @@ Agent handoff:
 4. Do **not** generate final label copy automatically.
 5. If the target is a custom component or the source no longer matches, stop and read the file normally.
 
+Operator-facing handoff card:
+
+```text
+First inspect: fixtures/compressed/FormControls.tsx:23 (native input)
+Next action: reopen the current source, confirm the reported input still matches, then continue the requested feature work.
+Human/source decision: choose the final accessible label/name from local JSX evidence.
+Preserve: decision, claimBoundary, humanDecisionNeeded, doNotDo, autoApply=false.
+Do not: auto-apply patches, generate final label/name copy, infer custom-component semantics, run a codemod, or widen this into a broad accessibility audit.
+Fallback: if source freshness fails or the target is not supported native React Web evidence, stop using the compact handoff and read the source normally.
+```
+
+This card is the demo-facing shape of the first-minute work order. It is meant for operator review or agent prompts, not as a new source of edit authority.
+
 ## Dry-run and safe-preview split (`--dry-run-json`)
 
 Migration planners can request candidate rows, but the projection is still dry-run-only.

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -5084,6 +5084,10 @@ test("React Web first-minute work-order docs stay discoverable and boundary-scop
   assert.match(demo, /react-web\.duplicate-literal-id/);
   assert.match(demo, /react-web\.conflicting-label-association/);
   assert.match(demo, /read-only review aid/);
+  assert.match(demo, /Operator-facing handoff card/);
+  assert.match(demo, /Preserve: decision, claimBoundary, humanDecisionNeeded, doNotDo, autoApply=false/);
+  assert.match(demo, /continue the requested feature work/);
+  assert.match(demo, /source freshness fails/);
   assert.match(demo, /Do \*\*not\*\* generate final label copy automatically/);
   assert.match(demo, /No broad accessibility audit/);
   assert.match(demo, /No RN\/WebView\/TUI expansion/);


### PR DESCRIPTION
## Summary

- Add an operator-facing handoff card to the React Web issue-card demo.
- Preserve the first-minute authority fields: `decision`, `claimBoundary`, `humanDecisionNeeded`, `doNotDo`, source freshness, and `autoApply=false`.
- Extend the existing discoverability/boundary smoke test so the card remains visible and scoped.

Closes #893.

## Validation

- `git diff --check`
- `node --test --test-name-pattern "React Web issue-card public demo|React Web issue report summary JSON matches selected golden contract|React Web issue report dry-run JSON matches selected golden contract|React Web issue report text output matches selected golden excerpt|README smoke keeps first-minute compare path discoverable|React Web first-minute work-order docs stay discoverable and boundary-scoped" test/react-web-issue-report.test.mjs test/fooks.test.mjs`
- Claim-boundary grep reviewed for auto-fix/auto-apply/codemod/broad-audit/source-freshness language.

## Boundaries

- No CLI behavior change.
- No golden fixture update.
- No auto-fix, auto-apply, generated-copy, codemod, custom-component semantic inference, or broad accessibility audit claim.
