### PR TITLE
Add stale context prompt audit

### DIFF
--- a/docs/stale-context.md
+++ b/docs/stale-context.md
@@ -1,0 +1,32 @@
+# Stale context audit
+
+`fooks stale-context` is a narrow, local-only prompt/handoff audit for issue #962.
+It does not query GitHub, CI, tmux, git remotes, provider runtimes, or hook state.
+Instead, it deterministically scans supplied text for stale-context patterns called out in
+`docs/research/context-trust-and-stale-evidence-research.md`.
+
+## Usage
+
+```sh
+fooks stale-context handoff.md
+fooks stale-context handoff.md --json
+cat prompt.md | fooks stale-context --stdin --json
+```
+
+## Output contract
+
+JSON output includes:
+
+- `summary.hardConflictCount`: text that appears to present stale/historical material as current authority.
+- `summary.advisorySuspectCount`: branch, worktree, or prior-session context that needs fresh evidence.
+- `warnings[].severity`: `hard-conflict` or `advisory-suspect`.
+- `warnings[].authority`: whether the evidence is advisory-only or must not be used as current work.
+- `warnings[].reason` and `warnings[].evidence`: agent-consumable explanation and source line.
+- `warnings[].recommendation`: the next re-check an agent/operator should perform.
+
+## Current limitations
+
+The audit is intentionally lexical and local. It can warn that a prompt says
+"merged PR #123 is the current target," but it cannot prove the live PR state.
+Use it as a preflight warning surface, then re-check current source, branch/worktree
+state, and open issue/PR evidence before editing.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "docs/CODE_OF_CONDUCT.md",
     "SECURITY.md",
     "CONTRIBUTING.md",
-    "CODE_OF_CONDUCT.md"
+    "CODE_OF_CONDUCT.md",
+    "docs/stale-context.md"
   ],
   "repository": {
     "type": "git",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|stale-context|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -644,6 +644,10 @@ Everyday commands:
 
   ${displayCliName} preflight [--json]
       Compact read-only agent guidance projected from the existing operator-check/contextTrust snapshot.
+
+  ${displayCliName} stale-context <prompt-or-handoff.md> [--json]
+  ${displayCliName} stale-context --stdin [--json]
+      Local-only stale-context audit for prompt/handoff text; separates hard conflicts from advisory/suspect warnings.
 
   ${displayCliName} run [--mode auto|raw|hybrid|compressed] [--runner auto|codex|claude] <prompt>
   ${displayCliName} extract <file> [--model-payload] [--json]
@@ -1004,6 +1008,49 @@ function parseStatusReactWebArgs(args: string[]): { json: boolean } {
   }
 
   return { json };
+}
+
+function parseStaleContextArgs(args: string[]): { filePath?: string; stdin: boolean; json: boolean; help: boolean } {
+  let filePath: string | undefined;
+  let stdin = false;
+  let json = false;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--stdin") {
+      stdin = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+    if (!filePath) {
+      filePath = arg;
+      continue;
+    }
+    throw new Error(`Unexpected stale-context argument: ${arg}`);
+  }
+
+  if (stdin && filePath) {
+    throw new Error("stale-context accepts either --stdin or a file path, not both");
+  }
+
+  return { filePath, stdin, json, help };
+}
+
+function staleContextHelp(displayCliName: string): string {
+  return `Usage: ${displayCliName} stale-context <prompt-or-handoff.md> [--json]
+       ${displayCliName} stale-context --stdin [--json]
+
+Deterministically inspect prompt/handoff text for stale-context risk.
+The audit is local-only: it does not query GitHub, git, tmux, provider runtimes, or CI.
+Warnings separate hard conflicts from advisory/suspect context and include evidence/reason.
+`;
 }
 
 function parseDoctorArgs(args: string[]): { target: "all" | "codex" | "claude"; json: boolean; help: boolean } {
@@ -1515,6 +1562,36 @@ async function run(): Promise<void> {
       }
       const { readOperatorCheckSnapshot } = await import("../ops/operator-check.js");
       print(readOperatorCheckSnapshot(process.cwd()));
+      return;
+    }
+    case "stale-context": {
+      let options: ReturnType<typeof parseStaleContextArgs>;
+      try {
+        options = parseStaleContextArgs(rest);
+      } catch (error) {
+        console.error(`fooks stale-context: ${error instanceof Error ? error.message : String(error)}`);
+        console.error(staleContextHelp(displayCliName));
+        process.exitCode = 1;
+        return;
+      }
+      if (options.help) {
+        process.stdout.write(staleContextHelp(displayCliName));
+        return;
+      }
+      if (!options.stdin && !options.filePath) {
+        console.error("fooks stale-context: missing file path or --stdin");
+        console.error(staleContextHelp(displayCliName));
+        process.exitCode = 1;
+        return;
+      }
+      const { auditStaleContextText, renderStaleContextAuditText } = await import("../ops/stale-context.js");
+      const text = options.stdin ? await readStdinText() : fs.readFileSync(requireFilePath(options.filePath), "utf8");
+      const result = auditStaleContextText(text, { source: options.stdin ? "stdin" : path.relative(process.cwd(), path.resolve(options.filePath!)) });
+      if (options.json) {
+        print(result);
+      } else {
+        process.stdout.write(renderStaleContextAuditText(result));
+      }
       return;
     }
     case "preflight": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,3 +282,21 @@ export {
   type WorkItemExplainRejectedEvidence,
   type WorkItemExplainResult,
 } from "./core/work-item-explain";
