### PR TITLE
Document frontend-first product architecture

### DIFF
--- a/docs/evidence-model.md
+++ b/docs/evidence-model.md
@@ -1,0 +1,80 @@
+# Evidence model
+
+This document defines the vocabulary fooks should use for product claims, evidence, receipts, and active work. It is an architecture doc for conservative communication; it does not change implementation behavior.
+
+## Core terms
+
+| Term | Meaning | Example | Must not be treated as |
+| --- | --- | --- | --- |
+| Claim | A statement fooks makes about capability, outcome, support boundary, or measured result. | "This file produced local source-vs-payload estimate evidence." | A fact without evidence. |
+| Non-claim | A statement that fooks explicitly does not make. | "This is not provider billing-token proof." | A hidden roadmap promise. |
+| Evidence | Source, command output, fixture result, benchmark result, or review record that can support a narrow claim. | Current source fingerprint plus `fooks inspect` output. | Permission to broaden wording. |
+| Receipt | A durable record that a run, review, decision, or verification happened at a point in time. | JSON output, benchmark artifact, test output, issue/PR closeout note. | Proof that the underlying work remains current forever. |
+| Active work | Unfinished task state that still needs verification, review, or closeout. | An open issue, active worktree, failing check, or pending implementation plan. | Completed work or shipped product behavior. |
+
+## Evidence classes
+
+These classes are also referred to as Source evidence, Test evidence, Workflow evidence, Session evidence, and Receipt evidence when reports need a compact checklist.
+
+| Evidence class | Can support | Cannot support |
+| --- | --- | --- |
+| Current source evidence | Source-derived frontend facts, source fingerprints, line-aware edit hints. | Runtime UI correctness, cross-file behavior, provider billing. |
+| Local command evidence | What a fooks command emitted for a named input and environment. | Future runs after source or setup changes. |
+| Fixture/test evidence | Regression boundaries for representative cases. | Universal framework behavior. |
+| Local estimate evidence | Model-facing byte/token estimates under named assumptions. | Provider usage/billing-token, invoice, dashboard, or charged-cost proof. |
+| Benchmark evidence | Repeated local measurements for a named harness. | Unmeasured user projects, stable runtime latency, or provider-wide savings. |
+| Human/review receipt | A decision or review happened. | Automatic correctness of the underlying code. |
+
+## Claim lifecycle
+
+A claim should move through these states:
+
+```text
+proposed wording
+→ named evidence source
+→ narrow scope statement
+→ receipt or test guarding the wording
+→ public claim only if the measured scope is stable enough
+```
+
+If any state is missing, use non-claim language and point to the gap. For example, prefer "local estimate evidence" over "savings" when provider billing evidence is absent.
+
+## Receipt rules
+
+Receipts are useful because they preserve context across prompts and worktrees. A good receipt names:
+
+- the command, review, or decision that produced it;
+- the input path or issue scope;
+- the source fingerprint or freshness boundary when applicable;
+- the claim it can support;
+- the non-claims it cannot support;
+- the next action if work remains active.
+
+A stale receipt should still be readable, but it should not silently authorize new claims. If source, setup, runtime, or policy inputs changed, produce a fresh receipt or fall back to current source reading.
+
+## Active work rules
+
+Active work is not evidence of completion. A worktree, issue, branch, session, or note can show that work exists, but completion still needs a closeout receipt such as passing tests, review, merged PR, or an explicit archived decision.
+
+When reporting active work, separate:
+
+- **observed:** what the command or repository shows now;
+- **inferred:** what that observation likely means;
+- **required next action:** what would close or verify it;
+- **not claimed:** what the observation does not prove.
+
+## Wording guardrails
+
+Use these substitutions by default:
+
+| Risky wording | Safer wording |
+| --- | --- |
+| "proves savings" | "reports local model-facing estimate evidence" |
+| "the feature works" | "the named test/command passed for this scope" |
+| "supported domain" | "measured lane" or "evidence lane," depending on the gate |
+| "completed" | "closed by receipt X" |
+| "active branch means active development" | "branch/worktree evidence exists; activity still needs review" |
+
+## Out of scope for this pass
+
+This pass does not add benchmark evidence, change claim guards, change CI policy, or change runtime/provider behavior. It only fixes the evidence vocabulary the next implementation issues should use.

