### PR TITLE
Add plan-before-execute guard for reliability runs

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -22,6 +22,7 @@ import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./co
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
+import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -571,6 +572,7 @@ export type OperatorCheckSnapshot = {
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
   activity: OperatorActivitySnapshot;
   blockers: string[];
@@ -1716,6 +1718,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, planningWarnings, combinedReliabilityWarnings });
+  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
@@ -1748,6 +1751,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     planningWarnings,
     combinedReliabilityWarnings,
     sequentialPlanningHints,
+    planBeforeExecuteGuards,
     reliabilityWarningVisibility,
     activity,
     blockers,

--- a/src/ops/plan-before-execute-guard.ts
+++ b/src/ops/plan-before-execute-guard.ts
@@ -1,0 +1,149 @@
+import type { CombinedReliabilityWarning } from "./combined-reliability-warning";
+import type { RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+import type { SequentialPlanningHint } from "./sequential-planning-hint";
+
+export const PLAN_BEFORE_EXECUTE_GUARD_SCHEMA_VERSION = 1;
+export const PLAN_BEFORE_EXECUTE_GUARD_ISSUE = "#984";
+export const PLAN_BEFORE_EXECUTE_GUARD_EPIC = "#960";
+export const PLAN_BEFORE_EXECUTE_GUARD_SOURCE = "deterministic plan-before-execute advisory guard";
+export const PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY =
+  "Advisory plan-before-execute guard only for issue #984 under epic #960; stop-before-more-execution is a local operator recommendation, not provider billing/runtime proof, not provider/runtime hook behavior, not autonomous execution or merge authority, not CI or merge-gate enforcement, not product support expansion, and not frontend behavior change.";
+
+export type PlanBeforeExecuteGuardTrigger =
+  | "branch-issue-984"
+  | "linked-issue-984"
+  | "long-run-planning-warning-present"
+  | "stale-reliability-overlap-with-sequential-hint";
+
+export type PlanBeforeExecuteGuardRequiredStep =
+  | "stop-before-more-execution"
+  | "write-or-refresh-bounded-plan"
+  | "split-long-run-into-verifiable-steps"
+  | "recheck-current-authority"
+  | "handoff-or-compress-current-source-of-truth";
+
+export type PlanBeforeExecuteGuard = {
+  schemaVersion: typeof PLAN_BEFORE_EXECUTE_GUARD_SCHEMA_VERSION;
+  issue: typeof PLAN_BEFORE_EXECUTE_GUARD_ISSUE;
+  epic: typeof PLAN_BEFORE_EXECUTE_GUARD_EPIC;
+  status: "advisory";
+  source: typeof PLAN_BEFORE_EXECUTE_GUARD_SOURCE;
+  trigger: PlanBeforeExecuteGuardTrigger;
+  stopBeforeMoreExecution: true;
+  message: string;
+  reasons: string[];
+  requiredBeforeContinuing: PlanBeforeExecuteGuardRequiredStep[];
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  claimBoundary: typeof PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY;
+  derivedFrom: {
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    sequentialPlanningHintCount: number;
+    planningWarningsField: "planningWarnings";
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+    sequentialPlanningHintsField: "sequentialPlanningHints";
+  };
+};
+
+function inferredIssueNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.match(/(?:^|[-_/])(?:issue|issues|gh)[-_/]?(\d+)(?:\D|$)/iu) ?? value.match(/#(\d+)\b/u);
+  if (!match) return undefined;
+  const issue = Number(match[1]);
+  return Number.isInteger(issue) && issue > 0 ? issue : undefined;
+}
+
+function chooseTrigger(input: {
+  branch?: string;
+  linkedIssueNumber?: number;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+}): PlanBeforeExecuteGuardTrigger | undefined {
+  const branchIssueNumber = inferredIssueNumber(input.branch);
+  if (input.linkedIssueNumber === 984) return "linked-issue-984";
+  if (branchIssueNumber === 984) return "branch-issue-984";
+
+  const hasLongRunWarning = input.planningWarnings.some((warning) => warning.issue === "#976");
+  if (hasLongRunWarning) return "long-run-planning-warning-present";
+
+  const hasStaleSequentialOverlap = input.combinedReliabilityWarnings.length > 0 && input.sequentialPlanningHints.length > 0;
+  if (hasStaleSequentialOverlap) return "stale-reliability-overlap-with-sequential-hint";
+
+  return undefined;
+}
+
+export function buildPlanBeforeExecuteGuards(input: {
+  branch?: string;
+  linkedIssueNumber?: number;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+}): PlanBeforeExecuteGuard[] {
+  const trigger = chooseTrigger(input);
+  if (!trigger) return [];
+
+  const reasons = trigger === "long-run-planning-warning-present"
+    ? [
+        "issue #976 long-run planning warning is present",
+        "long reliability runs should stop for a bounded plan before more execution",
+      ]
+    : trigger === "stale-reliability-overlap-with-sequential-hint"
+      ? [
+          "combined reliability warning reports stale/context risk overlapping runtime-planning risk",
+          "sequential-planning hint is already present, so continuing without a plan risks stale execution",
+        ]
+      : [
+          "current branch or linked issue targets issue #984 plan-before-execute guard work",
+          "this surface proves only deterministic advisory guard projection and must stay bounded",
+        ];
+
+  return [
+    {
+      schemaVersion: PLAN_BEFORE_EXECUTE_GUARD_SCHEMA_VERSION,
+      issue: PLAN_BEFORE_EXECUTE_GUARD_ISSUE,
+      epic: PLAN_BEFORE_EXECUTE_GUARD_EPIC,
+      status: "advisory",
+      source: PLAN_BEFORE_EXECUTE_GUARD_SOURCE,
+      trigger,
+      stopBeforeMoreExecution: true,
+      message:
+        "Stop before more execution on long or stale reliability runs: write or refresh a bounded plan, split the next run into verifiable steps, recheck current authority, and hand off or compress only current source-of-truth evidence before continuing.",
+      reasons,
+      requiredBeforeContinuing: [
+        "stop-before-more-execution",
+        "write-or-refresh-bounded-plan",
+        "split-long-run-into-verifiable-steps",
+        "recheck-current-authority",
+        "handoff-or-compress-current-source-of-truth",
+      ],
+      requiredRechecks: [
+        "Run fooks check --json to inspect current operator/check authority and advisory guard fields.",
+        "Run fooks preflight --json before deciding whether to continue, split, or stop.",
+        "Run fooks handoff --json before compressing context or handing work to a fresh agent.",
+        "Treat stopBeforeMoreExecution as advisory operator guidance, not CI, merge, provider, runtime, or frontend enforcement.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "provider/runtime hook behavior change",
+        "autonomous execution authority",
+        "merge authority or merge-gate policy change",
+        "CI enforcement or blocking merge policy",
+        "runtime/provider support expansion",
+        "frontend runtime behavior change",
+      ],
+      claimBoundary: PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY,
+      derivedFrom: {
+        planningWarningCount: input.planningWarnings.length,
+        combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+        sequentialPlanningHintCount: input.sequentialPlanningHints.length,
+        planningWarningsField: "planningWarnings",
+        combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+        sequentialPlanningHintsField: "sequentialPlanningHints",
+      },
+    },
+  ];
+}

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -6,6 +6,7 @@ import { STALE_CONTEXT_COMMAND } from "./stale-context";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
+import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -117,6 +118,7 @@ export type SourceOfTruthHandoffPacket = {
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   blockers: string[];
 };
 
@@ -132,6 +134,7 @@ const AUTHORITATIVE_FILES_AND_DOCS = [
   "src/ops/source-of-truth-handoff.ts",
   "src/ops/runtime-token-cost-planning-warning.ts",
   "src/ops/sequential-planning-hint.ts",
+  "src/ops/plan-before-execute-guard.ts",
   "src/cli/index.ts",
   "docs/research/context-trust-and-stale-evidence-research.md",
   "docs/stale-context.md",
@@ -292,6 +295,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
+  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
@@ -364,6 +368,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     planningWarnings,
     combinedReliabilityWarnings,
     sequentialPlanningHints,
+    planBeforeExecuteGuards,
     blockers,
   };
 }

