### PR TITLE
Surface operator-check reliability warnings

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -28,6 +28,7 @@ export const OPERATOR_CHECK_CLAIM_BOUNDARY =
   "Read-only operator/check artifact for the post-merge main echo versus active work boundary; it requires a concrete issue, PR, or mapped session artifact when the checkout is otherwise idle.";
 export const OPERATOR_CHECK_SOURCE = `status activity ${OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG} projection`;
 export const OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_SCHEMA_VERSION = 1;
@@ -36,6 +37,9 @@ export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
+export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE = "operator/check reliability warning visibility projection";
+export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY =
+  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, and combinedReliabilityWarnings fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
@@ -565,8 +569,51 @@ export type OperatorCheckSnapshot = {
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
   activity: OperatorActivitySnapshot;
   blockers: string[];
+};
+
+export type OperatorCheckReliabilityWarningVisibility = {
+  schemaVersion: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SCHEMA_VERSION;
+  source: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE;
+  status: "clear" | "advisory";
+  summary: {
+    existingWarningCount: number;
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    contextTrustCurrentAuthorityCount: number;
+    contextTrustNonAuthorizingCount: number;
+    contextTrustHistoricalOnlyCount: number;
+  };
+  warnings: Array<
+    | {
+        kind: "runtime-planning";
+        issue: RuntimeTokenCostPlanningWarning["issue"];
+        trigger: RuntimeTokenCostPlanningWarning["trigger"];
+        status: RuntimeTokenCostPlanningWarning["status"];
+        message: RuntimeTokenCostPlanningWarning["message"];
+        requiredRechecks: RuntimeTokenCostPlanningWarning["requiredRechecks"];
+        forbiddenClaims: RuntimeTokenCostPlanningWarning["forbiddenClaims"];
+        claimBoundary: RuntimeTokenCostPlanningWarning["claimBoundary"];
+      }
+    | {
+        kind: "combined-reliability";
+        trigger: CombinedReliabilityWarning["trigger"];
+        status: CombinedReliabilityWarning["status"];
+        message: CombinedReliabilityWarning["message"];
+        recommendedActions: CombinedReliabilityWarning["recommendedActions"];
+        requiredRechecks: CombinedReliabilityWarning["requiredRechecks"];
+        forbiddenClaims: CombinedReliabilityWarning["forbiddenClaims"];
+        claimBoundary: CombinedReliabilityWarning["claimBoundary"];
+      }
+  >;
+  derivedFrom: {
+    contextTrustSource: OperatorContextTrustPacket["source"];
+    planningWarningsField: "planningWarnings";
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+  };
+  claimBoundary: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY;
 };
 
 
@@ -1590,6 +1637,56 @@ function requiredActiveArtifact(state: { blocked: boolean; hasActiveArtifact: bo
   };
 }
 
+export function buildOperatorCheckReliabilityWarningVisibility(input: {
+  contextTrust: OperatorContextTrustPacket;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+}): OperatorCheckReliabilityWarningVisibility {
+  const warnings: OperatorCheckReliabilityWarningVisibility["warnings"] = [
+    ...input.planningWarnings.map((warning) => ({
+      kind: "runtime-planning" as const,
+      issue: warning.issue,
+      trigger: warning.trigger,
+      status: warning.status,
+      message: warning.message,
+      requiredRechecks: warning.requiredRechecks,
+      forbiddenClaims: warning.forbiddenClaims,
+      claimBoundary: warning.claimBoundary,
+    })),
+    ...input.combinedReliabilityWarnings.map((warning) => ({
+      kind: "combined-reliability" as const,
+      trigger: warning.trigger,
+      status: warning.status,
+      message: warning.message,
+      recommendedActions: warning.recommendedActions,
+      requiredRechecks: warning.requiredRechecks,
+      forbiddenClaims: warning.forbiddenClaims,
+      claimBoundary: warning.claimBoundary,
+    })),
+  ];
+
+  return {
+    schemaVersion: OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SCHEMA_VERSION,
+    source: OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE,
+    status: warnings.length > 0 ? "advisory" : "clear",
+    summary: {
+      existingWarningCount: warnings.length,
+      planningWarningCount: input.planningWarnings.length,
+      combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+      contextTrustCurrentAuthorityCount: input.contextTrust.sourceOfTruth.current.length,
+      contextTrustNonAuthorizingCount: input.contextTrust.nonAuthorizing.length,
+      contextTrustHistoricalOnlyCount: input.contextTrust.historicalOnly.length,
+    },
+    warnings,
+    derivedFrom: {
+      contextTrustSource: input.contextTrust.source,
+      planningWarningsField: "planningWarnings",
+      combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    },
+    claimBoundary: OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY,
+  };
+}
+
 export function readOperatorCheckSnapshot(cwd = process.cwd(), options: OperatorActivityOptions = {}): OperatorCheckSnapshot {
   const activity = readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true });
   const activeArtifacts = activeArtifactsFrom(activity);
