### PR TITLE
Add docs-backed work item dashboard model

### DIFF
--- a/docs/work-item-action-dashboard-audit.md
+++ b/docs/work-item-action-dashboard-audit.md
@@ -1,0 +1,33 @@
+# Docs-backed Work Item audit
+
+## Contract baseline
+
+#921 docs define the implementation order as docs baseline → shared Work Item model → CLI action dashboard → TUI board → explain. This pass is intentionally limited to the shared model plus the first `fooks status` connection.
+
+## status/check/TUI audit
+
+| Surface | Current code path | Divergence from #921 docs | This-pass result |
+| --- | --- | --- | --- |
+| `status` | `src/cli/index.ts` bare `fooks status` previously returned only local metric summary. | Metrics are receipt evidence only; they do not classify active work, rejected evidence, or required next action. | Connected `workItemDashboard` to bare `fooks status` while preserving existing metric fields. |
+| `check` | `src/ops/operator-check.ts` projects `status activity --include-remote-counts` into operator active-artifact boundaries. | It already has conservative active-artifact language, but shape is operator-specific rather than the shared WorkItem/Evidence/NextAction model. | Audited only; no behavior change in this first pass. |
+| TUI | No dedicated action-board rewrite in this issue. | A TUI board would duplicate judgment if it invents state separately from CLI/check. | `src/core/work-item-dashboard.ts` exports shared `WorkItem`, `Evidence`, `NextAction`, and `tuiCompatibility.modelOnly=true` for future render-only consumption. |
+
+## Shared model file
+
+`src/core/work-item-dashboard.ts`
+
+- `WorkItem`: issue/branch/session/worktree/PR-centered unit with observed evidence, inferred notes, non-claims, and required next action.
+- `Evidence`: exported alias of `WorkItemEvidence`; separates Source/Workflow/Session/Receipt classes.
+- `NextAction`: exported alias of `WorkItemNextAction`; labels the next concrete action without claiming completion.
+
+## Connected artifact chain
+
+- Issue: #922
+- Branch: `feature/issue-922-docs-backed-work-item-action-dashboard`
+- Worktree: `/home/bellman/Workspace/fooks.omx-worktrees/issue-922-docs-backed-work-item-action-dashboard`
+- Session: `fooks-issue-922-docs-backed-work-item-action-dashboard`
+- PR: not opened yet in this snapshot
+
+## Boundary
+
+No TUI rewrite, no `fooks explain`, no provider/runtime behavior change, and no completion claim from metric receipts alone.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1432,8 +1432,15 @@ async function run(): Promise<void> {
     }
     case "status": {
       if (!arg1) {
-        const { readProjectMetricSummary } = await import("../core/session-metrics.js");
-        print(readProjectMetricSummary(process.cwd()));
+        const [{ readProjectMetricSummary }, { buildWorkItemDashboard }] = await Promise.all([
+          import("../core/session-metrics.js"),
+          import("../core/work-item-dashboard.js"),
+        ]);
+        const metricStatus = readProjectMetricSummary(process.cwd());
+        print({
+          ...metricStatus,
+          workItemDashboard: buildWorkItemDashboard(process.cwd(), metricStatus),
+        });
         return;
       }
       if (arg1 === "codex") {

--- a/src/core/work-item-dashboard.ts
+++ b/src/core/work-item-dashboard.ts
@@ -1,0 +1,346 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import type { FooksProjectMetricStatus } from "./session-metrics";
+
+export const WORK_ITEM_DASHBOARD_SCHEMA_VERSION = 1;
+export const WORK_ITEM_DASHBOARD_SOURCE = "fooks status docs-backed work-item projection";
+export const WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY =
+  "Docs-backed active-work dashboard projection only; separates observed local evidence, conservative inference, required next action, and non-claims without changing runtime/provider behavior or rewriting TUI.";
+
+export type WorkItemEvidenceKind = "issue" | "branch" | "session" | "worktree" | "pullRequest" | "metricReceipt" | "architectureDoc";
+export type WorkItemEvidenceClass = "Source evidence" | "Local command evidence" | "Workflow evidence" | "Session evidence" | "Receipt evidence";
+export type WorkItemState = "uninspected" | "evidence-ready" | "fallback-required" | "context-issued" | "receipt-recorded" | "active-work" | "blocked";
+export type WorkItemNextActionKind = "inspect" | "verify" | "link" | "open-pr" | "continue" | "fallback";
+
+export type WorkItemEvidence = {
+  kind: WorkItemEvidenceKind;
+  evidenceClass: WorkItemEvidenceClass;
+  observed: string;
+  source: string;
+  fresh: boolean | "unknown";
+  supports: string;
+  doesNotSupport: string;
+};
+
+export type WorkItemNextAction = {
+  kind: WorkItemNextActionKind;
+  label: string;
+  command?: string;
+  reason: string;
+  closesWhen: string;
+};
+
+export type WorkItem = {
+  id: string;
+  title: string;
+  state: WorkItemState;
+  observed: string[];
+  inferred: string[];
+  requiredNextAction: WorkItemNextAction;
+  evidence: WorkItemEvidence[];
+  nonClaims: string[];
+};
+
+export type WorkItemArchitectureAudit = {
+  scope: "status" | "check" | "tui";
+  currentSurface: string;
+  docsBackedTarget: string;
+  divergence: string;
+  firstPassAction: string;
+};
+
+export type WorkItemDashboard = {
+  schemaVersion: typeof WORK_ITEM_DASHBOARD_SCHEMA_VERSION;
+  source: typeof WORK_ITEM_DASHBOARD_SOURCE;
+  generatedAt: string;
+  claimBoundary: typeof WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY;
+  readOnly: true;
+  generatedFrom: {
+    command: "status";
+    docs: ["docs/product-direction.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"];
+  };
+  anchors: {
+    repo?: string;
+    issue?: string;
+    issueUrl?: string;
+    branch?: string;
+    worktree: string;
+    session?: string;
+    pullRequest?: string;
+    pullRequestUrl?: string;
+  };
+  architectureAudit: WorkItemArchitectureAudit[];
+  workItems: WorkItem[];
+  nextActions: WorkItemNextAction[];
+  tuiCompatibility: {
+    modelOnly: true;
+    sharedTypes: ["WorkItem", "Evidence", "NextAction"];
+    note: string;
+  };
+};
+
+type GitSnapshot = {
+  repo?: string;
+  branch?: string;
+  head?: string;
+  clean: boolean | null;
+  changedPathCount?: number;
+  blocker?: string;
+};
+
+type CommandResult = { ok: true; stdout: string } | { ok: false; error: string };
+
+function runGit(cwd: string, args: string[]): CommandResult {
+  try {
+    return {
+      ok: true,
+      stdout: execFileSync("git", args, {
+        cwd,
+        encoding: "utf8",
+        timeout: 1000,
+        maxBuffer: 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      }).trim(),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: message };
+  }
+}
+
+function stdoutOrUndefined(result: CommandResult): string | undefined {
+  return result.ok ? result.stdout : undefined;
+}
+
+function canonicalRepoIdentifier(remoteUrl: string | undefined): string | undefined {
+  const trimmed = remoteUrl?.trim();
+  if (!trimmed) return undefined;
+  const ssh = trimmed.match(/^git@([^:]+):(.+?)(?:\.git)?$/u);
+  if (ssh) return `${ssh[1]}/${ssh[2].replace(/\.git$/u, "")}`;
+  try {
+    const parsed = new URL(trimmed);
+    const pathname = parsed.pathname.replace(/^\/+|\.git$/gu, "");
+    return pathname ? `${parsed.hostname}/${pathname}` : parsed.hostname;
+  } catch {
+    return trimmed.replace(/\.git$/u, "");
+  }
+}
+
+function readGitSnapshot(cwd: string): GitSnapshot {
+  const status = runGit(cwd, ["status", "--porcelain=v1"]);
+  const branch = stdoutOrUndefined(runGit(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]));
+  const head = stdoutOrUndefined(runGit(cwd, ["rev-parse", "--short", "HEAD"]));
+  const repo = canonicalRepoIdentifier(stdoutOrUndefined(runGit(cwd, ["config", "--get", "remote.origin.url"])));
+  if (!status.ok) {
+    return { repo, branch, head, clean: null, blocker: `git worktree evidence unavailable: ${status.error}` };
+  }
+  const changedPathCount = status.stdout === "" ? 0 : status.stdout.split(/\r?\n/u).filter(Boolean).length;
+  return { repo, branch, head, clean: changedPathCount === 0, changedPathCount };
+}
+
+function issueFromBranch(branch: string | undefined): string | undefined {
+  const match = branch?.match(/(?:^|[-_/#])issue[-_/#]?(\d{2,})(?=$|[-_/#])/iu) ?? branch?.match(/(?:^|[-_/#])#(\d{2,})(?=$|[-_/#])/u);
+  return match ? `#${match[1]}` : undefined;
+}
+
+function sessionFromEnv(): string | undefined {
+  const explicit = process.env.FOOKS_SESSION_ID || process.env.OMX_SESSION_ID;
+  if (explicit) return explicit;
+  const tmux = process.env.TMUX_PANE;
+  return tmux ? `tmux-pane:${tmux}` : undefined;
+}
+
+function prFromEnv(): { pullRequest?: string; pullRequestUrl?: string } {
+  const url = process.env.FOOKS_PULL_REQUEST_URL || process.env.PR_URL;
+  const number = process.env.FOOKS_PULL_REQUEST || process.env.PR_NUMBER;
+  if (url) return { pullRequest: number ? `#${number.replace(/^#/u, "")}` : url, pullRequestUrl: url };
+  return number ? { pullRequest: `#${number.replace(/^#/u, "")}` } : {};
+}
+
+function metricEvidence(metricStatus: FooksProjectMetricStatus): WorkItemEvidence {
+  return {
+    kind: "metricReceipt",
+    evidenceClass: "Receipt evidence",
+    observed: `${metricStatus.eventCount} metric event(s), ${metricStatus.sessionCount} session summary item(s), ${metricStatus.latestSessionCount} latest session key(s) summarized`,
+    source: "fooks status metric summary",
+    fresh: "unknown",
+    supports: "local estimated context-size telemetry exists for this checkout when events are present",
+    doesNotSupport: "provider usage, billing tokens, invoices, charged costs, runtime UI correctness, or completed active work",
+  };
+}
+
+function worktreeEvidence(snapshot: GitSnapshot, cwd: string): WorkItemEvidence {
+  const observed = snapshot.clean === null
+    ? "git worktree state unavailable"
+    : `branch ${snapshot.branch ?? "unknown"} at ${snapshot.head ?? "unknown"}; ${snapshot.clean ? "clean" : "dirty"} (${snapshot.changedPathCount ?? 0} changed path(s))`;
+  return {
+    kind: "worktree",
+    evidenceClass: "Workflow evidence",
+    observed,
+    source: "git status/rev-parse local snapshot",
+    fresh: snapshot.clean === null ? "unknown" : true,
+    supports: `local worktree evidence for ${path.basename(cwd)}`,
+    doesNotSupport: "merged PR status, remote freshness, or completion without a closeout receipt",
+  };
+}
+
+function docsEvidence(): WorkItemEvidence {
+  return {
+    kind: "architectureDoc",
+    evidenceClass: "Source evidence",
+    observed: "#921 architecture docs define evidence, receipts, active work, workflow states, and state-to-next-action vocabulary",
+    source: "docs/product-direction.md, docs/evidence-model.md, docs/workflow-architecture.md, docs/state-contract.md",
+    fresh: true,
+    supports: "conservative WorkItem/Evidence/NextAction vocabulary for CLI/TUI shared model",
+    doesNotSupport: "runtime/provider behavior changes or a broad TUI rewrite",
+  };
+}
+
+function hasActiveWorkAnchor(snapshot: GitSnapshot, anchors: WorkItemDashboard["anchors"]): boolean {
+  return Boolean(anchors.issue || anchors.pullRequest || snapshot.clean === false);
+}
+
+function workItemStateFor(snapshot: GitSnapshot, anchors: WorkItemDashboard["anchors"]): WorkItemState {
+  if (snapshot.blocker) return "blocked";
+  return hasActiveWorkAnchor(snapshot, anchors) ? "active-work" : "evidence-ready";
+}
+
+function nextActionFor(snapshot: GitSnapshot, anchors: WorkItemDashboard["anchors"]): WorkItemNextAction {
+  if (snapshot.blocker) {
+    return {
+      kind: "inspect",
+      label: "Inspect local git/worktree evidence before acting",
+      command: "fooks status worktree",
+      reason: snapshot.blocker,
+      closesWhen: "worktree evidence is available or the blocker is recorded in a receipt",
+    };
+  }
+  if (!anchors.issue) {
+    return {
+      kind: "link",
+      label: "Link an open issue before treating this as active product work",
+      reason: "docs-backed active-work state needs an issue, branch, session, worktree, or PR anchor; branch did not expose an issue number",
+      closesWhen: "an open issue or equivalent active-work receipt is recorded",
+    };
+  }
+  if (!anchors.pullRequest) {
+    return {
+      kind: "open-pr",
+      label: "Open or link the PR after focused verification passes",
+      command: "gh pr create",
+      reason: "issue/branch/worktree anchors exist, but no PR anchor is present in the local dashboard inputs",
+      closesWhen: "a PR URL/number is linked to the work item",
+    };
+  }
+  return {
+    kind: "verify",
+    label: "Verify and close active work with a fresh receipt",
+    command: "npm test",
+    reason: "issue, branch, worktree, and PR anchors are present; active work still needs test/review closeout evidence",
+    closesWhen: "targeted verification and review receipts are recorded",
+  };
+}
+
+export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMetricStatus): WorkItemDashboard {
+  const snapshot = readGitSnapshot(cwd);
+  const issue = issueFromBranch(snapshot.branch);
+  const pr = prFromEnv();
+  const anchors: WorkItemDashboard["anchors"] = {
+    repo: snapshot.repo,
+    issue,
+    issueUrl: snapshot.repo && issue ? `https://${snapshot.repo}/issues/${issue.slice(1)}` : undefined,
+    branch: snapshot.branch,
+    worktree: cwd,
+    session: sessionFromEnv(),
+    ...pr,
+  };
+  const action = nextActionFor(snapshot, anchors);
+  const evidence = [docsEvidence(), worktreeEvidence(snapshot, cwd), metricEvidence(metricStatus)];
+  if (issue) {
+    evidence.push({
+      kind: "issue",
+      evidenceClass: "Workflow evidence",
+      observed: `${issue} inferred from branch ${snapshot.branch}`,
+      source: "local branch naming convention",
+      fresh: true,
+      supports: "an active-work issue anchor candidate for this checkout",
+      doesNotSupport: "the issue is open remotely unless checked by a separate GitHub receipt",
+    });
+  }
+  if (anchors.session) {
+    evidence.push({
+      kind: "session",
+      evidenceClass: "Session evidence",
+      observed: anchors.session,
+      source: "OMX/FOOKS/TMUX environment",
+      fresh: true,
+      supports: "a local session anchor for this dashboard invocation",
+      doesNotSupport: "submitted work or review completion by itself",
+    });
+  }
+
+  return {
+    schemaVersion: WORK_ITEM_DASHBOARD_SCHEMA_VERSION,
+    source: WORK_ITEM_DASHBOARD_SOURCE,
+    generatedAt: new Date().toISOString(),
+    claimBoundary: WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY,
+    readOnly: true,
+    generatedFrom: {
+      command: "status",
+      docs: ["docs/product-direction.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"],
+    },
+    anchors,
+    architectureAudit: [
+      {
+        scope: "status",
+        currentSurface: "bare fooks status primarily returns estimated metric telemetry",
+        docsBackedTarget: "next-action-centered active-work dashboard that separates observed evidence, inference, required next action, and non-claims",
+        divergence: "metric receipts are useful but are not active-work closeout evidence by themselves; bare status now includes bounded local git probing for worktree evidence",
+        firstPassAction: "attach a WorkItem dashboard projection to fooks status without removing existing metric fields",
+      },
+      {
+        scope: "check",
+        currentSurface: "fooks check reports operator active-artifact boundaries and handoff requirements",
+        docsBackedTarget: "shared Evidence and NextAction vocabulary reusable by status/check/TUI surfaces",
+        divergence: "check already carries conservative boundaries but uses operator-specific shapes",
+        firstPassAction: "keep check behavior unchanged and model the shared vocabulary in a separate projection",
+      },
+      {
+        scope: "tui",
+        currentSurface: "TUI-related code is source/payload metadata and tests, not a rewritten action board",
+        docsBackedTarget: "TUI can consume WorkItem/Evidence/NextAction later without runtime/provider changes",
+        divergence: "no common board model existed before this pass",
+        firstPassAction: "export shared model types and a model-only TUI compatibility marker; do not rewrite UI",
+      },
+    ],
+    workItems: [
+      {
+        id: issue ? `work-item-${issue.slice(1)}` : "work-item-unlinked",
+        title: issue ? `Active work ${issue}` : "Unlinked work item candidate",
+        state: workItemStateFor(snapshot, anchors),
+        observed: evidence.map((item) => item.observed),
+        inferred: [
+          issue ? `${issue} is the local issue anchor inferred from branch naming.` : "No issue anchor was inferred from branch naming.",
+          snapshot.clean === false ? "The worktree has uncommitted local changes and still needs verification/closeout." : "Clean worktree evidence still needs a scoped receipt before active work is complete.",
+        ],
+        requiredNextAction: action,
+        evidence,
+        nonClaims: [
+          "This dashboard does not prove provider usage or billing-token savings.",
+          "This dashboard does not prove runtime UI correctness.",
+          "This dashboard does not close active work without test/review/PR receipt evidence.",
+        ],
+      },
+    ],
+    nextActions: [action],
+    tuiCompatibility: {
+      modelOnly: true,
+      sharedTypes: ["WorkItem", "Evidence", "NextAction"],
+      note: "The model is exported for future CLI/TUI sharing; this pass intentionally does not rewrite the TUI.",
+    },
+  };
+}
+
+export type Evidence = WorkItemEvidence;
+export type NextAction = WorkItemNextAction;

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,3 +262,14 @@ export type {
   ReactWebDecisionStopBenchmarkEntry,
   ReactWebDecisionStopHandoff,
 } from "./core/react-web-decision-handoff-benchmark";
+export {
+  WORK_ITEM_DASHBOARD_SCHEMA_VERSION,
+  WORK_ITEM_DASHBOARD_SOURCE,
+  WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY,
+  buildWorkItemDashboard,
+  type WorkItem,
+  type WorkItemEvidence,
+  type WorkItemNextAction,
+  type WorkItemDashboard,
+  type WorkItemArchitectureAudit,
+} from "./core/work-item-dashboard";

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -1,0 +1,232 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function makeRepo() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-work-item-dashboard-"));
+  git(tempDir, ["init", "-b", "main"]);
+  git(tempDir, ["config", "user.email", "test@example.com"]);
+  git(tempDir, ["config", "user.name", "Test User"]);
+  git(tempDir, ["remote", "add", "origin", "git@github.com:minislively/fooks.git"]);
+  fs.writeFileSync(path.join(tempDir, "README.md"), "# fixture\n");
+  git(tempDir, ["add", "README.md"]);
+  git(tempDir, ["commit", "-m", "initial"]);
+  git(tempDir, ["checkout", "-b", "feature/issue-922-docs-backed-work-item-action-dashboard"]);
+  return tempDir;
+}
+
+function runStatus(cwd, env = {}) {
+  return JSON.parse(execFileSync(process.execPath, [cli, "status"], { cwd, encoding: "utf8", env: { ...process.env, ...env } }));
+}
+
+test("bare status includes docs-backed WorkItem dashboard while preserving metric status shape", () => {
+  const tempDir = makeRepo();
+  const status = runStatus(tempDir, { OMX_SESSION_ID: "omx-test-session" });
+
+  assert.equal(status.schemaVersion, 1);
+  assert.equal(status.metricTier, "estimated");
+  assert.equal("sessions" in status, false);
+  assert.equal("latestSessionKeys" in status, false);
+
+  const dashboard = status.workItemDashboard;
+  assert.equal(dashboard.schemaVersion, 1);
+  assert.equal(dashboard.readOnly, true);
+  assert.match(dashboard.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.match(dashboard.claimBoundary, /Docs-backed active-work dashboard projection only/);
+  assert.equal(dashboard.anchors.issue, "#922");
+  assert.equal(dashboard.anchors.issueUrl, "https://github.com/minislively/fooks/issues/922");
+  assert.equal(dashboard.anchors.branch, "feature/issue-922-docs-backed-work-item-action-dashboard");
+  assert.equal(dashboard.anchors.session, "omx-test-session");
+  assert.equal(dashboard.anchors.worktree, tempDir);
+  assert.equal(dashboard.workItems[0].requiredNextAction.kind, "open-pr");
+  assert.deepEqual(dashboard.tuiCompatibility.sharedTypes, ["WorkItem", "Evidence", "NextAction"]);
+  assert.equal(dashboard.tuiCompatibility.modelOnly, true);
+  assert.ok(dashboard.architectureAudit.some((item) => item.scope === "status" && /metric telemetry/.test(item.currentSurface)));
+  assert.ok(dashboard.architectureAudit.some((item) => item.scope === "check" && /operator/.test(item.currentSurface)));
+  assert.ok(dashboard.architectureAudit.some((item) => item.scope === "tui" && /do not rewrite/.test(item.firstPassAction)));
+  assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "architectureDoc" && item.supports.includes("WorkItem/Evidence/NextAction")));
+  assert.ok(dashboard.workItems[0].nonClaims.some((item) => item.includes("provider usage")));
+});
+
+test("shared WorkItem dashboard builder is importable for non-CLI consumers", () => {
+  const { buildWorkItemDashboard, WORK_ITEM_DASHBOARD_SOURCE } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+  assert.equal(dashboard.source, WORK_ITEM_DASHBOARD_SOURCE);
+  assert.equal(dashboard.workItems[0].evidence.some((item) => item.kind === "worktree"), true);
+  assert.equal(dashboard.tuiCompatibility.modelOnly, true);
+});
+
+
+test("WorkItem dashboard marks unavailable git status as inspect action instead of clean", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-work-item-no-git-"));
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  assert.equal(dashboard.workItems[0].state, "blocked");
+  assert.equal(dashboard.nextActions[0].kind, "inspect");
+  assert.match(dashboard.nextActions[0].reason, /git worktree evidence unavailable/);
+  assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "worktree" && item.fresh === "unknown"));
+});
+
+
+test("WorkItem dashboard does not infer issue anchors from unrelated version numbers", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "react-18-upgrade"]);
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  assert.equal(dashboard.anchors.issue, undefined);
+  assert.equal(dashboard.nextActions[0].kind, "link");
+});
+
+
+test("WorkItem dashboard treats clean unlinked checkout as evidence-ready, not active work", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "main"]);
+  const previousFooksSession = process.env.FOOKS_SESSION_ID;
+  const previousOmxSession = process.env.OMX_SESSION_ID;
+  const previousTmuxPane = process.env.TMUX_PANE;
+  delete process.env.FOOKS_SESSION_ID;
+  delete process.env.OMX_SESSION_ID;
+  delete process.env.TMUX_PANE;
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  try {
+    assert.equal(dashboard.anchors.issue, undefined);
+    assert.equal(dashboard.anchors.session, undefined);
+    assert.equal(dashboard.workItems[0].state, "evidence-ready");
+    assert.equal(dashboard.nextActions[0].kind, "link");
+  } finally {
+    if (previousFooksSession === undefined) delete process.env.FOOKS_SESSION_ID; else process.env.FOOKS_SESSION_ID = previousFooksSession;
+    if (previousOmxSession === undefined) delete process.env.OMX_SESSION_ID; else process.env.OMX_SESSION_ID = previousOmxSession;
+    if (previousTmuxPane === undefined) delete process.env.TMUX_PANE; else process.env.TMUX_PANE = previousTmuxPane;
+  }
+});
+
+
+test("ambient session alone does not make a clean unlinked checkout active work", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "main"]);
+  const previousFooksSession = process.env.FOOKS_SESSION_ID;
+  process.env.FOOKS_SESSION_ID = "ambient-session-only";
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  try {
+    assert.equal(dashboard.anchors.issue, undefined);
+    assert.equal(dashboard.anchors.session, "ambient-session-only");
+    assert.equal(dashboard.workItems[0].state, "evidence-ready");
+    assert.equal(dashboard.nextActions[0].kind, "link");
+    assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "session"));
+  } finally {
+    if (previousFooksSession === undefined) delete process.env.FOOKS_SESSION_ID;
+    else process.env.FOOKS_SESSION_ID = previousFooksSession;
+  }
+});


### PR DESCRIPTION
Fixes #922

## Summary
- add docs-backed WorkItem / Evidence / NextAction model in `src/core/work-item-dashboard.ts`
- attach `workItemDashboard` to bare `fooks status` while preserving existing metric status fields
- add audit doc for current `status` / `check` / TUI divergence and first-pass boundary
- export the shared model for CLI/TUI consumers without rewriting TUI

## Verification
- npm run build
- node --test test/work-item-dashboard.test.mjs
- node dist/cli/index.js status (dashboard smoke: workItems=1, nextAction=open-pr, tuiCompatibility.modelOnly=true)
- git diff --check

## Boundary
No TUI rewrite, no `fooks explain`, no provider/runtime behavior change, and no completion claim from metric receipts alone.
