### PR TITLE
Improve domain-aware work item judgment

### DIFF
--- a/src/core/domain-detector.ts
+++ b/src/core/domain-detector.ts
@@ -21,6 +21,8 @@ const RN_MODULE = "react-native";
 const RN_NAVIGATION_MODULE = "@react-navigation/native";
 const WEBVIEW_MODULE = "react-native-webview";
 const INK_MODULE = "ink";
+const REACT_WEB_MODULES = new Set(["react-dom", "react-router-dom", "next", "next/link", "next/navigation"]);
+const SHARED_PATH_SEGMENTS = new Set(["shared", "common", "design-system", "tokens", "contracts", "schemas"]);
 const WEBVIEW_BRIDGE_MARKERS = [
   ["ReactNativeWebView.postMessage", "ReactNativeWebView.postMessage"],
   ["window.ReactNativeWebView", "window.ReactNativeWebView"],
@@ -50,6 +52,9 @@ const RN_API_CALLS = new Map([
 const RN_NAVIGATION_HOOKS = new Set(["useNavigation", "useRoute"]);
 const TUI_PRIMITIVES = new Set(["Box", "Text"]);
 const TUI_HOOKS = new Set(["useInput"]);
+const TUI_MODULES = new Set(["ink", "blessed", "readline", "readline/promises", "cli-table3"]);
+const TUI_TEXT_MARKERS = ["process.stdin", "process.stdout", "process.stderr", "isTTY", "setRawMode", "readline.emitKeypressEvents", "stdin.on(\"keypress", "stdout.write", "stderr.write"] as const;
+const SHARED_TEXT_MARKERS = ["design token", "designTokens", "createTheme", "api contract", "ApiContract", "shared state", "createStore"] as const;
 
 function getScriptKind(filePath: string): ts.ScriptKind {
   const ext = path.extname(filePath).toLowerCase();
@@ -126,6 +131,17 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
   const evidence: FrontendDomainEvidence[] = [];
   let hasReactWebEvidence = false;
 
+  const normalizedPathSegments = filePath.toLowerCase().split(/[\\/_.-]+/u).filter(Boolean);
+  if (normalizedPathSegments.some((segment) => SHARED_PATH_SEGMENTS.has(segment))) {
+    addEvidence(evidence, "shared", "path-segment", normalizedPathSegments.find((segment) => SHARED_PATH_SEGMENTS.has(segment)) ?? "shared");
+  }
+  if (/\b(?:ios|android)\b/iu.test(filePath)) {
+    addEvidence(evidence, "react-native", "platform-path", /\bios\b/iu.test(filePath) ? "ios" : "android");
+  }
+  if (/metro\.config\.[cm]?[jt]s$/iu.test(filePath)) {
+    addEvidence(evidence, "react-native", "metro-config", path.basename(filePath));
+  }
+
   function rememberImportedName(moduleName: string, name: string): void {
     const names = importedNamesByModule.get(moduleName) ?? new Set<string>();
     names.add(name);
@@ -151,6 +167,14 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
       if (moduleName === INK_MODULE) {
         addEvidence(evidence, "tui-ink", "import", moduleName);
       }
+      // React Web framework imports are remembered below, but imports alone are concern evidence;
+      // they become domain evidence only when paired with DOM JSX, browser globals, or JSX component use.
+      if (TUI_MODULES.has(moduleName)) {
+        addEvidence(evidence, "tui-ink", "terminal-import", moduleName);
+      }
+      if (/\b(?:tokens|design-system|shared|contracts)\b/iu.test(moduleName)) {
+        addEvidence(evidence, "shared", "shared-import", moduleName);
+      }
 
       const importClause = node.importClause;
       if (importClause?.name) rememberImportedName(moduleName, importClause.name.text);
@@ -168,6 +192,7 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
         if (moduleName === RN_MODULE || moduleName.startsWith(`${RN_MODULE}/`)) addEvidence(evidence, "react-native", "require", moduleName);
         if (moduleName === WEBVIEW_MODULE) addEvidence(evidence, "webview", "require", moduleName);
         if (moduleName === INK_MODULE) addEvidence(evidence, "tui-ink", "require", moduleName);
+        if (TUI_MODULES.has(moduleName)) addEvidence(evidence, "tui-ink", "terminal-require", moduleName);
       }
     }
 
@@ -181,6 +206,12 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
         if (WEB_DOM_TAGS.has(tag)) {
           hasReactWebEvidence = true;
           addEvidence(evidence, "react-web", "dom-tag", tag);
+        }
+        for (const moduleName of REACT_WEB_MODULES) {
+          if (hasImportedName(moduleName, tag)) {
+            hasReactWebEvidence = true;
+            addEvidence(evidence, "react-web", "framework-component", `${moduleName}:${tag}`);
+          }
         }
       }
     }
@@ -221,6 +252,26 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
       if (hasEvidence(evidence, "webview") && property === "postMessage") {
         addEvidence(evidence, "webview", "bridge-call", "postMessage");
       }
+      if (ts.isIdentifier(expression) && expression.text === "Linking" && property === "openURL" && hasEvidence(evidence, "webview")) {
+        addEvidence(evidence, "webview", "deeplink-call", "Linking.openURL");
+      }
+      if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.expression) && expression.expression.text === "process") {
+        const stream = expression.name.text;
+        if ((stream === "stdout" || stream === "stderr" || stream === "stdin") && (property === "write" || property === "on")) {
+          addEvidence(evidence, "tui-ink", "terminal-api", `process.${stream}.${property}`);
+        }
+      }
+    }
+
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "process") {
+      const property = node.name.text;
+      if (property === "stdout" || property === "stderr" || property === "stdin") {
+        addEvidence(evidence, "tui-ink", "terminal-stream", `process.${property}`);
+      }
+    }
+
+    if (ts.isPropertyAccessExpression(node) && node.name.text === "isTTY") {
+      addEvidence(evidence, "tui-ink", "terminal-tty", "isTTY");
     }
 
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
@@ -252,8 +303,26 @@ export function detectDomainFromSource(sourceText: string, filePath = "source.ts
       addEvidence(evidence, "tui-ink", "hook", node.text);
     }
 
