### PR TITLE
Add sequential planning advisory hint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,19 @@ export type {
   OrphanLocalWorktreeTriageResult,
 } from "./ops/orphan-local-worktree-triage";
 export {
+  SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY,
+  SEQUENTIAL_PLANNING_HINT_ISSUE,
+  SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION,
+  SEQUENTIAL_PLANNING_HINT_SOURCE,
+  buildSequentialPlanningHints,
+} from "./ops/sequential-planning-hint";
+export type {
+  SequentialPlanningHint,
+  SequentialPlanningHintRecommendation,
+  SequentialPlanningHintTrigger,
+} from "./ops/sequential-planning-hint";
+
+export {
   REACT_WEB_STATUS_CLAIM_BOUNDARY,
   REACT_WEB_STATUS_COMMAND,
   REACT_WEB_STATUS_SCHEMA_VERSION,

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -21,6 +21,7 @@ import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./context-trust";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
+import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -569,6 +570,7 @@ export type OperatorCheckSnapshot = {
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
   activity: OperatorActivitySnapshot;
   blockers: string[];
@@ -1713,6 +1715,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   });
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, planningWarnings, combinedReliabilityWarnings });
   const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
@@ -1744,6 +1747,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
+    sequentialPlanningHints,
     reliabilityWarningVisibility,
     activity,
     blockers,

--- a/src/ops/sequential-planning-hint.ts
+++ b/src/ops/sequential-planning-hint.ts
@@ -1,0 +1,116 @@
+import type { CombinedReliabilityWarning } from "./combined-reliability-warning";
+import type { RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+
+export const SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION = 1;
+export const SEQUENTIAL_PLANNING_HINT_ISSUE = "#982";
+export const SEQUENTIAL_PLANNING_HINT_SOURCE = "deterministic sequential planning advisory";
+export const SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY =
+  "Advisory sequential-planning hint only for issue #982 under epic #960; does not prove provider billing/runtime token usage, change provider/runtime hooks, grant autonomous execution or merge authority, alter merge-gate policy, expand runtime/provider support, product claims, or frontend behavior.";
+
+export type SequentialPlanningHintTrigger =
+  | "branch-issue-982"
+  | "linked-issue-982"
+  | "combined-reliability-warning-present";
+
+export type SequentialPlanningHintRecommendation =
+  | "write-plan-before-execute"
+  | "split-long-work-into-bounded-steps"
+  | "checkpoint-or-compress-current-source-of-truth"
+  | "handoff-before-burning-another-context-window";
+
+export type SequentialPlanningHint = {
+  schemaVersion: typeof SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION;
+  issue: typeof SEQUENTIAL_PLANNING_HINT_ISSUE;
+  status: "advisory";
+  source: typeof SEQUENTIAL_PLANNING_HINT_SOURCE;
+  trigger: SequentialPlanningHintTrigger;
+  message: string;
+  reasons: string[];
+  recommendations: SequentialPlanningHintRecommendation[];
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  claimBoundary: typeof SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY;
+  derivedFrom: {
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    planningWarningsField: "planningWarnings";
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+  };
+};
+
+function inferredIssueNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.match(/(?:^|[-_/])(?:issue|issues|gh)[-_/]?(\d+)(?:\D|$)/iu) ?? value.match(/#(\d+)\b/u);
+  if (!match) return undefined;
+  const issue = Number(match[1]);
+  return Number.isInteger(issue) && issue > 0 ? issue : undefined;
+}
+
+export function buildSequentialPlanningHints(input: {
+  branch?: string;
+  linkedIssueNumber?: number;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+}): SequentialPlanningHint[] {
+  const branchIssueNumber = inferredIssueNumber(input.branch);
+  const trigger: SequentialPlanningHintTrigger | undefined = input.linkedIssueNumber === 982
+    ? "linked-issue-982"
+    : branchIssueNumber === 982
+      ? "branch-issue-982"
+      : input.combinedReliabilityWarnings.length > 0
+        ? "combined-reliability-warning-present"
+        : undefined;
+
+  if (!trigger) return [];
+
+  const reasons = trigger === "combined-reliability-warning-present"
+    ? [
+        "combined reliability warning already reports overlapping stale/context risk and runtime-planning risk",
+        "long or sequential follow-up work should plan before executing to avoid context drift",
+      ]
+    : [
+        "current branch or linked issue targets issue #982 sequential-planning hint work",
+        "next-agent handoff should include a deterministic plan-before-execute reminder for long or sequential runs",
+      ];
+
+  return [
+    {
+      schemaVersion: SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION,
+      issue: SEQUENTIAL_PLANNING_HINT_ISSUE,
+      status: "advisory",
+      source: SEQUENTIAL_PLANNING_HINT_SOURCE,
+      trigger,
+      message:
+        "Before another long or sequential coding run, write a bounded plan, split the work, checkpoint or compress current source-of-truth evidence, and hand off to a fresh agent when context quality is at risk.",
+      reasons,
+      recommendations: [
+        "write-plan-before-execute",
+        "split-long-work-into-bounded-steps",
+        "checkpoint-or-compress-current-source-of-truth",
+        "handoff-before-burning-another-context-window",
+      ],
+      requiredRechecks: [
+        "Run fooks check --json to inspect current operator/check authority and warning surfaces.",
+        "Run fooks preflight --json before deciding whether to continue, split, or stop.",
+        "Run fooks handoff --json before compressing context or handing work to a fresh agent.",
+        "Keep implementation authority tied to a current issue, PR, branch, session, or explicit blocker.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "autonomous execution authority",
+        "merge authority or merge-gate policy change",
+        "runtime/provider support expansion",
+        "frontend runtime behavior change",
+      ],
+      claimBoundary: SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY,
+      derivedFrom: {
+        planningWarningCount: input.planningWarnings.length,
+        combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+        planningWarningsField: "planningWarnings",
+        combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+      },
+    },
+  ];
+}

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -5,6 +5,7 @@ import type { PreflightPacket } from "./preflight";
 import { STALE_CONTEXT_COMMAND } from "./stale-context";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
+import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -115,6 +116,7 @@ export type SourceOfTruthHandoffPacket = {
   };
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
   blockers: string[];
 };
 
