### PR TITLE
Implement fooks explain work-item evidence CLI

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|run|scan|extract|compare|decide|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -645,6 +645,7 @@ Everyday commands:
   ${displayCliName} run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
   ${displayCliName} compare <file> [--json]
+  ${displayCliName} explain <status|work-item|sample|current> [--json]
   ${displayCliName} inspect evidence <id> [--json]
   ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
@@ -672,6 +673,29 @@ Everyday commands:
 
 Install: npm install -g fxxk-frontend-hooks
 CLI command: ${displayCliName}`);
+}
+
+
+function parseExplainArgs(args: string[]): { artifact: "status" | "work-item" | "sample" | "current"; json: boolean } {
+  let artifact: "status" | "work-item" | "sample" | "current" | undefined;
+  let json = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "status" || arg === "work-item" || arg === "sample" || arg === "current") {
+      if (artifact) {
+        throw new Error("explain accepts at most one artifact: status, work-item, sample, or current");
+      }
+      artifact = arg;
+      continue;
+    }
+    throw new Error(`Unexpected explain argument: ${arg}`);
+  }
+
+  return { artifact: artifact ?? "current", json };
 }
 
 function parseExtractArgs(args: string[]): { filePath: string; modelPayload: boolean } {
@@ -1308,6 +1332,23 @@ async function run(): Promise<void> {
         tuiSourceMetadata,
         reactNativeSourceAnchorBeta,
       }));
+      return;
+    }
+    case "explain": {
+      const { artifact, json } = parseExplainArgs(rest);
+      const [{ readProjectMetricSummary }, { buildWorkItemDashboard }, { buildWorkItemExplain, renderWorkItemExplainText }] = await Promise.all([
+        import("../core/session-metrics.js"),
+        import("../core/work-item-dashboard.js"),
+        import("../core/work-item-explain.js"),
+      ]);
+      const metricStatus = readProjectMetricSummary(process.cwd());
+      const dashboard = buildWorkItemDashboard(process.cwd(), metricStatus);
+      const explanation = buildWorkItemExplain(artifact, dashboard);
+      if (json) {
+        print(explanation);
+      } else {
+        process.stdout.write(renderWorkItemExplainText(explanation));
+      }
       return;
     }
     case "inspect": {

--- a/src/core/work-item-explain.ts
+++ b/src/core/work-item-explain.ts
@@ -1,0 +1,170 @@
+import type { WorkItem, WorkItemDashboard, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
+import { WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY } from "./work-item-dashboard";
+
+export const WORK_ITEM_EXPLAIN_SCHEMA_VERSION = 1;
+export const WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY =
+  "CLI-only WorkItem evidence explanation: explains current status/work-item/sample artifacts from the docs-backed WorkItem model without changing provider/runtime behavior, detector scope, merge-gate policy, TUI, React Web, React Native, or WebView behavior.";
+
+export type WorkItemExplainArtifact = "status" | "work-item" | "sample" | "current";
+
+export type WorkItemExplainRejectedEvidence = {
+  evidence: string;
+  reason: string;
+};
+
+export type WorkItemExplainResult = {
+  schemaVersion: typeof WORK_ITEM_EXPLAIN_SCHEMA_VERSION;
+  command: "explain";
+  artifact: WorkItemExplainArtifact;
+  generatedAt: string;
+  claimBoundary: typeof WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY;
+  dashboardClaimBoundary: typeof WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY;
+  readOnly: true;
+  workItem: {
+    id: string;
+    title: string;
+    state: WorkItem["state"];
+  };
+  why: string[];
+  evidence: WorkItemEvidence[];
+  rejectedEvidence: WorkItemExplainRejectedEvidence[];
+  nextAction: WorkItemNextAction;
+  nonClaims: string[];
+};
+
+function sampleEvidence(): WorkItemEvidence[] {
+  return [
+    {
+      kind: "architectureDoc",
+      evidenceClass: "Source evidence",
+      observed: "sample artifact demonstrates WorkItem/Evidence/NextAction explanation shape",
+      source: "fooks explain sample",
+      fresh: true,
+      supports: "CLI formatting and machine-readable explanation contract for the WorkItem evidence model",
+      doesNotSupport: "provider/runtime behavior changes, detector expansion, merge-gate approval, TUI rewrite, or product/performance claims",
+    },
+    {
+      kind: "worktree",
+      evidenceClass: "Workflow evidence",
+      observed: "sample has no live worktree mutation or remote lookup",
+      source: "static sample fixture",
+      fresh: "unknown",
+      supports: "safe operator preview of the explain surface",
+      doesNotSupport: "current repository status, PR state, test pass, or closeout receipt",
+    },
+  ];
+}
+
+function sampleWorkItem(): WorkItem {
+  const nextAction: WorkItemNextAction = {
+    kind: "inspect",
+    label: "Run fooks explain status in a repository to inspect live WorkItem evidence",
+    command: "fooks explain status",
+    reason: "sample explains the model shape only; live status evidence is intentionally not inferred from the sample",
+    closesWhen: "a live status/work-item explanation is generated from the current repository dashboard",
+  };
+  const evidence = sampleEvidence();
+  return {
+    id: "work-item-sample",
+    title: "Sample WorkItem evidence explanation",
+    state: "uninspected",
+    observed: evidence.map((item) => item.observed),
+    inferred: [
+      "The sample is static and read-only.",
+      "Use status, current, or work-item to explain the current repository artifact.",
+    ],
+    requiredNextAction: nextAction,
+    evidence,
+    nonClaims: [
+      "The sample does not prove current repository readiness.",
+      "The sample does not prove provider usage, runtime behavior, detector support, TUI behavior, or performance results.",
+    ],
+  };
+}
+
+function evidenceForArtifact(artifact: WorkItemExplainArtifact, dashboard: WorkItemDashboard): WorkItem {
+  if (artifact === "sample") return sampleWorkItem();
+  const item = dashboard.workItems[0];
+  if (!item) {
+    const nextAction: WorkItemNextAction = {
+      kind: "inspect",
+      label: "Inspect status evidence before acting",
+      command: "fooks status",
+      reason: "dashboard contains no work item entries",
+      closesWhen: "a dashboard work item entry exists or the missing evidence is recorded",
+    };
+    return {
+      id: "work-item-missing",
+      title: "Missing WorkItem evidence",
+      state: "blocked",
+      observed: [],
+      inferred: ["No work item was available in the dashboard artifact."],
+      requiredNextAction: nextAction,
+      evidence: [],
+      nonClaims: ["No completion or readiness claim can be made without WorkItem evidence."],
+    };
+  }
+  return item;
+}
+
+function whyFor(item: WorkItem, dashboard: WorkItemDashboard, artifact: WorkItemExplainArtifact): string[] {
+  return [
+    `artifact '${artifact}' resolves to WorkItem '${item.id}' in state '${item.state}'`,
+    ...item.observed.map((observed) => `observed: ${observed}`),
+    ...item.inferred.map((inferred) => `inferred: ${inferred}`),
+    `next action: ${item.requiredNextAction.label} because ${item.requiredNextAction.reason}`,
+    `source model: ${dashboard.source}`,
+  ];
+}
+
+function rejectedEvidenceFor(item: WorkItem): WorkItemExplainRejectedEvidence[] {
+  const rejected = item.evidence.map((evidence) => ({
+    evidence: evidence.observed,
+    reason: evidence.doesNotSupport,
+  }));
+  for (const nonClaim of item.nonClaims) {
+    rejected.push({ evidence: nonClaim, reason: "explicit WorkItem non-claim" });
+  }
+  return rejected;
+}
+
+export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboard: WorkItemDashboard): WorkItemExplainResult {
+  const item = evidenceForArtifact(artifact, dashboard);
+  return {
+    schemaVersion: WORK_ITEM_EXPLAIN_SCHEMA_VERSION,
+    command: "explain",
+    artifact,
+    generatedAt: new Date().toISOString(),
+    claimBoundary: WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY,
+    dashboardClaimBoundary: WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY,
+    readOnly: true,
+    workItem: {
+      id: item.id,
+      title: item.title,
+      state: item.state,
+    },
+    why: whyFor(item, dashboard, artifact),
+    evidence: item.evidence,
+    rejectedEvidence: rejectedEvidenceFor(item),
+    nextAction: item.requiredNextAction,
+    nonClaims: item.nonClaims,
+  };
+}
+
+function bulletList(items: string[]): string {
+  return items.length > 0 ? items.map((item) => `- ${item}`).join("\n") : "- none";
+}
+
+export function renderWorkItemExplainText(explain: WorkItemExplainResult): string {
+  const evidence = explain.evidence.length > 0
+    ? explain.evidence
+        .map((item) => `- [${item.evidenceClass}/${item.kind}] ${item.observed}\n  supports: ${item.supports}\n  source: ${item.source}\n  fresh: ${item.fresh}`)
+        .join("\n")
+    : "- none";
+  const rejected = explain.rejectedEvidence.length > 0
+    ? explain.rejectedEvidence.map((item) => `- ${item.evidence}\n  rejected for: ${item.reason}`).join("\n")
+    : "- none";
+  const commandLine = explain.nextAction.command ? `\n- command: ${explain.nextAction.command}` : "";
+
+  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,3 +273,12 @@ export {
   type WorkItemDashboard,
   type WorkItemArchitectureAudit,
 } from "./core/work-item-dashboard";
+export {
+  WORK_ITEM_EXPLAIN_SCHEMA_VERSION,
+  WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY,
+  buildWorkItemExplain,
+  renderWorkItemExplainText,
+  type WorkItemExplainArtifact,
+  type WorkItemExplainRejectedEvidence,
+  type WorkItemExplainResult,
+} from "./core/work-item-explain";

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -230,3 +230,77 @@ test("ambient session alone does not make a clean unlinked checkout active work"
     else process.env.FOOKS_SESSION_ID = previousFooksSession;
   }
 });
+
+test("fooks explain status renders WorkItem evidence, rejected evidence, and next action", () => {
+  const tempDir = makeRepo();
+  const text = execFileSync(process.execPath, [cli, "explain", "status"], {
+    cwd: tempDir,
+    encoding: "utf8",
+    env: { ...process.env, OMX_SESSION_ID: "omx-explain-test" },
+  });
+
+  assert.match(text, /^# fooks explain status/m);
+  assert.match(text, /CLI-only WorkItem evidence explanation/);
+  assert.match(text, /## Why/);
+  assert.match(text, /artifact 'status' resolves to WorkItem 'work-item-922' in state 'active-work'/);
+  assert.match(text, /## Evidence/);
+  assert.match(text, /Source evidence\/architectureDoc/);
+  assert.match(text, /## Rejected evidence \/ non-claims/);
+  assert.match(text, /provider usage, billing tokens/);
+  assert.match(text, /## Next action/);
+  assert.match(text, /kind: open-pr/);
+});
+
+test("fooks explain work-item --json exposes machine-readable WorkItem explanation", () => {
+  const tempDir = makeRepo();
+  const explanation = JSON.parse(execFileSync(process.execPath, [cli, "explain", "work-item", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+    env: { ...process.env, FOOOKS_UNUSED: "ignored" },
+  }));
+
+  assert.equal(explanation.schemaVersion, 1);
+  assert.equal(explanation.command, "explain");
+  assert.equal(explanation.artifact, "work-item");
+  assert.equal(explanation.readOnly, true);
+  assert.equal(explanation.workItem.id, "work-item-922");
+  assert.equal(explanation.workItem.state, "active-work");
+  assert.ok(explanation.why.some((line) => line.includes("next action:")));
+  assert.ok(explanation.evidence.some((item) => item.kind === "worktree"));
+  assert.ok(explanation.rejectedEvidence.some((item) => item.reason.includes("provider usage")));
+  assert.equal(explanation.nextAction.kind, "open-pr");
+  assert.ok(explanation.claimBoundary.includes("without changing provider/runtime behavior"));
+});
+
+test("fooks explain sample is static and does not claim live repository evidence", () => {
+  const explanation = JSON.parse(execFileSync(process.execPath, [cli, "explain", "sample", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }));
+
+  assert.equal(explanation.artifact, "sample");
+  assert.equal(explanation.workItem.id, "work-item-sample");
+  assert.equal(explanation.workItem.state, "uninspected");
+  assert.equal(explanation.nextAction.command, "fooks explain status");
+  assert.ok(explanation.rejectedEvidence.some((item) => item.reason.includes("current repository status")));
+  assert.ok(explanation.nonClaims.some((item) => item.includes("does not prove current repository readiness")));
+});
+
+
+test("fooks explain current defaults to the current repository WorkItem artifact", () => {
+  const tempDir = makeRepo();
+  const explicit = JSON.parse(execFileSync(process.execPath, [cli, "explain", "current", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }));
+  const implicit = JSON.parse(execFileSync(process.execPath, [cli, "explain", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }));
+
+  assert.equal(explicit.artifact, "current");
+  assert.equal(implicit.artifact, "current");
+  assert.equal(explicit.workItem.id, "work-item-922");
+  assert.equal(implicit.workItem.id, "work-item-922");
+  assert.equal(explicit.nextAction.kind, "open-pr");
+});


### PR DESCRIPTION
Closes #927

## Summary
- add a bounded `fooks explain <status|work-item|sample|current>` CLI surface over the existing WorkItem dashboard model
- report state, why, evidence, rejected evidence/non-claims, and required next action in text and JSON forms
- export the explain builder/renderer for non-CLI consumers

## Scope boundary
- CLI/work-item evidence explain surface only
- no provider/runtime behavior changes
- no merge-gate policy changes
- no detector breadth changes
- no React Web/RN/TUI/WebView behavior changes
- no performance or product claim expansion

## Verification
- `npm run lint`
- `node --test test/work-item-dashboard.test.mjs`
- `npm test`

## Not tested
- live merge-gate behavior or PR automation beyond creating this PR
