### PR TITLE
Record generated runtime cleanup evidence for #942

### DIFF
--- a/docs/cleanup/issue-942-generated-runtime-cleanup-evidence.md
+++ b/docs/cleanup/issue-942-generated-runtime-cleanup-evidence.md
@@ -1,0 +1,53 @@
+# Issue #942 Generated/Runtime Artifact Cleanup Evidence
+
+- Updated: 2026-05-18T02:13:00Z
+- Tracking issue: #942
+- Source audit: `docs/cleanup/legacy-file-audit.md` from #940
+- Scope: only the #942 delete allowlist (`dist/`, `benchmarks/layer2-frontend-task/results/`, `.fooks/state/`, `.fooks/cache/`, `.fooks/artifacts/`, `.fooks/sessions/`)
+
+## Result
+
+No git-tracked files were present under the #942 delete allowlist, so there was no tracked generated/runtime artifact diff to delete. Per #942 acceptance, this note records the cleanup evidence instead of pretending a deletion occurred.
+
+## Allowlist verification
+
+| Path | Present before this note | Git-tracked files | Action |
+| --- | --- | ---: | --- |
+| `dist/` | no | 0 | no deletion needed |
+| `benchmarks/layer2-frontend-task/results/` | no | 0 | no deletion needed |
+| `.fooks/state/` | no | 0 | no deletion needed |
+| `.fooks/cache/` | no | 0 | no deletion needed |
+| `.fooks/artifacts/` | no | 0 | no deletion needed |
+| `.fooks/sessions/` | no | 0 | no deletion needed |
+
+Checked with:
+
+```sh
+git ls-files dist benchmarks/layer2-frontend-task/results .fooks/state .fooks/cache .fooks/artifacts .fooks/sessions
+```
+
+The command produced no paths.
+
+## Boundaries preserved
+
+No files were changed under the #942 do-not-touch areas:
+
+- `src/**`
+- `scripts/**`
+- `test/**`
+- `fixtures/**`
+- `.omx/`
+- `.fooks/evidence/**`
+- tracked legacy docs
+- `node_modules/`
+
+## Verification
+
+Completed in this branch:
+
+- `npm run typecheck` — pass
+- `npm run lint` — pass
+- `npm run build` — pass
+
+After `npm run build`, regenerated `dist/` was removed again to preserve the generated-artifact cleanup boundary.
+Post-cleaner verification repeated the same commands successfully, and regenerated `dist/` was removed again.


### PR DESCRIPTION
## Summary

Closes #942.

Adds `docs/cleanup/issue-942-generated-runtime-cleanup-evidence.md` because the #942 delete allowlist has no git-tracked files to remove in this branch.

## Scope

- Checked only the #942 low-risk generated/runtime allowlist:
  - `dist/`
  - `benchmarks/layer2-frontend-task/results/`
  - `.fooks/state/`
  - `.fooks/cache/`
  - `.fooks/artifacts/`
  - `.fooks/sessions/`
- Preserved the issue's do-not-touch areas, including `src/**`, `scripts/**`, `test/**`, `fixtures/**`, `.omx/`, `.fooks/evidence/**`, tracked legacy docs, and `node_modules/`.
- Removed regenerated `dist/` after build verification to keep generated output out of the workspace diff.

## Verification

- [x] `git ls-files dist benchmarks/layer2-frontend-task/results .fooks/state .fooks/cache .fooks/artifacts .fooks/sessions` — no tracked paths
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run build` — pass
- [x] Post-build allowlist cleanup — `dist/` and other allowlist paths absent after verification

## Review notes

- AI slop cleaner: passed/no-op for the single evidence note; no fallback-like terms found.
- Code review: APPROVE; architect status CLEAR. This is a docs-only evidence note with no product/runtime behavior change.
