### PR TITLE
Explain unknown exact-head CI evidence

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -34,6 +34,18 @@ export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE =
 export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY =
   "Read-only post-merge main CI evidence for the exact local origin/main head only; missing exact-head workflow evidence stays unknown or pending and never becomes success.";
 export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS = ["CI", "React Web Release Report"] as const;
+const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_GH_RUN_LIST_ARGS = [
+  "run",
+  "list",
+  "--branch",
+  "main",
+  "--limit",
+  "50",
+  "--json",
+  "databaseId,status,conclusion,createdAt,updatedAt,headBranch,headSha,event,name,workflowName,url",
+] as const;
+const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_REMOTE_FRESHNESS_CAVEAT =
+  "remote freshness not verified; local origin/main was not fetched before this read-only lookup";
 
 export type OperatorActivityCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
 export type OperatorActivityPathExists = (targetPath: string) => boolean;
@@ -155,6 +167,28 @@ export type OperatorActivityCurrentRunEvidence = {
 };
 
 export type OperatorActivityPostMergeMainWorkflowEvidenceStatus = "success" | "failure" | "pending" | "unknown";
+export type OperatorActivityPostMergeMainWorkflowDiagnosticReason =
+  | "success"
+  | "failure"
+  | "pending"
+  | "empty-run"
+  | "origin-main-head-unavailable"
+  | "remote-workflow-evidence-disabled"
+  | "timeout"
+  | "auth"
+  | "rate-limit"
+  | "parse-error"
+  | "unavailable"
+  | "missing-conclusion";
+
+export type OperatorActivityPostMergeMainWorkflowDiagnostic = {
+  source: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE;
+  command: string;
+  apiSurface: "gh run list";
+  lookup: string;
+  reason: OperatorActivityPostMergeMainWorkflowDiagnosticReason;
+  remoteFreshnessCaveat: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_REMOTE_FRESHNESS_CAVEAT;
+};
 
 export type OperatorActivityPostMergeMainWorkflowEvidence = {
   workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number];
@@ -168,6 +202,7 @@ export type OperatorActivityPostMergeMainWorkflowEvidence = {
   event?: string;
   updatedAt?: string;
   reason: string;
+  diagnostic: OperatorActivityPostMergeMainWorkflowDiagnostic;
 };
 
 export type OperatorActivityPostMergeMainCiEvidence = {
@@ -526,6 +561,35 @@ function parseGhRunList(output: string): { runs: GhRunListEntry[]; blocker?: str
   }
 }
 
+function postMergeMainCiCommandLabel(): string {
+  return `gh ${OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_GH_RUN_LIST_ARGS.join(" ")}`;
+}
+
+function classifyPostMergeMainCiDiagnosticReason(detail: string): OperatorActivityPostMergeMainWorkflowDiagnosticReason {
+  const normalized = detail.toLowerCase();
+  if (/timed? ?out|timeout|etimedout/.test(normalized)) return "timeout";
+  if (/rate.?limit|secondary rate limit|too many requests|http 429/.test(normalized)) return "rate-limit";
+  if (/auth|credential|unauthori[sz]ed|forbidden|http 401|http 403|bad credentials/.test(normalized)) return "auth";
+  if (/non-array json|json|parse|unexpected token/.test(normalized)) return "parse-error";
+  return "unavailable";
+}
+
+function postMergeMainCiDiagnostic(
+  workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number],
+  mainHead: string | undefined,
+  reason: OperatorActivityPostMergeMainWorkflowDiagnosticReason,
+): OperatorActivityPostMergeMainWorkflowDiagnostic {
+  const headFilter = mainHead ? `headSha=${mainHead}` : "headSha unavailable";
+  return {
+    source: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE,
+    command: postMergeMainCiCommandLabel(),
+    apiSurface: "gh run list",
+    lookup: `branch=main, workflowName=${workflow}, ${headFilter}; no git fetch or mutation performed`,
+    reason,
+    remoteFreshnessCaveat: OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_REMOTE_FRESHNESS_CAVEAT,
+  };
+}
+
 function workflowNameOf(run: GhRunListEntry): string {
   return run.workflowName || run.name || "";
 }
