### PR TITLE
Bound bulk CI replay echo

### DIFF
--- a/docs/dogfood/bulk-ci-replay-clean-main-968.md
+++ b/docs/dogfood/bulk-ci-replay-clean-main-968.md
@@ -1,0 +1,104 @@
+# Bulk CI replay clean-main echo boundary (#968)
+
+This is a narrow read-only dogfood docs/test/operator artifact for issue #968.
+It addresses the dogfood pain point where, after PR #967 merged clean, clawhip
+replayed a bulk batch of historical CI success URLs while the current `main`
+CI and release-report receipts were already green.
+
+## Strict check/reporting rule
+
+For strict `fooks check` reporting, a bulk batch of historical successful CI URLs
+is a replay echo, not active work evidence. Collapse the batch into one
+receipt-only echo lane and keep it separate from current active artifact
+evidence.
+
+The operator report must therefore:
+
+1. Treat historical successful CI URLs from the clawhip bulk replay as echo
+   receipts when current `main` CI/Release are already green.
+2. Keep the latest exact-head `main` CI/Release green receipt visible as
+   verification-only provenance.
+3. Require active artifact evidence before claiming current dogfood work:
+   an open issue, open PR, mapped fooks tmux/proc session, or the narrower
+   handoff-only live worktree evidence already documented by issue #885.
+4. Never let the replay batch satisfy the top-level `requiredActiveArtifact`
+   contract by itself.
+
+This artifact is intentionally operator/reporting-only. It does not implement
+#962 or #963, does not change merge-gate policy, does not alter CI workflows,
+does not change runtime hooks or provider behavior, and makes no broad product,
+performance, billing, or runtime-token claims.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#968",
+  "readOnly": true,
+  "question": "collapse bulk historical CI success replay after PR #967 clean merge and require active artifact evidence",
+  "sourcePullRequest": "#967",
+  "event": {
+    "afterCleanMerge": true,
+    "clawhipBulkReplay": true,
+    "historicalCiSuccessUrls": "many",
+    "currentMainCiAndReleaseAlreadyGreen": true
+  },
+  "classification": {
+    "bulkReplayLane": "receipt-only-echo",
+    "currentMainGreenLane": "verification-only-provenance",
+    "activeArtifactLane": "required-before-current-work-claim"
+  },
+  "strictFooksCheckDecision": {
+    "collapseBulkHistoricalSuccessUrls": true,
+    "bulkReplaySatisfiesRequiredActiveArtifact": false,
+    "currentMainGreenReceiptSatisfiesRequiredActiveArtifact": false,
+    "requiresActiveArtifactEvidence": true,
+    "acceptableTopLevelActiveArtifacts": [
+      "open GitHub issue",
+      "open GitHub pull request",
+      "mapped fooks tmux session"
+    ],
+    "handoffOnlyLiveWorktreeEvidence": "allowed only under the issue #885 nested handoff artifact boundary"
+  },
+  "currentRunEvidence": {
+    "adoptedIssue": "#968",
+    "adoptedBranch": "dogfood/issue-968-bulk-ci-replay-clean-main",
+    "mappedSession": "fooks-dogfood-issue-968-bulk-ci-replay-clean-main",
+    "worktree": "/home/bellman/Workspace/fooks.omx-worktrees/issue-968-bulk-ci-replay-clean-main",
+    "deltaAheadProcRequired": true
+  },
+  "prohibitedReportAnchors": [
+    "bulk historical CI success URL replay",
+    "prior clean merge receipt",
+    "current main CI green receipt alone",
+    "release-report green receipt alone",
+    "generic idle status summary"
+  ],
+  "operatorRule": "When clawhip replays a bulk batch of historical successful CI URLs after PR #967 merged clean and current main CI/Release are already green, strict fooks check/reporting collapses the batch as receipt-only echo. Report the current green main receipt as verification-only provenance, then name active artifact evidence before claiming current work; the replay batch never satisfies requiredActiveArtifact by itself."
+}
+```
+
+## Operator reading order
+
+1. Confirm the alert batch is a clawhip replay of historical successful CI URLs.
+2. Confirm current exact-head `main` CI and release-report receipts are green.
+3. Collapse the historical success URLs into one receipt-only echo lane.
+4. Check whether an open issue, open PR, or mapped fooks tmux/proc session is
+   present for the current run.
+5. If active artifact evidence is absent, strict `fooks check` must report that
+   active artifact evidence is required instead of answering with the replayed
+   green URLs.
+
+## Non-goals
+
+This artifact does not implement issue #962, issue #963, stale detection,
+automatic handoff generation, merge-gate policy, CI workflow behavior, runtime
+hook/provider behavior, React Web/RN/TUI/WebView behavior, cleanup authority,
+product claims, performance claims, billing proof, or runtime-token evidence. It
+documents and tests the strict `fooks check` operator/reporting boundary only.
+
+## Focused verification
+
+```sh
+node --test test/bulk-ci-replay-clean-main-doc.test.mjs test/ci-alert-triage.test.mjs test/operator-activity.test.mjs
+```

--- a/test/bulk-ci-replay-clean-main-doc.test.mjs
+++ b/test/bulk-ci-replay-clean-main-doc.test.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "bulk-ci-replay-clean-main-968.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+/** @param {string} markdown */
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #968 artifact collapses bulk CI replay as echo", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#968");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourcePullRequest, "#967");
+  assert.match(report.question, /bulk historical CI success replay/);
+  assert.match(report.question, /require active artifact evidence/);
+
+  assert.equal(report.event.afterCleanMerge, true);
+  assert.equal(report.event.clawhipBulkReplay, true);
+  assert.equal(report.event.historicalCiSuccessUrls, "many");
+  assert.equal(report.event.currentMainCiAndReleaseAlreadyGreen, true);
+
+  assert.deepEqual(report.classification, {
+    bulkReplayLane: "receipt-only-echo",
+    currentMainGreenLane: "verification-only-provenance",
+    activeArtifactLane: "required-before-current-work-claim",
+  });
+
+  assert.equal(report.strictFooksCheckDecision.collapseBulkHistoricalSuccessUrls, true);
+  assert.equal(report.strictFooksCheckDecision.bulkReplaySatisfiesRequiredActiveArtifact, false);
+  assert.equal(report.strictFooksCheckDecision.currentMainGreenReceiptSatisfiesRequiredActiveArtifact, false);
+  assert.equal(report.strictFooksCheckDecision.requiresActiveArtifactEvidence, true);
+  assert.deepEqual(report.strictFooksCheckDecision.acceptableTopLevelActiveArtifacts, [
+    "open GitHub issue",
+    "open GitHub pull request",
+    "mapped fooks tmux session",
+  ]);
+  assert.match(report.strictFooksCheckDecision.handoffOnlyLiveWorktreeEvidence, /issue #885/);
+});
+
+test("issue #968 artifact requires active evidence and preserves non-goals", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.currentRunEvidence.adoptedIssue, "#968");
+  assert.equal(report.currentRunEvidence.adoptedBranch, "dogfood/issue-968-bulk-ci-replay-clean-main");
+  assert.equal(report.currentRunEvidence.mappedSession, "fooks-dogfood-issue-968-bulk-ci-replay-clean-main");
+  assert.equal(report.currentRunEvidence.deltaAheadProcRequired, true);
+  assert.deepEqual(report.prohibitedReportAnchors, [
+    "bulk historical CI success URL replay",
+    "prior clean merge receipt",
+    "current main CI green receipt alone",
+    "release-report green receipt alone",
+    "generic idle status summary",
+  ]);
+  assert.match(report.operatorRule, /collapses the batch as receipt-only echo/);
+  assert.match(report.operatorRule, /verification-only provenance/);
+  assert.match(report.operatorRule, /active artifact evidence/);
+  assert.match(report.operatorRule, /never satisfies requiredActiveArtifact by itself/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/operator artifact for issue #968",
+    "after PR #967 merged clean",
+    "clawhip replayed a bulk batch of historical CI success URLs",
+    "current `main` CI and release-report receipts were already green",
+    "strict `fooks check` reporting",
+    "bulk batch of historical successful CI URLs is a replay echo",
+    "receipt-only echo lane",
+    "active artifact evidence",
+    "open issue, open PR, mapped fooks tmux/proc session",
+    "Never let the replay batch satisfy the top-level `requiredActiveArtifact` contract by itself",
+    "does not implement #962 or #963",
+    "does not change merge-gate policy",
+    "does not change runtime hooks or provider behavior",
+    "no broad product",
+    "performance",
+    "billing",
+    "runtime-token claims",
+    "strict `fooks check` operator/reporting boundary only",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #968 doc text: ${required}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Preserve the Issue #968 dogfood finding as docs/test evidence.
- Classify bulk historical CI success replay as receipt-only echo, not active work.
- Keep strict fooks check reports anchored to active issue, PR, mapped session, or bounded handoff evidence.

## Non-goals
- No #962 stale detector implementation.
- No #963 handoff generator implementation.
- No merge-gate policy changes.
- No runtime hook/provider behavior changes.

## Verification
- `git diff --check HEAD`
- `npm run build`
- `node --test test/bulk-ci-replay-clean-main-doc.test.mjs test/ci-alert-triage.test.mjs test/operator-activity.test.mjs`

Closes #968