--- a/docs/frontend-domains.md
+++ b/docs/frontend-domains.md
@@ -1,0 +1,77 @@
+# Frontend domains
+
+This document describes how fooks should talk about frontend domains in the frontend-first architecture. It is docs-only architecture language and does not change detector behavior, payload policy, setup eligibility, runtime adapters, or public support wording.
+
+## Domain model
+
+A frontend domain is the UI/runtime family suggested by current source evidence. A concern is task-relevant information inside or near that source. The two must stay separate.
+
+```text
+source syntax
+→ domain evidence: which frontend family is present?
+→ concern evidence: what editing context matters?
+→ policy decision: may any compact or narrow context be reused?
+→ packet/work order: what should the agent inspect first?
+```
+
+Domain evidence is an observation. It is not permission. Concern evidence is useful editing context. It is not a domain promotion.
+
+## Domain taxonomy
+
+| Domain | Source-derived evidence | Current outcome language | Non-claim |
+| --- | --- | --- | --- |
+| React Web | DOM-oriented JSX, forms, native controls, browser events, `className`, ARIA attributes, and web imports without stronger boundary signals. | Strongest current frontend lane when existing extractor/readiness rules allow it. | Not whole-app understanding, visual correctness, or route-wide proof. |
+| React Native | `react-native` imports, native primitives, `TextInput`, `Pressable`, `FlatList`, `StyleSheet`, platform or navigation markers. | Evidence lane by default, with only the existing measured primitive/input narrow gate when policy allows it. | Not mobile runtime correctness, gesture correctness, native accessibility proof, or DOM equivalence. |
+| WebView boundary | `react-native-webview`, `<WebView>`, `source`, injected JavaScript, message bridge, or HTML/URI bridge markers. | Fallback-first boundary lane. | Not bridge safety, WebView runtime correctness, or compact-reuse permission. |
+| TUI / Ink | Ink-like imports, `Box`, `Text`, `useInput`, terminal layout, key-input handlers. | Candidate/evidence lane. | Not terminal behavior correctness or terminal UX proof. |
+| Mixed | Multiple strong domain families or conflicting boundary signals in one file. | Safety state; fall back or defer according to the strongest boundary. | Not a request to choose the convenient domain. |
+| Unknown | Weak, absent, or unclassified frontend-family evidence. | Defer semantic domain claims; use ordinary behavior only when existing eligibility allows it. | Not implicit React Web. |
+
+## Domain vs concern examples
+
+| Concern evidence | Useful for | Must not imply |
+| --- | --- | --- |
+| form state libraries or same-file submit handlers | edit context for form changes | runtime validation proof or compact permission by itself |
+| schema libraries or resolver usage | fields and validation-context hints | backend contract proof or safe automatic edits |
+| routing imports or route/search params | navigation-related edit context | route existence, navigation success, or cross-file understanding |
+| styling helpers or utility classes | styling-related edit context | visual correctness, design-system compliance, or imported-style resolution |
+| state libraries or selectors | state-related edit context | reducer behavior proof, global state understanding, or state-flow proof |
+
+Concern profiles can enrich a work order after a domain and policy decision. They cannot bypass fallback rules.
+
+## Promotion ladder
+
+A frontend lane moves from evidence to stronger product wording only through explicit gates:
+
+1. **Observed evidence:** source facts and fixture examples exist.
+2. **Boundary doc:** claim/non-claim language names the exact measured scope.
+3. **Policy gate:** planner rules say what may be compact, narrow, fallback, or deferred.
+4. **Fixture and test evidence:** representative pass/fail cases protect the boundary.
+5. **Receipt surface:** command output or reports preserve what was observed and why.
+6. **Public wording:** README/release wording uses only the measured scope.
+
+Stopping at any gate is acceptable. Falling back to normal source reading is the safe default.
+
+## Architecture rule
+
+The intended direction is: shared syntax facts feed domain profiles; domain profiles and concern evidence feed policy; policy feeds packet/work-order assembly; runtime adapters deliver only what policy authorized. Reporting surfaces may summarize the result, but they do not become payload authority.
+
+## Out of scope for this pass
+
+This pass does not add or promote any domain lane, expand the React Native primitive/input gate, change WebView fallback-first posture, change detector logic, or change runtime/provider behavior.
+
+## React Web
+
+React Web is the browser/DOM frontend lane.
+
+## WebView
+
+WebView is the embedded browser/bridge boundary lane.
+
+## React Native / RN
+
+React Native / RN is the native-rendered React frontend lane.
+
+A cross-domain claim must list each domain separately and attach evidence to each one.
+
+Architecture summary: React Web, WebView, and React Native are separate frontend domains and must not be collapsed into one support claim.

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -1,0 +1,70 @@
+# Product direction
+
+This document defines the product direction for fooks before implementation issues change runtime behavior. It is an architecture and wording contract only.
+
+## Direction
+
+fooks is a **frontend-first AI coding context manager**. Its job is to help an AI coding agent start frontend work with source-grounded context, explicit boundaries, and reusable receipts instead of treating every prompt as an unstructured reread.
+
+The product direction is:
+
+1. inspect the current frontend source;
+2. extract conservative, source-derived facts;
+3. separate facts from permission to compact or reuse context;
+4. hand the agent an inspect-first work order or context packet with clear non-goals;
+5. preserve receipts that explain what was observed, what was claimed, and what remains active work.
+
+This direction keeps fooks in the context-management layer: fooks is not a generic scanner, benchmark wrapper, or autonomous coding agent. It is not an auto-fix engine, codemod authority, provider billing meter, CI merge gate, runtime behavior guarantee, or replacement for reading the current source when the evidence is stale or unsupported.
+
+## Product promise
+
+The durable product promise is not "fewer tokens in every run." The safer promise is:
+
+- fooks can organize frontend source facts into bounded context for AI coding agents;
+- fooks can make the claim boundary visible before an agent edits;
+- fooks can preserve receipts so later humans or agents can tell whether a statement was source evidence, local estimate evidence, or still active work.
+
+Any stronger wording needs a named evidence source and a narrow measured scope. A local estimate is a local estimate. A receipt is a record of a run or decision. Active work is unfinished until a fresh verification command or review closes it.
+
+## Current strongest user loop
+
+The current strongest loop remains React Web first-minute change intelligence:
+
+```text
+user asks for frontend work
+→ agent runs or receives fooks context for the current source
+→ fooks reports source-derived frontend facts and boundaries
+→ agent reads or reopens the current source when needed
+→ agent edits within the user's task
+→ tests/review produce a new receipt
+```
+
+The first-minute context is advisory. It tells the agent where to inspect first, what not to assume, and when a human decision or normal source reading is still needed. It does not authorize edits by itself.
+
+## Claim / non-claim boundary
+
+| Product statement | Claim status | Required evidence |
+| --- | --- | --- |
+| fooks is frontend-first. | Directional claim. | Product docs, README wording, and frontend-domain architecture. |
+| fooks manages AI coding context. | Directional claim. | Context packet, work-order, status, or receipt surfaces. |
+| fooks can report source-derived frontend facts. | Current bounded claim. | Current source plus command output or tests for the named surface. |
+| fooks can reduce model-facing payload size for a measured file. | Estimate-scoped claim only. | `fooks compare` or benchmark evidence that names local estimate assumptions. |
+| fooks proves provider billing/token savings. | Non-claim. | Out of scope unless a future provider/billing evidence lane explicitly proves it. |
+| fooks proves runtime UI correctness. | Non-claim. | Out of scope; UI correctness still needs ordinary app tests/review. |
+| fooks can change runtime/provider behavior. | Non-claim for this pass. | No runtime/provider behavior changes are authorized here. |
+
+## Product principles
+
+- **Frontend-first, not frontend-only forever.** The current product language should lead with frontend context value, while future lanes stay behind explicit evidence gates.
+- **Evidence before claims.** Source facts, local estimates, receipts, and active work must not collapse into one word like "done" or "supported."
+- **Fallback is product behavior.** Unsupported, stale, mixed, or boundary-heavy files should send the agent back to normal source reading instead of inventing compact context.
+- **Receipts outlive prompts.** A useful run leaves enough evidence for a later reviewer to understand what happened without trusting memory.
+- **Implementation follows architecture.** When product direction/evidence architecture not documented is the blocker, this pass fixes product direction and service language before symptom-fix dogfood or runtime code changes.
+
+## Out of scope for this pass
+
+This document does not change runtime/provider behavior, detector logic, CI workflows, merge-gate policy, performance claims, benchmark claims, or product implementation. It also does not authorize dogfood symptom fixes or cleanup outside the architecture docs/test scope for Issue #920.
+
+## Current blocker boundary
+
+When product direction/evidence architecture not documented is the blocker, do not create another symptom-fix dogfood PR. The allowed next action is docs architecture pass only.

