### PR TITLE
Audit status/explain UX after domain-aware judgment

### DIFF
--- a/docs/audits/issue-948-status-explain-ux-audit.md
+++ b/docs/audits/issue-948-status-explain-ux-audit.md
@@ -1,0 +1,28 @@
+# Issue #948 status/explain UX audit
+
+## Scope
+
+Audited the user-facing `fooks status` and `fooks explain` surfaces after the domain-aware judgment and cleanup architecture work. The audit focused on whether CLI output makes the work item domain, evidence, rejected evidence/non-claims, state, and next action understandable without changing hooks, watchers, daemon behavior, automatic notifications, the evidence model, or the TUI board.
+
+## Findings
+
+- `fooks status` already preserves the metric status shape and attaches `workItemDashboard`, including `frontendDomainTaxonomy`, `domainJudgment`, evidence, non-claims, state, and required next action.
+- `fooks explain status` and `fooks explain current` already render human-readable sections for Work item, Why, Evidence, Rejected evidence / non-claims, Domain judgment, Next action, and Non-claims.
+- JSON explain output already exposes machine-readable domain judgment details for React Web, React Native, WebView, TUI, Shared, and Unknown domain cases.
+- UX gaps found:
+  - `fooks status --json` was rejected even though status is JSON-shaped and other status subcommands support `--json` discovery patterns.
+  - The text explain surface showed the raw frontend domain slug, but did not pair it with the human domain label in the Work item and Domain judgment sections.
+  - The Domain judgment text listed the domain next-action label but omitted the next-action kind, reason, and close condition, making it harder to distinguish domain-aware guidance from the overall work-item next action.
+
+## Narrow changes made
+
+- Allowed `fooks status --json` as an alias for bare `fooks status`.
+- Clarified text explain output with human domain labels alongside slugs.
+- Expanded text explain Domain judgment details to include recommended state, confidence, domain next-action kind, reason, and close condition.
+- Added focused tests that cover status `--json`, text explain clarity, and all six domain judgments.
+
+## Non-changes
+
+- No evidence-model rewrite.
+- No hooks/watch/daemon/automatic notifications.
+- No TUI board redesign.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -656,7 +656,7 @@ Everyday commands:
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
   ${displayCliName} codex-pre-read <file> [--json]
-  ${displayCliName} status
+  ${displayCliName} status [--json]
   ${displayCliName} status codex
   ${displayCliName} status claude
   ${displayCliName} status cache