@@ -1616,6 +1713,11 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   });
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+  const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
+    contextTrust,
+    planningWarnings,
+    combinedReliabilityWarnings,
+  });
 
   return {
     schemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
@@ -1642,6 +1744,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
+    reliabilityWarningVisibility,
     activity,
     blockers,
   };

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -33,8 +33,19 @@ const {
   OPERATOR_CHECK_CLAIM_BOUNDARY,
   OPERATOR_CHECK_COMMAND,
   OPERATOR_CHECK_SOURCE,
+  OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY,
+  OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE,
+  buildOperatorCheckReliabilityWarningVisibility,
   readOperatorCheckSnapshot,
 } = require(path.join(repoRoot, "dist", "ops", "operator-check.js"));
+
+const {
+  buildRuntimeTokenCostPlanningWarnings,
+} = require(path.join(repoRoot, "dist", "ops", "runtime-token-cost-planning-warning.js"));
+
+const {
+  buildCombinedReliabilityWarnings,
+} = require(path.join(repoRoot, "dist", "ops", "combined-reliability-warning.js"));
 
 const {
   OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE,
@@ -3342,6 +3353,59 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.equal(snapshot.planningWarnings[0].trigger, "branch-issue-960");
   assert.match(snapshot.planningWarnings[0].message, /#961 preflight, #962 stale-context, and #963 handoff contracts/);
   assert.match(snapshot.planningWarnings[0].claimBoundary, /Advisory planning warning only/);
+  assert.equal(snapshot.reliabilityWarningVisibility.source, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE);
+  assert.equal(snapshot.reliabilityWarningVisibility.status, "advisory");
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.planningWarningCount, 1);
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.existingWarningCount, snapshot.planningWarnings.length + snapshot.combinedReliabilityWarnings.length);
+  assert.equal(snapshot.reliabilityWarningVisibility.derivedFrom.contextTrustSource, snapshot.contextTrust.source);
+  assert.equal(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "runtime-planning" && warning.issue === "#960"), true);
+  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, and combinedReliabilityWarnings fields only/);
+});
+
+test("operator check reliability warning visibility surfaces existing planning and combined warnings only", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-960-runtime-token-cost-plan" });
+  const contextTrust = syntheticPreflightSnapshot({
+    nonAuthorizing: [
+      {
+        kind: "stale-residue-active-boundary",
+        source: "synthetic stale residue",
+        reason: "synthetic stale residue risk",
+        referenceField: "staleResidueActiveBoundary",
+        contractScope: "stale-residue-boundary",
+        authority: "insufficient",
+      },
+    ],
+  }).contextTrust;
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+
+  const visibility = buildOperatorCheckReliabilityWarningVisibility({
+    contextTrust,
+    planningWarnings,
+    combinedReliabilityWarnings,
+  });
+
+  assert.equal(visibility.schemaVersion, 1);
+  assert.equal(visibility.source, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE);
+  assert.equal(visibility.status, "advisory");
+  assert.deepEqual(visibility.summary, {
+    existingWarningCount: 2,
+    planningWarningCount: 1,
+    combinedReliabilityWarningCount: 1,
+    contextTrustCurrentAuthorityCount: 0,
+    contextTrustNonAuthorizingCount: 1,
+    contextTrustHistoricalOnlyCount: 0,
+  });
+  assert.equal(visibility.warnings[0].kind, "runtime-planning");
+  assert.equal(visibility.warnings[0].issue, "#960");
+  assert.equal(visibility.warnings[1].kind, "combined-reliability");
+  assert.equal(visibility.warnings[1].trigger, "context-risk-and-runtime-planning-overlap");
+  assert.deepEqual(visibility.derivedFrom, {
+    contextTrustSource: OPERATOR_CONTEXT_TRUST_SOURCE,
+    planningWarningsField: "planningWarnings",
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+  });
+  assert.equal(visibility.claimBoundary, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY);
+  assert.match(visibility.claimBoundary, /adds no telemetry, provider\/runtime hooks, token\/cost accounting, merge-gate policy, product claims, or frontend behavior/);
 });
 
 test("operator check JSON includes narrow issue #976 long-run planning advisory", () => {


### PR DESCRIPTION
## Summary

Fixes #980.

Surfaces the existing #960 reliability warning layer in operator/check output:

- adds a read-only `reliabilityWarningVisibility` projection derived from existing contextTrust/source-of-truth counts, runtime planning warnings, and combined reliability warnings
- keeps JSON deterministic and advisory-only
- covers warning visibility and no-warning boundary cases in operator tests

## Boundaries

- No new telemetry or risk heuristics.
- No provider/runtime hook changes.
- No real billing/token accounting claims.
- No merge-gate policy changes.
- No product-positioning or frontend behavior expansion.

## Verification

- `git diff --check HEAD`
- `npm run build`
- `node --test test/operator-activity.test.mjs`
- `npm test`