+
+export {
+  STALE_CONTEXT_CLAIM_BOUNDARY,
+  STALE_CONTEXT_COMMAND,
+  STALE_CONTEXT_RESEARCH_REFERENCE,
+  STALE_CONTEXT_SCHEMA_VERSION,
+  auditStaleContextText,
+  renderStaleContextAuditText,
+} from "./ops/stale-context";
+export type {
+  StaleContextAuditResult,
+  StaleContextAuthority,
+  StaleContextEvidence,
+  StaleContextFreshness,
+  StaleContextSeverity,
+  StaleContextWarning,
+  StaleContextWarningKind,
+} from "./ops/stale-context";

--- a/src/ops/stale-context.ts
+++ b/src/ops/stale-context.ts
@@ -1,0 +1,213 @@
+export const STALE_CONTEXT_SCHEMA_VERSION = 1;
+export const STALE_CONTEXT_COMMAND = "stale-context";
+export const STALE_CONTEXT_RESEARCH_REFERENCE = "docs/research/context-trust-and-stale-evidence-research.md";
+export const STALE_CONTEXT_CLAIM_BOUNDARY =
+  "Deterministic local prompt/handoff text audit only; does not query GitHub, CI, tmux, git remotes, provider runtimes, or validate whether referenced issues/PRs/branches are truly open or closed. Warnings classify lexical stale-context risk and tell agents what evidence to re-check before treating text as current authority.";
+
+export type StaleContextSeverity = "hard-conflict" | "advisory-suspect";
+export type StaleContextAuthority = "must-not-use-as-current" | "advisory-only";
+export type StaleContextFreshness = "stale" | "unknown";
+export type StaleContextWarningKind =
+  | "closed-artifact-as-active"
+  | "receipt-as-active-work"
+  | "historical-doc-as-current-policy"
+  | "branch-or-worktree-without-current-evidence"
+  | "context-hint-authority-escalation"
+  | "previous-session-without-source-validation";
+
+export type StaleContextEvidence = {
+  text: string;
+  line: number;
+  startColumn: number;
+  endColumn: number;
+};
+
+export type StaleContextWarning = {
+  id: string;
+  severity: StaleContextSeverity;
+  kind: StaleContextWarningKind;
+  authority: StaleContextAuthority;
+  freshness: StaleContextFreshness;
+  reason: string;
+  evidence: StaleContextEvidence;
+  recommendation: string;
+};
+
+export type StaleContextAuditResult = {
+  schemaVersion: typeof STALE_CONTEXT_SCHEMA_VERSION;
+  command: typeof STALE_CONTEXT_COMMAND;
+  source: string;
+  mode: "deterministic-local-text-audit";
+  researchReference: typeof STALE_CONTEXT_RESEARCH_REFERENCE;
+  claimBoundary: typeof STALE_CONTEXT_CLAIM_BOUNDARY;
+  summary: {
+    warningCount: number;
+    hardConflictCount: number;
+    advisorySuspectCount: number;
+    requiresCurrentEvidenceRecheck: boolean;
+  };
+  warnings: StaleContextWarning[];
+  limitations: string[];
+};
+
+type Rule = {
+  kind: StaleContextWarningKind;
+  severity: StaleContextSeverity;
+  authority: StaleContextAuthority;
+  freshness: StaleContextFreshness;
+  reason: string;
+  recommendation: string;
+  test: (line: string) => boolean;
+};
+
+const ACTIVE_AUTHORITY_RE = /\b(active|current|continue|resume|target|source of truth|authoritative|use as current|next work|next development|must use|should use)\b/i;
+const CLOSED_ARTIFACT_RE = /\b(closed|merged|done|completed|resolved|archived)\b[^\n#]*(?:\b(?:pr|pull request|issue)\b\s*)?#\d+|(?:\b(?:pr|pull request|issue)\b\s*)?#\d+[^\n]*(?:\b(closed|merged|done|completed|resolved|archived)\b)/i;
+const RECEIPT_RE = /\b(receipt|green receipt|ci (?:passed|success|green)|release success|post-merge|merged commit|main ci)\b/i;
+const ARCHIVE_DOC_RE = /\b(?:docs\/[^\s]*archive[^\s]*|archive doc|archived doc|branch archive|historical doc)\b/i;
+const BRANCH_OR_WORKTREE_RE = /\b(?:worktree|worktrees|branch)\b[^\n]*(?:fooks[-_/][\w./-]+|issue[-_/]?\d+|pr[-_/]?\d+|\/[^\s]*worktrees?\/[^\s]+)/i;
+const CURRENT_EVIDENCE_RE = /\b(?:current evidence|checked now|live evidence|open issue|open pr|open pull request|git status|current source|source recheck|verified now)\b/i;
+const CONTEXT_HINT_RE = /\bcontext hints?\b/i;
+const AUTHORITY_ESCALATION_RE = /\b(?:change|override|grant|set|force|promote)\b[^\n]*(?:ranking|priority|authority|apply|copy|edit authority|source evidence)/i;
+const PREVIOUS_SESSION_RE = /\b(previous session|session summary|handoff summary|old handoff|prior run|prior context)\b/i;
+const SOURCE_VALIDATION_RE = /\b(?:current source|source validation|source recheck|verified against source|git diff|fresh evidence)\b/i;
+
+const RULES: Rule[] = [
+  {
+    kind: "closed-artifact-as-active",
+    severity: "hard-conflict",
+    authority: "must-not-use-as-current",
+    freshness: "stale",
+    reason: "The same line presents a closed/merged issue or PR reference with active/current-work language.",
+    recommendation: "Do not treat the referenced closed/merged artifact as an active target; re-check the current open issue/PR, branch, and source before editing.",
+    test: (line) => CLOSED_ARTIFACT_RE.test(line) && ACTIVE_AUTHORITY_RE.test(line),
+  },
+  {
+    kind: "receipt-as-active-work",
+    severity: "hard-conflict",
+    authority: "must-not-use-as-current",
+    freshness: "stale",
+    reason: "Completion or CI receipt language is being presented as current active-work authority.",
+    recommendation: "Treat receipts as historical evidence only; require a fresh active issue, PR, branch, session, or source diff anchor.",
+    test: (line) => RECEIPT_RE.test(line) && ACTIVE_AUTHORITY_RE.test(line),
+  },
+  {
+    kind: "historical-doc-as-current-policy",
+    severity: "hard-conflict",
+    authority: "must-not-use-as-current",
+    freshness: "stale",
+    reason: "Archive or historical documentation is being presented as current policy/authority.",
+    recommendation: "Use the archive only for background; check current docs and source before following it as policy.",
+    test: (line) => ARCHIVE_DOC_RE.test(line) && ACTIVE_AUTHORITY_RE.test(line),
+  },
+  {
+    kind: "branch-or-worktree-without-current-evidence",
+    severity: "advisory-suspect",
+    authority: "advisory-only",
+    freshness: "unknown",
+    reason: "A branch/worktree reference appears without lexical current-evidence proof on the same line.",
+    recommendation: "Re-check git status/worktree state and active issue/PR evidence before using this as current context.",
+    test: (line) => BRANCH_OR_WORKTREE_RE.test(line) && !CURRENT_EVIDENCE_RE.test(line),
+  },
+  {
+    kind: "context-hint-authority-escalation",
+    severity: "hard-conflict",
+    authority: "must-not-use-as-current",
+    freshness: "stale",
+    reason: "Context hints are advisory and must not alter ranking, priority, source authority, or apply/edit permission.",
+    recommendation: "Keep context hints advisory-only; source-derived evidence and explicit current artifacts win on conflicts.",
+    test: (line) => CONTEXT_HINT_RE.test(line) && AUTHORITY_ESCALATION_RE.test(line),
+  },
+  {
+    kind: "previous-session-without-source-validation",
+    severity: "advisory-suspect",
+    authority: "advisory-only",
+    freshness: "unknown",
+    reason: "Prior-session or handoff summary text appears without current source validation evidence.",
+    recommendation: "Use the summary only as a lead; re-read current source/diff before making or planning edits.",
+    test: (line) => PREVIOUS_SESSION_RE.test(line) && !SOURCE_VALIDATION_RE.test(line),
+  },
+];
+
+function compactLine(line: string): string {
+  return line.trim().replace(/\s+/g, " ");
+}
+
+function evidenceFor(line: string, lineNumber: number): StaleContextEvidence {
+  const compact = compactLine(line);
+  const originalStart = line.search(/\S/);
+  return {
+    text: compact.length > 240 ? `${compact.slice(0, 237)}...` : compact,
+    line: lineNumber,
+    startColumn: originalStart >= 0 ? originalStart + 1 : 1,
+    endColumn: line.length + 1,
+  };
+}
+
+export function auditStaleContextText(text: string, options: { source?: string } = {}): StaleContextAuditResult {
+  const warnings: StaleContextWarning[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    for (const rule of RULES) {
+      if (!rule.test(line)) continue;
+      warnings.push({
+        id: `stale-context-${String(warnings.length + 1).padStart(3, "0")}`,
+        severity: rule.severity,
+        kind: rule.kind,
+        authority: rule.authority,
+        freshness: rule.freshness,
+        reason: rule.reason,
+        evidence: evidenceFor(line, index + 1),
+        recommendation: rule.recommendation,
+      });
+    }
+  }
+
+  const hardConflictCount = warnings.filter((warning) => warning.severity === "hard-conflict").length;
+  const advisorySuspectCount = warnings.filter((warning) => warning.severity === "advisory-suspect").length;
+  return {
+    schemaVersion: STALE_CONTEXT_SCHEMA_VERSION,
+    command: STALE_CONTEXT_COMMAND,
+    source: options.source ?? "inline-text",
+    mode: "deterministic-local-text-audit",
+    researchReference: STALE_CONTEXT_RESEARCH_REFERENCE,
+    claimBoundary: STALE_CONTEXT_CLAIM_BOUNDARY,
+    summary: {
+      warningCount: warnings.length,
+      hardConflictCount,
+      advisorySuspectCount,
+      requiresCurrentEvidenceRecheck: warnings.length > 0,
+    },
+    warnings,
+    limitations: [
+      "No network checks: issue/PR open/closed state is inferred only from the supplied text.",
+      "No git/tmux/filesystem checks: branch, worktree, run, and session freshness must be verified separately.",
+      "Line-local heuristic: multi-line context can require human/operator review.",
+    ],
+  };
+}
+
+export function renderStaleContextAuditText(result: StaleContextAuditResult): string {
+  const lines = [
+    `fooks stale-context: ${result.summary.warningCount === 0 ? "no warnings" : `${result.summary.warningCount} warning(s)`}`,
+    `Source: ${result.source}`,
+    `Hard conflicts: ${result.summary.hardConflictCount}`,
+    `Advisory/suspect: ${result.summary.advisorySuspectCount}`,
+  ];
+
+  if (result.warnings.length > 0) {
+    lines.push("", "Warnings");
+    for (const warning of result.warnings) {
+      lines.push(
+        `- [${warning.severity}] ${warning.kind} at line ${warning.evidence.line}`,
+        `  evidence: ${warning.evidence.text}`,
+        `  reason: ${warning.reason}`,
+        `  next: ${warning.recommendation}`,
+      );
+    }
+  }
+
+  lines.push("", `Boundary: ${result.claimBoundary}`);
+  return `${lines.join("\n")}\n`;
+}

--- a/test/stale-context.test.mjs
+++ b/test/stale-context.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const require = createRequire(import.meta.url);
+const { auditStaleContextText } = require(path.join(repoRoot, "dist", "ops", "stale-context.js"));
+
+test("stale context audit distinguishes hard conflicts from advisory suspect context", () => {
+  const result = auditStaleContextText([
+    "Continue active work from merged PR #868 as the current target.",
+    "Use worktree /tmp/fooks-worktrees/fooks-issue-713 for the next edit.",
+    "Previous session summary says Button.tsx was fixed.",
+  ].join("\n"), { source: "fixture" });
+
+  assert.equal(result.summary.warningCount, 3);
+  assert.equal(result.summary.hardConflictCount, 1);
+  assert.equal(result.summary.advisorySuspectCount, 2);
+  assert.equal(result.summary.requiresCurrentEvidenceRecheck, true);
+  assert.deepEqual(result.warnings.map((warning) => warning.kind), [
+    "closed-artifact-as-active",
+    "branch-or-worktree-without-current-evidence",
+    "previous-session-without-source-validation",
+  ]);
+  assert.equal(result.warnings[0].authority, "must-not-use-as-current");
+  assert.equal(result.warnings[1].authority, "advisory-only");
+});
+
+test("stale context audit flags receipts, archive docs, and context-hint authority escalation", () => {
+  const result = auditStaleContextText([
+    "The green receipt is the current source of truth for next development.",
+    "Use docs/branch-archive-codex-ts-js-same-file-beta-2026-05-01.md as current policy.",
+    "Context hints can override ranking and apply authority.",
+  ].join("\n"));
+
+  assert.equal(result.summary.warningCount, 3);
+  assert.equal(result.summary.hardConflictCount, 3);
+  assert.deepEqual(new Set(result.warnings.map((warning) => warning.kind)), new Set([
+    "receipt-as-active-work",
+    "historical-doc-as-current-policy",
+    "context-hint-authority-escalation",
+  ]));
+  for (const warning of result.warnings) {
+    assert.ok(warning.reason.length > 0);
+    assert.ok(warning.evidence.text.length > 0);
+    assert.ok(warning.recommendation.includes("source") || warning.recommendation.includes("evidence") || warning.recommendation.includes("receipts"));
+  }
+});
+
+test("stale-context CLI reads stdin and emits JSON contract", () => {
+  const stdout = execFileSync(process.execPath, [cli, "stale-context", "--stdin", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input: "Use closed issue #962 as active source of truth.\n",
+  });
+  const result = JSON.parse(stdout);
+
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.command, "stale-context");
+  assert.equal(result.source, "stdin");
+  assert.equal(result.summary.hardConflictCount, 1);
+  assert.equal(result.warnings[0].kind, "closed-artifact-as-active");
+  assert.match(result.claimBoundary, /Deterministic local prompt\/handoff text audit only/);
+});
+
+test("stale-context CLI reads a file and renders text", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-stale-context-"));
+  const promptPath = path.join(tempDir, "handoff.md");
+  fs.writeFileSync(promptPath, "Previous session summary says continue branch fooks-issue-918.\n");
+
+  try {
+    const stdout = execFileSync(process.execPath, [cli, "stale-context", promptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    assert.match(stdout, /fooks stale-context: 2 warning\(s\)/);
+    assert.match(stdout, /advisory-suspect/);
+    assert.match(stdout, /branch-or-worktree-without-current-evidence/);
+    assert.match(stdout, /previous-session-without-source-validation/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #962.
Adds a narrow, local-only stale-context warning surface:

- `fooks stale-context <prompt-or-handoff.md> [--json]`
- `fooks stale-context --stdin [--json]`
- deterministic prompt/handoff text audit that distinguishes `hard-conflict` from `advisory-suspect` warnings
- agent-consumable JSON warnings with `kind`, `authority`, `freshness`, `reason`, `evidence`, and `recommendation`
- docs and focused tests for stale closed/merged artifacts, receipts, archive docs, branch/worktree mentions, context-hint authority escalation, and prior session summaries

## Boundaries

- Does not implement #963 handoff packet.
- Does not implement runtime/token-cost planning.
- Does not change provider/runtime hook behavior.
- Does not query GitHub, CI, tmux, git remotes, or provider runtimes; the detector is documented as deterministic local parsing with re-check recommendations.

## Verification

- `git diff --check`
- `npm run build && node --test test/stale-context.test.mjs`
- `npm test`
- `npm run lint && node --test test/stale-context.test.mjs`