@@ -129,6 +131,7 @@ const AUTHORITATIVE_FILES_AND_DOCS = [
   "src/ops/stale-context.ts",
   "src/ops/source-of-truth-handoff.ts",
   "src/ops/runtime-token-cost-planning-warning.ts",
+  "src/ops/sequential-planning-hint.ts",
   "src/cli/index.ts",
   "docs/research/context-trust-and-stale-evidence-research.md",
   "docs/stale-context.md",
@@ -288,6 +291,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const linkedIssueNumber = issue.status === "linked" ? issue.number : undefined;
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
@@ -359,6 +363,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     nextRecommendedAction: nextAction(preflight, issue, prResult.artifact, changedPaths.length),
     planningWarnings,
     combinedReliabilityWarnings,
+    sequentialPlanningHints,
     blockers,
   };
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -48,6 +48,11 @@ const {
 } = require(path.join(repoRoot, "dist", "ops", "combined-reliability-warning.js"));
 
 const {
+  SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY,
+  buildSequentialPlanningHints,
+} = require(path.join(repoRoot, "dist", "ops", "sequential-planning-hint.js"));
+
+const {
   OPERATOR_CONTEXT_TRUST_RESEARCH_REFERENCE,
   OPERATOR_CONTEXT_TRUST_SOURCE,
 } = require(path.join(repoRoot, "dist", "ops", "context-trust.js"));
@@ -3360,6 +3365,7 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.equal(snapshot.reliabilityWarningVisibility.derivedFrom.contextTrustSource, snapshot.contextTrust.source);
   assert.equal(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "runtime-planning" && warning.issue === "#960"), true);
   assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, and combinedReliabilityWarnings fields only/);
