### PR TITLE
Add contextTrust source-of-truth packet to check JSON

### DIFF
--- a/src/ops/context-trust.ts
+++ b/src/ops/context-trust.ts
@@ -1,0 +1,254 @@
+import type { OperatorActivitySnapshot } from "./operator-activity";
+import type {
+  OperatorCheckActiveArtifact,
+  OperatorCheckActiveWorkReceipts,
+  OperatorCheckRequiredActiveArtifact,
+} from "./operator-check";
+
+export const OPERATOR_CONTEXT_TRUST_SCHEMA_VERSION = 1;
+export const OPERATOR_CONTEXT_TRUST_SOURCE = "fooks check --json operator-check projection";
+export const OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE = "docs/research/context-trust-and-stale-evidence-research.md";
+export const OPERATOR_CONTEXT_TRUST_CLAIM_BOUNDARY =
+  "Read-only context trust projection over evidence already computed by operator-check; it separates current authority, advisory guidance, historical receipts, and non-authorizing caveats without performing stale detection, handoff generation, or additional git/gh/tmux/filesystem reads. The parent operator-check schema remains version 1 because this packet is additive and consumers should ignore unknown fields.";
+
+export type OperatorContextTrustEntryAuthority =
+  | "current-work"
+  | "handoff-candidate"
+  | "receipt"
+  | "guidance"
+  | "insufficient";
+
+export type OperatorContextTrustContractScope =
+  | "top-level-active-artifact"
+  | "active-artifact-guidance"
+  | "post-merge-receipt"
+  | "stale-residue-boundary"
+  | "cleanup-review-boundary"
+  | "handoff-artifact-boundary"
+  | "main-echo-boundary";
+
+export type OperatorContextTrustEntry = {
+  kind: string;
+  source: string;
+  reason: string;
+  referenceField?: string;
+  count?: number;
+  live?: boolean;
+  authority?: OperatorContextTrustEntryAuthority;
+  contractScope: OperatorContextTrustContractScope;
+};
+
+export type OperatorContextTrustPacket = {
+  schemaVersion: typeof OPERATOR_CONTEXT_TRUST_SCHEMA_VERSION;
+  source: typeof OPERATOR_CONTEXT_TRUST_SOURCE;
+  researchReference: typeof OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE;
+  claimBoundary: typeof OPERATOR_CONTEXT_TRUST_CLAIM_BOUNDARY;
+  sourceOfTruth: {
+    current: OperatorContextTrustEntry[];
+  };
+  advisoryOnly: OperatorContextTrustEntry[];
+  historicalOnly: OperatorContextTrustEntry[];
+  nonAuthorizing: OperatorContextTrustEntry[];
+};
+
+export type BuildOperatorContextTrustInput = {
+  activeArtifacts: OperatorCheckActiveArtifact[];
+  activeWorkReceipts: OperatorCheckActiveWorkReceipts;
+  requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
+  currentRunEvidence: OperatorActivitySnapshot["currentRunEvidence"];
+  postMergeMainCiEvidence: OperatorActivitySnapshot["postMergeMainCiEvidence"];
+};
+
+function activeArtifactReason(artifact: OperatorCheckActiveArtifact): string {
+  switch (artifact.kind) {
+    case "issue":
+      return "Existing operator-check activeArtifacts reports aggregate open issue count; count-only current-work presence, not per-issue identity.";
+    case "pullRequest":
+      return "Existing operator-check activeArtifacts reports aggregate open pull request count; count-only current-work presence, not per-PR identity.";
+    case "session":
+      return "Existing operator-check activeArtifacts reports mapped fooks session presence; session-count authority mirrors the top-level operator-check contract.";
+  }
+}
+
+function currentEntriesFromActiveArtifacts(activeArtifacts: OperatorCheckActiveArtifact[]): OperatorContextTrustEntry[] {
+  return activeArtifacts.map((artifact) => ({
+    kind: artifact.kind,
+    source: artifact.source,
+    reason: activeArtifactReason(artifact),
+    referenceField: "activeArtifacts",
+    count: artifact.count,
+    authority: "current-work" as const,
+    contractScope: "top-level-active-artifact" as const,
+  }));
+}
+
+function advisoryEntries(input: BuildOperatorContextTrustInput): OperatorContextTrustEntry[] {
+  const requiredActiveArtifact = input.requiredActiveArtifact;
+  const postReceipt = input.activeWorkReceipts.postReceiptNudgeAnchorBoundary;
+  const receiptLoop = input.activeWorkReceipts.receiptOnlyNudgeLoopBoundary;
+  return [
+    {
+      kind: "required-active-artifact-guidance",
+      source: "requiredActiveArtifact",
+      reason: requiredActiveArtifact.message,
+      referenceField: "requiredActiveArtifact",
+      authority: "guidance",
+      contractScope: "active-artifact-guidance",
+    },
+    {
+      kind: "dogfood-handoff-guidance",
+      source: "requiredActiveArtifact.dogfoodHandoff",
+      reason: requiredActiveArtifact.dogfoodHandoff.nextAction,
+      referenceField: "requiredActiveArtifact.dogfoodHandoff",
+      authority: "guidance",
+      contractScope: "active-artifact-guidance",
+    },
+    {
+      kind: "post-receipt-nudge-anchor-guidance",
+      source: postReceipt.source,
+      reason: postReceipt.nudgeRule,
+      referenceField: "activeWorkReceipts.postReceiptNudgeAnchorBoundary",
+      authority: "guidance",
+      contractScope: "active-artifact-guidance",
+    },
+    {
+      kind: "receipt-only-nudge-loop-guidance",
+      source: receiptLoop.source,
+      reason: receiptLoop.nudgeRule,
+      referenceField: "activeWorkReceipts.receiptOnlyNudgeLoopBoundary",
+      authority: "guidance",
+      contractScope: "active-artifact-guidance",
+    },
+  ];
+}
+
+function historicalEntries(input: BuildOperatorContextTrustInput): OperatorContextTrustEntry[] {
+  const entries: OperatorContextTrustEntry[] = [];
+  const postMerge = input.postMergeMainCiEvidence;
+  if (postMerge.summary.exactHeadWorkflowCount > 0) {
+    entries.push({
+      kind: "post-merge-main-ci-receipt",
+      source: postMerge.source,
+      reason: "Post-merge main CI exact-head evidence is a historical receipt and does not authorize current active work.",
+      referenceField: "postMergeMainCiEvidence",
+      count: postMerge.summary.exactHeadWorkflowCount,
+      authority: "receipt",
+      contractScope: "post-merge-receipt",
+    });
+  }
+
+  return entries;
+}
+
+function nonAuthorizingEntries(input: BuildOperatorContextTrustInput): OperatorContextTrustEntry[] {
+  const entries: OperatorContextTrustEntry[] = [];
+  const currentRun = input.currentRunEvidence;
+  if (currentRun.mainEchoEvidence) {
+    entries.push({
+      kind: "main-echo-boundary",
+      source: currentRun.source,
+      reason: currentRun.reasons.join("; ") || "Current run is a main-echo boundary and does not authorize active work by itself.",
+      referenceField: "postMergeMainEchoBoundary",
+      live: true,
+      authority: "insufficient",
+      contractScope: "main-echo-boundary",
+    });
+  }
+
+  const staleResidue = input.activeWorkReceipts.staleResidueActiveBoundary;
+  if (staleResidue.staleResidueCount > 0) {
+    entries.push({
+      kind: "stale-residue-active-boundary",
+      source: staleResidue.source,
+      reason: staleResidue.reminder,
+      referenceField: "activeWorkReceipts.staleResidueActiveBoundary",
+      count: staleResidue.staleResidueCount,
+      authority: "insufficient",
+      contractScope: "stale-residue-boundary",
+    });
+  }
+
+  const localOnly = input.activeWorkReceipts.localOnlyResidueActiveBoundary;
+  if (localOnly.cleanupReviewResidueEvidence.totalLocalOnlyResidueCount > 0) {
+    entries.push({
+      kind: "local-only-residue-active-boundary",
+      source: localOnly.source,
+      reason: localOnly.reminder,
+      referenceField: "activeWorkReceipts.localOnlyResidueActiveBoundary",
+      count: localOnly.cleanupReviewResidueEvidence.totalLocalOnlyResidueCount,
+      authority: "insufficient",
+      contractScope: "cleanup-review-boundary",
+    });
+  }
+
+  const legacyReview = input.activeWorkReceipts.legacyReviewWorktreeResidueBoundary;
+  if (legacyReview.legacyReviewWorktreeResidueCount > 0) {
+    entries.push({
+      kind: "legacy-review-worktree-residue",
+      source: legacyReview.source,
+      reason: legacyReview.nudgeRule,
+      referenceField: "activeWorkReceipts.legacyReviewWorktreeResidueBoundary",
+      count: legacyReview.legacyReviewWorktreeResidueCount,
+      authority: "insufficient",
+      contractScope: "cleanup-review-boundary",
+    });
+  }
+
+  const cleanupGuard = input.activeWorkReceipts.legacyReviewResidueCleanupReviewGuard;
+  const cleanupReviewResidueCount = cleanupGuard.cleanupReviewEvidence.legacyReviewWorktreeResidueCount
+    + cleanupGuard.cleanupReviewEvidence.legacyLocalResidueCleanupReviewRowCount;
+  if (cleanupReviewResidueCount > 0) {
+    entries.push({
+      kind: "legacy-review-residue-cleanup-review",
+      source: cleanupGuard.source,
+      reason: cleanupGuard.nudgeRediscoveryRule,
+      referenceField: "activeWorkReceipts.legacyReviewResidueCleanupReviewGuard",
+      count: cleanupReviewResidueCount,
+      authority: "insufficient",
+      contractScope: "cleanup-review-boundary",
+    });
+  }
+
+  const handoff = input.activeWorkReceipts.handoffArtifactEvidence;
+  if (handoff.currentEvidence.liveNonMainWorktreePresent) {
+    entries.push({
+      kind: "live-non-main-worktree-handoff-candidate",
+      source: handoff.source,
+      reason: "Live non-main worktree is adoptable #885 handoff evidence, but does not satisfy the top-level issue/PR/mapped-session active-artifact contract by itself.",
+      referenceField: "activeWorkReceipts.handoffArtifactEvidence.currentEvidence.liveNonMainWorktreePresent",
+      live: true,
+      authority: "handoff-candidate",
+      contractScope: "handoff-artifact-boundary",
+    });
+  }
+
+  if (handoff.currentEvidence.mappedFooksTmuxSessionCount > 0 && handoff.currentEvidence.liveMappedFooksTmuxSessionCount === 0) {
+    entries.push({
+      kind: "mapped-session-live-handoff-caveat",
+      source: handoff.source,
+      reason: "Mapped-session presence may mirror top-level active-artifact/session-count evidence, but #885 handoff authority still lacks a live mapped fooks tmux session.",
+      referenceField: "activeWorkReceipts.handoffArtifactEvidence.currentEvidence.liveMappedFooksTmuxSessionCount",
+      count: handoff.currentEvidence.mappedFooksTmuxSessionCount,
+      live: false,
+      authority: "insufficient",
+      contractScope: "handoff-artifact-boundary",
+    });
+  }
+
+  return entries;
+}
+
+export function buildOperatorContextTrust(input: BuildOperatorContextTrustInput): OperatorContextTrustPacket {
+  return {
+    schemaVersion: OPERATOR_CONTEXT_TRUST_SCHEMA_VERSION,
+    source: OPERATOR_CONTEXT_TRUST_SOURCE,
+    researchReference: OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE,
+    claimBoundary: OPERATOR_CONTEXT_TRUST_CLAIM_BOUNDARY,
+    sourceOfTruth: {
+      current: currentEntriesFromActiveArtifacts(input.activeArtifacts),
+    },
+    advisoryOnly: advisoryEntries(input),
+    historicalOnly: historicalEntries(input),
+    nonAuthorizing: nonAuthorizingEntries(input),
+  };
+}

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -18,6 +18,7 @@ import {
 } from "./orphan-local-worktree-triage";
 import { STALE_WORKTREE_AUDIT_COMMAND, STALE_WORKTREE_AUDIT_ISSUE } from "./stale-worktree-audit";
 import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