@@ -542,20 +606,31 @@ function workflowEvidenceFromRun(
   workflow: typeof OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS[number],
   mainHead: string | undefined,
   run: GhRunListEntry | undefined,
+  unavailableReason?: OperatorActivityPostMergeMainWorkflowDiagnosticReason,
 ): OperatorActivityPostMergeMainWorkflowEvidence {
   if (!mainHead) {
+    const diagnosticReason = unavailableReason ?? "origin-main-head-unavailable";
     return {
       workflow,
       status: "unknown",
-      reason: "origin/main head is unavailable; exact-head workflow evidence cannot be evaluated",
+      reason:
+        diagnosticReason === "remote-workflow-evidence-disabled"
+          ? "remote workflow evidence disabled; exact-head workflow evidence was not inspected"
+          : "origin/main head is unavailable; exact-head workflow evidence cannot be evaluated",
+      diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, diagnosticReason),
     };
   }
   if (!run) {
+    const diagnosticReason = unavailableReason ?? "empty-run";
     return {
       workflow,
       status: "unknown",
       headSha: mainHead,
-      reason: `no ${workflow} run was found for the exact origin/main head`,
+      reason:
+        diagnosticReason === "empty-run"
+          ? `no ${workflow} run was found for the exact origin/main head`
+          : `GitHub Actions run list unavailable (${diagnosticReason}); ${workflow} exact-head workflow evidence cannot be evaluated`,
+      diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, diagnosticReason),
     };
   }
 
@@ -577,6 +652,7 @@ function workflowEvidenceFromRun(
       ...base,
       status: "pending",
       reason: `${workflow} run for the exact origin/main head is ${runStatus ?? "not completed"}`,
+      diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, "pending"),
     };
   }
   if (conclusion === "success") {
@@ -584,6 +660,7 @@ function workflowEvidenceFromRun(
       ...base,
       status: "success",
       reason: `${workflow} run completed successfully for the exact origin/main head`,
+      diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, "success"),
     };
   }
   if (conclusion) {
@@ -591,12 +668,14 @@ function workflowEvidenceFromRun(
       ...base,
       status: "failure",
       reason: `${workflow} run for the exact origin/main head completed with conclusion ${conclusion}`,
+      diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, "failure"),
     };
   }
   return {
     ...base,
     status: "unknown",
     reason: `${workflow} run for the exact origin/main head is completed but has no conclusion`,
+    diagnostic: postMergeMainCiDiagnostic(workflow, mainHead, "missing-conclusion"),
   };
 }
 
