### PR TITLE
Add source-of-truth handoff packet

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|stale-context|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|handoff|stale-context|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -644,6 +644,9 @@ Everyday commands:
 
   ${displayCliName} preflight [--json]
       Compact read-only agent guidance projected from the existing operator-check/contextTrust snapshot.
+
+  ${displayCliName} handoff [--json]
+      Compact source-of-truth handoff packet for fresh agent sessions, bounded to the current branch/worktree.
 
   ${displayCliName} stale-context <prompt-or-handoff.md> [--json]
   ${displayCliName} stale-context --stdin [--json]
@@ -1607,6 +1610,23 @@ async function run(): Promise<void> {
       ]);
       const snapshot = readOperatorCheckSnapshot(process.cwd());
       print(buildPreflightPacket(snapshot));
+      return;
+    }
+    case "handoff": {
+      const allowed = new Set(["--json"]);
+      for (const arg of rest) {
+        if (!allowed.has(arg)) {
+          throw new Error(`Unexpected handoff argument: ${arg}`);
+        }
+      }
+      const [{ readOperatorCheckSnapshot }, { buildPreflightPacket }, { buildSourceOfTruthHandoffPacket }] = await Promise.all([
+        import("../ops/operator-check.js"),
+        import("../ops/preflight.js"),
+        import("../ops/source-of-truth-handoff.js"),
+      ]);
+      const snapshot = readOperatorCheckSnapshot(process.cwd());
+      const preflight = buildPreflightPacket(snapshot);
+      print(buildSourceOfTruthHandoffPacket(snapshot, preflight));
       return;
     }
     case "status": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,3 +300,17 @@ export type {
   StaleContextWarning,
   StaleContextWarningKind,
 } from "./ops/stale-context";
