### PR TITLE
Add combined reliability warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,3 +314,13 @@ export type {
   SourceOfTruthLinkedArtifact,
   SourceOfTruthPrCheck,
 } from "./ops/source-of-truth-handoff";
+export {
+  COMBINED_RELIABILITY_WARNING_CLAIM_BOUNDARY,
+  COMBINED_RELIABILITY_WARNING_SCHEMA_VERSION,
+  COMBINED_RELIABILITY_WARNING_SOURCE,
+  buildCombinedReliabilityWarnings,
+} from "./ops/combined-reliability-warning";
+export type {
+  CombinedReliabilityWarning,
+  CombinedReliabilityWarningContextRisk,
+} from "./ops/combined-reliability-warning";

--- a/src/ops/combined-reliability-warning.ts
+++ b/src/ops/combined-reliability-warning.ts
@@ -1,0 +1,98 @@
+import type { OperatorContextTrustEntry } from "./context-trust";
+import type { RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+
+export const COMBINED_RELIABILITY_WARNING_SCHEMA_VERSION = 1;
+export const COMBINED_RELIABILITY_WARNING_SOURCE = "deterministic combined context/runtime reliability advisory";
+export const COMBINED_RELIABILITY_WARNING_CLAIM_BOUNDARY =
+  "Advisory-only overlap warning for issue #978: combines existing contextTrust/source-of-truth stale or non-authorizing evidence with existing runtime planning warnings; it does not add telemetry, change provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
+
+export type CombinedReliabilityWarningContextRisk = Pick<
+  OperatorContextTrustEntry,
+  "kind" | "source" | "reason" | "referenceField" | "contractScope" | "authority" | "count" | "live"
+>;
+
+export type CombinedReliabilityWarning = {
+  schemaVersion: typeof COMBINED_RELIABILITY_WARNING_SCHEMA_VERSION;
+  status: "advisory";
+  source: typeof COMBINED_RELIABILITY_WARNING_SOURCE;
+  trigger: "context-risk-and-runtime-planning-overlap";
+  message: string;
+  recommendedActions: Array<"reset-context" | "compress-current-source-of-truth" | "handoff-to-fresh-agent">;
+  requiredOverlap: {
+    contextRisk: CombinedReliabilityWarningContextRisk[];
+    runtimePlanning: RuntimeTokenCostPlanningWarning[];
+  };
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  claimBoundary: typeof COMBINED_RELIABILITY_WARNING_CLAIM_BOUNDARY;
+};
+
+function contextRiskRef(entry: OperatorContextTrustEntry): CombinedReliabilityWarningContextRisk {
+  return {
+    kind: entry.kind,
+    source: entry.source,
+    reason: entry.reason,
+    ...(entry.referenceField ? { referenceField: entry.referenceField } : {}),
+    contractScope: entry.contractScope,
+    ...(entry.authority ? { authority: entry.authority } : {}),
+    ...(entry.count !== undefined ? { count: entry.count } : {}),
+    ...(entry.live !== undefined ? { live: entry.live } : {}),
+  };
+}
+
+function isContextOrStaleRisk(entry: OperatorContextTrustEntry): boolean {
+  return entry.contractScope === "stale-residue-boundary"
+    || entry.contractScope === "cleanup-review-boundary"
+    || entry.contractScope === "main-echo-boundary"
+    || entry.contractScope === "post-merge-receipt"
+    || entry.kind.includes("stale")
+    || entry.kind.includes("historical")
+    || entry.authority === "receipt"
+    || entry.authority === "insufficient";
+}
+
+export function buildCombinedReliabilityWarnings(input: {
+  contextTrust: {
+    nonAuthorizing: OperatorContextTrustEntry[];
+    historicalOnly: OperatorContextTrustEntry[];
+  };
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+}): CombinedReliabilityWarning[] {
+  if (input.planningWarnings.length === 0) return [];
+
+  const contextRisk = [...input.contextTrust.nonAuthorizing, ...input.contextTrust.historicalOnly]
+    .filter(isContextOrStaleRisk)
+    .map(contextRiskRef);
+  if (contextRisk.length === 0) return [];
+
+  return [
+    {
+      schemaVersion: COMBINED_RELIABILITY_WARNING_SCHEMA_VERSION,
+      status: "advisory",
+      source: COMBINED_RELIABILITY_WARNING_SOURCE,
+      trigger: "context-risk-and-runtime-planning-overlap",
+      message:
+        "Context/stale-risk evidence overlaps runtime-planning advisory evidence; pause before continuing and either reset context, compress only verified current source-of-truth, or hand off to a fresh agent with current check/preflight/handoff output.",
+      recommendedActions: ["reset-context", "compress-current-source-of-truth", "handoff-to-fresh-agent"],
+      requiredOverlap: {
+        contextRisk,
+        runtimePlanning: input.planningWarnings,
+      },
+      requiredRechecks: [
+        "Run fooks check --json to re-read current contextTrust authority and non-authorizing evidence.",
+        "Run fooks preflight --json to confirm current recommended action before continuing.",
+        "Run fooks handoff --json before fresh-agent handoff or context compression.",
+        "Run fooks stale-context --stdin --json on any pasted prompt/handoff text before treating it as current authority.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "automatic stale-context validation beyond supplied/current surfaces",
+        "merge-gate policy change",
+        "frontend runtime behavior change",
+      ],
+      claimBoundary: COMBINED_RELIABILITY_WARNING_CLAIM_BOUNDARY,
+    },
+  ];
+}

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -20,6 +20,7 @@ import { STALE_WORKTREE_AUDIT_COMMAND, STALE_WORKTREE_AUDIT_ISSUE } from "./stal
 import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./context-trust";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -563,6 +564,7 @@ export type OperatorCheckSnapshot = {
   requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
   activity: OperatorActivitySnapshot;
   blockers: string[];
 };
