### PR TITLE
Add preflight JSON guidance over contextTrust

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -641,6 +641,9 @@ Everyday commands:
 
   ${displayCliName} check [--json]
       Read-only operator/check artifact for post-merge main echo versus active issue/PR/session evidence.
+
+  ${displayCliName} preflight [--json]
+      Compact read-only agent guidance projected from the existing operator-check/contextTrust snapshot.
 
   ${displayCliName} run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
@@ -1512,6 +1515,21 @@ async function run(): Promise<void> {
       }
       const { readOperatorCheckSnapshot } = await import("../ops/operator-check.js");
       print(readOperatorCheckSnapshot(process.cwd()));
+      return;
+    }
+    case "preflight": {
+      const allowed = new Set(["--json"]);
+      for (const arg of rest) {
+        if (!allowed.has(arg)) {
+          throw new Error(`Unexpected preflight argument: ${arg}`);
+        }
+      }
+      const [{ readOperatorCheckSnapshot }, { buildPreflightPacket }] = await Promise.all([
+        import("../ops/operator-check.js"),
+        import("../ops/preflight.js"),
+      ]);
+      const snapshot = readOperatorCheckSnapshot(process.cwd());
+      print(buildPreflightPacket(snapshot));
       return;
     }
     case "status": {

--- a/src/ops/preflight.ts
+++ b/src/ops/preflight.ts
@@ -1,0 +1,165 @@
+import type { OperatorContextTrustEntry } from "./context-trust";
+import type { OperatorCheckSnapshot } from "./operator-check";
+
+export const PREFLIGHT_SCHEMA_VERSION = 1;
+export const PREFLIGHT_COMMAND = "preflight";
+export const PREFLIGHT_SOURCE = "operator-check/contextTrust preflight projection";
+export const PREFLIGHT_CLAIM_BOUNDARY =
+  "Read-only preflight projection over the already-assembled operator-check/contextTrust snapshot; it adds compact agent guidance without performing evidence collection, stale detection, handoff generation, hook enforcement, instruction persistence, or token/cost telemetry.";
+
+export type PreflightRiskLevel = "low" | "medium" | "high";
+
+export type PreflightRecommendedAction =
+  | "continue-with-current-authority"
+  | "create-or-link-active-artifact"
+  | "adopt-or-report-live-handoff"
+  | "resolve-blockers-first";
+
+export type PreflightAuthorityStatus = "present" | "missing" | "blocked";
+
+export type PreflightEvidenceRef = Pick<
+  OperatorContextTrustEntry,
+  "kind" | "source" | "referenceField" | "count" | "live" | "authority" | "contractScope" | "reason"
+>;
+
+export type PreflightPacket = {
+  schemaVersion: typeof PREFLIGHT_SCHEMA_VERSION;
+  command: typeof PREFLIGHT_COMMAND;
+  source: typeof PREFLIGHT_SOURCE;
+  claimBoundary: typeof PREFLIGHT_CLAIM_BOUNDARY;
+  derivedFrom: {
+    operatorCheckCommand: "check";
+    operatorCheckSchemaVersion: 1;
+    contextTrustSchemaVersion: 1;
+  };
+  summary: {
+    authorityStatus: PreflightAuthorityStatus;
+    currentAuthoritySummary: string;
+    nonAuthorizingSummary: string;
+    advisorySummary?: string;
+    historicalSummary?: string;
+  };
+  guidance: {
+    riskLevel: PreflightRiskLevel;
+    recommendedAction: PreflightRecommendedAction;
+    rationale: string;
+  };
+  currentAuthority: PreflightEvidenceRef[];
+  nonAuthorizing: PreflightEvidenceRef[];
+  advisoryOnly: PreflightEvidenceRef[];
+  historicalOnly: PreflightEvidenceRef[];
+};
+
+function evidenceRefs(entries: OperatorContextTrustEntry[]): PreflightEvidenceRef[] {
+  return entries.map((entry) => ({
+    kind: entry.kind,
+    source: entry.source,
+    reason: entry.reason,
+    ...(entry.referenceField ? { referenceField: entry.referenceField } : {}),
+    ...(entry.count !== undefined ? { count: entry.count } : {}),
+    ...(entry.live !== undefined ? { live: entry.live } : {}),
+    ...(entry.authority ? { authority: entry.authority } : {}),
+    contractScope: entry.contractScope,
+  }));
+}
+
+function summarizeEntries(empty: string, entries: PreflightEvidenceRef[]): string {
+  if (entries.length === 0) return empty;
+  const kinds = entries.map((entry) => entry.kind).join(", ");
+  return `${entries.length} entr${entries.length === 1 ? "y" : "ies"}: ${kinds}`;
+}
+
+function hasLiveHandoffCandidate(entries: PreflightEvidenceRef[]): boolean {
+  return entries.some((entry) =>
+    entry.authority === "handoff-candidate"
+    && entry.contractScope === "handoff-artifact-boundary"
+    && entry.live === true
+  );
+}
+
+function hasMappedSessionLiveHandoffCaveat(entries: PreflightEvidenceRef[]): boolean {
+  return entries.some((entry) =>
+    entry.authority === "insufficient"
+    && entry.contractScope === "handoff-artifact-boundary"
+    && entry.live === false
+  );
+}
+
+function guidanceFor(
+  snapshot: OperatorCheckSnapshot,
+  currentAuthority: PreflightEvidenceRef[],
+  nonAuthorizing: PreflightEvidenceRef[],
+): PreflightPacket["guidance"] {
+  const blocked = snapshot.verdict === "blocked" || snapshot.blockers.length > 0;
+  if (blocked) {
+    return {
+      riskLevel: "high",
+      recommendedAction: "resolve-blockers-first",
+      rationale: "operator-check reports blockers, so resolve the blocked snapshot before using any evidence as the next-work anchor.",
+    };
+  }
+
+  if (currentAuthority.length > 0) {
+    const riskLevel: PreflightRiskLevel = hasMappedSessionLiveHandoffCaveat(nonAuthorizing) ? "medium" : "low";
+    return {
+      riskLevel,
+      recommendedAction: "continue-with-current-authority",
+      rationale:
+        riskLevel === "medium"
+          ? "top-level current authority exists, but live-handoff caveats should be reviewed before continuing."
+          : "top-level issue, pull request, or mapped-session authority exists and satisfies the active-work boundary.",
+    };
+  }
+
+  if (hasLiveHandoffCandidate(nonAuthorizing)) {
+    return {
+      riskLevel: "high",
+      recommendedAction: "adopt-or-report-live-handoff",
+      rationale:
+        "no top-level current authority exists, but a live non-authorizing handoff candidate exists; adopt/report that artifact instead of inventing current authority.",
+    };
+  }
+
+  return {
+    riskLevel: "high",
+    recommendedAction: "create-or-link-active-artifact",
+    rationale: "no top-level current authority exists; create or link an issue, pull request, or mapped fooks session before continuing work.",
+  };
+}
+
+export function buildPreflightPacket(snapshot: OperatorCheckSnapshot): PreflightPacket {
+  const currentAuthority = evidenceRefs(snapshot.contextTrust.sourceOfTruth.current);
+  const nonAuthorizing = evidenceRefs(snapshot.contextTrust.nonAuthorizing);
+  const advisoryOnly = evidenceRefs(snapshot.contextTrust.advisoryOnly);
+  const historicalOnly = evidenceRefs(snapshot.contextTrust.historicalOnly);
+  const blocked = snapshot.verdict === "blocked" || snapshot.blockers.length > 0;
+  const authorityStatus: PreflightAuthorityStatus = blocked
+    ? "blocked"
+    : currentAuthority.length > 0
+      ? "present"
+      : "missing";
+
+  return {
+    schemaVersion: PREFLIGHT_SCHEMA_VERSION,
+    command: PREFLIGHT_COMMAND,
+    source: PREFLIGHT_SOURCE,
+    claimBoundary: PREFLIGHT_CLAIM_BOUNDARY,
+    derivedFrom: {
+      operatorCheckCommand: snapshot.command,
+      operatorCheckSchemaVersion: snapshot.schemaVersion,
+      contextTrustSchemaVersion: snapshot.contextTrust.schemaVersion,
+    },
+    summary: {
+      authorityStatus,
+      currentAuthoritySummary: summarizeEntries("no top-level issue, pull request, or mapped-session authority", currentAuthority),
+      nonAuthorizingSummary: summarizeEntries("no non-authorizing evidence", nonAuthorizing),
+      ...(advisoryOnly.length > 0 ? { advisorySummary: summarizeEntries("no advisory guidance", advisoryOnly) } : {}),
+      ...(historicalOnly.length > 0 ? { historicalSummary: summarizeEntries("no historical receipts", historicalOnly) } : {}),
+    },
+    guidance: guidanceFor(snapshot, currentAuthority, nonAuthorizing),
+    currentAuthority,
+    nonAuthorizing,
+    advisoryOnly,
+    historicalOnly,
+  };
+}

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -41,6 +41,12 @@ const {
   OPERATOR_CONTEXT_TRUST_SOURCE,
 } = require(path.join(repoRoot, "dist", "ops", "context-trust.js"));
 
+const {
+  PREFLIGHT_COMMAND,
+  PREFLIGHT_SOURCE,
+  buildPreflightPacket,
+} = require(path.join(repoRoot, "dist", "ops", "preflight.js"));
+
 function runWithCli(cliPath, args, cwd, envOverrides = {}) {
   return JSON.parse(execFileSync(process.execPath, [cliPath, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...envOverrides } }));
 }
