### PR TITLE
Add operator npm aliases for source checkouts

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -92,6 +92,13 @@ Good signs:
 - Check status reports a read-only post-merge main echo boundary; if there is no open issue, no open PR, and no mapped fooks tmux session, it requires a concrete active artifact instead of treating idle main echoes as work.
 - Activity status reports a compact read-only operator snapshot: current worktree branch/divergence/current dirty-path delta plus active fooks-like tmux panes when tmux is available. Open issue/PR counts are omitted unless `--include-remote-counts` is passed.
 
+From a source checkout after `npm run build`, maintainers may use the npm aliases
+`npm run -s check -- --json` and `npm run -s status:activity -- --json`.
+They are thin routes to the same built `dist/cli/index.js` `fooks check` and
+`fooks status activity` behavior, so they do not change provider/runtime behavior,
+merge-gate policy, detector scope, React/RN/TUI/WebView behavior, or
+product/performance claims.
+
 `fooks doctor [codex|claude] [--json]` is read-only. Human output starts with status, why, first blocker, and next action, while `--json` exposes the same readiness summary for tools. It checks local fooks setup artifacts, runtime manifests, hook event installation, Codex trust status, cache health, and supported source-file presence. Focused `fooks doctor claude` also includes an optional TypeScript language server host-tooling check as warning-only. It does not mutate `.fooks/`, Codex hooks, Claude project-local settings, or runtime-home manifests. It also does not prove live provider health; it is not a ccusage replacement and not provider usage/billing-token telemetry, invoices, dashboards, or charged costs.
 
 For source checkouts, fresh clones, and temporary git worktrees, `fooks doctor` may be `unhealthy` before activation because project-local adapters and runtime manifests are intentionally not committed as universal defaults. Treat that as a setup reminder, not package corruption: run `fooks setup` in the checkout you plan to use, then rerun `fooks doctor` for the real dogfood readiness verdict.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "npm run build && node dist/cli/index.js check",
+    "status:activity": "npm run build && node dist/cli/index.js status activity",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:integration": "npm run build && node --test test/*.test.mjs",
     "bench:cache": "npm run build && node scripts/benchmark-cache.mjs",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3855,6 +3855,8 @@ test("cli help advertises setup and package install has no auto hook side effect
 
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   assert.match(pkg.scripts?.["smoke:domain-detector"], /inspect-domain test\/fixtures\/frontend-domain-expectations\/webview-boundary-basic\.tsx --json/);
+  assert.equal(pkg.scripts?.check, "npm run build && node dist/cli/index.js check");
+  assert.equal(pkg.scripts?.["status:activity"], "npm run build && node dist/cli/index.js status activity");
   assert.equal(pkg.scripts?.postinstall, undefined);
   assert.equal(pkg.scripts?.preinstall, undefined);
   assert.equal(pkg.scripts?.prepare, undefined);

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -48,6 +48,10 @@ function runText(args, cwd) {
   return execFileSync(process.execPath, [cli, ...args], { cwd, encoding: "utf8" });
 }
 
+function runNpmScript(script, args = []) {
+  return JSON.parse(execFileSync("npm", ["run", "-s", script, "--", ...args], { cwd: repoRoot, encoding: "utf8" }));
+}
+
 function makeTempProject() {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-activity-"));
   fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
@@ -3038,4 +3042,22 @@ test("status activity CLI route preserves existing status contracts", () => {
   }
   assert.match(output, /Unexpected status activity argument/);
   assert.match(OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG, /--include-remote-counts/);
+});
+
+test("source checkout npm operator aliases route to built CLI behavior", () => {
+  const check = runNpmScript("check", ["--json"]);
+  assert.equal(check.command, OPERATOR_CHECK_COMMAND);
+  assert.equal(check.readOnly, true);
+  assert.equal(check.activity.optionalCounts.enabled, true);
+  assert.equal(check.runtimeProvenance.artifacts.executionKind, "built-dist");
+  assert.match(check.runtimeProvenance.artifacts.cliEntrypointPath, /dist[\\/]cli[\\/]index\.js$/);
+  assert.match(check.runtimeProvenance.artifacts.operatorCheckModulePath, /dist[\\/]ops[\\/]operator-check\.js$/);
+
+  const activity = runNpmScript("status:activity", ["--json"]);
+  assert.equal(activity.command, OPERATOR_ACTIVITY_COMMAND);
+  assert.equal(activity.readOnly, true);
+  assert.equal(activity.optionalCounts.enabled, false);
+  assert.equal(activity.runtimeProvenance.artifacts.executionKind, "built-dist");
+  assert.match(activity.runtimeProvenance.artifacts.cliEntrypointPath, /dist[\\/]cli[\\/]index\.js$/);
+  assert.match(activity.runtimeProvenance.artifacts.operatorActivityModulePath, /dist[\\/]ops[\\/]operator-activity\.js$/);
 });


### PR DESCRIPTION
Fixes #912

## Summary
- add source-checkout npm aliases for `fooks check` and `fooks status activity`
- document that the aliases are thin built-CLI routes with no runtime/provider/policy behavior change
- add regression coverage that verifies both aliases route through built dist operator modules

## Verification
- npm run build && node --test test/operator-activity.test.mjs
- npm run build && node --test test/fooks.test.mjs
- npm run -s check -- --json
- npm run -s status:activity -- --json

## Boundary
- no provider/runtime behavior change
- no merge-gate policy change
- no detector scope change
- no React/RN/TUI/WebView behavior change
- no product/performance claim change