@@ -1612,6 +1614,8 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     currentRunEvidence: activity.currentRunEvidence,
     postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
   });
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
 
   return {
     schemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
@@ -1636,7 +1640,8 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     activeWorkReceipts,
     requiredActiveArtifact: requiredArtifact,
     contextTrust,
-    planningWarnings: buildRuntimeTokenCostPlanningWarnings({ branch }),
+    planningWarnings,
+    combinedReliabilityWarnings,
     activity,
     blockers,
   };

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -4,6 +4,7 @@ import type { OperatorCheckSnapshot } from "./operator-check";
 import type { PreflightPacket } from "./preflight";
 import { STALE_CONTEXT_COMMAND } from "./stale-context";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -113,6 +114,7 @@ export type SourceOfTruthHandoffPacket = {
     suggestedCommands: string[];
   };
   planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
   blockers: string[];
 };
 
@@ -285,6 +287,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const prResult = linkedPullRequest(cwd, branch, blockers, options.commandRunner);
   const linkedIssueNumber = issue.status === "linked" ? issue.number : undefined;
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
@@ -355,6 +358,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     staleOrHistoricalContextToAvoid: staleAvoidList(snapshot, preflight),
     nextRecommendedAction: nextAction(preflight, issue, prResult.artifact, changedPaths.length),
     planningWarnings,