@@ -62,6 +68,25 @@ function makeTempProject() {
   fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
   fs.writeFileSync(path.join(tempDir, "src", "index.ts"), "export const value = 1;\n");
   return tempDir;
+}
+
+function syntheticPreflightSnapshot({ current = [], nonAuthorizing = [], advisoryOnly = [], historicalOnly = [], verdict = "idleRequiresActiveArtifact", blockers = [] } = {}) {
+  return {
+    schemaVersion: 1,
+    command: OPERATOR_CHECK_COMMAND,
+    verdict,
+    blockers,
+    contextTrust: {
+      schemaVersion: 1,
+      source: OPERATOR_CONTEXT_TRUST_SOURCE,
+      researchReference: OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE,
+      claimBoundary: "synthetic test contextTrust",
+      sourceOfTruth: { current },
+      advisoryOnly,
+      historicalOnly,
+      nonAuthorizing,
+    },
+  };
 }
 
 function writeExecutable(filePath, body) {
@@ -212,6 +237,94 @@ function tmuxNoServerError(socket = "/tmp/tmux-1000/default", stream = "stderr")
   error.code = 1;
   return error;
 }
+
+test("preflight builder projects synthetic contextTrust without evidence reads", () => {
+  const preflightSource = fs.readFileSync(path.join(repoRoot, "src", "ops", "preflight.ts"), "utf8");
+  const operatorCheckSource = fs.readFileSync(path.join(repoRoot, "src", "ops", "operator-check.ts"), "utf8");
+  assert.doesNotMatch(preflightSource, /node:(?:fs|child_process)/);
+  assert.doesNotMatch(preflightSource, /\bexecFileSync\b|\bspawnSync\b|\breadFileSync\b/);
+  assert.doesNotMatch(operatorCheckSource, /preflight/);
+
+  const mainEchoEntry = {
+    kind: "main-echo-boundary",
+    source: OPERATOR_ACTIVITY_CURRENT_RUN_SOURCE,
+    reason: "main echo only",
+    referenceField: "postMergeMainEchoBoundary",
+    live: true,
+    authority: "insufficient",
+    contractScope: "main-echo-boundary",
+  };
+  const noAuthority = buildPreflightPacket(syntheticPreflightSnapshot({ nonAuthorizing: [mainEchoEntry] }));
+  assert.equal(noAuthority.schemaVersion, 1);
+  assert.equal(noAuthority.command, PREFLIGHT_COMMAND);
+  assert.equal(noAuthority.source, PREFLIGHT_SOURCE);
+  assert.equal(noAuthority.derivedFrom.operatorCheckCommand, OPERATOR_CHECK_COMMAND);
+  assert.equal(noAuthority.derivedFrom.operatorCheckSchemaVersion, 1);
+  assert.equal(noAuthority.derivedFrom.contextTrustSchemaVersion, 1);
+  assert.equal(noAuthority.summary.authorityStatus, "missing");
+  assert.equal(noAuthority.guidance.riskLevel, "high");
+  assert.equal(noAuthority.guidance.recommendedAction, "create-or-link-active-artifact");
+  assert.equal(noAuthority.currentAuthority.length, 0);
+  assert.equal(noAuthority.nonAuthorizing[0].contractScope, "main-echo-boundary");
+
+  const handoff = buildPreflightPacket(syntheticPreflightSnapshot({
+    nonAuthorizing: [
+      {
+        kind: "live-non-main-worktree-handoff-candidate",
+        source: "activeWorkReceipts.handoffArtifactEvidence",
+        reason: "live handoff candidate only",
+        referenceField: "activeWorkReceipts.handoffArtifactEvidence.currentEvidence.liveNonMainWorktreePresent",
+        live: true,
+        authority: "handoff-candidate",
+        contractScope: "handoff-artifact-boundary",
+      },
+    ],
+  }));
+  assert.equal(handoff.summary.authorityStatus, "missing");
+  assert.equal(handoff.guidance.riskLevel, "high");
+  assert.equal(handoff.guidance.recommendedAction, "adopt-or-report-live-handoff");
+  assert.equal(handoff.currentAuthority.some((entry) => entry.kind === "worktree"), false);
+  assert.equal(handoff.nonAuthorizing[0].contractScope, "handoff-artifact-boundary");
+
+  const mappedSessionWithCaveat = buildPreflightPacket(syntheticPreflightSnapshot({
+    current: [
+      {
+        kind: "session",
+        source: OPERATOR_ACTIVITY_TMUX_COMMAND,
+        reason: "mapped session count-only current-work presence",
+        referenceField: "activeArtifacts",
+        count: 1,
+        authority: "current-work",
+        contractScope: "top-level-active-artifact",
+      },
+    ],
+    nonAuthorizing: [
+      {
+        kind: "mapped-session-live-handoff-caveat",
+        source: "activeWorkReceipts.handoffArtifactEvidence",
+        reason: "mapped session lacks live handoff",
+        referenceField: "activeWorkReceipts.handoffArtifactEvidence.currentEvidence.liveMappedFooksTmuxSessionCount",
+        count: 1,
+        live: false,
+        authority: "insufficient",
+        contractScope: "handoff-artifact-boundary",
+      },
+    ],
+  }));
+  assert.equal(mappedSessionWithCaveat.summary.authorityStatus, "present");
+  assert.equal(mappedSessionWithCaveat.guidance.riskLevel, "medium");
+  assert.equal(mappedSessionWithCaveat.guidance.recommendedAction, "continue-with-current-authority");
+  assert.equal(mappedSessionWithCaveat.currentAuthority[0].contractScope, "top-level-active-artifact");
+  assert.equal("number" in mappedSessionWithCaveat.currentAuthority[0], false);
+
+  const blocked = buildPreflightPacket(syntheticPreflightSnapshot({
+    verdict: "blocked",
+    blockers: ["tmux unavailable"],
+  }));
+  assert.equal(blocked.summary.authorityStatus, "blocked");
+  assert.equal(blocked.guidance.riskLevel, "high");
+  assert.equal(blocked.guidance.recommendedAction, "resolve-blockers-first");
+});
 
 test("operator reminder docs require a blocker or active artifact after clean CI/React echoes", () => {
   const boundaryDoc = fs.readFileSync(path.join(repoRoot, "docs", "post-merge-main-ci-echo-boundary.md"), "utf8");
@@ -2807,6 +2920,15 @@ test("operator check exposes issue #885 handoff artifact evidence rule", () => {
   assert.equal(worktreeOnlyTrust?.contractScope, "handoff-artifact-boundary");
   assert.equal(worktreeOnlyTrust?.live, true);
   assert.equal(worktreeOnlySnapshot.contextTrust.sourceOfTruth.current.some((entry) => entry.kind === "worktree"), false);
+  const worktreeOnlyPreflight = buildPreflightPacket(worktreeOnlySnapshot);
+  assert.equal(worktreeOnlyPreflight.summary.authorityStatus, "missing");
+  assert.equal(worktreeOnlyPreflight.guidance.riskLevel, "high");
+  assert.equal(worktreeOnlyPreflight.guidance.recommendedAction, "adopt-or-report-live-handoff");
+  assert.equal(worktreeOnlyPreflight.nonAuthorizing.some((entry) =>
+    entry.authority === "handoff-candidate"
+    && entry.contractScope === "handoff-artifact-boundary"
+    && entry.live === true
+  ), true);
 
   const staleSessionWorktree = path.join(tempDir, ".omx-worktrees", "issue-885-stale-session");
   const staleSessionOnlySnapshot = readOperatorCheckSnapshot(tempDir, {
@@ -2854,6 +2976,11 @@ test("operator check exposes issue #885 handoff artifact evidence rule", () => {
   assert.equal(liveSessionCaveat?.live, false);
   assert.equal(liveSessionCaveat?.contractScope, "handoff-artifact-boundary");
   assert.match(liveSessionCaveat?.reason ?? "", /top-level active-artifact\/session-count evidence/);
+  const staleSessionPreflight = buildPreflightPacket(staleSessionOnlySnapshot);
+  assert.equal(staleSessionPreflight.summary.authorityStatus, "present");
+  assert.equal(staleSessionPreflight.guidance.riskLevel, "medium");
+  assert.equal(staleSessionPreflight.guidance.recommendedAction, "continue-with-current-authority");
+  assert.equal(staleSessionPreflight.currentAuthority.find((entry) => entry.kind === "session")?.contractScope, "top-level-active-artifact");
 
   const activeSnapshot = readOperatorCheckSnapshot(tempDir, {
     now: () => "2026-05-16T06:25:00.000Z",
@@ -3078,6 +3205,22 @@ test("status activity CLI route preserves existing status contracts", () => {
   assert.equal(check.contextTrust.schemaVersion, 1);
   assert.equal(check.contextTrust.researchReference, OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE);
   assert.equal(check.contextTrust.advisoryOnly.every((entry) => typeof entry.contractScope === "string"), true);
+  assert.equal("preflight" in check, false);
+  assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
+
+  const preflight = run(["preflight", "--json"], tempDir);
+  assert.equal(preflight.command, PREFLIGHT_COMMAND);
+  assert.equal(preflight.source, PREFLIGHT_SOURCE);
+  assert.equal(preflight.derivedFrom.operatorCheckCommand, OPERATOR_CHECK_COMMAND);
+  assert.equal(preflight.derivedFrom.operatorCheckSchemaVersion, 1);
+  assert.equal(preflight.derivedFrom.contextTrustSchemaVersion, 1);
+  assert.equal(typeof preflight.claimBoundary, "string");
+  assert.equal(typeof preflight.summary.authorityStatus, "string");
+  assert.equal(typeof preflight.guidance.riskLevel, "string");
+  assert.equal(typeof preflight.guidance.recommendedAction, "string");
+  assert.equal(Array.isArray(preflight.currentAuthority), true);
+  assert.equal(Array.isArray(preflight.nonAuthorizing), true);
+  assert.equal(preflight.advisoryOnly.every((entry) => typeof entry.contractScope === "string"), true);
   assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
 
   const activity = run(["status", "activity"], tempDir);
@@ -3109,6 +3252,7 @@ test("status activity CLI route preserves existing status contracts", () => {
 
   const help = runText(["--help"], tempDir);
   assert.match(help, /fooks check \[--json\]/);
+  assert.match(help, /fooks preflight \[--json\]/);
   assert.match(help, /fooks status activity \[--include-remote-counts\]/);
 
   let output = "";
@@ -3118,6 +3262,14 @@ test("status activity CLI route preserves existing status contracts", () => {
     output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
   }
   assert.match(output, /Unexpected check argument/);
+
+  output = "";
+  try {
+    runText(["preflight", "--unexpected"], tempDir);
+  } catch (error) {
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.match(output, /Unexpected preflight argument/);
 
   output = "";
   try {


### PR DESCRIPTION
## Summary
- Closes #970
- Add `fooks preflight --json` as a compact, CLI-only guidance packet over existing `operator-check` / `contextTrust` evidence.
- Keep `check --json` unchanged and keep `operator-check` as the evidence producer.
- Add regression coverage for pure projection behavior, real snapshot handoff/caveat paths, CLI contract, blocked state, and additive-only boundaries.

## Design notes
- New `src/ops/preflight.ts` consumes an assembled `OperatorCheckSnapshot`; it performs no git/gh/tmux/filesystem reads.
- CLI flow stays: `readOperatorCheckSnapshot()` → `buildPreflightPacket(snapshot)`.
- Guidance decisions use stable semantic fields (`authority`, `contractScope`, `live`) instead of exact `contextTrust.kind` strings.

## Verification
- `npm run build`
- `node --test test/operator-activity.test.mjs` — 44/44 passing
- `node dist/cli/index.js preflight --json` parse smoke
- `node dist/cli/index.js check --json` no top-level `preflight` field smoke
- Final code review: APPROVE
- Final architect review: CLEAR

## Non-goals preserved
- No automatic hooks
- No blocking gate / visible enforcement
- No instructionTrust persistence
- No new evidence reads beyond existing operator-check path
- No token/cost telemetry
- No #962 stale detector or #963 handoff generator
