### PR TITLE
Add runtime token-cost planning warning

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -19,6 +19,7 @@ import {
 import { STALE_WORKTREE_AUDIT_COMMAND, STALE_WORKTREE_AUDIT_ISSUE } from "./stale-worktree-audit";
 import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./context-trust";
+import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -561,6 +562,7 @@ export type OperatorCheckSnapshot = {
   activeWorkReceipts: OperatorCheckActiveWorkReceipts;
   requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
   contextTrust: OperatorContextTrustPacket;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
   activity: OperatorActivitySnapshot;
   blockers: string[];
 };
@@ -1590,6 +1592,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const activity = readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true });
   const activeArtifacts = activeArtifactsFrom(activity);
   const activeWorkReceipts = buildActiveWorkReceipts(cwd, activity, options);
+  const branch = activity.worktree.branch;
   const blockers = checkProjectionBlockers([...activity.blockers]);
   const hasActiveArtifact = activeArtifacts.length > 0;
   const optionalCountBlockers = activity.optionalCounts.enabled ? activity.optionalCounts.blockers : [];
@@ -1633,6 +1636,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     activeWorkReceipts,
     requiredActiveArtifact: requiredArtifact,
     contextTrust,
+    planningWarnings: buildRuntimeTokenCostPlanningWarnings({ branch }),
     activity,
     blockers,
   };

--- a/src/ops/runtime-token-cost-planning-warning.ts
+++ b/src/ops/runtime-token-cost-planning-warning.ts
@@ -1,0 +1,67 @@
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION = 1;
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE = "#960";
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE = "deterministic issue #960 runtime/token-cost planning advisory";
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_CLAIM_BOUNDARY =
+  "Advisory planning warning only for issue #960; does not change provider/runtime hooks, real billing/token accounting, merge-gate policy, frontend behavior, or product claims.";
+
+export type RuntimeTokenCostPlanningWarningTrigger = "branch-issue-960" | "linked-issue-960";
+
+export type RuntimeTokenCostPlanningWarning = {
+  schemaVersion: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION;
+  issue: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE;
+  status: "advisory";
+  source: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE;
+  trigger: RuntimeTokenCostPlanningWarningTrigger;
+  prerequisiteIssues: ["#961", "#962", "#963"];
+  message: string;
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  claimBoundary: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_CLAIM_BOUNDARY;
+};
+
+function inferredIssueNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.match(/(?:^|[-_/])(?:issue|issues|gh)[-_/]?(\d+)(?:\D|$)/iu) ?? value.match(/#(\d+)\b/u);
+  if (!match) return undefined;
+  const issue = Number(match[1]);
+  return Number.isInteger(issue) && issue > 0 ? issue : undefined;
+}
+
+export function buildRuntimeTokenCostPlanningWarnings(input: {
+  branch?: string;
+  linkedIssueNumber?: number;
+}): RuntimeTokenCostPlanningWarning[] {
+  const trigger: RuntimeTokenCostPlanningWarningTrigger | undefined = input.linkedIssueNumber === 960
+    ? "linked-issue-960"
+    : inferredIssueNumber(input.branch) === 960
+      ? "branch-issue-960"
+      : undefined;
+
+  if (!trigger) return [];
+
+  return [
+    {
+      schemaVersion: RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION,
+      issue: RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE,
+      status: "advisory",
+      source: RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE,
+      trigger,
+      prerequisiteIssues: ["#961", "#962", "#963"],
+      message: "Issue #960 runtime/token-cost work must stay in planning/advisory mode unless current source-of-truth evidence confirms the #961 preflight, #962 stale-context, and #963 handoff contracts are already in place.",
+      requiredRechecks: [
+        "Run fooks check --json to inspect current operator/check authority.",
+        "Run fooks preflight --json to inspect current preflight guidance.",
+        "Run fooks handoff --json to inspect current source-of-truth handoff state before fresh-agent handoff.",
+        "Use separate explicit implementation approval before changing provider/runtime hooks or token/cost accounting.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "merge-gate policy change",
+        "frontend runtime behavior change",
+      ],
+      claimBoundary: RUNTIME_TOKEN_COST_PLANNING_WARNING_CLAIM_BOUNDARY,
+    },
+  ];
+}

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OperatorCheckSnapshot } from "./operator-check";
 import type { PreflightPacket } from "./preflight";
 import { STALE_CONTEXT_COMMAND } from "./stale-context";
+import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -111,6 +112,7 @@ export type SourceOfTruthHandoffPacket = {
     rationale: string;
     suggestedCommands: string[];
   };
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
   blockers: string[];
 };
 
