### PR TITLE
Keep legacy review residue out of active anchors

### DIFF
--- a/docs/dogfood/legacy-review-residue-cleanup-review-guard-895.md
+++ b/docs/dogfood/legacy-review-residue-cleanup-review-guard-895.md
@@ -1,0 +1,110 @@
+# Legacy review residue cleanup-review guard (#895)
+
+This is a narrow read-only dogfood docs/test/operator guard for issue #895.
+It covers the post-PR #894 clean-merge state where raw local
+`fooks.omx-worktrees` inventory still shows eight legacy review/refresh
+worktrees, while current active anchors are absent:
+
+- open PR count: `0`
+- open issue count: `0`
+- mapped fooks tmux session count: `0`
+- mapped `/proc` worktree process count: `0`
+- `worktree:audit` scoped stale-review candidates: `0`
+- `worktree:audit` scoped entries: `1` keep/root entry
+- `worktree:audit.linkedIssue`: `#854`
+- nested orphan-triage `linkedIssue`: `#711`
+
+The eight legacy review/refresh worktrees are actionable operator residue for
+cleanup-review evidence. They are not current active anchors and must not be
+rediscovered manually on every nudge as if they were live development.
+
+## Boundary rule
+
+Keep these two lanes separate:
+
+1. **Cleanup-review evidence lane**: raw legacy review/refresh worktree residue,
+   cleanup-review row counts, and manual operator review classification. This
+   lane is actionable residue evidence only.
+2. **Current active anchor lane**: live issue, live PR, non-main active branch,
+   mapped fooks tmux session, mapped `/proc` worktree process, or a concrete
+   blocker. Only this lane may justify an active development claim.
+
+`worktree:audit` metadata is provenance, not an active anchor. A scoped
+`staleReviewCandidates=0` result and a single keep/root entry do not erase the
+raw local residue count, and linked issues `#854` / `#711` remain audit IDs.
+
+## Captured read-only report shape
+
+```json
+{
+  "issue": "#895",
+  "readOnly": true,
+  "question": "separate legacy review residue cleanup-review evidence from current active anchors after PR #894",
+  "observedAfterCleanup": "PR #894 clean merge",
+  "cleanupReviewEvidence": {
+    "rawLocalFooksWorktreeInventory": {
+      "source": "git worktree list --porcelain over fooks.omx-worktrees",
+      "legacyReviewRefreshWorktreeCount": 8,
+      "classification": "actionable-operator-residue-cleanup-review",
+      "isCurrentActiveAnchor": false
+    },
+    "operatorCheckProjection": {
+      "source": "fooks check activeWorkReceipts.legacyReviewResidueCleanupReviewGuard",
+      "classification": "operator-cleanup-review-evidence",
+      "actionableOperatorResidue": true,
+      "cleanupCommandsIncluded": false
+    }
+  },
+  "currentActiveAnchorEvidence": {
+    "openPullRequests": 0,
+    "openIssues": 0,
+    "mappedFooksTmuxSessions": 0,
+    "mappedProcWorktreeProcesses": 0,
+    "activeAnchorPresent": false,
+    "allowedActiveAnchorKinds": ["live-issue", "live-pr", "live-branch", "live-tmux", "live-proc", "concrete-blocker"]
+  },
+  "auditScopedEvidence": {
+    "command": "worktree:audit",
+    "staleReviewCandidates": 0,
+    "entries": 1,
+    "entryScope": "keep/root",
+    "linkedIssue": "#854",
+    "triageLinkedIssue": "#711",
+    "isCurrentActiveAnchor": false,
+    "operatorMeaning": "audit provenance and scoped stale-candidate result; does not erase raw local cleanup-review residue"
+  },
+  "decision": {
+    "legacyReviewResidueIsCleanupReviewEvidence": true,
+    "legacyReviewResidueSatisfiesActiveAnchorRequirement": false,
+    "auditLinkedIssuesAreActiveAnchors": false,
+    "nudgeRule": "Report the eight legacy review/refresh worktrees once as cleanup-review residue evidence; with open PR/issue/tmux/proc anchors at zero, do not rediscover or present them as current active work. Name a distinct live issue, branch, session, PR, proc target, or concrete blocker before claiming active development."
+  }
+}
+```
+
+## Operator reading order
+
+1. Read live active anchors first: open issue, open PR, non-main active branch,
+   mapped tmux, mapped `/proc`, or concrete blocker.
+2. Read the #895 cleanup-review guard for raw legacy review/refresh residue as
+   actionable operator residue only.
+3. Read `worktree:audit` `#854` and nested `#711` as audit provenance only.
+4. If live anchors remain zero, do not answer with the residue bucket as current
+   work; report it as cleanup-review evidence and require a distinct live anchor
+   before active-development claims.
+
+## Non-goals
+
+This artifact does not change runtime/provider behavior, merge-gate policy,
+detector scope, React Web/RN/TUI/WebView behavior, product claims, performance
+claims, duplicate-guard detection, `worktree:audit` output shape, nested orphan
+triage output shape, `fooks check` verdict policy, cleanup authority, or
+branch/worktree deletion policy. It documents and tests the operator reporting
+boundary only.
+
+## Focused verification
+
+```sh
+npm run build
+node --test test/legacy-review-residue-cleanup-review-guard-doc.test.mjs test/operator-activity.test.mjs
+```

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -14,6 +14,7 @@ import {
   triageOrphanLocalWorktrees,
   type OrphanLocalWorktreeEntry,
 } from "./orphan-local-worktree-triage";