--- a/test/plan-before-execute-guard.test.mjs
+++ b/test/plan-before-execute-guard.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const {
+  PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY,
+  buildPlanBeforeExecuteGuards,
+} = require(path.join(repoRoot, "dist", "ops", "plan-before-execute-guard.js"));
+const { buildRuntimeTokenCostPlanningWarnings } = require(path.join(repoRoot, "dist", "ops", "runtime-token-cost-planning-warning.js"));
+const { buildCombinedReliabilityWarnings } = require(path.join(repoRoot, "dist", "ops", "combined-reliability-warning.js"));
+const { buildSequentialPlanningHints } = require(path.join(repoRoot, "dist", "ops", "sequential-planning-hint.js"));
+
+const staleContextTrust = {
+  nonAuthorizing: [
+    {
+      kind: "stale-residue-active-boundary",
+      source: "synthetic stale residue",
+      reason: "cleanup-review only",
+      contractScope: "stale-residue-boundary",
+      authority: "insufficient",
+    },
+  ],
+  historicalOnly: [],
+};
+
+test("plan-before-execute guard stops long-run planning warnings before more execution", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: { nonAuthorizing: [], historicalOnly: [] }, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch: "fooks-issue-976-runtime-planning-warning", planningWarnings, combinedReliabilityWarnings });
+
+  const guards = buildPlanBeforeExecuteGuards({
+    branch: "fooks-issue-976-runtime-planning-warning",
+    planningWarnings,
+    combinedReliabilityWarnings,
+    sequentialPlanningHints,
+  });
+
+  assert.equal(guards.length, 1);
+  assert.equal(guards[0].issue, "#984");
+  assert.equal(guards[0].epic, "#960");
+  assert.equal(guards[0].trigger, "long-run-planning-warning-present");
+  assert.equal(guards[0].stopBeforeMoreExecution, true);
+  assert.ok(guards[0].requiredBeforeContinuing.includes("write-or-refresh-bounded-plan"));
+  assert.match(guards[0].message, /Stop before more execution/);
+  assert.equal(guards[0].derivedFrom.planningWarningCount, 1);
+  assert.equal(guards[0].derivedFrom.sequentialPlanningHintCount, 0);
+  assert.match(guards[0].claimBoundary, /Advisory plan-before-execute guard only/);
+  assert.match(guards[0].forbiddenClaims.join("\n"), /provider usage\/billing-token proof/);
+  assert.match(guards[0].forbiddenClaims.join("\n"), /autonomous execution authority/);
+  assert.match(guards[0].forbiddenClaims.join("\n"), /merge authority or merge-gate policy change/);
+  assert.match(guards[0].forbiddenClaims.join("\n"), /frontend runtime behavior change/);
+});
+
+test("plan-before-execute guard uses sequential hint plus stale reliability overlap as deterministic stop advice", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-960-runtime-token-cost-plan" });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: staleContextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch: "fooks-issue-960-runtime-token-cost-plan", planningWarnings, combinedReliabilityWarnings });
+
+  const guards = buildPlanBeforeExecuteGuards({
+    branch: "fooks-issue-960-runtime-token-cost-plan",
+    planningWarnings,
+    combinedReliabilityWarnings,
+    sequentialPlanningHints,
+  });
+
+  assert.equal(guards.length, 1);
+  assert.equal(guards[0].trigger, "stale-reliability-overlap-with-sequential-hint");
+  assert.equal(guards[0].derivedFrom.combinedReliabilityWarningCount, 1);
+  assert.equal(guards[0].derivedFrom.sequentialPlanningHintCount, 1);
+  assert.deepEqual(guards[0].derivedFrom, {
+    planningWarningCount: 1,
+    combinedReliabilityWarningCount: 1,
+    sequentialPlanningHintCount: 1,
+    planningWarningsField: "planningWarnings",
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    sequentialPlanningHintsField: "sequentialPlanningHints",
+  });
+});
+
+test("plan-before-execute guard remains absent for ordinary non-reliability handoffs", () => {
+  const guards = buildPlanBeforeExecuteGuards({
+    branch: "fooks-issue-963-source-of-truth-handoff",
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+    sequentialPlanningHints: [],
+  });
+
+  assert.deepEqual(guards, []);
+  assert.match(PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY, /not provider billing\/runtime proof/);
+  assert.match(PLAN_BEFORE_EXECUTE_GUARD_CLAIM_BOUNDARY, /not frontend behavior change/);
+});

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -273,3 +273,35 @@ test("source-of-truth handoff emits issue #982 sequential planning hint without 
   assert.match(packet.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /autonomous execution authority/);
   assert.match(packet.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /merge authority or merge-gate policy change/);
 });
