### PR TITLE
Add TUI as a frontend work domain

### DIFF
--- a/docs/evidence-model.md
+++ b/docs/evidence-model.md
@@ -20,7 +20,7 @@ These classes are also referred to as Source evidence, Test evidence, Workflow e
 | --- | --- | --- |
 | Current source evidence | Source-derived frontend facts, source fingerprints, line-aware edit hints. | Runtime UI correctness, cross-file behavior, provider billing. |
 | Local command evidence | What a fooks command emitted for a named input and environment. | Future runs after source or setup changes. |
-| Fixture/test evidence | Regression boundaries for representative cases. | Universal framework behavior. |
+| Fixture/test evidence | Regression boundaries for representative cases, including terminal snapshots or golden output for TUI work. | Universal framework behavior. |
 | Local estimate evidence | Model-facing byte/token estimates under named assumptions. | Provider usage/billing-token, invoice, dashboard, or charged-cost proof. |
 | Benchmark evidence | Repeated local measurements for a named harness. | Unmeasured user projects, stable runtime latency, or provider-wide savings. |
 | Human/review receipt | A decision or review happened. | Automatic correctness of the underlying code. |
@@ -37,7 +37,7 @@ proposed wording
 → public claim only if the measured scope is stable enough
 ```
 
-If any state is missing, use non-claim language and point to the gap. For example, prefer "local estimate evidence" over "savings" when provider billing evidence is absent.
+If any state is missing, use non-claim language and point to the gap. For example, prefer "local estimate evidence" over "savings" when provider billing evidence is absent; prefer "TUI-domain work item" over "terminal UX works" unless terminal rendering, keyboard flow, stdout/stderr, TTY/non-TTY, and snapshot/golden evidence exist for that scope.
 
 ## Receipt rules
 
@@ -71,7 +71,7 @@ Use these substitutions by default:
 | --- | --- |
 | "proves savings" | "reports local model-facing estimate evidence" |
 | "the feature works" | "the named test/command passed for this scope" |
-| "supported domain" | "measured lane" or "evidence lane," depending on the gate |
+| "supported domain" | "measured lane," "frontend work domain," or "evidence lane," depending on the gate |
 | "completed" | "closed by receipt X" |
 | "active branch means active development" | "branch/worktree evidence exists; activity still needs review" |
 

--- a/docs/frontend-domains.md
+++ b/docs/frontend-domains.md
@@ -1,6 +1,6 @@
 # Frontend domains
 
-This document describes how fooks should talk about frontend domains in the frontend-first architecture. It is docs-only architecture language and does not change detector behavior, payload policy, setup eligibility, runtime adapters, or public support wording.
+This document describes how fooks should talk about frontend domains in the frontend-first architecture. It is architecture language for product/domain support. It does not redesign fooks' own TUI board, does not change detector behavior, change setup eligibility, or claim runtime correctness beyond the explicitly measured surfaces.
 
 ## Domain model
 
@@ -23,7 +23,8 @@ Domain evidence is an observation. It is not permission. Concern evidence is use
 | React Web | DOM-oriented JSX, forms, native controls, browser events, `className`, ARIA attributes, and web imports without stronger boundary signals. | Strongest current frontend lane when existing extractor/readiness rules allow it. | Not whole-app understanding, visual correctness, or route-wide proof. |
 | React Native | `react-native` imports, native primitives, `TextInput`, `Pressable`, `FlatList`, `StyleSheet`, platform or navigation markers. | Evidence lane by default, with only the existing measured primitive/input narrow gate when policy allows it. | Not mobile runtime correctness, gesture correctness, native accessibility proof, or DOM equivalence. |
 | WebView boundary | `react-native-webview`, `<WebView>`, `source`, injected JavaScript, message bridge, or HTML/URI bridge markers. | Fallback-first boundary lane. | Not bridge safety, WebView runtime correctness, or compact-reuse permission. |
-| TUI / Ink | Ink-like imports, `Box`, `Text`, `useInput`, terminal layout, key-input handlers. | Candidate/evidence lane. | Not terminal behavior correctness or terminal UX proof. |
+| TUI | Terminal UI source such as Ink-like imports, `Box`, `Text`, `useInput`, terminal layout, key-input handlers, stdout/stderr rendering paths, TTY branches, or non-interactive fallback code. | First-class frontend work domain / interface target; evidence lane unless a narrower policy explicitly promotes a measured payload. | Not terminal behavior correctness, terminal UX proof, fooks' own rendering surface, or proof that every CLI is a TUI. |
+| Shared | Cross-domain frontend utilities, design tokens, schema/state helpers, test utilities, or docs that intentionally apply to more than one interface target. | First-class shared frontend work domain when the work target is intentionally cross-domain rather than a single runtime family. | Not permission to collapse evidence from React Web, React Native, WebView, or TUI into one support claim. |
 | Mixed | Multiple strong domain families or conflicting boundary signals in one file. | Safety state; fall back or defer according to the strongest boundary. | Not a request to choose the convenient domain. |
 | Unknown | Weak, absent, or unclassified frontend-family evidence. | Defer semantic domain claims; use ordinary behavior only when existing eligibility allows it. | Not implicit React Web. |
 
@@ -58,7 +59,7 @@ The intended direction is: shared syntax facts feed domain profiles; domain prof
 
 ## Out of scope for this pass
 
-This pass does not add or promote any domain lane, expand the React Native primitive/input gate, change WebView fallback-first posture, change detector logic, or change runtime/provider behavior.
+This pass does not redesign fooks' own TUI board, expand the React Native primitive/input gate, change WebView fallback-first posture, rewrite the evidence engine, or change runtime/provider behavior.
 
 ## React Web
 
@@ -68,10 +69,16 @@ React Web is the browser/DOM frontend lane.
 
 WebView is the embedded browser/bridge boundary lane.
 
+## TUI
+
+TUI is a terminal UI frontend domain for user-developed interface targets. It can include Ink-based applications and other terminal-rendered UI code. This meaning is distinct from fooks' own TUI rendering surface; adding a TUI work item must not imply a redesign of the fooks board.
+
+TUI evidence should name terminal-specific proof such as terminal rendering output, keyboard navigation behavior, stdout/stderr behavior, TTY versus non-TTY behavior, and snapshot/golden output. Useful next actions include running a TTY smoke check, verifying keyboard flow, and checking the non-interactive fallback path.
+
 ## React Native / RN
 
 React Native / RN is the native-rendered React frontend lane.
 
 A cross-domain claim must list each domain separately and attach evidence to each one.
 
-Architecture summary: React Web, WebView, and React Native are separate frontend domains and must not be collapsed into one support claim.
+Architecture summary: React Web, WebView, and React Native remain separate frontend domains; React Web, React Native, WebView, TUI, Shared, and Unknown are separate frontend work domains and must not be collapsed into one support claim. Mixed remains a safety state for conflicting evidence rather than a target work domain.

--- a/docs/state-contract.md
+++ b/docs/state-contract.md
@@ -7,7 +7,7 @@ This document defines the product-facing state contract for fooks as a frontend-
 | State category | Owner | Purpose | Claim boundary |
 | --- | --- | --- | --- |
 | Source state | Current project files plus source fingerprint/range metadata. | Tie evidence to the source that was inspected. | Stale when the source changes. |
-| Context state | Prepared packet, first-minute summary, issue cards, warnings, or fallback guidance. | Help the agent inspect and edit within scope. | Advisory unless current source and policy still match. |
+| Context state | Prepared packet, first-minute summary, issue cards, warnings, domain labels or hints, or fallback guidance. | Help the agent inspect and edit within scope. | Advisory unless current source and policy still match. |
 | Policy state | Decision that context is compact, narrow, fallback, or deferred for a measured scope. | Keep permission separate from evidence. | Cannot be inferred from domain or concern evidence alone. |
 | Receipt state | Durable command/test/review output. | Record what happened and what claim it can support. | Time- and scope-bound; not eternal proof. |
 | Active-work state | Open issue, branch, worktree, session, task note, or unverified result. | Show unfinished work and next action. | Not completion evidence. |
@@ -35,10 +35,11 @@ Compatibility state term: `receipt_only` is reserved for operator reports that n
 
 1. **Freshness first.** A context packet or work order is valid only for the source/fingerprint/scope it names.
 2. **Policy before reuse.** Evidence can be observed before policy, but compact or narrow reuse needs a policy decision.
-3. **Fallback is explicit state.** Unsupported, mixed, stale, or boundary-heavy inputs should record why normal source reading is required.
-4. **Receipts are scoped.** A receipt supports only the command, file, issue, or test run it names.
-5. **Active is not done.** Active-work evidence needs a closeout receipt before it becomes completion evidence.
-6. **Internal is not public.** Orchestration files can help local agents, but public product claims must cite product surfaces, tests, or docs.
+3. **Hints are not source evidence.** A branch/work-item label may hint at React Web, React Native, WebView, TUI, Shared, or Unknown work, but source evidence still requires current source inspection.
+4. **Fallback is explicit state.** Unsupported, mixed, stale, or boundary-heavy inputs should record why normal source reading is required. TUI fallback should name whether the missing proof is terminal rendering, keyboard navigation, stdout/stderr, TTY/non-TTY behavior, or snapshot/golden output.
+5. **Receipts are scoped.** A receipt supports only the command, file, issue, or test run it names.
+6. **Active is not done.** Active-work evidence needs a closeout receipt before it becomes completion evidence.
+7. **Internal is not public.** Orchestration files can help local agents, but public product claims must cite product surfaces, tests, or docs.
 
 ## Freshness and fingerprints
 
@@ -52,7 +53,7 @@ Source-derived evidence should carry enough freshness context for a later agent 
 - relevant included/omitted ranges;
 - non-claims.
 
-If a freshness anchor is absent or stale, the safe next action is to read the current source or rerun the relevant fooks command.
+If a freshness anchor is absent or stale, the safe next action is to read the current source or rerun the relevant fooks command. For a TUI work domain, safe next actions can also include a TTY smoke run, keyboard-flow verification, or a non-interactive fallback check when those are the relevant missing receipts.
 
 ## Receipt shape
 

--- a/docs/workflow-architecture.md
+++ b/docs/workflow-architecture.md
@@ -33,7 +33,7 @@ The workflow starts with source context and ends with a receipt. It should not b
 
 The first-minute workflow is the preferred product shape for frontend feature work:
 
-1. identify the user-requested frontend source or scope;
+1. identify the user-requested frontend source or scope, including React Web, React Native, WebView, TUI, Shared, or Unknown targets;
 2. inspect the current file or named source surface;
 3. produce bounded findings and next-inspection guidance;
 4. tell the agent what not to assume;
@@ -42,7 +42,7 @@ The first-minute workflow is the preferred product shape for frontend feature wo
 
 Issue cards, summaries, and dry-run previews are advisory context. They are not automatic edits, not final accessibility copy, not broad audits, and not permission to change task scope.
 
-Evidence model selects the required proof before a workflow state can authorize the next action.
+Evidence model selects the required proof before a workflow state can authorize the next action. TUI next actions should be terminal-specific when relevant: run a TTY smoke check, verify keyboard flow, check stdout/stderr behavior, and confirm the non-interactive fallback.
 
 ## Workflow states
 
@@ -86,4 +86,4 @@ A PR that changes runtime/provider behavior, merge gates, detector logic, CI wor
 
 ## Architecture pass boundary
 
-This docs architecture pass fixes language before implementation issues. It does not create a symptom-fix PR and does not authorize implementation work beyond the five architecture documents and their doc regression test.
+This docs architecture pass fixes language before implementation issues. This architecture boundary keeps user-project frontend domains separate from fooks' own operator UI. Adding TUI as a work domain must not redesign the fooks TUI board or broaden the evidence engine.

--- a/src/core/work-item-dashboard.ts
+++ b/src/core/work-item-dashboard.ts
@@ -2,12 +2,14 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import type { FooksProjectMetricStatus } from "./session-metrics";
 
-export const WORK_ITEM_DASHBOARD_SCHEMA_VERSION = 1;
+export const WORK_ITEM_DASHBOARD_SCHEMA_VERSION = 2;
 export const WORK_ITEM_DASHBOARD_SOURCE = "fooks status docs-backed work-item projection";
 export const WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY =
   "Docs-backed active-work dashboard projection only; separates observed local evidence, conservative inference, required next action, and non-claims without changing runtime/provider behavior or rewriting TUI.";
 
-export type WorkItemEvidenceKind = "issue" | "branch" | "session" | "worktree" | "pullRequest" | "metricReceipt" | "architectureDoc";
+export type WorkItemEvidenceKind = "issue" | "branch" | "session" | "worktree" | "pullRequest" | "metricReceipt" | "architectureDoc" | "domainHint";
+export type WorkItemFrontendDomain = "react-web" | "react-native" | "webview" | "tui" | "shared" | "unknown";
+export const WORK_ITEM_FRONTEND_DOMAIN_TAXONOMY: WorkItemFrontendDomain[] = ["react-web", "react-native", "webview", "tui", "shared", "unknown"];
 export type WorkItemEvidenceClass = "Source evidence" | "Local command evidence" | "Workflow evidence" | "Session evidence" | "Receipt evidence";
 export type WorkItemState = "uninspected" | "evidence-ready" | "fallback-required" | "context-issued" | "receipt-recorded" | "active-work" | "blocked";
 export type WorkItemNextActionKind = "inspect" | "verify" | "link" | "open-pr" | "continue" | "fallback";
@@ -34,6 +36,7 @@ export type WorkItem = {
   id: string;
   title: string;
   state: WorkItemState;
+  frontendDomain: WorkItemFrontendDomain;
   observed: string[];
   inferred: string[];
   requiredNextAction: WorkItemNextAction;
@@ -57,7 +60,7 @@ export type WorkItemDashboard = {
   readOnly: true;
   generatedFrom: {
     command: "status";
-    docs: ["docs/product-direction.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"];
+    docs: ["docs/product-direction.md", "docs/frontend-domains.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"];
   };
   anchors: {
     repo?: string;
@@ -72,6 +75,7 @@ export type WorkItemDashboard = {
   architectureAudit: WorkItemArchitectureAudit[];
   workItems: WorkItem[];
   nextActions: WorkItemNextAction[];
+  frontendDomainTaxonomy: WorkItemFrontendDomain[];
   tuiCompatibility: {
     modelOnly: true;
     sharedTypes: ["WorkItem", "Evidence", "NextAction"];
@@ -197,6 +201,48 @@ function docsEvidence(): WorkItemEvidence {
   };
 }
 
+function displayFrontendDomain(frontendDomain: WorkItemFrontendDomain): string {
+  switch (frontendDomain) {
+    case "react-web":
+      return "React Web";
+    case "react-native":
+      return "React Native";
+    case "webview":
+      return "WebView";
+    case "tui":
+      return "TUI";
+    case "shared":
+      return "Shared";
+    case "unknown":
+      return "Unknown-domain";
+  }
+}
+
+function frontendDomainFor(snapshot: GitSnapshot): WorkItemFrontendDomain {
+  const branch = snapshot.branch?.toLowerCase() ?? "";
+  if (/(^|[-_/#])react[-_]web($|[-_/#])|(^|[-_/#])web($|[-_/#])/.test(branch)) return "react-web";
+  if (/(^|[-_/#])react[-_]native($|[-_/#])|(^|[-_/#])rn($|[-_/#])/.test(branch)) return "react-native";
+  if (/(^|[-_/#])webview($|[-_/#])/.test(branch)) return "webview";
+  if (/(^|[-_/#])tui($|[-_/#])|(^|[-_/#])terminal[-_]ui($|[-_/#])/.test(branch)) return "tui";
+  if (/(^|[-_/#])shared($|[-_/#])/.test(branch)) return "shared";
+  return "unknown";
+}
+
+function domainHintEvidence(frontendDomain: WorkItemFrontendDomain, snapshot: GitSnapshot): WorkItemEvidence {
+  const observed = frontendDomain === "unknown"
+    ? `no frontend work domain hinted by branch ${snapshot.branch ?? "unknown"}`
+    : `${frontendDomain} frontend work domain hinted by branch ${snapshot.branch ?? "unknown"}`;
+  return {
+    kind: "domainHint",
+    evidenceClass: "Workflow evidence",
+    observed,
+    source: "local branch naming plus WorkItem frontend domain taxonomy",
+    fresh: snapshot.branch ? true : "unknown",
+    supports: "React Web / React Native / WebView / TUI / Shared / Unknown work-domain hint representation in the shared WorkItem model",
+    doesNotSupport: "runtime UI correctness, broad framework support, detector expansion, or changes to fooks' own TUI board",
+  };
+}
+
 function hasActiveWorkAnchor(snapshot: GitSnapshot, anchors: WorkItemDashboard["anchors"]): boolean {
   return Boolean(anchors.issue || anchors.pullRequest || snapshot.clean === false);
 }
@@ -256,7 +302,8 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
     ...pr,
   };
   const action = nextActionFor(snapshot, anchors);
-  const evidence = [docsEvidence(), worktreeEvidence(snapshot, cwd), metricEvidence(metricStatus)];
+  const frontendDomain = frontendDomainFor(snapshot);
+  const evidence = [docsEvidence(), domainHintEvidence(frontendDomain, snapshot), worktreeEvidence(snapshot, cwd), metricEvidence(metricStatus)];
   if (issue) {
     evidence.push({
       kind: "issue",
@@ -288,9 +335,10 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
     readOnly: true,
     generatedFrom: {
       command: "status",
-      docs: ["docs/product-direction.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"],
+      docs: ["docs/product-direction.md", "docs/frontend-domains.md", "docs/evidence-model.md", "docs/workflow-architecture.md", "docs/state-contract.md"],
     },
     anchors,
+    frontendDomainTaxonomy: WORK_ITEM_FRONTEND_DOMAIN_TAXONOMY,
     architectureAudit: [
       {
         scope: "status",
@@ -309,16 +357,17 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
       {
         scope: "tui",
         currentSurface: "TUI-related code is source/payload metadata and tests, not a rewritten action board",
-        docsBackedTarget: "TUI can consume WorkItem/Evidence/NextAction later without runtime/provider changes",
+        docsBackedTarget: "TUI is represented as a user-project frontend work domain in WorkItem/Evidence/NextAction without runtime/provider changes",
         divergence: "no common board model existed before this pass",
-        firstPassAction: "export shared model types and a model-only TUI compatibility marker; do not rewrite UI",
+        firstPassAction: "export shared model types, include the TUI frontend domain, and do not rewrite fooks' own TUI board",
       },
     ],
     workItems: [
       {
         id: issue ? `work-item-${issue.slice(1)}` : "work-item-unlinked",
-        title: issue ? `Active work ${issue}` : "Unlinked work item candidate",
+        title: issue ? `Active ${displayFrontendDomain(frontendDomain)} work ${issue}` : "Unlinked work item candidate",
         state: workItemStateFor(snapshot, anchors),
+        frontendDomain,
         observed: evidence.map((item) => item.observed),
         inferred: [
           issue ? `${issue} is the local issue anchor inferred from branch naming.` : "No issue anchor was inferred from branch naming.",
@@ -329,6 +378,7 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
         nonClaims: [
           "This dashboard does not prove provider usage or billing-token savings.",
           "This dashboard does not prove runtime UI correctness.",
+          "A TUI-domain work item means a user-developed terminal UI target, not fooks' own rendering surface.",
           "This dashboard does not close active work without test/review/PR receipt evidence.",
         ],
       },
@@ -337,7 +387,7 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
     tuiCompatibility: {
       modelOnly: true,
       sharedTypes: ["WorkItem", "Evidence", "NextAction"],
-      note: "The model is exported for future CLI/TUI sharing; this pass intentionally does not rewrite the TUI.",
+      note: "The model represents TUI as a user-project frontend domain for status/explain consumers; this pass intentionally does not rewrite fooks' own TUI board.",
     },
   };
 }

--- a/src/core/work-item-explain.ts
+++ b/src/core/work-item-explain.ts
@@ -1,7 +1,7 @@
 import type { WorkItem, WorkItemDashboard, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
 import { WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY } from "./work-item-dashboard";
 
-export const WORK_ITEM_EXPLAIN_SCHEMA_VERSION = 1;
+export const WORK_ITEM_EXPLAIN_SCHEMA_VERSION = 2;
 export const WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY =
   "CLI-only WorkItem evidence explanation: explains current status/work-item/sample artifacts from the docs-backed WorkItem model without changing provider/runtime behavior, detector scope, merge-gate policy, TUI, React Web, React Native, or WebView behavior.";
 
@@ -24,6 +24,7 @@ export type WorkItemExplainResult = {
     id: string;
     title: string;
     state: WorkItem["state"];
+    frontendDomain: WorkItem["frontendDomain"];
   };
   why: string[];
   evidence: WorkItemEvidence[];
@@ -40,7 +41,7 @@ function sampleEvidence(): WorkItemEvidence[] {
       observed: "sample artifact demonstrates WorkItem/Evidence/NextAction explanation shape",
       source: "fooks explain sample",
       fresh: true,
-      supports: "CLI formatting and machine-readable explanation contract for the WorkItem evidence model",
+      supports: "CLI formatting and machine-readable explanation contract for the WorkItem evidence model, including frontend domain representation",
       doesNotSupport: "provider/runtime behavior changes, detector expansion, merge-gate approval, TUI rewrite, or product/performance claims",
     },
     {
@@ -68,6 +69,7 @@ function sampleWorkItem(): WorkItem {
     id: "work-item-sample",
     title: "Sample WorkItem evidence explanation",
     state: "uninspected",
+    frontendDomain: "unknown",
     observed: evidence.map((item) => item.observed),
     inferred: [
       "The sample is static and read-only.",
@@ -97,6 +99,7 @@ function evidenceForArtifact(artifact: WorkItemExplainArtifact, dashboard: WorkI
       id: "work-item-missing",
       title: "Missing WorkItem evidence",
       state: "blocked",
+      frontendDomain: "unknown",
       observed: [],
       inferred: ["No work item was available in the dashboard artifact."],
       requiredNextAction: nextAction,
@@ -109,7 +112,7 @@ function evidenceForArtifact(artifact: WorkItemExplainArtifact, dashboard: WorkI
 
 function whyFor(item: WorkItem, dashboard: WorkItemDashboard, artifact: WorkItemExplainArtifact): string[] {
   return [
-    `artifact '${artifact}' resolves to WorkItem '${item.id}' in state '${item.state}'`,
+    `artifact '${artifact}' resolves to WorkItem '${item.id}' in state '${item.state}' for frontend domain '${item.frontendDomain}'`,
     ...item.observed.map((observed) => `observed: ${observed}`),
     ...item.inferred.map((inferred) => `inferred: ${inferred}`),
     `next action: ${item.requiredNextAction.label} because ${item.requiredNextAction.reason}`,
@@ -142,6 +145,7 @@ export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboar
       id: item.id,
       title: item.title,
       state: item.state,
+      frontendDomain: item.frontendDomain,
     },
     why: whyFor(item, dashboard, artifact),
     evidence: item.evidence,
@@ -166,5 +170,5 @@ export function renderWorkItemExplainText(explain: WorkItemExplainResult): strin
     : "- none";
   const commandLine = explain.nextAction.command ? `\n- command: ${explain.nextAction.command}` : "";
 
-  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
+  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${explain.workItem.frontendDomain}\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
 }

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -44,7 +44,7 @@ test("bare status includes docs-backed WorkItem dashboard while preserving metri
   assert.equal("latestSessionKeys" in status, false);
 
   const dashboard = status.workItemDashboard;
-  assert.equal(dashboard.schemaVersion, 1);
+  assert.equal(dashboard.schemaVersion, 2);
   assert.equal(dashboard.readOnly, true);
   assert.match(dashboard.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.match(dashboard.claimBoundary, /Docs-backed active-work dashboard projection only/);
@@ -259,7 +259,7 @@ test("fooks explain work-item --json exposes machine-readable WorkItem explanati
     env: { ...process.env, FOOOKS_UNUSED: "ignored" },
   }));
 
-  assert.equal(explanation.schemaVersion, 1);
+  assert.equal(explanation.schemaVersion, 2);
   assert.equal(explanation.command, "explain");
   assert.equal(explanation.artifact, "work-item");
   assert.equal(explanation.readOnly, true);
@@ -324,4 +324,85 @@ test("fooks explain exposes command help without reading live WorkItem evidence"
     encoding: "utf8",
   });
   assert.equal(shortHelp, help);
+});
+
+test("WorkItem dashboard represents TUI as a first-class frontend work domain", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "feature/issue-933-tui-frontend-domain"]);
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  assert.deepEqual(dashboard.frontendDomainTaxonomy, ["react-web", "react-native", "webview", "tui", "shared", "unknown"]);
+  assert.equal(dashboard.anchors.issue, "#933");
+  assert.equal(dashboard.workItems[0].frontendDomain, "tui");
+  assert.equal(dashboard.workItems[0].title, "Active TUI work #933");
+  assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Workflow evidence" && /tui frontend work domain hinted by branch/.test(item.observed)));
+  assert.ok(dashboard.workItems[0].nonClaims.some((item) => /user-developed terminal UI target/.test(item)));
+});
+
+test("fooks status and explain expose TUI-domain work item details", () => {
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "feature/issue-933-tui-frontend-domain"]);
+
+  const status = runStatus(tempDir);
+  assert.equal(status.workItemDashboard.workItems[0].frontendDomain, "tui");
+  assert.ok(status.workItemDashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Workflow evidence"));
+
+  const explanation = JSON.parse(execFileSync(process.execPath, [cli, "explain", "status", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }));
+  assert.equal(explanation.workItem.id, "work-item-933");
+  assert.equal(explanation.workItem.frontendDomain, "tui");
+  assert.ok(explanation.why.some((line) => line.includes("frontend domain 'tui'")));
+  assert.ok(explanation.rejectedEvidence.some((item) => /fooks' own TUI board/.test(item.reason)));
+});
+
+
+test("WorkItem dashboard keeps unknown branch domain explicit and non-source", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "feature/issue-934-maintenance"]);
+  const dashboard = buildWorkItemDashboard(tempDir, {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  });
+
+  assert.equal(dashboard.workItems[0].frontendDomain, "unknown");
+  assert.equal(dashboard.workItems[0].title, "Active Unknown-domain work #934");
+  assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Workflow evidence"));
+  assert.equal(dashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Source evidence"), false);
 });


### PR DESCRIPTION
## Summary
- Add TUI to the docs as a first-class user-project frontend work domain / interface target alongside React Web, React Native, WebView, Shared, and Unknown.
- Extend the shared WorkItem status/explain model with frontend work-domain hints, including TUI, while keeping branch-derived labels as Workflow evidence rather than Source evidence.
- Add focused status/explain tests for TUI-domain representation and explicit Unknown-domain handling.

## Guardrails
- Does not redesign fooks' own TUI board.
- Does not rewrite the evidence engine or change detector/runtime behavior.
- Keeps TUI labels advisory until source inspection or terminal receipts support stronger claims.

## Verification
- `node --test test/work-item-dashboard.test.mjs test/frontend-first-architecture-docs.test.mjs test/product-architecture-docs.test.mjs test/payload-policy-tui-ink.test.mjs test/domain-detector.test.mjs` (56 pass)
- `npm run build`
- `git diff --check`
- Final review gate: code-reviewer APPROVE; architect CLEAR.

Fixes #933