@@ -124,6 +126,7 @@ const AUTHORITATIVE_FILES_AND_DOCS = [
   "src/ops/preflight.ts",
   "src/ops/stale-context.ts",
   "src/ops/source-of-truth-handoff.ts",
+  "src/ops/runtime-token-cost-planning-warning.ts",
   "src/cli/index.ts",
   "docs/research/context-trust-and-stale-evidence-research.md",
   "docs/stale-context.md",
@@ -280,6 +283,8 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const changedPaths = readChangedPaths(cwd, options.commandRunner);
   const issue = linkedIssue(cwd, branch, blockers, options.commandRunner);
   const prResult = linkedPullRequest(cwd, branch, blockers, options.commandRunner);
+  const linkedIssueNumber = issue.status === "linked" ? issue.number : undefined;
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
@@ -349,6 +354,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     },
     staleOrHistoricalContextToAvoid: staleAvoidList(snapshot, preflight),
     nextRecommendedAction: nextAction(preflight, issue, prResult.artifact, changedPaths.length),
+    planningWarnings,
     blockers,
   };
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3298,3 +3298,48 @@ test("source checkout npm operator aliases route to built CLI behavior", () => {
   assert.match(activity.runtimeProvenance.artifacts.cliEntrypointPath, /dist[\\/]cli[\\/]index\.js$/);
   assert.match(activity.runtimeProvenance.artifacts.operatorActivityModulePath, /dist[\\/]ops[\\/]operator-activity\.js$/);
 });
+
+test("operator check JSON includes narrow issue #960 runtime/token-cost planning advisory", () => {
+  const tempDir = makeTempProject();
+  const branch = "fooks-issue-960-runtime-token-cost-plan";
+  const head = "issue-960-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-19T02:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return `${branch}\n`;
+      if (args[0] === "rev-parse") return `${head}\n`;
+      if (args[0] === "rev-list") return "1\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number,title,url --limit 20") {
+        return JSON.stringify([{ number: 960, title: "runtime token cost planning", url: "https://github.com/minislively/fooks/issues/960" }]);
+      }
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${head}`, `branch refs/heads/${branch}`, ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return `${branch}\nmain\n`;
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 1\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.planningWarnings.length, 1);
+  assert.equal(snapshot.planningWarnings[0].issue, "#960");
+  assert.equal(snapshot.planningWarnings[0].trigger, "branch-issue-960");
+  assert.match(snapshot.planningWarnings[0].message, /#961 preflight, #962 stale-context, and #963 handoff contracts/);
+  assert.match(snapshot.planningWarnings[0].claimBoundary, /Advisory planning warning only/);
+});

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -109,3 +109,43 @@ test("handoff CLI emits JSON packet", () => {
   assert.ok(Array.isArray(packet.sourceOfTruth.authoritativeFilesAndDocs));
   assert.ok(packet.currentStatus.operatorCheck.verdict);
 });
+
+test("source-of-truth handoff emits narrow issue #960 runtime/token-cost planning warning only", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-960-runtime-token-cost-plan";
+  snapshot.activity.worktree.branch = "fooks-issue-960-runtime-token-cost-plan";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-960-runtime-token-cost-plan";
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 960 --json number,title,state,url") {
+      return JSON.stringify({ number: 960, title: "runtime token cost planning", state: "OPEN", url: "https://github.com/minislively/fooks/issues/960" });
+    }
+    if (key === "gh pr list --head fooks-issue-960-runtime-token-cost-plan --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-19T01:02:03.000Z" });
+  assert.equal(packet.planningWarnings.length, 1);
+  assert.equal(packet.planningWarnings[0].issue, "#960");
+  assert.equal(packet.planningWarnings[0].status, "advisory");
+  assert.equal(packet.planningWarnings[0].trigger, "linked-issue-960");
+  assert.deepEqual(packet.planningWarnings[0].prerequisiteIssues, ["#961", "#962", "#963"]);
+  assert.match(packet.planningWarnings[0].claimBoundary, /does not change provider\/runtime hooks/);
+  assert.match(packet.planningWarnings[0].forbiddenClaims.join("\n"), /provider usage\/billing-token proof/);
+
+  const nonTargetPacket = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), {
+    commandRunner: (command, args) => {
+      const key = `${command} ${args.join(" ")}`;
+      if (key === "git status --porcelain=v1") return "";
+      if (key === "gh issue view 963 --json number,title,state,url") return JSON.stringify({ number: 963, state: "OPEN" });
+      if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") return "[]";
+      throw new Error(`unexpected command: ${key}`);
+    },
+    now: () => "2026-05-19T01:02:03.000Z",
+  });
+  assert.deepEqual(nonTargetPacket.planningWarnings, []);
+});


### PR DESCRIPTION
## Summary

Fixes #974.

Adds a narrow runtime/token-cost planning warning for the #960 reliability epic:

- deterministic advisory-only warning in check JSON for issue #960 branches/anchors
- source-of-truth handoff packet carries the same advisory boundary
- focused tests lock that the warning is planning guidance, not billing telemetry or runtime/provider behavior

## Boundaries

- Does not change provider/runtime hooks.
- Does not claim real billing or token accounting telemetry.
- Does not change merge-gate policy.
- Does not broaden React Web/RN/TUI/WebView behavior or product claims.
- Keeps #961/#962/#963 rechecks as recommendations only.

## Verification

- `npm ci`
- `git diff --check HEAD`
- `npm run build`
- `node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs`
- `npm test`
