### PR TITLE
Fix check provenance for absent tmux sockets

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import {
   readOperatorActivitySnapshot,
   type OperatorActivityOptions,
@@ -22,6 +24,7 @@ export const OPERATOR_CHECK_COMMAND = "check";
 export const OPERATOR_CHECK_CLAIM_BOUNDARY =
   "Read-only operator/check artifact for the post-merge main echo versus active work boundary; it requires a concrete issue, PR, or mapped session artifact when the checkout is otherwise idle.";
 export const OPERATOR_CHECK_SOURCE = `status activity ${OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG} projection`;
+export const OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_SCHEMA_VERSION = 1;
@@ -487,6 +490,40 @@ export type OperatorCheckActiveWorkReceipts = {
   blockers: string[];
 };
 
+export type OperatorCheckRuntimeProvenance = {
+  schemaVersion: typeof OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION;
+  source: "operator/check runtime provenance";
+  claimBoundary: "Runtime provenance is diagnostic only; it distinguishes the executing entrypoint/build artifact from current source files and does not prove functional freshness by itself.";
+  package: {
+    name?: string;
+    version?: string;
+    packageJsonPath?: string;
+  };
+  git: {
+    head?: string;
+    branch?: string;
+    source: "local git refs only; no fetch performed";
+    blockers: string[];
+  };
+  runtime: {
+    node: string;
+    platform: NodeJS.Platform;
+    arch: string;
+    argv1?: string;
+    cwd: string;
+  };
+  artifacts: {
+    operatorCheckModulePath: string;
+    operatorCheckModuleMtimeMs?: number;
+    cliEntrypointPath?: string;
+    cliEntrypointMtimeMs?: number;
+    sourceOperatorCheckPath?: string;
+    sourceOperatorCheckMtimeMs?: number;
+    sourceNewerThanOperatorCheckModule?: boolean;
+    executionKind: "built-dist" | "source-or-non-dist" | "unknown";
+  };
+};
+
 export type OperatorCheckSnapshot = {
   schemaVersion: typeof OPERATOR_CHECK_SCHEMA_VERSION;
   command: typeof OPERATOR_CHECK_COMMAND;
@@ -495,6 +532,7 @@ export type OperatorCheckSnapshot = {
   claimBoundary: typeof OPERATOR_CHECK_CLAIM_BOUNDARY;
   readOnly: true;
   source: typeof OPERATOR_CHECK_SOURCE;
+  runtimeProvenance: OperatorCheckRuntimeProvenance;
   verdict: OperatorCheckVerdict;
   postMergeMainEchoBoundary: {
     explicit: true;
@@ -556,6 +594,109 @@ function readRepoIdentifier(cwd: string, options: OperatorActivityOptions): { re
     const detail = error instanceof Error ? error.message : String(error);
     return { blockers: [`repo identifier unavailable: ${detail}`] };
   }
+}
+
+function readJsonFile(filePath: string): { name?: string; version?: string } | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as { name?: string; version?: string };
+  } catch {
+    return undefined;
+  }
+}
+
+function fileMtimeMs(filePath: string | undefined): number | undefined {
+  if (!filePath) return undefined;
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+function firstExistingAncestorPackageJson(startPath: string): string | undefined {
+  let current = path.dirname(path.resolve(startPath));
+  while (true) {
+    const candidate = path.join(current, "package.json");
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+function readGitField(cwd: string, args: string[]): { value?: string; blocker?: string } {
+  try {
+    return {
+      value: execFileSync("git", args, {
+        cwd,
+        encoding: "utf8",
+        timeout: 1000,
+        maxBuffer: 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      }).trim() || undefined,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { blocker: `git ${args.join(" ")} unavailable: ${detail}` };
+  }
+}
+
+function readOperatorCheckRuntimeProvenance(cwd: string): OperatorCheckRuntimeProvenance {
+  const modulePath = __filename;
+  const packageJsonPath = firstExistingAncestorPackageJson(modulePath);
+  const packageJson = packageJsonPath ? readJsonFile(packageJsonPath) : undefined;
+  const repoRoot = packageJsonPath ? path.dirname(packageJsonPath) : undefined;
+  const sourceOperatorCheckPath = repoRoot ? path.join(repoRoot, "src", "ops", "operator-check.ts") : undefined;
+  const cliEntrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
+  const operatorCheckModuleMtimeMs = fileMtimeMs(modulePath);
+  const sourceOperatorCheckMtimeMs = fileMtimeMs(sourceOperatorCheckPath);
+  const head = readGitField(cwd, ["rev-parse", "HEAD"]);
+  const branch = readGitField(cwd, ["branch", "--show-current"]);
+  const blockers = [head.blocker, branch.blocker].filter((item): item is string => Boolean(item));
+  const normalizedModulePath = path.normalize(modulePath);
+  const executionKind = normalizedModulePath.includes(`${path.sep}dist${path.sep}`)
+    ? "built-dist"
+    : normalizedModulePath.includes(`${path.sep}src${path.sep}`)
+      ? "source-or-non-dist"
+      : "unknown";
+
+  return {
+    schemaVersion: OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION,
+    source: "operator/check runtime provenance",
+    claimBoundary:
+      "Runtime provenance is diagnostic only; it distinguishes the executing entrypoint/build artifact from current source files and does not prove functional freshness by itself.",
+    package: {
+      name: packageJson?.name,
+      version: packageJson?.version,
+      packageJsonPath,
+    },
+    git: {
+      head: head.value,
+      branch: branch.value,
+      source: "local git refs only; no fetch performed",
+      blockers,
+    },
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      argv1: cliEntrypointPath,
+      cwd,
+    },
+    artifacts: {
+      operatorCheckModulePath: modulePath,
+      operatorCheckModuleMtimeMs,
+      cliEntrypointPath,
+      cliEntrypointMtimeMs: fileMtimeMs(cliEntrypointPath),
+      sourceOperatorCheckPath,
+      sourceOperatorCheckMtimeMs,
+      sourceNewerThanOperatorCheckModule: sourceOperatorCheckMtimeMs !== undefined && operatorCheckModuleMtimeMs !== undefined
+        ? sourceOperatorCheckMtimeMs > operatorCheckModuleMtimeMs
+        : undefined,
+      executionKind,
+    },
+  };
 }
 
 function baseReceiptIdentifiers(
@@ -1391,6 +1532,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     claimBoundary: OPERATOR_CHECK_CLAIM_BOUNDARY,
     readOnly: true,
     source: OPERATOR_CHECK_SOURCE,
+    runtimeProvenance: readOperatorCheckRuntimeProvenance(cwd),
     verdict,
     postMergeMainEchoBoundary: {
       explicit: true,

--- a/src/ops/tmux-errors.ts
+++ b/src/ops/tmux-errors.ts
@@ -37,7 +37,8 @@ function errorTextParts(value: unknown, seen = new Set<unknown>()): string[] {
 }
 
 export function isTmuxNoServerRunningError(error: unknown): boolean {
-  return /no server running on\b/i.test(errorTextParts(error).join("\n"));
+  const text = errorTextParts(error).join("\n");
+  return /no server running on\b/i.test(text) || /error connecting to\b[\s\S]*\bNo such file or directory\b/i.test(text);
 }
 
 export function isTmuxActivityNoServerBlocker(blocker: string): boolean {

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -54,12 +54,12 @@ function writeExecutable(filePath, body) {
   fs.writeFileSync(filePath, body, { mode: 0o755 });
 }
 
-function makeNoTmuxServerCliFixture() {
+function makeNoTmuxServerCliFixture(tmuxError = "no server running on /tmp/tmux-1000/default\n") {
   const tempDir = makeTempProject();
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-no-tmux-bin-"));
   const mainHead = "no-tmux-cli-main-head";
   writeExecutable(path.join(binDir, "tmux"), `#!/usr/bin/env node
-process.stderr.write("no server running on /tmp/tmux-1000/default\\n");
+process.stderr.write(${JSON.stringify(tmuxError)});
 process.exit(1);
 `);
   writeExecutable(path.join(binDir, "gh"), `#!/usr/bin/env node
@@ -107,6 +107,14 @@ if (joined === "worktree list --porcelain") {
 }
 if (joined === "rev-parse --verify origin/main") {
   process.stdout.write(mainHead + "\\n");
+  process.exit(0);
+}
+if (joined === "rev-parse HEAD") {
+  process.stdout.write(mainHead + "\\n");
+  process.exit(0);
+}
+if (joined === "branch --show-current") {
+  process.stdout.write("main\\n");
   process.exit(0);
 }
 if (joined === "branch --format=%(refname:short)") {
@@ -770,6 +778,13 @@ test("CLI check and status activity treat absent tmux server as zero mapped sess
   assert.equal(check.blockers.includes("tmux activity unavailable: no server running on /tmp/tmux-1000/default"), false);
   assert.equal(JSON.stringify(check).includes("tmux activity unavailable"), false);
   assert.equal(check.postMergeMainCiEvidence.summary.unknownCount, 2);
+  assert.equal(check.runtimeProvenance.schemaVersion, 1);
+  assert.equal(check.runtimeProvenance.artifacts.executionKind, "built-dist");
+  assert.match(check.runtimeProvenance.artifacts.operatorCheckModulePath, /dist[\\/]ops[\\/]operator-check\.js$/);
+  assert.match(check.runtimeProvenance.artifacts.cliEntrypointPath, /dist[\\/]cli[\\/]index\.js$/);
+  assert.match(check.runtimeProvenance.artifacts.sourceOperatorCheckPath, /src[\\/]ops[\\/]operator-check\.ts$/);
+  assert.equal(check.runtimeProvenance.git.head, "no-tmux-cli-main-head");
+  assert.equal(check.runtimeProvenance.git.branch, "main");
 
   const activity = run(["status", "activity", "--include-remote-counts", "--json"], tempDir, env);
   assert.equal(activity.tmux.available, true);
@@ -777,6 +792,23 @@ test("CLI check and status activity treat absent tmux server as zero mapped sess
   assert.deepEqual(activity.tmux.blockers, []);
   assert.deepEqual(activity.blockers, []);
   assert.equal(activity.currentRunEvidence.mainEchoEvidence, true);
+});
+
+test("root built CLI check treats tmux socket ENOENT as absent server, not a blocker", () => {
+  const { tempDir, env } = makeNoTmuxServerCliFixture("error connecting to /tmp/fooks-empty-tmux/tmux-1000/default (No such file or directory)\n");
+
+  const check = run(["check", "--json"], tempDir, env);
+  assert.equal(check.verdict, "idleRequiresActiveArtifact");
+  assert.deepEqual(check.blockers, []);
+  assert.equal(check.activity.tmux.available, true);
+  assert.deepEqual(check.activity.tmux.sessions, []);
+  assert.deepEqual(check.activity.tmux.blockers, []);
+  assert.equal(check.activeWorkReceipts.classification, "mainEcho");
+  assert.deepEqual(check.activeWorkReceipts.blockers, []);
+  assert.equal(check.activeWorkReceipts.reportLine.includes("blocked"), false);
+  assert.equal(JSON.stringify(check).includes("tmux activity unavailable"), false);
+  assert.equal(JSON.stringify(check).includes("tmux pane list unavailable"), false);
+  assert.equal(check.runtimeProvenance.artifacts.executionKind, "built-dist");
 });
 
 test("operator check suppresses no-server tmux output from top-level blockers", () => {


### PR DESCRIPTION
## Summary
- Treat tmux socket ENOENT as an absent tmux server so `check --json` reports zero mapped sessions instead of blockers.
- Add diagnostic `runtimeProvenance` to `check --json` so dogfood can distinguish built `dist` execution, source paths, git head/branch, and source-vs-dist mtime evidence.
- Add built root CLI smoke coverage for absent tmux server and provenance, while preserving true tmux failures and CI unknowns separately.

Fixes #897

## Tests
- `npm run build`
- `node --test test/operator-activity.test.mjs`
- `npm test`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- built `node dist/cli/index.js check --json` smoke with empty `TMUX_TMPDIR`

## Review
- Code review: APPROVE
- Architecture review: CLEAR