+import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./context-trust";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -559,6 +560,7 @@ export type OperatorCheckSnapshot = {
   activeArtifacts: OperatorCheckActiveArtifact[];
   activeWorkReceipts: OperatorCheckActiveWorkReceipts;
   requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
+  contextTrust: OperatorContextTrustPacket;
   activity: OperatorActivitySnapshot;
   blockers: string[];
 };
@@ -1599,6 +1601,15 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
       ? "activeArtifactPresent"
       : "idleRequiresActiveArtifact";
 
+  const requiredArtifact = requiredActiveArtifact({ blocked, hasActiveArtifact });
+  const contextTrust = buildOperatorContextTrust({
+    activeArtifacts,
+    activeWorkReceipts,
+    requiredActiveArtifact: requiredArtifact,
+    currentRunEvidence: activity.currentRunEvidence,
+    postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
+  });
+
   return {
     schemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
     command: OPERATOR_CHECK_COMMAND,
@@ -1620,7 +1631,8 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
     activeArtifacts,
     activeWorkReceipts,
-    requiredActiveArtifact: requiredActiveArtifact({ blocked, hasActiveArtifact }),
+    requiredActiveArtifact: requiredArtifact,
+    contextTrust,
     activity,
     blockers,
   };

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -36,6 +36,11 @@ const {
   readOperatorCheckSnapshot,
 } = require(path.join(repoRoot, "dist", "ops", "operator-check.js"));
 