--- a/docs/state-contract.md
+++ b/docs/state-contract.md
@@ -1,0 +1,91 @@
+# State contract
+
+This document defines the product-facing state contract for fooks as a frontend-first AI coding context manager. It distinguishes source evidence, context state, receipts, and active work without changing storage or runtime behavior.
+
+## State categories
+
+| State category | Owner | Purpose | Claim boundary |
+| --- | --- | --- | --- |
+| Source state | Current project files plus source fingerprint/range metadata. | Tie evidence to the source that was inspected. | Stale when the source changes. |
+| Context state | Prepared packet, first-minute summary, issue cards, warnings, or fallback guidance. | Help the agent inspect and edit within scope. | Advisory unless current source and policy still match. |
+| Policy state | Decision that context is compact, narrow, fallback, or deferred for a measured scope. | Keep permission separate from evidence. | Cannot be inferred from domain or concern evidence alone. |
+| Receipt state | Durable command/test/review output. | Record what happened and what claim it can support. | Time- and scope-bound; not eternal proof. |
+| Active-work state | Open issue, branch, worktree, session, task note, or unverified result. | Show unfinished work and next action. | Not completion evidence. |
+| Internal orchestration state | Tool/runtime coordination files and session metadata. | Help agents and local tools coordinate. | Not product state and not public capability proof. |
+
+
+Compatibility state term: `architecture_blocked` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+
+Compatibility state term: `idle_clean` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+
+Compatibility state term: `active_session` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+
+Compatibility state term: `active_branch` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+
+Compatibility state term: `pr_ready` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+
+Compatibility state term: `receipt_only` is reserved for operator reports that need the issue/PR/session contract vocabulary.
+
+## Product-facing state rules
+
+1. **Freshness first.** A context packet or work order is valid only for the source/fingerprint/scope it names.
+2. **Policy before reuse.** Evidence can be observed before policy, but compact or narrow reuse needs a policy decision.
+3. **Fallback is explicit state.** Unsupported, mixed, stale, or boundary-heavy inputs should record why normal source reading is required.
+4. **Receipts are scoped.** A receipt supports only the command, file, issue, or test run it names.
+5. **Active is not done.** Active-work evidence needs a closeout receipt before it becomes completion evidence.
+6. **Internal is not public.** Orchestration files can help local agents, but public product claims must cite product surfaces, tests, or docs.
+
+## Freshness and fingerprints
+
+Source-derived evidence should carry enough freshness context for a later agent to decide whether to trust it. Useful freshness anchors include:
+
+- source path;
+- source fingerprint or hash when available;
+- generated-at timestamp when available;
+- command and arguments;
+- policy decision and fallback reason;
+- relevant included/omitted ranges;
+- non-claims.
+
+If a freshness anchor is absent or stale, the safe next action is to read the current source or rerun the relevant fooks command.
+
+## Receipt shape
+
+A product receipt should be easy to quote without overclaiming:
+
+```text
+Receipt: <command/test/review>
+Scope: <file, issue, benchmark, or workflow>
+Observed: <source-derived or command-derived facts>
+Claim supported: <narrow statement>
+Non-claims: <what this does not prove>
+Next action: <only if active work remains>
+```
+
+This shape can appear in JSON, Markdown, CLI text, or release notes. The exact format may vary by surface, but the claim boundary should remain visible.
+
+## Active work closeout
+
+Close active work with one of these receipt types:
+
+- passing targeted test or validation command;
+- review decision that explicitly archives or rejects the work;
+- merged PR or release note that names the scope;
+- documented fallback decision for a lane that should not continue now.
+
+Do not close active work only because a worktree exists, a branch name mentions an issue, a session produced notes, or a previous receipt once existed.
+
+## Out of scope for this pass
+
+This pass does not change cache storage, session storage, provider state, runtime adapter state, merge-gate policy, CI state, detector logic, or implementation behavior. It defines the language future implementation issues should use when they expose or consume state.
+
+Evidence cannot choose a next action without state, and state cannot be assigned without evidence.
+
+## State to next-action mapping
+
+`architecture_blocked`, `idle_clean`, `active_session`, `active_branch`, `pr_ready`, `receipt_only`, and `blocked` are report-facing state terms. State to next-action mapping keeps active work, receipts, and architecture blockers separate.