+    if (ts.isIdentifier(node) && (node.text === "window" || node.text === "document" || node.text === "localStorage")) {
+      hasReactWebEvidence = true;
+      addEvidence(evidence, "react-web", "browser-global", node.text);
+    }
+
+    if (ts.isIdentifier(node) && /^(?:tokens|designTokens|theme|contract|sharedState|ApiContract)$/u.test(node.text)) {
+      addEvidence(evidence, "shared", "shared-identifier", node.text);
+    }
+
     if (ts.isStringLiteralLike(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
       addWebViewBridgeMarkerEvidence(evidence, node.text);
+      for (const marker of TUI_TEXT_MARKERS) {
+        if (node.text.includes(marker)) addEvidence(evidence, "tui-ink", "terminal-marker", marker);
+      }
+      if (hasEvidence(evidence, "webview") && /(?:deeplink|deep link|session handoff|app container|[a-z][a-z0-9+.-]*:\/\/)/iu.test(node.text)) {
+        addEvidence(evidence, "webview", "handoff-marker", node.text.includes("://") ? "uri-scheme" : "handoff-text");
+      }
+      for (const marker of SHARED_TEXT_MARKERS) {
+        if (node.text.includes(marker)) addEvidence(evidence, "shared", "shared-marker", marker);
+      }
     }
 
     ts.forEachChild(node, visit);

--- a/src/core/domain-profiles/registry.ts
+++ b/src/core/domain-profiles/registry.ts
@@ -1,6 +1,7 @@
 import { REACT_NATIVE_DOMAIN_PROFILE } from "./react-native";
 import { REACT_WEB_DOMAIN_PROFILE } from "./react-web";
 import { TUI_INK_DOMAIN_PROFILE } from "./tui-ink";
+import { SHARED_DOMAIN_PROFILE } from "./shared";
 import {
   FRONTEND_DOMAIN_BOUNDARY_REASON,
   type DomainLabel,
@@ -33,11 +34,12 @@ export const FRONTEND_DOMAIN_PROFILE_REGISTRY = [
   REACT_NATIVE_DOMAIN_PROFILE,
   WEBVIEW_DOMAIN_PROFILE,
   TUI_INK_DOMAIN_PROFILE,
+  SHARED_DOMAIN_PROFILE,
   MIXED_DOMAIN_PROFILE,
   UNKNOWN_DOMAIN_PROFILE,
 ] as const;
 
-const EVIDENCE_DOMAINS = ["react-native", "webview", "tui-ink"] as const;
+const EVIDENCE_DOMAINS = ["react-native", "webview", "tui-ink", "shared"] as const;
 const profilesByLane = new Map<DomainLabel, DomainProfileDefinition>(
   FRONTEND_DOMAIN_PROFILE_REGISTRY.map((profile) => [profile.lane, profile]),
 );

--- a/src/core/domain-profiles/shared.ts
+++ b/src/core/domain-profiles/shared.ts
@@ -1,0 +1,10 @@
+import type { DomainProfileDefinition } from "./types";
+
+export const SHARED_DOMAIN_PROFILE: DomainProfileDefinition = {
+  lane: "shared",
+  evidenceDomain: "shared",
+  outcome: "extract",
+  claimStatus: "evidence-only",
+  fallbackFirst: false,
+  claimBoundary: "domain-evidence-only",
+};

--- a/src/core/domain-profiles/types.ts
+++ b/src/core/domain-profiles/types.ts
@@ -1,4 +1,4 @@
-export type DomainLabel = "react-web" | "react-native" | "webview" | "tui-ink" | "mixed" | "unknown";
+export type DomainLabel = "react-web" | "react-native" | "webview" | "tui-ink" | "shared" | "mixed" | "unknown";
 export type FrontendDomainClassification = DomainLabel;
 export type FrontendDomainOutcome = "extract" | "fallback" | "deferred" | "unsupported";
 export type FrontendDomainProfileClaimStatus = "current-supported-lane" | "evidence-only" | "fallback-boundary" | "deferred";

--- a/src/core/payload-policy/fallback.ts
+++ b/src/core/payload-policy/fallback.ts
@@ -4,6 +4,7 @@ import type { FrontendPayloadPolicyDecision } from "./types";
 
 export const MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY = "mixed-frontend-boundary-fallback";
 export const UNKNOWN_FRONTEND_DEFERRED_PAYLOAD_POLICY = "unknown-frontend-deferred-fallback";
+export const SHARED_FRONTEND_EVIDENCE_ONLY_PAYLOAD_POLICY = "shared-frontend-evidence-only-fallback";
 export const UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON = "unsupported-frontend-domain-profile";
 
 export function assessFallbackPayloadPolicy(domainDetection: DomainDetectionResult): FrontendPayloadPolicyDecision | undefined {
@@ -12,6 +13,14 @@ export function assessFallbackPayloadPolicy(domainDetection: DomainDetectionResu
       name: MIXED_FRONTEND_BOUNDARY_PAYLOAD_POLICY,
       allowed: false,
       reason: domainDetection.reason ?? FRONTEND_DOMAIN_BOUNDARY_REASON,
+    };
+  }
+
+  if (domainDetection.classification === "shared") {
+    return {
+      name: SHARED_FRONTEND_EVIDENCE_ONLY_PAYLOAD_POLICY,
+      allowed: false,
+      reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
     };
   }
 

--- a/src/core/work-item-dashboard.ts
+++ b/src/core/work-item-dashboard.ts
@@ -13,6 +13,7 @@ export const WORK_ITEM_FRONTEND_DOMAIN_TAXONOMY: WorkItemFrontendDomain[] = ["re
 export type WorkItemEvidenceClass = "Source evidence" | "Local command evidence" | "Workflow evidence" | "Session evidence" | "Receipt evidence";
 export type WorkItemState = "uninspected" | "evidence-ready" | "fallback-required" | "context-issued" | "receipt-recorded" | "active-work" | "blocked";
 export type WorkItemNextActionKind = "inspect" | "verify" | "link" | "open-pr" | "continue" | "fallback";
+export type WorkItemDomainJudgmentConfidence = "high" | "medium" | "low";
 
 export type WorkItemEvidence = {
   kind: WorkItemEvidenceKind;
@@ -32,11 +33,23 @@ export type WorkItemNextAction = {
   closesWhen: string;
 };
 
+export type WorkItemDomainJudgment = {
+  frontendDomain: WorkItemFrontendDomain;
+  confidence: WorkItemDomainJudgmentConfidence;
+  recommendedState: WorkItemState;
+  evidenceFocus: string[];
+  requiredEvidence: string[];
+  nextAction: WorkItemNextAction;
+  rationale: string;
+  nonClaims: string[];
+};
+
 export type WorkItem = {
   id: string;
   title: string;
   state: WorkItemState;
   frontendDomain: WorkItemFrontendDomain;
+  domainJudgment: WorkItemDomainJudgment;
   observed: string[];
   inferred: string[];
   requiredNextAction: WorkItemNextAction;
@@ -89,6 +102,7 @@ type GitSnapshot = {
   head?: string;
   clean: boolean | null;
   changedPathCount?: number;
+  changedPaths: string[];
   blocker?: string;
 };
 
@@ -137,10 +151,12 @@ function readGitSnapshot(cwd: string): GitSnapshot {
   const head = stdoutOrUndefined(runGit(cwd, ["rev-parse", "--short", "HEAD"]));
   const repo = canonicalRepoIdentifier(stdoutOrUndefined(runGit(cwd, ["config", "--get", "remote.origin.url"])));
   if (!status.ok) {
-    return { repo, branch, head, clean: null, blocker: `git worktree evidence unavailable: ${status.error}` };
+    return { repo, branch, head, clean: null, changedPaths: [], blocker: `git worktree evidence unavailable: ${status.error}` };
   }
-  const changedPathCount = status.stdout === "" ? 0 : status.stdout.split(/\r?\n/u).filter(Boolean).length;
-  return { repo, branch, head, clean: changedPathCount === 0, changedPathCount };
+  const statusLines = status.stdout === "" ? [] : status.stdout.split(/\r?\n/u).filter(Boolean);
+  const changedPaths = statusLines.map((line) => line.slice(3).replace(/^.* -> /u, "")).filter(Boolean);
+  const changedPathCount = changedPaths.length;
+  return { repo, branch, head, clean: changedPathCount === 0, changedPathCount, changedPaths };
 }
 
 function issueFromBranch(branch: string | undefined): string | undefined {
@@ -218,14 +234,124 @@ function displayFrontendDomain(frontendDomain: WorkItemFrontendDomain): string {
   }
 }
 
+function tokenizeDomainInput(snapshot: GitSnapshot): string {
+  return [snapshot.branch, ...snapshot.changedPaths].filter(Boolean).join(" ").toLowerCase();
+}
+
 function frontendDomainFor(snapshot: GitSnapshot): WorkItemFrontendDomain {
-  const branch = snapshot.branch?.toLowerCase() ?? "";
-  if (/(^|[-_/#])react[-_]web($|[-_/#])|(^|[-_/#])web($|[-_/#])/.test(branch)) return "react-web";
-  if (/(^|[-_/#])react[-_]native($|[-_/#])|(^|[-_/#])rn($|[-_/#])/.test(branch)) return "react-native";
-  if (/(^|[-_/#])webview($|[-_/#])/.test(branch)) return "webview";
-  if (/(^|[-_/#])tui($|[-_/#])|(^|[-_/#])terminal[-_]ui($|[-_/#])/.test(branch)) return "tui";
-  if (/(^|[-_/#])shared($|[-_/#])/.test(branch)) return "shared";
+  const input = tokenizeDomainInput(snapshot);
+  if (/(^|[\s_/#.-])(?:webview|web-view|react-native-webview|deeplink|deep-link|bridge|postmessage|session-handoff|app-container)(?=$|[\s_/#.-])/u.test(input)) return "webview";
+  if (/(^|[\s_/#.-])(?:react-native|rn|ios|android|metro|native-module|xcode|gradle)(?=$|[\s_/#.-])/u.test(input)) return "react-native";
+  if (/(^|[\s_/#.-])(?:tui|terminal-ui|terminal|tty|stdout|stderr|keyboard|snapshot|golden|ink)(?=$|[\s_/#.-])/u.test(input)) return "tui";
+  if (/(^|[\s_/#.-])(?:react-web|browser-ui|browser|page|pages|route|routes|component|components|visual|dom|css)(?=$|[\s_/#.-])/u.test(input)) return "react-web";
+  if (/(^|[\s_/#.-])(?:shared|common|design-system|tokens|api-contract|contract|schema|shared-state|shared-store)(?=$|[\s_/#.-])/u.test(input)) return "shared";
   return "unknown";
+}
+
+function domainEvidenceFocus(frontendDomain: WorkItemFrontendDomain): string[] {
+  switch (frontendDomain) {
+    case "react-web":
+      return ["components/pages/routes", "browser UI behavior", "build output", "visual evidence"];
+    case "react-native":
+      return ["ios/android platform evidence", "Metro bundling", "native module boundaries", "device/runtime proof"];
+    case "webview":
+      return ["bridge message flow", "deeplink/session handoff", "app container boundary", "embedded page source"];
+    case "tui":
+      return ["terminal/TTY behavior", "stdout/stderr rendering", "keyboard navigation", "snapshot/golden output"];
+    case "shared":
+      return ["design system or tokens", "shared state", "API contract/schema", "cross-domain compatibility"];
+    case "unknown":
+      return ["source inspection", "issue scope", "changed paths", "explicit domain evidence"];
+  }
+}
+
+function domainRequiredEvidence(frontendDomain: WorkItemFrontendDomain): string[] {
+  switch (frontendDomain) {
+    case "react-web":
+      return ["targeted component/page/route test or browser smoke evidence", "fresh build/typecheck evidence", "visual or DOM-facing receipt when UI changes"];
+    case "react-native":
+      return ["iOS/Android or Metro evidence before claiming runtime readiness", "native module/platform boundary inspection", "fallback source-reading receipt when device proof is unavailable"];
+    case "webview":
+      return ["bridge and postMessage/deeplink handoff inspection", "container/session boundary evidence", "fallback source-reading receipt before compact reuse claims"];
+    case "tui":
+      return ["TTY/non-TTY behavior check", "keyboard/input flow evidence", "stdout/stderr snapshot or golden output when rendering changes"];
+    case "shared":
+      return ["contract or schema compatibility evidence", "design-token/state consumer impact check", "at least one affected domain-specific verification when consumers are known"];
+    case "unknown":
+      return ["explicit domain evidence before automatic ingestion", "fallback source inspection", "issue or receipt link before active-work claims"];
+  }
+}
+
+function domainJudgmentState(frontendDomain: WorkItemFrontendDomain): WorkItemState {
+  if (frontendDomain === "unknown" || frontendDomain === "webview" || frontendDomain === "react-native") return "fallback-required";
+  return "evidence-ready";
+}
+
+function domainJudgmentAction(frontendDomain: WorkItemFrontendDomain): WorkItemNextAction {
+  switch (frontendDomain) {
+    case "react-web":
+      return {
+        kind: "verify",
+        label: "Collect React Web build/browser/visual evidence before closeout",
+        command: "npm run build",
+        reason: "React Web work needs component/page/route plus browser-facing evidence before status/explain should imply readiness",
+        closesWhen: "build and targeted browser/UI evidence are recorded for the changed React Web surface",
+      };
+    case "react-native":
+      return {
+        kind: "fallback",
+        label: "Inspect React Native platform evidence before automatic ingestion",
+        reason: "React Native work is fallback-first unless iOS/Android/Metro/native-module proof is explicitly recorded",
+        closesWhen: "platform or Metro evidence and a targeted native-runtime receipt are recorded, or a fallback source-reading receipt is linked",
+      };
+    case "webview":
+      return {
+        kind: "fallback",
+        label: "Inspect WebView bridge/container handoff evidence before automatic ingestion",
+        reason: "WebView work crosses app-container, bridge, deeplink, and session-handoff boundaries that require conservative source reading",
+        closesWhen: "bridge/deeplink/session handoff evidence and a fallback receipt are recorded",
+      };
+    case "tui":
+      return {
+        kind: "verify",
+        label: "Collect TUI terminal/TTY/snapshot evidence before closeout",
+        reason: "TUI work needs terminal rendering, keyboard, stdout/stderr, or golden-output evidence rather than fooks board assumptions",
+        closesWhen: "TTY/non-TTY or snapshot/golden evidence is recorded for the terminal UI target",
+      };
+    case "shared":
+      return {
+        kind: "verify",
+        label: "Verify shared contract/design-system impact across known consumers",
+        reason: "Shared work needs contract, token, state, or schema evidence plus consumer impact checks",
+        closesWhen: "shared contract evidence and affected-domain verification receipts are recorded",
+      };
+    case "unknown":
+      return {
+        kind: "inspect",
+        label: "Inspect source and link explicit domain evidence before automatic ingestion",
+        reason: "Unknown work items must remain conservative until branch, paths, source, or receipts identify a frontend work domain",
+        closesWhen: "a domain-specific evidence receipt or explicit fallback source-reading receipt is recorded",
+      };
+  }
+}
+
+function buildDomainJudgment(frontendDomain: WorkItemFrontendDomain, snapshot: GitSnapshot): WorkItemDomainJudgment {
+  const evidenceFocus = domainEvidenceFocus(frontendDomain);
+  const requiredEvidence = domainRequiredEvidence(frontendDomain);
+  const observedInput = [snapshot.branch, ...snapshot.changedPaths].filter(Boolean).join(", ") || "no branch/path hints";
+  return {
+    frontendDomain,
+    confidence: frontendDomain === "unknown" ? "low" : snapshot.changedPaths.length > 0 ? "high" : "medium",
+    recommendedState: domainJudgmentState(frontendDomain),
+    evidenceFocus,
+    requiredEvidence,
+    nextAction: domainJudgmentAction(frontendDomain),
+    rationale: `${displayFrontendDomain(frontendDomain)} judgment from branch/path hints: ${observedInput}`,
+    nonClaims: [
+      "Domain judgment is pre-ingestion guidance, not runtime correctness proof.",
+      "Domain judgment does not add hooks, watchers, daemon behavior, notifications, or output push.",
+    ],
+  };
 }
 
 function domainHintEvidence(frontendDomain: WorkItemFrontendDomain, snapshot: GitSnapshot): WorkItemEvidence {
@@ -239,7 +365,7 @@ function domainHintEvidence(frontendDomain: WorkItemFrontendDomain, snapshot: Gi
     source: "local branch naming plus WorkItem frontend domain taxonomy",
     fresh: snapshot.branch ? true : "unknown",
     supports: "React Web / React Native / WebView / TUI / Shared / Unknown work-domain hint representation in the shared WorkItem model",
-    doesNotSupport: "runtime UI correctness, broad framework support, detector expansion, or changes to fooks' own TUI board",
+    doesNotSupport: "runtime UI correctness, broad framework support, automatic ingestion permission, hooks, watchers, or changes to fooks' own TUI board",
   };
 }
 
@@ -303,6 +429,7 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
   };
   const action = nextActionFor(snapshot, anchors);
   const frontendDomain = frontendDomainFor(snapshot);
+  const domainJudgment = buildDomainJudgment(frontendDomain, snapshot);
   const evidence = [docsEvidence(), domainHintEvidence(frontendDomain, snapshot), worktreeEvidence(snapshot, cwd), metricEvidence(metricStatus)];
   if (issue) {
     evidence.push({
@@ -368,10 +495,12 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
         title: issue ? `Active ${displayFrontendDomain(frontendDomain)} work ${issue}` : "Unlinked work item candidate",
         state: workItemStateFor(snapshot, anchors),
         frontendDomain,
-        observed: evidence.map((item) => item.observed),
+        domainJudgment,
+        observed: [...evidence.map((item) => item.observed), domainJudgment.rationale],
         inferred: [
           issue ? `${issue} is the local issue anchor inferred from branch naming.` : "No issue anchor was inferred from branch naming.",
           snapshot.clean === false ? "The worktree has uncommitted local changes and still needs verification/closeout." : "Clean worktree evidence still needs a scoped receipt before active work is complete.",
+          `Domain judgment recommends state ${domainJudgment.recommendedState} and next action ${domainJudgment.nextAction.kind}.`,
         ],
         requiredNextAction: action,
         evidence,
@@ -380,6 +509,7 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
           "This dashboard does not prove runtime UI correctness.",
           "A TUI-domain work item means a user-developed terminal UI target, not fooks' own rendering surface.",
           "This dashboard does not close active work without test/review/PR receipt evidence.",
+          ...domainJudgment.nonClaims,
         ],
       },
     ],

--- a/src/core/work-item-explain.ts
+++ b/src/core/work-item-explain.ts
@@ -1,4 +1,4 @@
-import type { WorkItem, WorkItemDashboard, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
+import type { WorkItem, WorkItemDashboard, WorkItemDomainJudgment, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
 import { WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY } from "./work-item-dashboard";
 
 export const WORK_ITEM_EXPLAIN_SCHEMA_VERSION = 2;
@@ -25,6 +25,7 @@ export type WorkItemExplainResult = {
     title: string;
     state: WorkItem["state"];
     frontendDomain: WorkItem["frontendDomain"];
+    domainJudgment: WorkItemDomainJudgment;
   };
   why: string[];
   evidence: WorkItemEvidence[];
@@ -32,6 +33,23 @@ export type WorkItemExplainResult = {
   nextAction: WorkItemNextAction;
   nonClaims: string[];
 };
+
+
+function unknownDomainJudgment(nextAction: WorkItemNextAction, rationale: string): WorkItemDomainJudgment {
+  return {
+    frontendDomain: "unknown",
+    confidence: "low",
+    recommendedState: "fallback-required",
+    evidenceFocus: ["source inspection", "issue scope", "changed paths", "explicit domain evidence"],
+    requiredEvidence: ["explicit domain evidence before automatic ingestion", "fallback source inspection", "issue or receipt link before active-work claims"],
+    nextAction,
+    rationale,
+    nonClaims: [
+      "Domain judgment is pre-ingestion guidance, not runtime correctness proof.",
+      "Unknown work items do not imply React Web, React Native, WebView, TUI, or Shared support.",
+    ],
+  };
+}
 
 function sampleEvidence(): WorkItemEvidence[] {
   return [
@@ -65,11 +83,13 @@ function sampleWorkItem(): WorkItem {
     closesWhen: "a live status/work-item explanation is generated from the current repository dashboard",
   };
   const evidence = sampleEvidence();
+  const domainJudgment = unknownDomainJudgment(nextAction, "sample artifact has no live branch/path/source domain hints");
   return {
     id: "work-item-sample",
     title: "Sample WorkItem evidence explanation",
     state: "uninspected",
     frontendDomain: "unknown",
+    domainJudgment,
     observed: evidence.map((item) => item.observed),
     inferred: [
       "The sample is static and read-only.",
@@ -95,11 +115,13 @@ function evidenceForArtifact(artifact: WorkItemExplainArtifact, dashboard: WorkI
       reason: "dashboard contains no work item entries",
       closesWhen: "a dashboard work item entry exists or the missing evidence is recorded",
     };
+    const domainJudgment = unknownDomainJudgment(nextAction, "dashboard contains no work item entries");
     return {
       id: "work-item-missing",
       title: "Missing WorkItem evidence",
       state: "blocked",
       frontendDomain: "unknown",
+      domainJudgment,
       observed: [],
       inferred: ["No work item was available in the dashboard artifact."],
       requiredNextAction: nextAction,
@@ -146,6 +168,7 @@ export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboar
       title: item.title,
       state: item.state,
       frontendDomain: item.frontendDomain,
+      domainJudgment: item.domainJudgment,
     },
     why: whyFor(item, dashboard, artifact),
     evidence: item.evidence,
@@ -170,5 +193,5 @@ export function renderWorkItemExplainText(explain: WorkItemExplainResult): strin
     : "- none";
   const commandLine = explain.nextAction.command ? `\n- command: ${explain.nextAction.command}` : "";
 
-  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${explain.workItem.frontendDomain}\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
+  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${explain.workItem.frontendDomain}\n- domain judgment: ${explain.workItem.domainJudgment.recommendedState} / ${explain.workItem.domainJudgment.nextAction.kind} (${explain.workItem.domainJudgment.confidence} confidence)\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Domain judgment\n\n- rationale: ${explain.workItem.domainJudgment.rationale}\n- evidence focus: ${explain.workItem.domainJudgment.evidenceFocus.join(", ")}\n- required evidence: ${explain.workItem.domainJudgment.requiredEvidence.join(", ")}\n- recommended next action: ${explain.workItem.domainJudgment.nextAction.label}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
 }

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -253,6 +253,62 @@ test("keeps WebView bridge-pair evidence as fallback-only boundary facts", () =>
   assert.ok(result.signals.includes("webview:bridge-call:postMessage"));
 });
 
+
+
+test("detects expanded domain-aware source evidence for web, native, webview, tui, and shared lanes", () => {
+  const web = detectDomainFromSource(
+    `import Link from "next/link";
+     export function AccountRoute() {
+       window.localStorage.setItem("visited", "1");
+       return <div className="route"><Link href="/account"><label htmlFor="account">Account</label></Link></div>;
+     }`,
+    "src/app/account/page.tsx",
+  );
+  assert.equal(web.classification, "react-web");
+  assertSignals(web, ["react-web:framework-component:next/link:Link", "react-web:browser-global:window", "react-web:jsx-attribute:className", "react-web:jsx-attribute:htmlFor"]);
+
+  const native = detectDomainFromSource(
+    `export default { resolver: { sourceExts: ["tsx"] } };`,
+    "metro.config.js",
+  );
+  assert.equal(native.classification, "react-native");
+  assertSignals(native, ["react-native:metro-config:metro.config.js"]);
+
+  const webview = detectDomainFromSource(
+    `import { WebView } from "react-native-webview";
+     import { Linking } from "react-native";
+     export function CheckoutWebView() {
+       return <WebView source={{ uri: "myapp://checkout/session" }} onMessage={() => Linking.openURL("myapp://handoff")} />;
+     }`,
+    "CheckoutWebView.tsx",
+  );
+  assert.equal(webview.classification, "mixed");
+  assertSignals(webview, ["webview:handoff-marker:uri-scheme", "webview:deeplink-call:Linking.openURL"]);
+
+  const tui = detectDomainFromSource(
+    `export function renderStatus() {
+       if (process.stdout.isTTY) process.stdout.write("golden snapshot");
+       process.stderr.write("warning");
+     }`,
+    "src/tui/status-board.ts",
+  );
+  assert.equal(tui.classification, "tui-ink");
+  assertSignals(tui, ["tui-ink:terminal-stream:process.stdout", "tui-ink:terminal-api:process.stdout.write", "tui-ink:terminal-tty:isTTY", "tui-ink:terminal-api:process.stderr.write"]);
+
+  const shared = detectDomainFromSource(
+    `export const designTokens = { color: "red" };
+     export type ApiContract = { id: string };
+     export const schema = "api contract";`,
+    "src/shared/contracts/theme-tokens.ts",
+  );
+  assert.equal(shared.classification, "shared");
+  assert.equal(shared.profile.claimStatus, "evidence-only");
+  assertSignals(shared, ["shared:path-segment:shared", "shared:shared-identifier:designTokens", "shared:shared-identifier:ApiContract", "shared:shared-marker:api contract"]);
+
+  assert.doesNotMatch(JSON.stringify([web, native, webview, tui, shared]), forbiddenSupportClaims);
+});
+
+
 test("selected fixture manifest stays aligned with detector classifications and outcomes", () => {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 

--- a/test/domain-payload-policy-coverage.test.mjs
+++ b/test/domain-payload-policy-coverage.test.mjs
@@ -44,6 +44,12 @@ const DOMAIN_PROFILE_PAYLOAD_POLICY_COVERAGE = {
     policyConstant: "TUI_INK_EVIDENCE_ONLY_PAYLOAD_POLICY",
     preReadDelegationAssertion: "preRead.assessFrontendPayloadPolicy(domainDetection)",
   },
+  shared: {
+    profileSource: "src/core/domain-profiles/shared.ts",
+    policySource: null,
+    policyTest: "test/domain-profiles.test.mjs",
+    terminalProfileReason: "shared frontend evidence is pre-ingestion work-item guidance only; no compact payload is authorized without domain-specific consumer receipts",
+  },
   mixed: {
     profileSource: "src/core/domain-profiles/registry.ts",
     policySource: null,

--- a/test/domain-profiles.test.mjs
+++ b/test/domain-profiles.test.mjs
@@ -67,7 +67,7 @@ test("React Native profile owns the primitive/input signal taxonomy contract", (
 test("domain profile registry exposes behavior-neutral lane ownership metadata", () => {
   assert.deepEqual(
     FRONTEND_DOMAIN_PROFILE_REGISTRY.map((profile) => profile.lane),
-    ["react-web", "react-native", "webview", "tui-ink", "mixed", "unknown"],
+    ["react-web", "react-native", "webview", "tui-ink", "shared", "mixed", "unknown"],
   );
 
   assert.deepEqual(getDomainProfileDefinition("react-web"), {
@@ -82,6 +82,7 @@ test("domain profile registry exposes behavior-neutral lane ownership metadata",
   assert.equal(getDomainProfileDefinition("react-native").boundaryReason, "unsupported-react-native-webview-boundary");
   assert.equal(getDomainProfileDefinition("webview").fallbackFirst, true);
   assert.equal(getDomainProfileDefinition("tui-ink").claimStatus, "evidence-only");
+  assert.equal(getDomainProfileDefinition("shared").claimStatus, "evidence-only");
 });
 
 test("domain profile registry preserves existing detector classification outcomes", () => {
@@ -90,12 +91,14 @@ test("domain profile registry preserves existing detector classification outcome
   assert.equal(resolveDomainClassification(evidence("react-native"), false), "react-native");
   assert.equal(resolveDomainClassification(evidence("webview"), false), "webview");
   assert.equal(resolveDomainClassification(evidence("tui-ink"), false), "tui-ink");
+  assert.equal(resolveDomainClassification(evidence("shared"), false), "shared");
   assert.equal(resolveDomainClassification(evidence("react-native"), true), "mixed");
   assert.equal(resolveDomainClassification([...evidence("react-native"), ...evidence("webview")], false), "mixed");
 
   assert.deepEqual(outcomeForClassification("react-web"), { outcome: "extract" });
   assert.deepEqual(outcomeForClassification("react-native"), { outcome: "fallback", reason: "unsupported-react-native-webview-boundary" });
   assert.deepEqual(outcomeForClassification("webview"), { outcome: "fallback", reason: "unsupported-react-native-webview-boundary" });
+  assert.deepEqual(outcomeForClassification("shared"), { outcome: "extract" });
   assert.deepEqual(outcomeForClassification("mixed"), { outcome: "fallback", reason: "unsupported-react-native-webview-boundary" });
   assert.deepEqual(outcomeForClassification("unknown"), { outcome: "deferred" });
 });
@@ -137,6 +140,7 @@ test("domain profile metadata remains evidence and policy boundary, not support 
     "src/core/domain-profiles/react-native.ts",
     "src/core/domain-profiles/webview.ts",
     "src/core/domain-profiles/tui-ink.ts",
+    "src/core/domain-profiles/shared.ts",
   ]) {
     assert.doesNotMatch(fs.readFileSync(path.join(repoRoot, file), "utf8"), forbiddenSupportClaims, `${file} must not add support claims`);
   }

--- a/test/payload-policy-registry-drift.test.mjs
+++ b/test/payload-policy-registry-drift.test.mjs
@@ -13,7 +13,7 @@ const { FRONTEND_DOMAIN_PROFILE_REGISTRY } = require(path.join(repoRoot, "dist",
 const { FRONTEND_PAYLOAD_POLICY_REGISTRY } = require(path.join(repoRoot, "dist", "core", "payload-policy", "registry.js"));
 
 const FALLBACK_POLICY_LANE_COVERAGE = {
-  fallback: ["mixed", "unknown"],
+  fallback: ["mixed", "shared", "unknown"],
 };
 
 function listSourceFiles(directory) {

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -34,6 +34,28 @@ function runStatus(cwd, env = {}) {
   return JSON.parse(execFileSync(process.execPath, [cli, "status"], { cwd, encoding: "utf8", env: { ...process.env, ...env } }));
 }
 
+function testMetricStatus() {
+  return {
+    schemaVersion: 1,
+    metricTier: "estimated",
+    updatedAt: new Date(0).toISOString(),
+    sessionCount: 0,
+    latestSessionCount: 0,
+    eventCount: 0,
+    comparableEventCount: 0,
+    injectCount: 0,
+    fallbackCount: 0,
+    recordCount: 0,
+    noopCount: 0,
+    observedOpportunityCount: 0,
+    observedOriginalEstimatedBytes: 0,
+    observedOriginalEstimatedTokens: 0,
+    totals: { originalEstimatedBytes: 0, actualEstimatedBytes: 0, savedEstimatedBytes: 0, originalEstimatedTokens: 0, actualEstimatedTokens: 0, savedEstimatedTokens: 0, savingsRatio: 0 },
+    breakdown: { byRuntime: {}, byMeasurementSource: {}, byRuntimeAndSource: {} },
+    claimBoundary: "test metric boundary",
+  };
+}
+
 test("bare status includes docs-backed WorkItem dashboard while preserving metric status shape", () => {
   const tempDir = makeRepo();
   const status = runStatus(tempDir, { OMX_SESSION_ID: "omx-test-session" });
@@ -405,4 +427,95 @@ test("WorkItem dashboard keeps unknown branch domain explicit and non-source", (
   assert.equal(dashboard.workItems[0].title, "Active Unknown-domain work #934");
   assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Workflow evidence"));
   assert.equal(dashboard.workItems[0].evidence.some((item) => item.kind === "domainHint" && item.evidenceClass === "Source evidence"), false);
+});
+
+
+test("WorkItem dashboard maps domain-aware judgment to evidence focus, recommended state, and next action", () => {
+  const { buildWorkItemDashboard } = require(path.join(repoRoot, "dist", "core", "work-item-dashboard.js"));
+
+  const cases = [
+    {
+      branch: "feature/issue-935-react-web-routes",
+      file: "src/pages/account/settings.tsx",
+      domain: "react-web",
+      state: "evidence-ready",
+      action: "verify",
+      focus: "browser UI behavior",
+    },
+    {
+      branch: "feature/issue-935-react-native-ios-platform",
+      file: "ios/ProfileView.tsx",
+      domain: "react-native",
+      state: "fallback-required",
+      action: "fallback",
+      focus: "ios/android platform evidence",
+    },
+    {
+      branch: "feature/issue-935-webview-session-handoff",
+      file: "src/mobile/CheckoutWebView.tsx",
+      domain: "webview",
+      state: "fallback-required",
+      action: "fallback",
+      focus: "bridge message flow",
+    },
+    {
+      branch: "feature/issue-935-tui-keyboard-golden",
+      file: "src/cli/StatusBoard.tsx",
+      domain: "tui",
+      state: "evidence-ready",
+      action: "verify",
+      focus: "keyboard navigation",
+    },
+    {
+      branch: "feature/issue-935-shared-api-contract",
+      file: "src/shared/contracts/settings.ts",
+      domain: "shared",
+      state: "evidence-ready",
+      action: "verify",
+      focus: "API contract/schema",
+    },
+    {
+      branch: "feature/issue-935-maintenance",
+      file: "README.md",
+      domain: "unknown",
+      state: "fallback-required",
+      action: "inspect",
+      focus: "explicit domain evidence",
+    },
+  ];
+
+  for (const item of cases) {
+    const tempDir = makeRepo();
+    git(tempDir, ["checkout", "-b", item.branch]);
+    const target = path.join(tempDir, item.file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "// changed domain fixture\n");
+
+    const dashboard = buildWorkItemDashboard(tempDir, testMetricStatus());
+    const workItem = dashboard.workItems[0];
+    assert.equal(workItem.frontendDomain, item.domain, item.domain);
+    assert.equal(workItem.domainJudgment.frontendDomain, item.domain, item.domain);
+    assert.equal(workItem.domainJudgment.recommendedState, item.state, item.domain);
+    assert.equal(workItem.domainJudgment.nextAction.kind, item.action, item.domain);
+    assert.ok(workItem.domainJudgment.evidenceFocus.some((focus) => focus.includes(item.focus)), item.domain);
+    assert.ok(workItem.inferred.some((line) => line.includes(`Domain judgment recommends state ${item.state}`)), item.domain);
+    assert.ok(workItem.nonClaims.some((line) => line.includes("pre-ingestion guidance")), item.domain);
+  }
+});
+
+test("fooks explain surfaces machine-readable domain judgment details", () => {
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "feature/issue-935-webview-deeplink-bridge"]);
+  fs.mkdirSync(path.join(tempDir, "src", "mobile"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, "src", "mobile", "CheckoutWebView.tsx"), "// WebView bridge fixture\n");
+
+  const explanation = JSON.parse(execFileSync(process.execPath, [cli, "explain", "status", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }));
+
+  assert.equal(explanation.workItem.frontendDomain, "webview");
+  assert.equal(explanation.workItem.domainJudgment.recommendedState, "fallback-required");
+  assert.equal(explanation.workItem.domainJudgment.nextAction.kind, "fallback");
+  assert.ok(explanation.workItem.domainJudgment.requiredEvidence.some((line) => /bridge.*handoff/i.test(line)));
 });


### PR DESCRIPTION
## Summary
- Improve pre-ingestion domain evidence detection for React Web, React Native, WebView, TUI, and Shared lanes while keeping unsupported/shared lanes conservative.
- Add WorkItem domain judgment metadata for status/explain with evidence focus, recommended state, and next action guidance.
- Add focused detector, profile, payload-policy drift, dashboard, and explain coverage for issue #935.

Fixes #935

## Tests
- npm test
- npm run build
- node --test test/domain-detector.test.mjs test/domain-profiles.test.mjs test/domain-payload-policy-coverage.test.mjs test/payload-policy-registry-drift.test.mjs test/work-item-dashboard.test.mjs

## Non-goals preserved
- No OMX hooks added.
- No watch/daemon behavior added.
- No automatic notification/output push added.
- No fooks TUI board redesign.