+    combinedReliabilityWarnings,
     blockers,
   };
 }

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -21,6 +21,27 @@ function baseSnapshot(cwd) {
     verdict: "ready",
     blockers: [],
     runtimeProvenance: { git: { branch: "fooks-issue-963-source-of-truth-handoff", head: "abc123" } },
+    contextTrust: {
+      schemaVersion: 1,
+      source: "fooks check --json operator-check projection",
+      researchReference: "docs/research/context-trust-and-stale-evidence-research.md",
+      claimBoundary: "synthetic test contextTrust",
+      sourceOfTruth: {
+        current: [{ kind: "issue", source: "activeArtifacts", reason: "open issue count", contractScope: "top-level-active-artifact", authority: "current-work" }],
+      },
+      advisoryOnly: [],
+      historicalOnly: [],
+      nonAuthorizing: [
+        {
+          kind: "stale-residue-active-boundary",
+          source: "stale residue",
+          reason: "cleanup-review only",
+          referenceField: "activeWorkReceipts.staleResidueActiveBoundary",
+          contractScope: "stale-residue-boundary",
+          authority: "insufficient",
+        },
+      ],
+    },
     activity: {
       worktree: {
         branch: "fooks-issue-963-source-of-truth-handoff",
@@ -96,6 +117,8 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/source-of-truth-handoff.ts"));
   assert.equal(packet.staleOrHistoricalContextToAvoid.length, 2);
   assert.equal(packet.nextRecommendedAction.action, "continue-implementation-for-linked-issue");
+  assert.deepEqual(packet.planningWarnings, []);
+  assert.deepEqual(packet.combinedReliabilityWarnings, []);
 });
 
 test("handoff CLI emits JSON packet", () => {
@@ -136,6 +159,13 @@ test("source-of-truth handoff emits narrow issue #960 runtime/token-cost plannin
   assert.deepEqual(packet.planningWarnings[0].prerequisiteIssues, ["#961", "#962", "#963"]);
   assert.match(packet.planningWarnings[0].claimBoundary, /does not change provider\/runtime hooks/);
   assert.match(packet.planningWarnings[0].forbiddenClaims.join("\n"), /provider usage\/billing-token proof/);
+  assert.equal(packet.combinedReliabilityWarnings.length, 1);
+  assert.equal(packet.combinedReliabilityWarnings[0].trigger, "context-risk-and-runtime-planning-overlap");
+  assert.deepEqual(packet.combinedReliabilityWarnings[0].recommendedActions, ["reset-context", "compress-current-source-of-truth", "handoff-to-fresh-agent"]);
+  assert.equal(packet.combinedReliabilityWarnings[0].requiredOverlap.contextRisk[0].contractScope, "stale-residue-boundary");
+  assert.equal(packet.combinedReliabilityWarnings[0].requiredOverlap.runtimePlanning[0].issue, "#960");
+  assert.match(packet.combinedReliabilityWarnings[0].claimBoundary, /Advisory-only overlap warning/);
+  assert.match(packet.combinedReliabilityWarnings[0].forbiddenClaims.join("\n"), /runtime-token savings proof/);
 
   const nonTargetPacket = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), {
     commandRunner: (command, args) => {
@@ -148,6 +178,28 @@ test("source-of-truth handoff emits narrow issue #960 runtime/token-cost plannin
     now: () => "2026-05-19T01:02:03.000Z",
   });
   assert.deepEqual(nonTargetPacket.planningWarnings, []);
+  assert.deepEqual(nonTargetPacket.combinedReliabilityWarnings, []);
+});
+
+test("source-of-truth handoff does not emit combined reliability warning for runtime-only risk", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-960-runtime-token-cost-plan";
+  snapshot.activity.worktree.branch = "fooks-issue-960-runtime-token-cost-plan";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-960-runtime-token-cost-plan";
+  snapshot.contextTrust.nonAuthorizing = [];
+  snapshot.contextTrust.historicalOnly = [];
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 960 --json number,title,state,url") return JSON.stringify({ number: 960, state: "OPEN" });
+    if (key === "gh pr list --head fooks-issue-960-runtime-token-cost-plan --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") return "[]";
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-19T01:02:03.000Z" });
+  assert.equal(packet.planningWarnings.length, 1);
+  assert.deepEqual(packet.combinedReliabilityWarnings, []);
 });
 
 test("source-of-truth handoff emits issue #976 long-run runtime planning warning", () => {
@@ -175,4 +227,6 @@ test("source-of-truth handoff emits issue #976 long-run runtime planning warning
   assert.equal(packet.planningWarnings[0].trigger, "linked-issue-976");
   assert.match(packet.planningWarnings[0].message, /context quality degrades/);
   assert.match(packet.planningWarnings[0].forbiddenClaims.join("\n"), /runtime-token savings proof/);
+  assert.equal(packet.combinedReliabilityWarnings.length, 1);
+  assert.equal(packet.combinedReliabilityWarnings[0].requiredOverlap.runtimePlanning[0].issue, "#976");
 });


### PR DESCRIPTION
Closes #978

## Summary
- Add a deterministic advisory-only combined reliability warning surface.
- Emit the warning from `check --json` and source-of-truth handoff only when context/stale/non-authorizing evidence overlaps existing runtime-planning warnings.
- Add source-of-truth handoff coverage for overlap, context-only, and runtime-only boundaries.

## Verification
- npm run build
- node --test test/source-of-truth-handoff.test.mjs test/operator-activity.test.mjs
- npm test

## Safety
- Advisory-only; no provider/runtime hooks, billing/token accounting, merge-gate policy, product claims, or frontend behavior changes.