### PR TITLE
Stop ancestor tmux panes from proving repo activity

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -100,12 +100,13 @@ export type OperatorActivityTmuxPane = {
   exists: boolean;
   deleted: boolean;
   current: boolean;
+  ancestorOfCurrentCwd?: boolean;
   command?: string;
   paneId?: string;
   promptEvidence?: OperatorActivityPanePromptEvidence;
 };
 
-export type OperatorActivityTmuxSessionStatus = "current" | "activeOrUnknown" | "staleRuntimeCandidate" | "stagedPromptOnly";
+export type OperatorActivityTmuxSessionStatus = "current" | "activeOrUnknown" | "staleRuntimeCandidate" | "stagedPromptOnly" | "ancestorMaintenance";
 
 export type OperatorActivityTmuxSession = {
   session: string;
@@ -687,7 +688,9 @@ function readTmuxActivity(cwd: string, worktree: OperatorActivityWorktree, optio
     const cleanPanePath = panePathWithoutDeletedMarker(pane.path);
     const deleted = panePathDeleted(pane.path);
     const exists = !deleted && pathExists(cleanPanePath);
-    const current = exists && (pathContainsCwd(cleanPanePath, currentCwd) || pathContainsCwd(currentCwd, cleanPanePath));
+    const paneInsideCurrentCwd = exists && pathContainsCwd(currentCwd, cleanPanePath);
+    const ancestorOfCurrentCwd = exists && !paneInsideCurrentCwd && pathContainsCwd(cleanPanePath, currentCwd);
+    const current = paneInsideCurrentCwd;
     if (!includesFooksSignal(pane.session, cwd) && !includesFooksSignal(cleanPanePath, cwd) && !current) continue;
     const panes = panesBySession.get(pane.session) ?? [];
     const promptEvidence = inspectPanePromptEvidence(cwd, runner, pane, cleanPanePath, current, worktree);
@@ -696,6 +699,7 @@ function readTmuxActivity(cwd: string, worktree: OperatorActivityWorktree, optio
       exists,
       deleted,
       current,
+      ...(ancestorOfCurrentCwd ? { ancestorOfCurrentCwd: true } : {}),
       ...(pane.command ? { command: pane.command } : {}),
       ...(pane.paneId ? { paneId: pane.paneId } : {}),
       ...(promptEvidence ? { promptEvidence } : {}),
@@ -711,6 +715,7 @@ function readTmuxActivity(cwd: string, worktree: OperatorActivityWorktree, optio
       .map(([session, panes]) => {
         const current = panes.some((pane) => pane.current);
         const allPanesMissing = panes.length > 0 && panes.every((pane) => pane.deleted || !pane.exists);
+        const ancestorMaintenance = !current && panes.length > 0 && panes.some((pane) => pane.ancestorOfCurrentCwd) && panes.every((pane) => pane.ancestorOfCurrentCwd || pane.deleted || !pane.exists);
         const stagedPromptOnly = current && panes.some((pane) => pane.current) && panes.every((pane) => {
           if (!pane.current) return pane.deleted || !pane.exists;
           return pane.promptEvidence?.classification === "stagedPromptOnly";
@@ -721,14 +726,18 @@ function readTmuxActivity(cwd: string, worktree: OperatorActivityWorktree, optio
             ? "current"
             : allPanesMissing
               ? "staleRuntimeCandidate"
-              : "activeOrUnknown";
+              : ancestorMaintenance
+                ? "ancestorMaintenance"
+                : "activeOrUnknown";
         const reasons = status === "stagedPromptOnly"
           ? ["current OMX pane has only staged prompt-placeholder evidence; no UserPromptSubmit, Working, or tool-output evidence was captured"]
           : status === "current"
             ? ["session has a pane at the current working directory"]
             : status === "staleRuntimeCandidate"
               ? ["all panes point at missing or deleted paths"]
-              : ["session has live panes away from the current working directory; activity is unknown"];
+              : status === "ancestorMaintenance"
+                ? ["session pane is at an ancestor of the current checkout; ancestor maintenance panes do not prove active work for this repo"]
+                : ["session has live panes away from the current working directory; activity is unknown"];
         const manualCleanupCommands = status === "staleRuntimeCandidate" ? [`tmux kill-session -t ${shellQuote(session)}`] : [];
         const cleanupOrder = status === "staleRuntimeCandidate"
           ? [
@@ -1304,8 +1313,9 @@ function buildCurrentRunEvidence(
 ): OperatorActivityCurrentRunEvidence {
   const blockers: string[] = [];
   const reasons: string[] = [];
-  const fooksSessionCount = tmux.sessions.filter((session) => session.status !== "stagedPromptOnly").length;
+  const fooksSessionCount = tmux.sessions.filter((session) => session.status !== "stagedPromptOnly" && session.status !== "ancestorMaintenance").length;
   const stagedPromptOnlySessionCount = tmux.sessions.filter((session) => session.status === "stagedPromptOnly").length;
+  const ancestorMaintenanceSessionCount = tmux.sessions.filter((session) => session.status === "ancestorMaintenance").length;
   const remoteCountsAvailable = optionalCounts.enabled && optionalCounts.openIssues !== undefined && optionalCounts.openPullRequests !== undefined;
   const openIssues = optionalCounts.enabled ? optionalCounts.openIssues : undefined;
   const openPullRequests = optionalCounts.enabled ? optionalCounts.openPullRequests : undefined;
@@ -1333,6 +1343,9 @@ function buildCurrentRunEvidence(
   else reasons.push(`${fooksSessionCount} fooks-like tmux session(s) are mapped to this snapshot`);
   if (stagedPromptOnlySessionCount > 0) {
     reasons.push(`${stagedPromptOnlySessionCount} staged OMX prompt-only session(s) were not counted as active work evidence`);
+  }
+  if (ancestorMaintenanceSessionCount > 0) {
+    reasons.push(`${ancestorMaintenanceSessionCount} ancestor maintenance tmux session(s) were not counted as active work evidence`);
   }
   if (zeroRemoteCounts) reasons.push("open issue and pull request counts are both zero");
   if (legacyWorktreeEvidence.staleClosedArtifactWorktreeCount > 0) {

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -1275,7 +1275,7 @@ function buildHandoffArtifactEvidence(
   const openPullRequestCount = activity.currentRunEvidence.evidence.openPullRequests;
   const mappedFooksTmuxSessionCount = activity.currentRunEvidence.evidence.fooksSessionCount;
   const liveMappedFooksTmuxSessionCount = activity.tmux.sessions.filter((session) =>
-    session.status !== "staleRuntimeCandidate" && session.status !== "stagedPromptOnly"
+    session.status !== "staleRuntimeCandidate" && session.status !== "stagedPromptOnly" && session.status !== "ancestorMaintenance"
   ).length;
   const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main");
   const activeReceiptCount = receipts.filter((receipt) => receipt.classification === "active").length;
@@ -1451,7 +1451,7 @@ function buildActiveWorkReceipts(
 
   for (const session of activity.tmux.sessions) {
     const classification: OperatorCheckActiveWorkReceiptClassification =
-      session.status === "staleRuntimeCandidate" || session.status === "stagedPromptOnly" ? "closedOrStale" : "active";
+      session.status === "staleRuntimeCandidate" || session.status === "stagedPromptOnly" || session.status === "ancestorMaintenance" ? "closedOrStale" : "active";
     receipts.push({
       kind: "session",
       classification,
@@ -1553,7 +1553,7 @@ function activeArtifactsFrom(activity: OperatorActivitySnapshot): OperatorCheckA
   if (counts.enabled && typeof counts.openPullRequests === "number" && counts.openPullRequests > 0) {
     artifacts.push({ kind: "pullRequest", count: counts.openPullRequests, source: counts.source });
   }
-  const activeTmuxSessions = activity.tmux.sessions.filter((session) => session.status !== "stagedPromptOnly");
+  const activeTmuxSessions = activity.tmux.sessions.filter((session) => session.status !== "stagedPromptOnly" && session.status !== "ancestorMaintenance");
   if (activeTmuxSessions.length > 0) {
     artifacts.push({ kind: "session", count: activeTmuxSessions.length, source: activity.tmux.command });
   }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -950,6 +950,46 @@ test("operator activity marks clean current main with zero counts and no session
   assert.deepEqual(snapshot.currentRunEvidence.blockers, []);
 });
 
+test("operator activity does not count ancestor tmux panes as current active work for nested checkouts", () => {
+  const tempDir = makeTempProject();
+  const ancestorDir = path.dirname(path.dirname(tempDir));
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-17T11:30:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux" && args[0] === "list-panes") return `omx-fooks-maintenance\t${ancestorDir}\tbash\t%13\n`;
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD 111", "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir || targetPath === ancestorDir,
+  });
+
+  assert.equal(snapshot.tmux.sessions.length, 1);
+  assert.equal(snapshot.tmux.sessions[0].status, "ancestorMaintenance");
+  assert.equal(snapshot.tmux.sessions[0].current, false);
+  assert.equal(snapshot.tmux.sessions[0].panes[0].ancestorOfCurrentCwd, true);
+  assert.equal(snapshot.currentRunEvidence.evidence.fooksSessionCount, 0);
+  assert.equal(snapshot.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, false);
+  assert.match(snapshot.currentRunEvidence.reasons.join("\n"), /ancestor maintenance tmux session\(s\) were not counted as active work evidence/);
+});
+
 test("operator check forces a concrete active artifact when post-merge main echo is idle", () => {
   const tempDir = makeTempProject();
   const snapshot = readOperatorCheckSnapshot(tempDir, {


### PR DESCRIPTION
## Summary

- Add `ancestorMaintenance` tmux-session classification for panes that sit at an ancestor of the current checkout.
- Exclude ancestor maintenance panes from active fooks session counts and operator-check active artifacts.
- Add a regression test proving a home/root maintenance pane does not turn a clean nested checkout into active work evidence.

Closes #916.

## Validation

- `git diff --check`
- `npm run typecheck`
- `node --test --test-name-pattern "ancestor tmux panes|clean current main|staged unsubmitted OMX prompt|handoff artifact evidence|stale session and legacy closed branch" test/operator-activity.test.mjs`

## Notes

A broader local `node --test test/operator-activity.test.mjs` run still hits pre-existing macOS `/var` vs `/private/var` temp-path assertions in three CLI provenance tests. The #916 targeted coverage and typecheck pass.