@@ -626,7 +705,7 @@ function remoteWorkflowEvidenceEnabled(options: OperatorActivityOptions): boolea
 function readPostMergeMainCiEvidence(cwd: string, options: OperatorActivityOptions): OperatorActivityPostMergeMainCiEvidence {
   if (!remoteWorkflowEvidenceEnabled(options)) {
     const workflowEvidence = OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.map((workflow) =>
-      workflowEvidenceFromRun(workflow, undefined, undefined)
+      workflowEvidenceFromRun(workflow, undefined, undefined, "remote-workflow-evidence-disabled")
     );
     const blockers = ["remote workflow evidence disabled; pass --include-remote-counts to inspect exact-head post-merge main CI evidence"];
     return {
@@ -649,31 +728,33 @@ function readPostMergeMainCiEvidence(cwd: string, options: OperatorActivityOptio
   const blockers = [...mainHeadResult.blockers];
   let runs: GhRunListEntry[] = [];
 
+  let unavailableReason: OperatorActivityPostMergeMainWorkflowDiagnosticReason | undefined;
   try {
     const output = runner(
       "gh",
-      [
-        "run",
-        "list",
-        "--branch",
-        "main",
-        "--limit",
-        "50",
-        "--json",
-        "databaseId,status,conclusion,createdAt,updatedAt,headBranch,headSha,event,name,workflowName,url",
-      ],
+      [...OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_GH_RUN_LIST_ARGS],
       cwd,
       DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS,
     );
     const parsed = parseGhRunList(output);
     runs = parsed.runs;
-    if (parsed.blocker) blockers.push(parsed.blocker);
+    if (parsed.blocker) {
+      blockers.push(parsed.blocker);
+      unavailableReason = classifyPostMergeMainCiDiagnosticReason(parsed.blocker);
+    }
   } catch (error) {
-    blockers.push(`GitHub Actions run list unavailable: ${errorDetail(error)}`);
+    const detail = errorDetail(error);
+    blockers.push(`GitHub Actions run list unavailable: ${detail}`);
+    unavailableReason = classifyPostMergeMainCiDiagnosticReason(detail);
   }
 
   const workflowEvidence = OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS.map((workflow) =>
-    workflowEvidenceFromRun(workflow, mainHeadResult.head, mainHeadResult.head ? latestRunForWorkflow(runs, workflow, mainHeadResult.head) : undefined)
+    workflowEvidenceFromRun(
+      workflow,
+      mainHeadResult.head,
+      mainHeadResult.head ? latestRunForWorkflow(runs, workflow, mainHeadResult.head) : undefined,
+      unavailableReason,
+    )
   );
 
   return {

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -144,6 +144,57 @@ process.exit(2);
   return { tempDir, env: { PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` } };
 }
 
+function assertPostMergeMainCiDiagnostic(item, { workflow, reason, headSha }) {
+  assert.equal(item.workflow, workflow);
+  assert.equal(item.diagnostic.source, OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE);
+  assert.equal(item.diagnostic.apiSurface, "gh run list");
+  assert.match(item.diagnostic.command, /^gh run list --branch main --limit 50 --json /);
+  assert.match(item.diagnostic.lookup, new RegExp(`workflowName=${workflow.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(item.diagnostic.lookup, /branch=main/);
+  assert.match(item.diagnostic.lookup, /no git fetch or mutation performed/);
+  if (headSha) assert.match(item.diagnostic.lookup, new RegExp(`headSha=${headSha}`));
+  assert.equal(item.diagnostic.reason, reason);
+  assert.match(item.diagnostic.remoteFreshnessCaveat, /remote freshness not verified/);
+  assert.match(item.diagnostic.remoteFreshnessCaveat, /not fetched/);
+}
+
+function readOperatorActivitySnapshotWithGhRunListError(detail) {
+  const tempDir = makeTempProject();
+  const mainHead = `main-head-${detail.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-12T11:30:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") throw new Error(detail);
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${mainHead}`, "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return `${mainHead}\n`;
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+  return { snapshot, mainHead };
+}
+
 function tmuxNoServerError(socket = "/tmp/tmux-1000/default", stream = "stderr") {
   const error = new Error(`Command failed: tmux list-panes -a -F #{session_name}\t#{pane_current_path}`);
   const output = `no server running on ${socket}\n`;
@@ -559,11 +610,37 @@ test("operator check keeps missing exact-head workflow evidence unknown instead 
     ["CI", "unknown"],
     ["React Web Release Report", "pending"],
   ]);
+  assertPostMergeMainCiDiagnostic(snapshot.postMergeMainCiEvidence.workflowEvidence[0], {
+    workflow: "CI",
+    reason: "empty-run",
+    headSha: mainHead,
+  });
+  assertPostMergeMainCiDiagnostic(snapshot.postMergeMainCiEvidence.workflowEvidence[1], {
+    workflow: "React Web Release Report",
+    reason: "pending",
+    headSha: mainHead,
+  });
   assert.equal(snapshot.postMergeMainCiEvidence.summary.successCount, 0);
   assert.equal(snapshot.postMergeMainCiEvidence.summary.unknownCount, 1);
   assert.equal(snapshot.postMergeMainCiEvidence.summary.pendingCount, 1);
   assert.equal(snapshot.postMergeMainCiEvidence.summary.allExactHeadConclusionsSuccessful, false);
   assert.equal(snapshot.activity.postMergeMainCiEvidence, snapshot.postMergeMainCiEvidence);
+});
+
+test("operator activity diagnoses unavailable exact-head workflow lookups by bounded failure reason", () => {
+  for (const { detail, reason } of [
+    { detail: "HTTP 401 Bad credentials", reason: "auth" },
+    { detail: "HTTP 429 API rate limit exceeded", reason: "rate-limit" },
+  ]) {
+    const { snapshot, mainHead } = readOperatorActivitySnapshotWithGhRunListError(detail);
+    assert.equal(snapshot.postMergeMainCiEvidence.available, false);
+    assert.equal(snapshot.postMergeMainCiEvidence.summary.exactHeadWorkflowCount, 0);
+    assert.equal(snapshot.postMergeMainCiEvidence.summary.unknownCount, 2);
+    assert.match(snapshot.postMergeMainCiEvidence.blockers.join("\n"), new RegExp(detail.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    for (const item of snapshot.postMergeMainCiEvidence.workflowEvidence) {
+      assertPostMergeMainCiDiagnostic(item, { workflow: item.workflow, reason, headSha: mainHead });
+    }
+  }
 });
 
 test("operator activity marks clean current main with zero counts and no sessions as non-active main echo evidence", () => {
@@ -757,6 +834,10 @@ test("operator check treats absent tmux server as zero mapped sessions and keeps
   assert.equal(snapshot.postMergeMainCiEvidence.available, false);
   assert.match(snapshot.postMergeMainCiEvidence.blockers.join("\n"), /GitHub Actions run list unavailable: gh run list timed out/);
   assert.equal(snapshot.postMergeMainCiEvidence.summary.unknownCount, 2);
+  assert.deepEqual(snapshot.postMergeMainCiEvidence.workflowEvidence.map((item) => item.diagnostic.reason), ["timeout", "timeout"]);
+  for (const item of snapshot.postMergeMainCiEvidence.workflowEvidence) {
+    assertPostMergeMainCiDiagnostic(item, { workflow: item.workflow, reason: "timeout", headSha: mainHead });
+  }
   assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
   assert.equal(snapshot.activeWorkReceipts.localOnlyResidueActiveBoundary.activeRequirementEvidence.mappedFooksTmuxProcSessionCount, 0);
 });
@@ -781,7 +862,12 @@ test("CLI check and status activity treat absent tmux server as zero mapped sess
   assert.equal(check.activeWorkReceipts.localOnlyResidueActiveBoundary.activeRequirementEvidence.mappedFooksTmuxProcSessionCount, 0);
   assert.equal(check.blockers.includes("tmux activity unavailable: no server running on /tmp/tmux-1000/default"), false);
   assert.equal(JSON.stringify(check).includes("tmux activity unavailable"), false);
+  assert.equal(check.postMergeMainCiEvidence.summary.exactHeadWorkflowCount, 0);
   assert.equal(check.postMergeMainCiEvidence.summary.unknownCount, 2);
+  assert.deepEqual(check.postMergeMainCiEvidence.workflowEvidence.map((item) => item.diagnostic.reason), ["empty-run", "empty-run"]);
+  for (const item of check.postMergeMainCiEvidence.workflowEvidence) {
+    assertPostMergeMainCiDiagnostic(item, { workflow: item.workflow, reason: "empty-run", headSha: "no-tmux-cli-main-head" });
+  }
   assert.equal(check.runtimeProvenance.schemaVersion, 1);
   assert.notEqual(check.runtimeProvenance, null);
   assert.equal(check.runtimeProvenance.package.status, "known");


### PR DESCRIPTION
## Summary
- add per-workflow postMergeMainCiEvidence diagnostics for exact-head CI lookups
- report attempted gh run list/API surface, bounded unknown reasons (empty, pending, auth, timeout, rate-limit), and remote freshness caveat
- preserve existing verdict/count semantics and read-only/no-fetch behavior

Fixes #903

## Tests
- node --test test/operator-activity.test.mjs
- npm run typecheck
- npm run build
- npm test

## Scope
No unrelated react-web typecheck changes were needed; repo-wide verification passed after npm ci restored dependencies.