+import { STALE_WORKTREE_AUDIT_COMMAND, STALE_WORKTREE_AUDIT_ISSUE } from "./stale-worktree-audit";
 import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
@@ -27,6 +28,7 @@ export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_SCHEMA_VERSI
 export const OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
@@ -44,6 +46,7 @@ export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_ISSUE = "#86
 export const OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_ISSUE = "#867";
 export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_ISSUE = "#869";
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_ISSUE = "#885";
+export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE = "#895";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE_URL = "https://github.com/minislively/fooks/issues/736";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE_URL = "https://github.com/minislively/fooks/issues/739";
 export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL = "https://github.com/minislively/fooks/issues/778";
@@ -52,6 +55,7 @@ export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_ISSUE_URL = 
 export const OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_ISSUE_URL = "https://github.com/minislively/fooks/issues/867";
 export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_ISSUE_URL = "https://github.com/minislively/fooks/issues/869";
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_ISSUE_URL = "https://github.com/minislively/fooks/issues/885";
+export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE_URL = "https://github.com/minislively/fooks/issues/895";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SOURCE = "operator/check stale worktree residue ledger projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SOURCE = "operator/check stale worktree residue cleanup-review manifest projection";
 export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_SOURCE = "operator/check legacy local residue cleanup-review projection";
@@ -61,6 +65,7 @@ export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_SOURCE = "op
 export const OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_SOURCE = "operator/check post-receipt dogfood nudge anchor projection";
 export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_SOURCE = "operator/check receipt-only dogfood nudge loop boundary projection";
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_SOURCE = "operator/check issue #885 handoff artifact evidence projection";
+export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SOURCE = "operator/check issue #895 legacy review residue cleanup-review guard projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_CLAIM_BOUNDARY =
   "Read-only issue #736 operator receipt for stale sibling worktree residue; groups existing triage classes by count and next review action only, without paths, cleanup commands, fetch, delete, push, or mutation authority.";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_CLAIM_BOUNDARY =
@@ -79,6 +84,8 @@ export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_CLAIM_BOUNDARY =
   "Read-only issue #869 dogfood receipt-only nudge loop artifact; after PR #868 receipt-only closeout, the next nudge report must name newly created or adopted issue evidence plus mapped OMX session evidence, not the last merged commit, main CI run, or release receipt.";
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_CLAIM_BOUNDARY =
   "Read-only issue #885 fooks-check handoff artifact; adopt live issue, PR, mapped session, or live non-main worktree evidence when present, otherwise require exactly one run-created issue, branch, or session evidence report without mutating runtime/provider behavior.";
+export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_CLAIM_BOUNDARY =
+  "Read-only issue #895 operator guard for legacy review/refresh worktree residue after clean merges; preserves local residue as actionable cleanup-review evidence while keeping current active anchors limited to live issue, PR, branch, tmux, or proc evidence.";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_ISSUE = "#720";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_CLAIM_BOUNDARY =
   "Bounded local/static active-work receipt for fooks session-whip handling; aggregate issue/PR counts are not per-artifact identity, stale sibling worktree receipts are adoption classifiers only, and report lines omit paths and cleanup commands.";
@@ -314,6 +321,38 @@ export type OperatorCheckLegacyReviewWorktreeResidueBoundary = {
   nudgeRule: string;
 };
 
