### PR TITLE
Add issue 976 runtime planning advisory

### DIFF
--- a/src/ops/runtime-token-cost-planning-warning.ts
+++ b/src/ops/runtime-token-cost-planning-warning.ts
@@ -1,14 +1,23 @@
 export const RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION = 1;
 export const RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE = "#960";
-export const RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE = "deterministic issue #960 runtime/token-cost planning advisory";
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_FOLLOWUP_ISSUE = "#976";
+export const RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE = "deterministic runtime/token-cost planning advisory";
 export const RUNTIME_TOKEN_COST_PLANNING_WARNING_CLAIM_BOUNDARY =
-  "Advisory planning warning only for issue #960; does not change provider/runtime hooks, real billing/token accounting, merge-gate policy, frontend behavior, or product claims.";
+  "Advisory planning warning only for issues #960/#976; does not change provider/runtime hooks, real billing/token accounting, merge-gate policy, frontend behavior, or product claims.";
 
-export type RuntimeTokenCostPlanningWarningTrigger = "branch-issue-960" | "linked-issue-960";
+export type RuntimeTokenCostPlanningWarningIssue =
+  | typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE
+  | typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_FOLLOWUP_ISSUE;
+
+export type RuntimeTokenCostPlanningWarningTrigger =
+  | "branch-issue-960"
+  | "linked-issue-960"
+  | "branch-issue-976"
+  | "linked-issue-976";
 
 export type RuntimeTokenCostPlanningWarning = {
   schemaVersion: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION;
-  issue: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE;
+  issue: RuntimeTokenCostPlanningWarningIssue;
   status: "advisory";
   source: typeof RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE;
   trigger: RuntimeTokenCostPlanningWarningTrigger;
@@ -31,23 +40,40 @@ export function buildRuntimeTokenCostPlanningWarnings(input: {
   branch?: string;
   linkedIssueNumber?: number;
 }): RuntimeTokenCostPlanningWarning[] {
+  const branchIssueNumber = inferredIssueNumber(input.branch);
+  const issueNumber = input.linkedIssueNumber === 960 || input.linkedIssueNumber === 976
+    ? input.linkedIssueNumber
+    : branchIssueNumber === 960 || branchIssueNumber === 976
+      ? branchIssueNumber
+      : undefined;
   const trigger: RuntimeTokenCostPlanningWarningTrigger | undefined = input.linkedIssueNumber === 960
     ? "linked-issue-960"
-    : inferredIssueNumber(input.branch) === 960
-      ? "branch-issue-960"
-      : undefined;
+    : input.linkedIssueNumber === 976
+      ? "linked-issue-976"
+      : branchIssueNumber === 960
+        ? "branch-issue-960"
+        : branchIssueNumber === 976
+          ? "branch-issue-976"
+          : undefined;
 
   if (!trigger) return [];
+
+  const issue: RuntimeTokenCostPlanningWarningIssue = issueNumber === 976
+    ? RUNTIME_TOKEN_COST_PLANNING_WARNING_FOLLOWUP_ISSUE
+    : RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE;
+  const message = issueNumber === 976
+    ? "Issue #976 long AI coding runs should pause for an explicit plan/checkpoint/compression or handoff review before context quality degrades; this is advisory runtime planning evidence only, not token billing telemetry."
+    : "Issue #960 runtime/token-cost work must stay in planning/advisory mode unless current source-of-truth evidence confirms the #961 preflight, #962 stale-context, and #963 handoff contracts are already in place.";
 
   return [
     {
       schemaVersion: RUNTIME_TOKEN_COST_PLANNING_WARNING_SCHEMA_VERSION,
-      issue: RUNTIME_TOKEN_COST_PLANNING_WARNING_ISSUE,
+      issue,
       status: "advisory",
       source: RUNTIME_TOKEN_COST_PLANNING_WARNING_SOURCE,
       trigger,
       prerequisiteIssues: ["#961", "#962", "#963"],
-      message: "Issue #960 runtime/token-cost work must stay in planning/advisory mode unless current source-of-truth evidence confirms the #961 preflight, #962 stale-context, and #963 handoff contracts are already in place.",
+      message,
       requiredRechecks: [
         "Run fooks check --json to inspect current operator/check authority.",
         "Run fooks preflight --json to inspect current preflight guidance.",

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3343,3 +3343,48 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.match(snapshot.planningWarnings[0].message, /#961 preflight, #962 stale-context, and #963 handoff contracts/);
   assert.match(snapshot.planningWarnings[0].claimBoundary, /Advisory planning warning only/);
 });
+
+test("operator check JSON includes narrow issue #976 long-run planning advisory", () => {
+  const tempDir = makeTempProject();
+  const branch = "fooks-issue-976-runtime-planning-warning";
+  const head = "issue-976-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-19T22:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return `${branch}\n`;
+      if (args[0] === "rev-parse") return `${head}\n`;
+      if (args[0] === "rev-list") return "1\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number,title,url --limit 20") {
+        return JSON.stringify([{ number: 976, title: "runtime planning warning", url: "https://github.com/minislively/fooks/issues/976" }]);
+      }
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${head}`, `branch refs/heads/${branch}`, ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return `${branch}\nmain\n`;
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 1\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.planningWarnings.length, 1);
+  assert.equal(snapshot.planningWarnings[0].issue, "#976");
+  assert.equal(snapshot.planningWarnings[0].trigger, "branch-issue-976");
+  assert.match(snapshot.planningWarnings[0].message, /plan\/checkpoint\/compression or handoff review/);
+  assert.match(snapshot.planningWarnings[0].claimBoundary, /issues #960\/#976/);
+});

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -149,3 +149,30 @@ test("source-of-truth handoff emits narrow issue #960 runtime/token-cost plannin
   });
   assert.deepEqual(nonTargetPacket.planningWarnings, []);
 });
+
+test("source-of-truth handoff emits issue #976 long-run runtime planning warning", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-976-runtime-planning-warning";
+  snapshot.activity.worktree.branch = "fooks-issue-976-runtime-planning-warning";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-976-runtime-planning-warning";
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 976 --json number,title,state,url") {
+      return JSON.stringify({ number: 976, title: "runtime planning warning", state: "OPEN", url: "https://github.com/minislively/fooks/issues/976" });
+    }
+    if (key === "gh pr list --head fooks-issue-976-runtime-planning-warning --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-19T22:02:03.000Z" });
+  assert.equal(packet.planningWarnings.length, 1);
+  assert.equal(packet.planningWarnings[0].issue, "#976");
+  assert.equal(packet.planningWarnings[0].status, "advisory");
+  assert.equal(packet.planningWarnings[0].trigger, "linked-issue-976");
+  assert.match(packet.planningWarnings[0].message, /context quality degrades/);
+  assert.match(packet.planningWarnings[0].forbiddenClaims.join("\n"), /runtime-token savings proof/);
+});


### PR DESCRIPTION
## Summary

Fixes #976.

PR #975 / commit c7ea39b already added the core issue #960 runtime/token-cost planning warning. This follow-up keeps that implementation intact and adds the narrow #976-facing gap: current issue #976 branches and linked handoff packets now emit the same advisory planning-warning surface with long AI coding run wording.

## Scope and boundaries

- Additive only: extends the existing `planningWarnings` JSON packet to issue #976 branch/linked-issue triggers.
- Keeps the warning advisory-only for plan/checkpoint/compression/handoff review before context quality degrades.
- Does not change provider/runtime hook behavior.
- Does not implement #963-style handoff generation.
- Does not claim billing telemetry, real token accounting, token savings, merge policy, frontend behavior, or product support changes.

## Verification

- `npm ci`
- `npm run build`
- `node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs`
- `git diff --check`
- `npm test`
- Live check evidence after build: `node dist/cli/index.js check --json` emits `planningWarnings[0].issue == "#976"` and `trigger == "branch-issue-976"` on this branch.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