+export {
+  SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY,
+  SOURCE_OF_TRUTH_HANDOFF_COMMAND,
+  SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION,
+  SOURCE_OF_TRUTH_HANDOFF_SOURCE,
+  buildSourceOfTruthHandoffPacket,
+} from "./ops/source-of-truth-handoff";
+export type {
+  SourceOfTruthHandoffCommandRunner,
+  SourceOfTruthHandoffOptions,
+  SourceOfTruthHandoffPacket,
+  SourceOfTruthLinkedArtifact,
+  SourceOfTruthPrCheck,
+} from "./ops/source-of-truth-handoff";

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -1,0 +1,354 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import type { OperatorCheckSnapshot } from "./operator-check";
+import type { PreflightPacket } from "./preflight";
+import { STALE_CONTEXT_COMMAND } from "./stale-context";
+
+export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
+export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
+export const SOURCE_OF_TRUTH_HANDOFF_SOURCE = "fooks check/preflight plus current-branch source-of-truth handoff projection";
+export const SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY =
+  "Compact read-only handoff packet for fresh agent sessions; bounded to the invocation cwd/current branch/worktree, reuses operator-check/preflight contracts, performs only narrow git and gh issue/PR/status reads for linked current artifacts, and does not mutate hooks, provider/runtime behavior, stale detector scope, token/cost planning, product claims, or frontend behavior.";
+
+export type SourceOfTruthHandoffCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
+
+export type SourceOfTruthHandoffOptions = {
+  commandRunner?: SourceOfTruthHandoffCommandRunner;
+  now?: () => string;
+};
+
+export type SourceOfTruthLinkedArtifact =
+  | {
+      status: "linked";
+      source: string;
+      number: number;
+      state?: string;
+      title?: string;
+      url?: string;
+      headRefName?: string;
+      baseRefName?: string;
+      isDraft?: boolean;
+    }
+  | {
+      status: "not-found" | "not-inferred" | "unavailable";
+      source: string;
+      reason: string;
+      number?: number;
+    };
+
+export type SourceOfTruthPrCheck = {
+  name: string;
+  status?: string;
+  conclusion?: string;
+  detailsUrl?: string;
+};
+
+export type SourceOfTruthHandoffPacket = {
+  schemaVersion: typeof SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION;
+  command: typeof SOURCE_OF_TRUTH_HANDOFF_COMMAND;
+  generatedAt: string;
+  cwd: string;
+  source: typeof SOURCE_OF_TRUTH_HANDOFF_SOURCE;
+  claimBoundary: typeof SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY;
+  derivedFrom: {
+    operatorCheckCommand: "check";
+    operatorCheckSchemaVersion: 1;
+    preflightCommand: "preflight";
+    preflightSchemaVersion: 1;
+    staleContextCommand: typeof STALE_CONTEXT_COMMAND;
+  };
+  scope: {
+    cwd: string;
+    branch?: string;
+    head?: string;
+    upstream?: string;
+    clean: boolean | null;
+    ahead?: number;
+    behind?: number;
+    changedPathCount: number;
+    changedPaths: string[];
+    changedPathLimit: number;
+    source: string;
+  };
+  linkedArtifacts: {
+    issue: SourceOfTruthLinkedArtifact;
+    pullRequest: SourceOfTruthLinkedArtifact;
+  };
+  currentStatus: {
+    operatorCheck: {
+      verdict: OperatorCheckSnapshot["verdict"];
+      generatedAt: string;
+      blockers: string[];
+      source: OperatorCheckSnapshot["source"];
+    };
+    preflight: PreflightPacket["guidance"] & { authorityStatus: PreflightPacket["summary"]["authorityStatus"] };
+    ci: {
+      source: OperatorCheckSnapshot["postMergeMainCiEvidence"]["source"];
+      remoteFreshness: OperatorCheckSnapshot["postMergeMainCiEvidence"]["remoteFreshness"];
+      summary: OperatorCheckSnapshot["postMergeMainCiEvidence"]["summary"];
+      workflows: Array<Pick<OperatorCheckSnapshot["postMergeMainCiEvidence"]["workflowEvidence"][number], "workflow" | "status" | "conclusion" | "runStatus" | "url" | "headSha" | "reason">>;
+    };
+    pullRequestChecks: {
+      status: "available" | "not-linked" | "unavailable";
+      source: string;
+      checks: SourceOfTruthPrCheck[];
+      reason?: string;
+    };
+  };
+  sourceOfTruth: {
+    currentAuthority: PreflightPacket["currentAuthority"];
+    authoritativeFilesAndDocs: string[];
+    currentChangedFiles: string[];
+  };
+  staleOrHistoricalContextToAvoid: Array<{
+    kind: string;
+    source: string;
+    reason: string;
+    referenceField?: string;
+  }>;
+  nextRecommendedAction: {
+    action: PreflightPacket["guidance"]["recommendedAction"] | "continue-implementation-for-linked-issue" | "open-pr-or-push-current-branch";
+    rationale: string;
+    suggestedCommands: string[];
+  };
+  blockers: string[];
+};
+
+const GIT_SOURCE = "local git for invocation cwd/current branch; no fetch performed";
+const ISSUE_SOURCE = "gh issue view <inferred issue number> --json number,title,state,url";
+const PR_SOURCE = "gh pr list --head <current branch> --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1";
+const CHANGED_PATH_LIMIT = 40;
+const AUTHORITATIVE_FILES_AND_DOCS = [
+  "src/ops/operator-check.ts",
+  "src/ops/context-trust.ts",
+  "src/ops/preflight.ts",
+  "src/ops/stale-context.ts",
+  "src/ops/source-of-truth-handoff.ts",
+  "src/cli/index.ts",
+  "docs/research/context-trust-and-stale-evidence-research.md",
+  "docs/stale-context.md",
+];
+
+function run(command: string, args: string[], cwd: string, timeoutMs: number, runner?: SourceOfTruthHandoffCommandRunner): string {
+  if (runner) return runner(command, args, cwd, timeoutMs);
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+}
+
+function tryRun(command: string, args: string[], cwd: string, timeoutMs: number, runner?: SourceOfTruthHandoffCommandRunner): { output?: string; blocker?: string } {
+  try {
+    return { output: run(command, args, cwd, timeoutMs, runner).trim() };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { blocker: `${command} ${args.join(" ")} unavailable: ${detail}` };
+  }
+}
+
+function parseJson<T>(text: string | undefined, fallback: T): T {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function inferIssueNumber(branch: string | undefined): number | undefined {
+  if (!branch) return undefined;
+  const match = branch.match(/(?:^|[-_/])(?:issue|issues|gh)[-_/]?(\d+)(?:\D|$)/iu) ?? branch.match(/#(\d+)\b/u);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  return Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function readChangedPaths(cwd: string, runner?: SourceOfTruthHandoffCommandRunner): string[] {
+  const status = tryRun("git", ["status", "--porcelain=v1"], cwd, 1000, runner);
+  if (!status.output) return [];
+  return status.output
+    .split(/\r?\n/u)
+    .map((line) => line.replace(/^.. ?/u, "").trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^(.+?) -> /u, ""))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function linkedIssue(cwd: string, branch: string | undefined, blockers: string[], runner?: SourceOfTruthHandoffCommandRunner): SourceOfTruthLinkedArtifact {
+  const issueNumber = inferIssueNumber(branch);
+  if (!issueNumber) {
+    return { status: "not-inferred", source: ISSUE_SOURCE, reason: "current branch name does not contain an issue number" };
+  }
+  const result = tryRun("gh", ["issue", "view", String(issueNumber), "--json", "number,title,state,url"], cwd, 1500, runner);
+  if (result.blocker) {
+    blockers.push(result.blocker);
+    return { status: "unavailable", source: ISSUE_SOURCE, reason: result.blocker, number: issueNumber };
+  }
+  const parsed = parseJson<{ number?: number; title?: string; state?: string; url?: string }>(result.output, {});
+  if (!parsed.number) {
+    return { status: "not-found", source: ISSUE_SOURCE, reason: "gh returned no issue number", number: issueNumber };
+  }
+  return { status: "linked", source: ISSUE_SOURCE, number: parsed.number, title: parsed.title, state: parsed.state, url: parsed.url };
+}
+
+function linkedPullRequest(cwd: string, branch: string | undefined, blockers: string[], runner?: SourceOfTruthHandoffCommandRunner): { artifact: SourceOfTruthLinkedArtifact; checks: SourceOfTruthPrCheck[]; checksReason?: string } {
+  if (!branch) {
+    return { artifact: { status: "not-inferred", source: PR_SOURCE, reason: "current branch is unavailable" }, checks: [], checksReason: "current branch is unavailable" };
+  }
+  const result = tryRun("gh", ["pr", "list", "--head", branch, "--state", "all", "--json", "number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup", "--limit", "1"], cwd, 1500, runner);
+  if (result.blocker) {
+    blockers.push(result.blocker);
+    return { artifact: { status: "unavailable", source: PR_SOURCE, reason: result.blocker }, checks: [], checksReason: result.blocker };
+  }
+  const parsedList = parseJson<Array<{
+    number?: number;
+    title?: string;
+    state?: string;
+    url?: string;
+    headRefName?: string;
+    baseRefName?: string;
+    isDraft?: boolean;
+    statusCheckRollup?: Array<{ name?: string; workflowName?: string; status?: string; conclusion?: string; detailsUrl?: string }>;
+  }>>(result.output, []);
+  const parsed = parsedList[0] ?? {};
+  if (!parsed.number) {
+    return { artifact: { status: "not-found", source: PR_SOURCE, reason: `gh returned no pull request for current branch ${branch}` }, checks: [], checksReason: "no linked pull request" };
+  }
+  const checks = (parsed.statusCheckRollup ?? []).slice(0, 20).map((check) => ({
+    name: check.name ?? check.workflowName ?? "unnamed-check",
+    ...(check.status ? { status: check.status } : {}),
+    ...(check.conclusion ? { conclusion: check.conclusion } : {}),
+    ...(check.detailsUrl ? { detailsUrl: check.detailsUrl } : {}),
+  }));
+  return {
+    artifact: {
+      status: "linked",
+      source: PR_SOURCE,
+      number: parsed.number,
+      title: parsed.title,
+      state: parsed.state,
+      url: parsed.url,
+      headRefName: parsed.headRefName,
+      baseRefName: parsed.baseRefName,
+      isDraft: parsed.isDraft,
+    },
+    checks,
+  };
+}
+
+function staleAvoidList(snapshot: OperatorCheckSnapshot, preflight: PreflightPacket): SourceOfTruthHandoffPacket["staleOrHistoricalContextToAvoid"] {
+  return [...preflight.historicalOnly, ...preflight.nonAuthorizing].map((entry) => ({
+    kind: entry.kind,
+    source: entry.source,
+    reason: entry.reason,
+    ...(entry.referenceField ? { referenceField: entry.referenceField } : {}),
+  }));
+}
+
+function nextAction(preflight: PreflightPacket, issue: SourceOfTruthLinkedArtifact, pr: SourceOfTruthLinkedArtifact, changedPathCount: number): SourceOfTruthHandoffPacket["nextRecommendedAction"] {
+  if (preflight.guidance.recommendedAction === "continue-with-current-authority" && issue.status === "linked" && issue.state === "OPEN" && pr.status !== "linked" && changedPathCount > 0) {
+    return {
+      action: "open-pr-or-push-current-branch",
+      rationale: "linked open issue and local changes exist, but no current-branch pull request was found; finish verification, then publish/link the branch or open a PR.",
+      suggestedCommands: ["npm run build", "npm test", "gh pr create --fill"],
+    };
+  }
+  if (preflight.guidance.recommendedAction === "continue-with-current-authority" && issue.status === "linked") {
+    return {
+      action: "continue-implementation-for-linked-issue",
+      rationale: `continue against linked issue #${issue.number}; keep source authority in current files and re-run check/handoff before handing off again.`,
+      suggestedCommands: ["npm run build", "npm test", "fooks check --json", "fooks handoff --json"],
+    };
+  }
+  return {
+    action: preflight.guidance.recommendedAction,
+    rationale: preflight.guidance.rationale,
+    suggestedCommands: ["fooks check --json", "fooks preflight --json", "fooks stale-context --stdin --json"],
+  };
+}
+
+export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot, preflight: PreflightPacket, options: SourceOfTruthHandoffOptions = {}): SourceOfTruthHandoffPacket {
+  const cwd = snapshot.cwd;
+  const blockers = [...snapshot.blockers];
+  const branch = snapshot.activity.worktree.branch ?? snapshot.runtimeProvenance.git.branch;
+  const head = snapshot.runtimeProvenance.git.head;
+  const upstream = snapshot.activity.worktree.upstream;
+  const changedPaths = readChangedPaths(cwd, options.commandRunner);
+  const issue = linkedIssue(cwd, branch, blockers, options.commandRunner);
+  const prResult = linkedPullRequest(cwd, branch, blockers, options.commandRunner);
+  const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
+    workflow: workflow.workflow,
+    status: workflow.status,
+    ...(workflow.conclusion ? { conclusion: workflow.conclusion } : {}),
+    ...(workflow.runStatus ? { runStatus: workflow.runStatus } : {}),
+    ...(workflow.url ? { url: workflow.url } : {}),
+    ...(workflow.headSha ? { headSha: workflow.headSha } : {}),
+    reason: workflow.reason,
+  }));
+
+  return {
+    schemaVersion: SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION,
+    command: SOURCE_OF_TRUTH_HANDOFF_COMMAND,
+    generatedAt: options.now ? options.now() : new Date().toISOString(),
+    cwd,
+    source: SOURCE_OF_TRUTH_HANDOFF_SOURCE,
+    claimBoundary: SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY,
+    derivedFrom: {
+      operatorCheckCommand: snapshot.command,
+      operatorCheckSchemaVersion: snapshot.schemaVersion,
+      preflightCommand: preflight.command,
+      preflightSchemaVersion: preflight.schemaVersion,
+      staleContextCommand: STALE_CONTEXT_COMMAND,
+    },
+    scope: {
+      cwd,
+      ...(branch ? { branch } : {}),
+      ...(head ? { head } : {}),
+      ...(upstream ? { upstream } : {}),
+      clean: snapshot.activity.worktree.clean,
+      ...(snapshot.activity.worktree.ahead !== undefined ? { ahead: snapshot.activity.worktree.ahead } : {}),
+      ...(snapshot.activity.worktree.behind !== undefined ? { behind: snapshot.activity.worktree.behind } : {}),
+      changedPathCount: changedPaths.length,
+      changedPaths: changedPaths.slice(0, CHANGED_PATH_LIMIT),
+      changedPathLimit: CHANGED_PATH_LIMIT,
+      source: GIT_SOURCE,
+    },
+    linkedArtifacts: {
+      issue,
+      pullRequest: prResult.artifact,
+    },
+    currentStatus: {
+      operatorCheck: {
+        verdict: snapshot.verdict,
+        generatedAt: snapshot.generatedAt,
+        blockers: snapshot.blockers,
+        source: snapshot.source,
+      },
+      preflight: {
+        ...preflight.guidance,
+        authorityStatus: preflight.summary.authorityStatus,
+      },
+      ci: {
+        source: snapshot.postMergeMainCiEvidence.source,
+        remoteFreshness: snapshot.postMergeMainCiEvidence.remoteFreshness,
+        summary: snapshot.postMergeMainCiEvidence.summary,
+        workflows,
+      },
+      pullRequestChecks: prResult.artifact.status === "linked"
+        ? { status: "available", source: PR_SOURCE, checks: prResult.checks }
+        : { status: prResult.artifact.status === "unavailable" ? "unavailable" : "not-linked", source: PR_SOURCE, checks: [], ...(prResult.checksReason ? { reason: prResult.checksReason } : {}) },
+    },
+    sourceOfTruth: {
+      currentAuthority: preflight.currentAuthority,
+      authoritativeFilesAndDocs: AUTHORITATIVE_FILES_AND_DOCS.map((entry) => path.normalize(entry)),
+      currentChangedFiles: changedPaths.slice(0, CHANGED_PATH_LIMIT),
+    },
+    staleOrHistoricalContextToAvoid: staleAvoidList(snapshot, preflight),
+    nextRecommendedAction: nextAction(preflight, issue, prResult.artifact, changedPaths.length),
+    blockers,
+  };
+}

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const cli = path.join(repoRoot, "dist", "cli", "index.js");
+const { buildSourceOfTruthHandoffPacket } = require(path.join(repoRoot, "dist", "ops", "source-of-truth-handoff.js"));
+
+function baseSnapshot(cwd) {
+  return {
+    schemaVersion: 1,
+    command: "check",
+    generatedAt: "2026-05-19T00:00:00.000Z",
+    cwd,
+    source: "fooks check --json",
+    verdict: "ready",
+    blockers: [],
+    runtimeProvenance: { git: { branch: "fooks-issue-963-source-of-truth-handoff", head: "abc123" } },
+    activity: {
+      worktree: {
+        branch: "fooks-issue-963-source-of-truth-handoff",
+        upstream: "origin/fooks-issue-963-source-of-truth-handoff",
+        clean: false,
+        ahead: 1,
+        behind: 0,
+      },
+    },
+    postMergeMainCiEvidence: {
+      source: "GitHub Actions run list for exact local origin/main head; read-only and no fetch performed",
+      remoteFreshness: "not verified",
+      summary: {
+        exactHeadWorkflowCount: 1,
+        successCount: 1,
+        pendingCount: 0,
+        unknownCount: 0,
+        failureCount: 0,
+        allExactHeadConclusionsSuccessful: true,
+      },
+      workflowEvidence: [
+        { workflow: "CI", status: "success", conclusion: "success", reason: "success", url: "https://example.test/run", headSha: "abc123" },
+      ],
+    },
+  };
+}
+
+function basePreflight() {
+  return {
+    schemaVersion: 1,
+    command: "preflight",
+    summary: { authorityStatus: "present" },
+    guidance: { riskLevel: "low", recommendedAction: "continue-with-current-authority", rationale: "current authority exists" },
+    currentAuthority: [{ kind: "issue", source: "activeArtifacts", reason: "open issue count", contractScope: "top-level-active-artifact" }],
+    historicalOnly: [{ kind: "post-merge-main-ci-receipt", source: "main ci", reason: "receipt only", referenceField: "postMergeMainCiEvidence" }],
+    nonAuthorizing: [{ kind: "stale-residue-active-boundary", source: "stale residue", reason: "cleanup-review only" }],
+  };
+}
+
+test("source-of-truth handoff packet links inferred issue, current branch PR checks, and stale avoid list", () => {
+  const cwd = repoRoot;
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return " M src/ops/source-of-truth-handoff.ts\n?? test/source-of-truth-handoff.test.mjs\n";
+    if (key === "gh issue view 963 --json number,title,state,url") {
+      return JSON.stringify({ number: 963, title: "source of truth handoff", state: "OPEN", url: "https://github.com/minislively/fooks/issues/963" });
+    }
+    if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return JSON.stringify([{
+        number: 1001,
+        title: "handoff",
+        state: "OPEN",
+        url: "https://github.com/minislively/fooks/pull/1001",
+        headRefName: "fooks-issue-963-source-of-truth-handoff",
+        baseRefName: "main",
+        isDraft: false,
+        statusCheckRollup: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS", detailsUrl: "https://example.test/check" }],
+      }]);
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), { runner, commandRunner: runner, now: () => "2026-05-19T01:02:03.000Z" });
+  assert.equal(packet.command, "handoff");
+  assert.equal(packet.linkedArtifacts.issue.status, "linked");
+  assert.equal(packet.linkedArtifacts.issue.number, 963);
+  assert.equal(packet.linkedArtifacts.pullRequest.status, "linked");
+  assert.equal(packet.currentStatus.pullRequestChecks.status, "available");
+  assert.equal(packet.currentStatus.pullRequestChecks.checks[0].name, "CI");
+  assert.deepEqual(packet.scope.changedPaths, ["src/ops/source-of-truth-handoff.ts", "test/source-of-truth-handoff.test.mjs"]);
+  assert.match(packet.claimBoundary, /bounded to the invocation cwd\/current branch\/worktree/);
+  assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/operator-check.ts"));
+  assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/source-of-truth-handoff.ts"));
+  assert.equal(packet.staleOrHistoricalContextToAvoid.length, 2);
+  assert.equal(packet.nextRecommendedAction.action, "continue-implementation-for-linked-issue");
+});
+
+test("handoff CLI emits JSON packet", () => {
+  const stdout = execFileSync(process.execPath, [cli, "handoff", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
+  const packet = JSON.parse(stdout);
+  assert.equal(packet.schemaVersion, 1);
+  assert.equal(packet.command, "handoff");
+  assert.equal(packet.derivedFrom.operatorCheckCommand, "check");
+  assert.equal(packet.derivedFrom.preflightCommand, "preflight");
+  assert.equal(packet.derivedFrom.staleContextCommand, "stale-context");
+  assert.ok(Array.isArray(packet.sourceOfTruth.authoritativeFilesAndDocs));
+  assert.ok(packet.currentStatus.operatorCheck.verdict);
+});


### PR DESCRIPTION
## Summary

Fixes #963.

Adds a narrow source-of-truth handoff packet surface for fresh agent sessions:

- `fooks source-of-truth-handoff [--json]`
- branch/worktree and inferred issue/PR anchors
- current PR check evidence when available
- authoritative source files/docs
- stale/historical context to avoid carrying forward
- next recommended action for the next agent session

## Boundaries

- Does not broaden #962 stale-context detection.
- Does not change provider/runtime hooks, token-cost planning, merge-gate policy, React Web/RN/TUI/WebView behavior, or product claims.
- Keeps the packet deterministic and local-first, with GitHub evidence only through existing CLI/gh surfaces.

## Verification

- `npm ci`
- `git diff --check HEAD`
- `npm run build`
- `node --test test/source-of-truth-handoff.test.mjs`
