### PR TITLE
Add explain npm alias for source checkouts

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -92,10 +92,11 @@ Good signs:
 - Check status reports a read-only post-merge main echo boundary; if there is no open issue, no open PR, and no mapped fooks tmux session, it requires a concrete active artifact instead of treating idle main echoes as work.
 - Activity status reports a compact read-only operator snapshot: current worktree branch/divergence/current dirty-path delta plus active fooks-like tmux panes when tmux is available. Open issue/PR counts are omitted unless `--include-remote-counts` is passed.
 
-From a source checkout after `npm run build`, maintainers may use the npm aliases
-`npm run -s check -- --json` and `npm run -s status:activity -- --json`.
-They are thin routes to the same built `dist/cli/index.js` `fooks check` and
-`fooks status activity` behavior, so they do not change provider/runtime behavior,
+From a source checkout, maintainers may use the npm aliases
+`npm run -s check -- --json`, `npm run -s status:activity -- --json`, and
+`npm run -s explain -- status --json`. They are thin build-and-run routes to the
+same built `dist/cli/index.js` `fooks check`, `fooks status activity`, and
+`fooks explain` behavior, so they do not change provider/runtime behavior,
 merge-gate policy, detector scope, React/RN/TUI/WebView behavior, or
 product/performance claims.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "check": "npm run build && node dist/cli/index.js check",
     "status:activity": "npm run build && node dist/cli/index.js status activity",
+    "explain": "npm run build && node dist/cli/index.js explain",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:integration": "npm run build && node --test test/*.test.mjs",
     "bench:cache": "npm run build && node scripts/benchmark-cache.mjs",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3857,6 +3857,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(pkg.scripts?.["smoke:domain-detector"], /inspect-domain test\/fixtures\/frontend-domain-expectations\/webview-boundary-basic\.tsx --json/);
   assert.equal(pkg.scripts?.check, "npm run build && node dist/cli/index.js check");
   assert.equal(pkg.scripts?.["status:activity"], "npm run build && node dist/cli/index.js status activity");
+  assert.equal(pkg.scripts?.explain, "npm run build && node dist/cli/index.js explain");
   assert.equal(pkg.scripts?.postinstall, undefined);
   assert.equal(pkg.scripts?.preinstall, undefined);
   assert.equal(pkg.scripts?.prepare, undefined);


### PR DESCRIPTION
Fixes #931

## Summary
- add a source-checkout `npm run explain` alias that builds and routes to `node dist/cli/index.js explain`
- document the explain alias beside the existing `check` and `status:activity` source-checkout operator aliases
- lock the alias in the package/CLI help regression test

## Scope boundary
- help/discovery/source-checkout operator UX only
- no provider/runtime behavior changes
- no merge-gate policy changes
- no detector scope expansion
- no React Web/RN/TUI/WebView behavior changes
- no product/performance claim broadening

## Verification
- `npm run -s explain -- --help`
- `node --test --test-name-pattern 'cli help advertises setup and package install has no auto hook side effects' test/fooks.test.mjs`
- `npm run build`
- `git diff --check`