+  assert.deepEqual(snapshot.sequentialPlanningHints, []);
 });
 
 test("operator check reliability warning visibility surfaces existing planning and combined warnings only", () => {
@@ -3451,4 +3457,115 @@ test("operator check JSON includes narrow issue #976 long-run planning advisory"
   assert.equal(snapshot.planningWarnings[0].trigger, "branch-issue-976");
   assert.match(snapshot.planningWarnings[0].message, /plan\/checkpoint\/compression or handoff review/);
   assert.match(snapshot.planningWarnings[0].claimBoundary, /issues #960\/#976/);
+  assert.deepEqual(snapshot.sequentialPlanningHints, []);
+});
+
+test("operator check JSON includes narrow issue #982 sequential planning hint", () => {
+  const tempDir = makeTempProject();
+  const branch = "fooks-issue-982-sequential-planning-hint";
+  const head = "issue-982-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-20T04:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return `${branch}\n`;
+      if (args[0] === "rev-parse") return `${head}\n`;
+      if (args[0] === "rev-list") return "1\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number,title,url --limit 20") {
+        return JSON.stringify([{ number: 982, title: "sequential planning hint", url: "https://github.com/minislively/fooks/issues/982" }]);
+      }
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${head}`, `branch refs/heads/${branch}`, ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return `${branch}\nmain\n`;
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 1\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.deepEqual(snapshot.planningWarnings, []);
+  assert.deepEqual(snapshot.combinedReliabilityWarnings, []);
+  assert.equal(snapshot.sequentialPlanningHints.length, 1);
+  assert.equal(snapshot.sequentialPlanningHints[0].issue, "#982");
+  assert.equal(snapshot.sequentialPlanningHints[0].trigger, "branch-issue-982");
+  assert.deepEqual(snapshot.sequentialPlanningHints[0].recommendations, [
+    "write-plan-before-execute",
+    "split-long-work-into-bounded-steps",
+    "checkpoint-or-compress-current-source-of-truth",
+    "handoff-before-burning-another-context-window",
+  ]);
+  assert.match(snapshot.sequentialPlanningHints[0].claimBoundary, /does not prove provider billing\/runtime token usage/);
+  assert.match(snapshot.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /autonomous execution authority/);
+});
+
+test("sequential planning hint builder is deterministic, bounded, and trigger-gated", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
+  const contextTrust = syntheticPreflightSnapshot({
+    nonAuthorizing: [
+      {
+        kind: "stale-residue-active-boundary",
+        source: "synthetic stale residue",
+        reason: "synthetic stale residue risk",
+        referenceField: "staleResidueActiveBoundary",
+        contractScope: "stale-residue-boundary",
+        authority: "insufficient",
+      },
+    ],
+  }).contextTrust;
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+
+  const hints = buildSequentialPlanningHints({
+    branch: "feature-without-issue",
+    planningWarnings,
+    combinedReliabilityWarnings,
+  });
+
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].schemaVersion, 1);
+  assert.equal(hints[0].issue, "#982");
+  assert.equal(hints[0].status, "advisory");
+  assert.equal(hints[0].trigger, "combined-reliability-warning-present");
+  assert.deepEqual(hints[0].recommendations, [
+    "write-plan-before-execute",
+    "split-long-work-into-bounded-steps",
+    "checkpoint-or-compress-current-source-of-truth",
+    "handoff-before-burning-another-context-window",
+  ]);
+  assert.match(hints[0].message, /Before another long or sequential coding run/);
+  assert.deepEqual(hints[0].derivedFrom, {
+    planningWarningCount: 1,
+    combinedReliabilityWarningCount: 1,
+    planningWarningsField: "planningWarnings",
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+  });
+  assert.equal(hints[0].claimBoundary, SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY);
+  assert.match(hints[0].claimBoundary, /does not prove provider billing\/runtime token usage/);
+  assert.match(hints[0].claimBoundary, /grant autonomous execution or merge authority/);
+  assert.match(hints[0].forbiddenClaims.join("\n"), /runtime-token savings proof/);
+  assert.match(hints[0].forbiddenClaims.join("\n"), /runtime\/provider support expansion/);
+
+  assert.deepEqual(buildSequentialPlanningHints({ branch: "feature-without-issue", planningWarnings: [], combinedReliabilityWarnings: [] }), []);
+
+  const issueHints = buildSequentialPlanningHints({
+    branch: "fooks-issue-982-sequential-planning-hint",
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+  });
+  assert.equal(issueHints.length, 1);
+  assert.equal(issueHints[0].trigger, "branch-issue-982");
 });

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -115,10 +115,12 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.match(packet.claimBoundary, /bounded to the invocation cwd\/current branch\/worktree/);
   assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/operator-check.ts"));
   assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/source-of-truth-handoff.ts"));
+  assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/sequential-planning-hint.ts"));
   assert.equal(packet.staleOrHistoricalContextToAvoid.length, 2);
   assert.equal(packet.nextRecommendedAction.action, "continue-implementation-for-linked-issue");
   assert.deepEqual(packet.planningWarnings, []);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
+  assert.deepEqual(packet.sequentialPlanningHints, []);
 });
 
 test("handoff CLI emits JSON packet", () => {
@@ -179,6 +181,7 @@ test("source-of-truth handoff emits narrow issue #960 runtime/token-cost plannin
   });
   assert.deepEqual(nonTargetPacket.planningWarnings, []);
   assert.deepEqual(nonTargetPacket.combinedReliabilityWarnings, []);
+  assert.deepEqual(nonTargetPacket.sequentialPlanningHints, []);
 });
 
 test("source-of-truth handoff does not emit combined reliability warning for runtime-only risk", () => {
@@ -229,4 +232,44 @@ test("source-of-truth handoff emits issue #976 long-run runtime planning warning
   assert.match(packet.planningWarnings[0].forbiddenClaims.join("\n"), /runtime-token savings proof/);
   assert.equal(packet.combinedReliabilityWarnings.length, 1);
   assert.equal(packet.combinedReliabilityWarnings[0].requiredOverlap.runtimePlanning[0].issue, "#976");
+  assert.equal(packet.sequentialPlanningHints.length, 1);
+  assert.equal(packet.sequentialPlanningHints[0].issue, "#982");
+  assert.equal(packet.sequentialPlanningHints[0].trigger, "combined-reliability-warning-present");
+  assert.match(packet.sequentialPlanningHints[0].message, /write a bounded plan/);
+  assert.match(packet.sequentialPlanningHints[0].claimBoundary, /no provider billing-runtime proof|does not prove provider billing\/runtime token usage/);
+});
+
+
+test("source-of-truth handoff emits issue #982 sequential planning hint without runtime proof claims", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-982-sequential-planning-hint";
+  snapshot.activity.worktree.branch = "fooks-issue-982-sequential-planning-hint";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-982-sequential-planning-hint";
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 982 --json number,title,state,url") {
+      return JSON.stringify({ number: 982, title: "sequential planning hint", state: "OPEN", url: "https://github.com/minislively/fooks/issues/982" });
+    }
+    if (key === "gh pr list --head fooks-issue-982-sequential-planning-hint --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-20T04:02:03.000Z" });
+  assert.deepEqual(packet.planningWarnings, []);
+  assert.deepEqual(packet.combinedReliabilityWarnings, []);
+  assert.equal(packet.sequentialPlanningHints.length, 1);
+  assert.equal(packet.sequentialPlanningHints[0].trigger, "linked-issue-982");
+  assert.deepEqual(packet.sequentialPlanningHints[0].recommendations, [
+    "write-plan-before-execute",
+    "split-long-work-into-bounded-steps",
+    "checkpoint-or-compress-current-source-of-truth",
+    "handoff-before-burning-another-context-window",
+  ]);
+  assert.match(packet.sequentialPlanningHints[0].claimBoundary, /does not prove provider billing\/runtime token usage/);
+  assert.match(packet.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /autonomous execution authority/);
+  assert.match(packet.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /merge authority or merge-gate policy change/);
 });


### PR DESCRIPTION
## Summary
- add a deterministic issue #982 sequential planning advisory builder
- surface advisory hints in operator check and source-of-truth handoff JSON
- cover branch-linked, linked-issue, and combined reliability warning triggers without broadening provider/runtime claims

## Verification
- npm run build && node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs
- npm run build
- git diff --check

Closes #982