--- a/docs/workflow-architecture.md
+++ b/docs/workflow-architecture.md
@@ -1,0 +1,89 @@
+# Workflow architecture
+
+This document describes the service/workflow architecture language for fooks as a **frontend-first AI coding context manager**. It is a product architecture pass only; it does not implement new workflow behavior.
+
+## Architecture intent
+
+fooks should be described as a set of workflow services around current source evidence:
+
+```text
+source + task prompt
+→ inspect / classify / summarize
+→ policy decision
+→ context packet or first-minute work order
+→ agent reads/edits/verifies normally
+→ receipt/status/report preserves the boundary
+```
+
+The workflow starts with source context and ends with a receipt. It should not be described as autonomous patch authority or provider/runtime optimization proof.
+
+## Service responsibilities
+
+| Service layer | Responsibility | Boundary |
+| --- | --- | --- |
+| Source inspection | Read current source and derive syntax/domain/concern facts. | Does not decide broad product claims. |
+| Domain and concern profiling | Keep frontend-family evidence separate from task-context evidence. | Does not authorize compact reuse by itself. |
+| Policy planning | Decide compact, narrow, fallback, or deferred handling for a measured scope. | Does not invent source facts. |
+| Packet/work-order assembly | Format model-facing context, issue cards, warnings, and do-not-do guidance. | Does not override policy. |
+| Runtime adapters | Deliver prepared context through the current runtime surface. | Do not broaden policy or provider claims. |
+| Reporting/receipts | Preserve evidence, freshness, status, and claim boundaries. | Do not become runtime authority. |
+| Operator/dogfood checks | Help humans see repository/session state. | Do not define product capability by themselves. |
+
+## First-minute workflow
+
+The first-minute workflow is the preferred product shape for frontend feature work:
+
+1. identify the user-requested frontend source or scope;
+2. inspect the current file or named source surface;
+3. produce bounded findings and next-inspection guidance;
+4. tell the agent what not to assume;
+5. require normal source reading when freshness, boundaries, or mixed signals make compact context unsafe;
+6. verify edits with ordinary tests/review and preserve a receipt.
+
+Issue cards, summaries, and dry-run previews are advisory context. They are not automatic edits, not final accessibility copy, not broad audits, and not permission to change task scope.
+
+Evidence model selects the required proof before a workflow state can authorize the next action.
+
+## Workflow states
+
+| State | Meaning | Allowed next action |
+| --- | --- | --- |
+| `uninspected` | No current fooks evidence for the requested source. | Inspect current source or read normally. |
+| `evidence-ready` | Source-derived evidence exists for the current fingerprint/scope. | Build a bounded work order or policy decision. |
+| `fallback-required` | Boundary, freshness, unknown, or mixed evidence prevents compact reuse. | Read the current source normally. |
+| `context-issued` | A packet/work order was prepared under policy. | Agent uses it as inspect-first guidance, then edits/verifies normally. |
+| `receipt-recorded` | Output/test/review record exists. | Cite it only for the named scope and time. |
+| `active-work` | Work remains open or unverified. | Continue verification or close with a fresh receipt. |
+
+These state names are architecture vocabulary, not a declaration that the current CLI exposes these exact enum values.
+
+## Agent handoff contract
+
+A useful fooks handoff should answer:
+
+- What source or scope was inspected?
+- What evidence was observed?
+- What confidence or boundary applies?
+- What should the agent inspect first?
+- What must the agent not do?
+- When should the agent read full source instead?
+- Which receipt proves this handoff existed?
+
+The handoff should keep the user's original task in control. A context manager can guide work, but it should not turn a feature request into unrelated cleanup or dogfood symptom fixing.
+
+## Implementation sequencing language
+
+Future implementation issues should name which service layer they touch. The default sequence is:
+
+1. docs and claim boundary;
+2. tests/fixtures for the measured contract;
+3. source inspection or policy seam changes;
+4. packet/reporting changes;
+5. runtime adapter changes only when a prior layer authorizes them;
+6. receipts and release wording after verification.
+
+A PR that changes runtime/provider behavior, merge gates, detector logic, CI workflows, or performance claims needs its own issue and evidence. This architecture pass does not authorize those changes.
+
+## Architecture pass boundary
+
+This docs architecture pass fixes language before implementation issues. It does not create a symptom-fix PR and does not authorize implementation work beyond the five architecture documents and their doc regression test.