+
+test("source-of-truth handoff emits issue #984 plan-before-execute guard without authority or frontend claims", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-984-plan-before-execute-guard";
+  snapshot.activity.worktree.branch = "fooks-issue-984-plan-before-execute-guard";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-984-plan-before-execute-guard";
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return " M src/ops/plan-before-execute-guard.ts\n";
+    if (key === "gh issue view 984 --json number,title,state,url") {
+      return JSON.stringify({ number: 984, title: "plan before execute guard", state: "OPEN", url: "https://github.com/minislively/fooks/issues/984" });
+    }
+    if (key === "gh pr list --head fooks-issue-984-plan-before-execute-guard --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-20T08:02:03.000Z" });
+  assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/plan-before-execute-guard.ts"));
+  assert.equal(packet.planBeforeExecuteGuards.length, 1);
+  assert.equal(packet.planBeforeExecuteGuards[0].issue, "#984");
+  assert.equal(packet.planBeforeExecuteGuards[0].epic, "#960");
+  assert.equal(packet.planBeforeExecuteGuards[0].trigger, "linked-issue-984");
+  assert.equal(packet.planBeforeExecuteGuards[0].stopBeforeMoreExecution, true);
+  assert.match(packet.planBeforeExecuteGuards[0].message, /write or refresh a bounded plan/);
+  assert.match(packet.planBeforeExecuteGuards[0].claimBoundary, /not provider billing\/runtime proof/);
+  assert.match(packet.planBeforeExecuteGuards[0].claimBoundary, /not autonomous execution or merge authority/);
+  assert.match(packet.planBeforeExecuteGuards[0].claimBoundary, /not frontend behavior change/);
+  assert.match(packet.planBeforeExecuteGuards[0].forbiddenClaims.join("\n"), /CI enforcement or blocking merge policy/);
+});


### PR DESCRIPTION
Closes #984.\n\n## Summary\n- Adds a bounded advisory `planBeforeExecuteGuards` surface under epic #960 for long/stale reliability runs.\n- Projects the guard through `fooks check` and `fooks handoff` without changing provider/runtime hooks, merge authority, CI policy, or frontend behavior.\n- Adds focused regression coverage for long-run, stale-overlap, ordinary no-op, and issue #984 handoff projection cases.\n\n## Verification\n- `npm run build`\n- `node --test test/plan-before-execute-guard.test.mjs test/source-of-truth-handoff.test.mjs`\n- `node dist/cli/index.js handoff --json` guard smoke\n\n## Boundaries\nAdvisory only: no provider billing/runtime proof, no autonomous merge authority, no CI/merge-gate enforcement, and no frontend behavior change.