+const {
+  OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE,
+  OPERATOR_CONTEXT_TRUST_SOURCE,
+} = require(path.join(repoRoot, "dist", "ops", "context-trust.js"));
+
 function runWithCli(cliPath, args, cwd, envOverrides = {}) {
   return JSON.parse(execFileSync(process.execPath, [cliPath, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } }));
 }
@@ -64,7 +69,7 @@ function writeExecutable(filePath, body) {
 }
 
 function makeNoTmuxServerCliFixture(tmuxError = "no server running on /tmp/tmux-1000/default\n") {
-  const tempDir = makeTempProject();
+  const tempDir = fs.realpathSync(makeTempProject());
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-no-tmux-bin-"));
   const mainHead = "no-tmux-cli-main-head";
   writeExecutable(path.join(binDir, "tmux"), `#!/usr/bin/env node
@@ -1071,6 +1076,19 @@ test("operator check forces a concrete active artifact when post-merge main echo
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.activeArtifactReceiptCount, 0);
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
+  assert.equal(snapshot.contextTrust.schemaVersion, 1);
+  assert.equal(snapshot.contextTrust.source, OPERATOR_CONTEXT_TRUST_SOURCE);
+  assert.equal(snapshot.contextTrust.researchReference, OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE);
+  assert.deepEqual(snapshot.contextTrust.sourceOfTruth.current, []);
+  assert.equal(snapshot.contextTrust.advisoryOnly.some((entry) => entry.kind === "required-active-artifact-guidance"), true);
+  assert.equal(snapshot.contextTrust.nonAuthorizing.some((entry) => entry.kind === "main-echo-boundary" && entry.referenceField === "postMergeMainEchoBoundary"), true);
+  assert.equal(snapshot.contextTrust.nonAuthorizing.find((entry) => entry.kind === "main-echo-boundary")?.contractScope, "main-echo-boundary");
+  assert.equal(snapshot.contextTrust.historicalOnly.some((entry) => entry.kind === "main-echo-boundary"), false);
+  assert.equal(snapshot.contextTrust.historicalOnly.some((entry) => entry.kind === "post-merge-main-ci-receipt"), false);
+  assert.equal(snapshot.contextTrust.historicalOnly.some((entry) => entry.kind === "post-receipt-nudge-anchor"), false);
+  assert.equal(snapshot.contextTrust.historicalOnly.some((entry) => entry.kind === "receipt-only-nudge-loop"), false);
+  assert.equal(snapshot.contextTrust.advisoryOnly.some((entry) => entry.kind === "post-receipt-nudge-anchor-guidance"), true);
+  assert.equal(snapshot.contextTrust.advisoryOnly.some((entry) => entry.kind === "receipt-only-nudge-loop-guidance"), true);
   assert.deepEqual(snapshot.blockers, []);
 });
 
@@ -1512,6 +1530,14 @@ test("operator check treats issue, PR, or mapped session as the concrete active 
     "open GitHub pull request",
     "mapped fooks tmux session",
   ]);
+  const trustCurrentByKind = new Map(snapshot.contextTrust.sourceOfTruth.current.map((entry) => [entry.kind, entry]));
+  assert.equal(trustCurrentByKind.get("issue")?.count, 1);
+  assert.equal(trustCurrentByKind.get("issue")?.authority, "current-work");
+  assert.equal(trustCurrentByKind.get("issue")?.contractScope, "top-level-active-artifact");
+  assert.match(trustCurrentByKind.get("issue")?.reason ?? "", /count-only current-work presence/);
+  assert.equal(trustCurrentByKind.get("pullRequest")?.count, 1);
+  assert.equal(trustCurrentByKind.get("session")?.count, 1);
+  assert.equal("number" in trustCurrentByKind.get("issue"), false);
 });
 
 test("operator check does not treat staged unsubmitted OMX prompt pane as active session evidence for #910", () => {
@@ -1707,6 +1733,11 @@ test("operator check projects sibling worktree adoption receipts without cleanup
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
   assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
   assert.match(snapshot.activeWorkReceipts.staleResidueActiveBoundary.reminder, /require an open issue, open PR, or mapped fooks tmux session/);
+  const staleResidueTrust = snapshot.contextTrust.nonAuthorizing.find((entry) => entry.kind === "stale-residue-active-boundary");
+  assert.equal(staleResidueTrust?.count, 2);
+  assert.equal(staleResidueTrust?.authority, "insufficient");
+  assert.equal(staleResidueTrust?.contractScope, "stale-residue-boundary");
+  assert.equal(snapshot.contextTrust.sourceOfTruth.current.some((entry) => entry.kind === "worktree"), false);
   const byBranch = new Map(worktreeReceipts.map((receipt) => [receipt.identifiers.worktree.branch, receipt]));
   const manifestRowsByBranch = new Map(snapshot.activeWorkReceipts.cleanupReviewManifest.rows.map((row) => [row.branch, row]));
 
@@ -2771,6 +2802,11 @@ test("operator check exposes issue #885 handoff artifact evidence rule", () => {
   assert.equal(worktreeOnlyBoundary.runCreatedArtifactRequirement.required, false);
   assert.equal(worktreeOnlyBoundary.currentEvidence.liveNonMainWorktreePresent, true);
   assert.match(worktreeOnlyBoundary.nextReportRule, /separate from the top-level requiredActiveArtifact issue\/PR\/session contract/);
+  const worktreeOnlyTrust = worktreeOnlySnapshot.contextTrust.nonAuthorizing.find((entry) => entry.kind === "live-non-main-worktree-handoff-candidate");
+  assert.equal(worktreeOnlyTrust?.authority, "handoff-candidate");
+  assert.equal(worktreeOnlyTrust?.contractScope, "handoff-artifact-boundary");
+  assert.equal(worktreeOnlyTrust?.live, true);
+  assert.equal(worktreeOnlySnapshot.contextTrust.sourceOfTruth.current.some((entry) => entry.kind === "worktree"), false);
 
   const staleSessionWorktree = path.join(tempDir, ".omx-worktrees", "issue-885-stale-session");
   const staleSessionOnlySnapshot = readOperatorCheckSnapshot(tempDir, {
@@ -2812,6 +2848,12 @@ test("operator check exposes issue #885 handoff artifact evidence rule", () => {
   assert.equal(staleSessionOnlyBoundary.adoptedLiveArtifactPresent, false);
   assert.equal(staleSessionOnlyBoundary.runCreatedArtifactRequirement.required, true);
   assert.equal(staleSessionOnlyBoundary.satisfiesHandoffRule, false);
+  assert.equal(staleSessionOnlySnapshot.contextTrust.sourceOfTruth.current.find((entry) => entry.kind === "session")?.count, 1);
+  const liveSessionCaveat = staleSessionOnlySnapshot.contextTrust.nonAuthorizing.find((entry) => entry.kind === "mapped-session-live-handoff-caveat");
+  assert.equal(liveSessionCaveat?.count, 1);
+  assert.equal(liveSessionCaveat?.live, false);
+  assert.equal(liveSessionCaveat?.contractScope, "handoff-artifact-boundary");
+  assert.match(liveSessionCaveat?.reason ?? "", /top-level active-artifact\/session-count evidence/);
 
   const activeSnapshot = readOperatorCheckSnapshot(tempDir, {
     now: () => "2026-05-16T06:25:00.000Z",
@@ -3033,6 +3075,9 @@ test("status activity CLI route preserves existing status contracts", () => {
   assert.equal(check.command, OPERATOR_CHECK_COMMAND);
   assert.equal(check.readOnly, true);
   assert.equal(check.activity.optionalCounts.enabled, true);
+  assert.equal(check.contextTrust.schemaVersion, 1);
+  assert.equal(check.contextTrust.researchReference, OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE);
+  assert.equal(check.contextTrust.advisoryOnly.every((entry) => typeof entry.contractScope === "string"), true);
   assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
 
   const activity = run(["status", "activity"], tempDir);


### PR DESCRIPTION
## Summary
- Add an ops-local `contextTrust` projection to `fooks check --json`.
- Split already-computed operator-check evidence into `sourceOfTruth.current`, `advisoryOnly`, `historicalOnly`, and `nonAuthorizing` buckets.
- Add required `contractScope` metadata so consumers can distinguish top-level active-artifact authority from handoff, stale residue, cleanup, main-echo, guidance, and receipt boundaries.

## Scope boundaries
- Additive only; top-level operator-check schema version remains `1`.
- No new git/gh/tmux/filesystem/freshness reads.
- No #962 stale detector, no #963 handoff generator, no React summary surface, no runtime hook/provider token-cost behavior, and no new dependency.

## Verification
- `npm run build`
- `node --test test/operator-activity.test.mjs` (43/43)
- `node dist/cli/index.js check --json` parse smoke for `contextTrust.schemaVersion`, exact `researchReference`, and `contractScope` strings
- Ultragoal final quality gate: ai-slop-cleaner PASS, code-review APPROVE, architect CLEAR

Fixes #961