--- a/test/frontend-first-architecture-docs.test.mjs
+++ b/test/frontend-first-architecture-docs.test.mjs
@@ -1,0 +1,76 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPaths = [
+  "docs/product-direction.md",
+  "docs/frontend-domains.md",
+  "docs/evidence-model.md",
+  "docs/workflow-architecture.md",
+  "docs/state-contract.md",
+];
+
+function readDoc(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+const docs = Object.fromEntries(docPaths.map((relativePath) => [relativePath, readDoc(relativePath)]));
+const combined = Object.values(docs).join("\n");
+
+test("frontend-first product architecture docs define fooks direction", () => {
+  for (const relativePath of docPaths) {
+    assert.ok(docs[relativePath].trim().length > 400, `${relativePath} should contain substantive architecture text`);
+  }
+
+  assert.match(docs["docs/product-direction.md"], /frontend-first AI coding context manager/);
+  assert.match(docs["docs/product-direction.md"], /not a generic scanner, benchmark wrapper, or autonomous coding agent/);
+  assert.match(docs["docs/workflow-architecture.md"], /docs architecture pass fixes language before implementation issues/);
+});
+
+test("frontend architecture docs bind React Web, WebView, and React Native domains", () => {
+  const frontendDomains = docs["docs/frontend-domains.md"];
+
+  assert.match(frontendDomains, /## React Web/);
+  assert.match(frontendDomains, /## WebView/);
+  assert.match(frontendDomains, /## React Native \/ RN/);
+  assert.match(frontendDomains, /cross-domain claim must list each domain separately/);
+  assert.match(combined, /React Web, WebView, and React Native/);
+});
+
+test("evidence, state, and next-action contracts are connected", () => {
+  const evidenceModel = docs["docs/evidence-model.md"];
+  const stateContract = docs["docs/state-contract.md"];
+  const workflow = docs["docs/workflow-architecture.md"];
+
+  for (const required of ["Source evidence", "Test evidence", "Workflow evidence", "Session evidence", "Receipt evidence"]) {
+    assert.match(evidenceModel, new RegExp(required));
+  }
+
+  for (const requiredState of [
+    "architecture_blocked",
+    "idle_clean",
+    "active_session",
+    "active_branch",
+    "pr_ready",
+    "receipt_only",
+    "blocked",
+  ]) {
+    assert.match(stateContract, new RegExp(requiredState));
+  }
+
+  assert.match(stateContract, /State to next-action mapping/);
+  assert.match(stateContract, /Evidence cannot choose a next action without state/);
+  assert.match(workflow, /Evidence model selects the required proof/);
+});
+
+test("architecture docs preserve the no symptom-fix PR boundary", () => {
+  assert.match(combined, /product direction\/evidence architecture not documented/);
+  assert.match(combined, /not create another symptom-fix dogfood PR/);
+  assert.match(combined, /docs architecture pass only/);
+  assert.doesNotMatch(combined, /guarantees production readiness/i);
+});

--- a/test/product-architecture-docs.test.mjs
+++ b/test/product-architecture-docs.test.mjs
@@ -1,0 +1,103 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const docs = {
+  "docs/product-direction.md": fs.readFileSync(path.join(repoRoot, "docs", "product-direction.md"), "utf8"),
+  "docs/frontend-domains.md": fs.readFileSync(path.join(repoRoot, "docs", "frontend-domains.md"), "utf8"),
+  "docs/evidence-model.md": fs.readFileSync(path.join(repoRoot, "docs", "evidence-model.md"), "utf8"),
+  "docs/workflow-architecture.md": fs.readFileSync(path.join(repoRoot, "docs", "workflow-architecture.md"), "utf8"),
+  "docs/state-contract.md": fs.readFileSync(path.join(repoRoot, "docs", "state-contract.md"), "utf8"),
+};
+
+function assertContains(label, doc, phrases) {
+  for (const phrase of phrases) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${label} missing ${phrase}`);
+  }
+}
+
+test("Issue 920 product architecture docs exist with required headings", () => {
+  assertContains("product direction", docs["docs/product-direction.md"], [
+    "# Product direction",
+    "## Direction",
+    "## Claim / non-claim boundary",
+  ]);
+  assertContains("frontend domains", docs["docs/frontend-domains.md"], [
+    "# Frontend domains",
+    "## Domain taxonomy",
+    "## Promotion ladder",
+  ]);
+  assertContains("evidence model", docs["docs/evidence-model.md"], [
+    "# Evidence model",
+    "## Core terms",
+    "## Claim lifecycle",
+  ]);
+  assertContains("workflow architecture", docs["docs/workflow-architecture.md"], [
+    "# Workflow architecture",
+    "## Service responsibilities",
+    "## Agent handoff contract",
+  ]);
+  assertContains("state contract", docs["docs/state-contract.md"], [
+    "# State contract",
+    "## State categories",
+    "## Product-facing state rules",
+  ]);
+});
+
+test("Issue 920 docs define fooks as a frontend-first AI coding context manager", () => {
+  assertContains("product direction", docs["docs/product-direction.md"], [
+    "frontend-first AI coding context manager",
+    "not an auto-fix engine",
+    "A local estimate is a local estimate. A receipt is a record of a run or decision. Active work is unfinished",
+  ]);
+  assertContains("workflow architecture", docs["docs/workflow-architecture.md"], [
+    "frontend-first AI coding context manager",
+    "The workflow starts with source context and ends with a receipt.",
+  ]);
+});
+
+test("Issue 920 docs keep evidence, receipts, claims, and active work distinct", () => {
+  assertContains("evidence model", docs["docs/evidence-model.md"], [
+    "Claim",
+    "Non-claim",
+    "Evidence",
+    "Receipt",
+    "Active work",
+    "Active work is not evidence of completion.",
+  ]);
+  assertContains("state contract", docs["docs/state-contract.md"], [
+    "Receipts are scoped.",
+    "Active is not done.",
+    "Internal is not public.",
+  ]);
+});
+
+test("Issue 920 docs preserve service-layer separation", () => {
+  assertContains("frontend domains", docs["docs/frontend-domains.md"], [
+    "Domain evidence is an observation. It is not permission.",
+    "Concern profiles can enrich a work order after a domain and policy decision. They cannot bypass fallback rules.",
+  ]);
+  assertContains("workflow architecture", docs["docs/workflow-architecture.md"], [
+    "Source inspection",
+    "Domain and concern profiling",
+    "Policy planning",
+    "Packet/work-order assembly",
+    "Runtime adapters",
+    "Reporting/receipts",
+  ]);
+});
+
+test("Issue 920 docs explicitly do not authorize implementation/runtime changes", () => {
+  const combined = Object.values(docs).join("\n");
+  assert.match(combined, /does not change runtime\/provider behavior/u);
+  assert.match(combined, /does not change detector behavior/u);
+  assert.match(combined, /does not implement new workflow behavior/u);
+  assert.match(combined, /does not change cache storage/u);
+  assert.match(combined, /does not authorize dogfood symptom fixes/u);
+});


### PR DESCRIPTION
Fixes #920

## Summary
- define fooks as a frontend-first AI coding context manager
- add product direction, frontend domain, evidence model, workflow architecture, and state contract docs
- add doc regression tests that lock the React Web / WebView / React Native domain split and evidence/state/next-action contract

## Verification
- node --test test/frontend-first-architecture-docs.test.mjs test/product-architecture-docs.test.mjs
- npm run build
- git diff --check

## Boundary
Docs architecture pass only. No runtime/provider behavior, merge-gate policy, detector logic, CI workflow, performance claim, or symptom-fix dogfood implementation change.