+export type OperatorCheckLegacyReviewResidueCleanupReviewGuard = {
+  schemaVersion: typeof OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION;
+  issue: typeof OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE;
+  issueUrl: typeof OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE_URL;
+  source: typeof OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SOURCE;
+  claimBoundary: typeof OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_CLAIM_BOUNDARY;
+  readOnly: true;
+  cleanupReviewEvidence: {
+    legacyReviewWorktreeResidueCount: number;
+    legacyLocalResidueCleanupReviewRowCount: number;
+    classification: "operator-cleanup-review-evidence";
+    actionableOperatorResidue: true;
+  };
+  currentActiveAnchorEvidence: {
+    openIssueCount?: number;
+    openPullRequestCount?: number;
+    mappedFooksTmuxProcSessionCount: number;
+    activeArtifactReceiptCount: number;
+    activeAnchorPresent: boolean;
+  };
+  auditProvenanceBoundary: {
+    command: typeof STALE_WORKTREE_AUDIT_COMMAND;
+    linkedIssue: typeof STALE_WORKTREE_AUDIT_ISSUE;
+    triageLinkedIssue: typeof ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE;
+    staleReviewCandidatesZeroMeansNoActiveAnchor: false;
+    entriesKeepRootMeansCurrentActiveWork: false;
+  };
+  residueSatisfiesActiveAnchorRequirement: false;
+  cleanupReviewEvidenceIsActiveWork: false;
+  nudgeRediscoveryRule: string;
+};
+
 export type OperatorCheckPostReceiptNudgeAnchorBoundary = {
   schemaVersion: typeof OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_SCHEMA_VERSION;
   issue: typeof OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_ISSUE;
@@ -441,6 +480,7 @@ export type OperatorCheckActiveWorkReceipts = {
   localOnlyResidueActiveBoundary: OperatorCheckLocalOnlyResidueActiveBoundary;
   staleResidueActiveBoundary: OperatorCheckStaleResidueActiveBoundary;
   legacyReviewWorktreeResidueBoundary: OperatorCheckLegacyReviewWorktreeResidueBoundary;
+  legacyReviewResidueCleanupReviewGuard: OperatorCheckLegacyReviewResidueCleanupReviewGuard;
   postReceiptNudgeAnchorBoundary: OperatorCheckPostReceiptNudgeAnchorBoundary;
   receiptOnlyNudgeLoopBoundary: OperatorCheckReceiptOnlyNudgeLoopBoundary;
   handoffArtifactEvidence: OperatorCheckHandoffArtifactEvidence;
@@ -872,6 +912,55 @@ function buildLegacyReviewWorktreeResidueBoundary(
   };
 }
 
+function buildLegacyReviewResidueCleanupReviewGuard(
+  activity: OperatorActivitySnapshot,
+  legacyLocalResidueCleanupReviewRowCount: number,
+  activeArtifactReceiptCount: number,
+): OperatorCheckLegacyReviewResidueCleanupReviewGuard {
+  const openIssueCount = activity.currentRunEvidence.evidence.openIssues;
+  const openPullRequestCount = activity.currentRunEvidence.evidence.openPullRequests;
+  const mappedFooksTmuxProcSessionCount = activity.currentRunEvidence.evidence.fooksSessionCount;
+  const activeAnchorPresent = activeArtifactReceiptCount > 0
+    || (typeof openIssueCount === "number" && openIssueCount > 0)
+    || (typeof openPullRequestCount === "number" && openPullRequestCount > 0)
+    || mappedFooksTmuxProcSessionCount > 0
+    || Boolean(activity.worktree.branch && activity.worktree.branch !== "main");
+
+  return {
+    schemaVersion: OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION,
+    issue: OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE,
+    issueUrl: OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE_URL,
+    source: OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SOURCE,
+    claimBoundary: OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_CLAIM_BOUNDARY,
+    readOnly: true,
+    cleanupReviewEvidence: {
+      legacyReviewWorktreeResidueCount: activity.legacyWorktreeEvidence.staleClosedArtifactWorktreeCount,
+      legacyLocalResidueCleanupReviewRowCount,
+      classification: "operator-cleanup-review-evidence",
+      actionableOperatorResidue: true,
+    },
+    currentActiveAnchorEvidence: {
+      openIssueCount,
+      openPullRequestCount,
+      mappedFooksTmuxProcSessionCount,
+      activeArtifactReceiptCount,
+      activeAnchorPresent,
+    },
+    auditProvenanceBoundary: {
+      command: STALE_WORKTREE_AUDIT_COMMAND,
+      linkedIssue: STALE_WORKTREE_AUDIT_ISSUE,
+      triageLinkedIssue: ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE,
+      staleReviewCandidatesZeroMeansNoActiveAnchor: false,
+      entriesKeepRootMeansCurrentActiveWork: false,
+    },
+    residueSatisfiesActiveAnchorRequirement: false,
+    cleanupReviewEvidenceIsActiveWork: false,
+    nudgeRediscoveryRule: activeAnchorPresent
+      ? "Legacy review/refresh worktree residue remains cleanup-review evidence; report active work from the separate live anchor evidence already present."
+      : "Legacy review/refresh worktree residue remains actionable cleanup-review evidence, but with open PR/issue/tmux/proc anchors at zero it must not be rediscovered as current active work; name a distinct live issue, branch, session, PR, proc target, or concrete blocker before claiming active development.",
+  };
+}
+
 function buildPostReceiptNudgeAnchorBoundary(
   activity: OperatorActivitySnapshot,
 ): OperatorCheckPostReceiptNudgeAnchorBoundary {
@@ -1228,6 +1317,11 @@ function buildActiveWorkReceipts(
       activeArtifactReceiptCount,
     ),
     legacyReviewWorktreeResidueBoundary: buildLegacyReviewWorktreeResidueBoundary(activity.legacyWorktreeEvidence.staleClosedArtifactWorktreeCount),
+    legacyReviewResidueCleanupReviewGuard: buildLegacyReviewResidueCleanupReviewGuard(
+      activity,
+      legacyLocalResidueCleanupReview.rowCount,
+      activeArtifactReceiptCount,
+    ),
     postReceiptNudgeAnchorBoundary: buildPostReceiptNudgeAnchorBoundary(activity),
     receiptOnlyNudgeLoopBoundary: buildReceiptOnlyNudgeLoopBoundary(activity),
     handoffArtifactEvidence: buildHandoffArtifactEvidence(activity, receipts),

--- a/test/legacy-review-residue-cleanup-review-guard-doc.test.mjs
+++ b/test/legacy-review-residue-cleanup-review-guard-doc.test.mjs
@@ -1,0 +1,83 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "legacy-review-residue-cleanup-review-guard-895.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #895 artifact separates cleanup-review residue from active anchors", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#895");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.observedAfterCleanup, "PR #894 clean merge");
+  assert.equal(report.cleanupReviewEvidence.rawLocalFooksWorktreeInventory.legacyReviewRefreshWorktreeCount, 8);
+  assert.equal(report.cleanupReviewEvidence.rawLocalFooksWorktreeInventory.classification, "actionable-operator-residue-cleanup-review");
+  assert.equal(report.cleanupReviewEvidence.rawLocalFooksWorktreeInventory.isCurrentActiveAnchor, false);
+  assert.equal(report.cleanupReviewEvidence.operatorCheckProjection.classification, "operator-cleanup-review-evidence");
+  assert.equal(report.cleanupReviewEvidence.operatorCheckProjection.actionableOperatorResidue, true);
+  assert.equal(report.cleanupReviewEvidence.operatorCheckProjection.cleanupCommandsIncluded, false);
+
+  assert.deepEqual(report.currentActiveAnchorEvidence, {
+    openPullRequests: 0,
+    openIssues: 0,
+    mappedFooksTmuxSessions: 0,
+    mappedProcWorktreeProcesses: 0,
+    activeAnchorPresent: false,
+    allowedActiveAnchorKinds: ["live-issue", "live-pr", "live-branch", "live-tmux", "live-proc", "concrete-blocker"],
+  });
+
+  assert.equal(report.auditScopedEvidence.command, "worktree:audit");
+  assert.equal(report.auditScopedEvidence.staleReviewCandidates, 0);
+  assert.equal(report.auditScopedEvidence.entries, 1);
+  assert.equal(report.auditScopedEvidence.entryScope, "keep/root");
+  assert.equal(report.auditScopedEvidence.linkedIssue, "#854");
+  assert.equal(report.auditScopedEvidence.triageLinkedIssue, "#711");
+  assert.equal(report.auditScopedEvidence.isCurrentActiveAnchor, false);
+  assert.match(report.auditScopedEvidence.operatorMeaning, /does not erase raw local cleanup-review residue/);
+
+  assert.equal(report.decision.legacyReviewResidueIsCleanupReviewEvidence, true);
+  assert.equal(report.decision.legacyReviewResidueSatisfiesActiveAnchorRequirement, false);
+  assert.equal(report.decision.auditLinkedIssuesAreActiveAnchors, false);
+  assert.match(report.decision.nudgeRule, /do not rediscover or present them as current active work/);
+});
+
+test("issue #895 artifact preserves narrow non-goals", () => {
+  for (const required of [
+    "narrow read-only dogfood docs/test/operator guard for issue #895",
+    "PR #894 clean-merge state",
+    "eight legacy review/refresh worktrees",
+    "actionable operator residue for cleanup-review evidence",
+    "not current active anchors",
+    "must not be rediscovered manually on every nudge",
+    "Cleanup-review evidence lane",
+    "Current active anchor lane",
+    "`worktree:audit` metadata is provenance",
+    "staleReviewCandidates=0",
+    "single keep/root entry",
+    "linked issues `#854` / `#711` remain audit IDs",
+    "does not change runtime/provider behavior",
+    "merge-gate policy",
+    "detector scope",
+    "React Web/RN/TUI/WebView behavior",
+    "product claims",
+    "performance claims",
+    "`worktree:audit` output shape",
+    "`fooks check` verdict policy",
+    "operator reporting boundary only",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #895 doc text: ${required}`);
+  }
+});

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1796,6 +1796,30 @@ test("operator check classifies eight legacy review worktrees as stale manual-re
     snapshot.activeWorkReceipts.receipts.some((receipt) => receipt.classification === "active"),
     false,
   );
+  const cleanupReviewGuard = snapshot.activeWorkReceipts.legacyReviewResidueCleanupReviewGuard;
+  assert.equal(cleanupReviewGuard.issue, "#895");
+  assert.equal(cleanupReviewGuard.readOnly, true);
+  assert.equal(cleanupReviewGuard.cleanupReviewEvidence.legacyReviewWorktreeResidueCount, 8);
+  assert.equal(cleanupReviewGuard.cleanupReviewEvidence.legacyLocalResidueCleanupReviewRowCount, OPERATOR_ACTIVITY_LEGACY_WORKTREE_ENTRY_LIMIT);
+  assert.equal(cleanupReviewGuard.cleanupReviewEvidence.classification, "operator-cleanup-review-evidence");
+  assert.equal(cleanupReviewGuard.cleanupReviewEvidence.actionableOperatorResidue, true);
+  assert.deepEqual(cleanupReviewGuard.currentActiveAnchorEvidence, {
+    openIssueCount: 0,
+    openPullRequestCount: 0,
+    mappedFooksTmuxProcSessionCount: 0,
+    activeArtifactReceiptCount: 0,
+    activeAnchorPresent: false,
+  });
+  assert.equal(cleanupReviewGuard.auditProvenanceBoundary.command, "worktree:audit");
+  assert.equal(cleanupReviewGuard.auditProvenanceBoundary.linkedIssue, "#854");
+  assert.equal(cleanupReviewGuard.auditProvenanceBoundary.triageLinkedIssue, "#711");
+  assert.equal(cleanupReviewGuard.auditProvenanceBoundary.staleReviewCandidatesZeroMeansNoActiveAnchor, false);
+  assert.equal(cleanupReviewGuard.auditProvenanceBoundary.entriesKeepRootMeansCurrentActiveWork, false);
+  assert.equal(cleanupReviewGuard.residueSatisfiesActiveAnchorRequirement, false);
+  assert.equal(cleanupReviewGuard.cleanupReviewEvidenceIsActiveWork, false);
+  assert.match(cleanupReviewGuard.nudgeRediscoveryRule, /actionable cleanup-review evidence/);
+  assert.match(cleanupReviewGuard.nudgeRediscoveryRule, /must not be rediscovered as current active work/);
+
 
   const receiptJson = JSON.stringify(snapshot.activeWorkReceipts);
   assert.equal(/worktree remove|branch -d|deleteCommand|manualCleanupCommands|cleanupOrder|kill-session/.test(receiptJson), false);


### PR DESCRIPTION
Closes #895

Pain point: after clean-slate fooks merges, raw legacy review/refresh worktrees remain visible and can keep being rediscovered as if they were current active work.

Scope: operator-check/docs/tests only. This separates cleanup-review residue evidence from current active anchors without changing provider/runtime behavior, merge-gate policy, React behavior, detector expansion beyond residue classification, or product/performance claims.

Verification:
- git diff --check HEAD
- npm run typecheck -- --pretty false
- node --test test/legacy-review-residue-cleanup-review-guard-doc.test.mjs test/operator-activity.test.mjs
- npm run build