@@ -1515,7 +1515,7 @@ async function run(): Promise<void> {
       return;
     }
     case "status": {
-      if (!arg1) {
+      if (!arg1 || (arg1 === "--json" && rest.length === 1)) {
         const [{ readProjectMetricSummary }, { buildWorkItemDashboard }] = await Promise.all([
           import("../core/session-metrics.js"),
           import("../core/work-item-dashboard.js"),

--- a/src/core/work-item-explain.ts
+++ b/src/core/work-item-explain.ts
@@ -178,6 +178,24 @@ export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboar
   };
 }
 
+
+function displayFrontendDomain(frontendDomain: WorkItem["frontendDomain"]): string {
+  switch (frontendDomain) {
+    case "react-web":
+      return "React Web";
+    case "react-native":
+      return "React Native";
+    case "webview":
+      return "WebView";
+    case "tui":
+      return "TUI";
+    case "shared":
+      return "Shared";
+    case "unknown":
+      return "Unknown-domain";
+  }
+}
+
 function bulletList(items: string[]): string {
   return items.length > 0 ? items.map((item) => `- ${item}`).join("\n") : "- none";
 }
@@ -192,6 +210,9 @@ export function renderWorkItemExplainText(explain: WorkItemExplainResult): strin
     ? explain.rejectedEvidence.map((item) => `- ${item.evidence}\n  rejected for: ${item.reason}`).join("\n")
     : "- none";
   const commandLine = explain.nextAction.command ? `\n- command: ${explain.nextAction.command}` : "";
+  const domainLabel = displayFrontendDomain(explain.workItem.frontendDomain);
+  const judgmentAction = explain.workItem.domainJudgment.nextAction;
+  const judgmentCommandLine = judgmentAction.command ? `\n- domain command: ${judgmentAction.command}` : "";
 
-  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${explain.workItem.frontendDomain}\n- domain judgment: ${explain.workItem.domainJudgment.recommendedState} / ${explain.workItem.domainJudgment.nextAction.kind} (${explain.workItem.domainJudgment.confidence} confidence)\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Domain judgment\n\n- rationale: ${explain.workItem.domainJudgment.rationale}\n- evidence focus: ${explain.workItem.domainJudgment.evidenceFocus.join(", ")}\n- required evidence: ${explain.workItem.domainJudgment.requiredEvidence.join(", ")}\n- recommended next action: ${explain.workItem.domainJudgment.nextAction.label}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
+  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${domainLabel} (${explain.workItem.frontendDomain})\n- domain judgment: ${explain.workItem.domainJudgment.recommendedState} / ${judgmentAction.kind} (${explain.workItem.domainJudgment.confidence} confidence)\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Domain judgment\n\n- frontend domain: ${domainLabel} (${explain.workItem.domainJudgment.frontendDomain})\n- recommended state: ${explain.workItem.domainJudgment.recommendedState}\n- confidence: ${explain.workItem.domainJudgment.confidence}\n- rationale: ${explain.workItem.domainJudgment.rationale}\n- evidence focus: ${explain.workItem.domainJudgment.evidenceFocus.join(", ")}\n- required evidence: ${explain.workItem.domainJudgment.requiredEvidence.join(", ")}\n- domain next action kind: ${judgmentAction.kind}\n- domain next action: ${judgmentAction.label}${judgmentCommandLine}\n- domain reason: ${judgmentAction.reason}\n- domain closes when: ${judgmentAction.closesWhen}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
 }

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -519,3 +519,66 @@ test("fooks explain surfaces machine-readable domain judgment details", () => {
   assert.equal(explanation.workItem.domainJudgment.nextAction.kind, "fallback");
   assert.ok(explanation.workItem.domainJudgment.requiredEvidence.some((line) => /bridge.*handoff/i.test(line)));
 });
+
+test("fooks status --json is an alias for bare status JSON", () => {
+  const tempDir = makeRepo();
+  const status = JSON.parse(execFileSync(process.execPath, [cli, "status", "--json"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }));
+
+  assert.equal(status.schemaVersion, 1);
+  assert.equal(status.workItemDashboard.schemaVersion, 2);
+  assert.equal(status.workItemDashboard.workItems[0].id, "work-item-922");
+});
+
+test("fooks explain text pairs domain labels with slugs and domain action details", () => {
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "-b", "feature/issue-948-webview-bridge-ux"]);
+  fs.mkdirSync(path.join(tempDir, "src", "mobile"), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, "src", "mobile", "CheckoutWebView.tsx"), "// WebView bridge fixture\n");
+
+  const text = execFileSync(process.execPath, [cli, "explain", "status"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+
+  assert.match(text, /- frontend domain: WebView \(webview\)/);
+  assert.match(text, /## Domain judgment/);
+  assert.match(text, /- recommended state: fallback-required/);
+  assert.match(text, /- confidence: high/);
+  assert.match(text, /- domain next action kind: fallback/);
+  assert.match(text, /- domain reason: WebView work crosses app-container, bridge, deeplink, and session-handoff boundaries/);
+  assert.match(text, /- domain closes when: bridge\/deeplink\/session handoff evidence and a fallback receipt are recorded/);
+});
+
+test("fooks explain JSON preserves domain judgments for every frontend domain", () => {
+  const cases = [
+    { branch: "feature/issue-948-react-web-routes", file: "src/pages/settings.tsx", domain: "react-web", state: "evidence-ready", action: "verify" },
+    { branch: "feature/issue-948-react-native-ios", file: "ios/ProfileView.tsx", domain: "react-native", state: "fallback-required", action: "fallback" },
+    { branch: "feature/issue-948-webview-bridge", file: "src/mobile/CheckoutWebView.tsx", domain: "webview", state: "fallback-required", action: "fallback" },
+    { branch: "feature/issue-948-tui-keyboard", file: "src/cli/StatusBoard.tsx", domain: "tui", state: "evidence-ready", action: "verify" },
+    { branch: "feature/issue-948-shared-contract", file: "src/shared/contracts/settings.ts", domain: "shared", state: "evidence-ready", action: "verify" },
+    { branch: "feature/issue-948-maintenance", file: "README.md", domain: "unknown", state: "fallback-required", action: "inspect" },
+  ];
+
+  for (const item of cases) {
+    const tempDir = makeRepo();
+    git(tempDir, ["checkout", "-b", item.branch]);
+    const target = path.join(tempDir, item.file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "// changed domain fixture\n");
+
+    const explanation = JSON.parse(execFileSync(process.execPath, [cli, "explain", "status", "--json"], {
+      cwd: tempDir,
+      encoding: "utf8",
+    }));
+
+    assert.equal(explanation.workItem.frontendDomain, item.domain, item.domain);
+    assert.equal(explanation.workItem.domainJudgment.frontendDomain, item.domain, item.domain);
+    assert.equal(explanation.workItem.domainJudgment.recommendedState, item.state, item.domain);
+    assert.equal(explanation.workItem.domainJudgment.nextAction.kind, item.action, item.domain);
+    assert.ok(explanation.workItem.domainJudgment.requiredEvidence.length > 0, item.domain);
+    assert.ok(explanation.rejectedEvidence.some((rejected) => /pre-ingestion guidance|automatic ingestion|runtime UI correctness/.test(rejected.reason)), item.domain);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #948.

Audited the user-facing `fooks status` / `fooks explain` surfaces after the domain-aware judgment work (#936) and cleanup architecture work (#945/#947), then made only narrow UX/test fixes where the audit found gaps.

## Audit findings

- `fooks status` already preserves metric status and includes the docs-backed `workItemDashboard` with domain taxonomy, evidence, rejected evidence/non-claims, state, and next action.
- `fooks explain status` / `fooks explain current` already expose the WorkItem explanation model and machine-readable domain judgment details.
- Narrow gaps fixed:
  - Allow `fooks status --json` as an alias for bare JSON status.
  - Pair human domain labels with slugs in text explain output.
  - Include domain judgment recommended state, confidence, domain next-action kind, reason, and close condition in text explain output.

## Files changed

- `docs/audits/issue-948-status-explain-ux-audit.md`
- `src/cli/index.ts`
- `src/core/work-item-explain.ts`
- `test/work-item-dashboard.test.mjs`

## Validation

- `node --test test/work-item-dashboard.test.mjs`
- `git diff --check HEAD`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Commit trailer verification

Verified with `git log -1 --format=%B`; commit includes:

`Co-authored-by: minislively <81848425+minislively@users.noreply.github.com>`

## Non-goals preserved

- No hooks/watch/daemon/automatic notifications.
- No TUI board redesign.
- No evidence-model rewrite.
- No cleanup deletion work reopened.
