### PR TITLE
Add compact authoritative resume packet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,6 +314,10 @@ export type {
   StaleContextWarningKind,
 } from "./ops/stale-context";
 export {
+  AUTHORITATIVE_RESUME_PACKET_CLAIM_BOUNDARY,
+  AUTHORITATIVE_RESUME_PACKET_ISSUE,
+  AUTHORITATIVE_RESUME_PACKET_SCHEMA_VERSION,
+  AUTHORITATIVE_RESUME_PACKET_SOURCE,
   SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY,
   SOURCE_OF_TRUTH_HANDOFF_COMMAND,
   SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION,
@@ -321,6 +325,8 @@ export {
   buildSourceOfTruthHandoffPacket,
 } from "./ops/source-of-truth-handoff";
 export type {
+  AuthoritativeResumePacket,
+  AuthoritativeResumePacketAction,
   SourceOfTruthHandoffCommandRunner,
   SourceOfTruthHandoffOptions,
   SourceOfTruthHandoffPacket,

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -13,6 +13,11 @@ export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
 export const SOURCE_OF_TRUTH_HANDOFF_SOURCE = "fooks check/preflight plus current-branch source-of-truth handoff projection";
 export const SOURCE_OF_TRUTH_HANDOFF_CLAIM_BOUNDARY =
   "Compact read-only handoff packet for fresh agent sessions; bounded to the invocation cwd/current branch/worktree, reuses operator-check/preflight contracts, performs only narrow git and gh issue/PR/status reads for linked current artifacts, and does not mutate hooks, provider/runtime behavior, stale detector scope, token/cost planning, product claims, or frontend behavior.";
+export const AUTHORITATIVE_RESUME_PACKET_SCHEMA_VERSION = 1;
+export const AUTHORITATIVE_RESUME_PACKET_ISSUE = "#986";
+export const AUTHORITATIVE_RESUME_PACKET_SOURCE = "compact authoritative resume packet derived from source-of-truth handoff";
+export const AUTHORITATIVE_RESUME_PACKET_CLAIM_BOUNDARY =
+  "Compact advisory/read-only resume packet for issue #986; it reuses existing handoff/source-of-truth/context-trust/reliability warning fields before a new session, preserves the full handoff output, and is not provider billing/runtime proof, not autonomous CI/merge authority, not provider/runtime hook behavior, not product support expansion, and not frontend behavior change.";
 
 export type SourceOfTruthHandoffCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
 
@@ -119,13 +124,93 @@ export type SourceOfTruthHandoffPacket = {
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+  authoritativeResumePacket: AuthoritativeResumePacket;
   blockers: string[];
+};
+
+export type AuthoritativeResumePacketAction =
+  | "stop-before-more-execution"
+  | SourceOfTruthHandoffPacket["nextRecommendedAction"]["action"];
+
+export type AuthoritativeResumePacket = {
+  schemaVersion: typeof AUTHORITATIVE_RESUME_PACKET_SCHEMA_VERSION;
+  issue: typeof AUTHORITATIVE_RESUME_PACKET_ISSUE;
+  status: "advisory";
+  compact: true;
+  beforeNewSession: true;
+  source: typeof AUTHORITATIVE_RESUME_PACKET_SOURCE;
+  claimBoundary: typeof AUTHORITATIVE_RESUME_PACKET_CLAIM_BOUNDARY;
+  derivedFrom: {
+    handoffCommand: typeof SOURCE_OF_TRUTH_HANDOFF_COMMAND;
+    handoffSchemaVersion: typeof SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION;
+    operatorCheckCommand: "check";
+    preflightCommand: "preflight";
+    fields: [
+      "scope",
+      "linkedArtifacts",
+      "currentStatus.operatorCheck",
+      "currentStatus.preflight",
+      "sourceOfTruth.currentAuthority",
+      "sourceOfTruth.authoritativeFilesAndDocs",
+      "staleOrHistoricalContextToAvoid",
+      "nextRecommendedAction",
+      "planningWarnings",
+      "combinedReliabilityWarnings",
+      "sequentialPlanningHints",
+      "planBeforeExecuteGuards",
+    ];
+  };
+  currentSourceOfTruth: {
+    authorityStatus: PreflightPacket["summary"]["authorityStatus"];
+    currentAuthority: PreflightPacket["currentAuthority"];
+    authoritativeFilesAndDocs: string[];
+    scope: {
+      cwd: string;
+      branch?: string;
+      head?: string;
+      upstream?: string;
+      clean: boolean | null;
+      changedPathCount: number;
+      changedPaths: string[];
+      changedPathLimit: number;
+    };
+    linkedArtifacts: {
+      issue: SourceOfTruthLinkedArtifact;
+      pullRequest: SourceOfTruthLinkedArtifact;
+    };
+  };
+  staleHistoricalBoundary: {
+    status: "clear" | "present";
+    avoidCount: number;
+    entries: SourceOfTruthHandoffPacket["staleOrHistoricalContextToAvoid"];
+    entryLimit: number;
+    omittedCount: number;
+    instruction: string;
+  };
+  reliabilityBoundary: {
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    sequentialPlanningHintCount: number;
+    planBeforeExecuteGuardCount: number;
+    staleContextReliabilityOverlap: boolean;
+    stopBeforeMoreExecution: boolean;
+  };
+  nextSessionAdvisory: {
+    action: AuthoritativeResumePacketAction;
+    rationale: string;
+    suggestedCommands: string[];
+    requiredRechecks: string[];
+  };
+  forbiddenClaims: string[];
 };
 
 const GIT_SOURCE = "local git for invocation cwd/current branch; no fetch performed";
 const ISSUE_SOURCE = "gh issue view <inferred issue number> --json number,title,state,url";
 const PR_SOURCE = "gh pr list --head <current branch> --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1";
 const CHANGED_PATH_LIMIT = 40;
+const RESUME_CHANGED_PATH_LIMIT = 12;
+const RESUME_AUTHORITATIVE_FILE_LIMIT = 12;
+const RESUME_STALE_ENTRY_LIMIT = 10;
 const AUTHORITATIVE_FILES_AND_DOCS = [
   "src/ops/operator-check.ts",
   "src/ops/context-trust.ts",
@@ -282,6 +367,125 @@ function nextAction(preflight: PreflightPacket, issue: SourceOfTruthLinkedArtifa
   };
 }
 
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function buildAuthoritativeResumePacket(input: {
+  cwd: string;
+  branch?: string;
+  head?: string;
+  upstream?: string;
+  clean: boolean | null;
+  changedPaths: string[];
+  issue: SourceOfTruthLinkedArtifact;
+  pullRequest: SourceOfTruthLinkedArtifact;
+  preflight: PreflightPacket;
+  staleOrHistoricalContextToAvoid: SourceOfTruthHandoffPacket["staleOrHistoricalContextToAvoid"];
+  nextRecommendedAction: SourceOfTruthHandoffPacket["nextRecommendedAction"];
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+}): AuthoritativeResumePacket {
+  const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
+  const requiredRechecks = uniqueStrings([
+    ...input.planBeforeExecuteGuards.flatMap((guard) => guard.requiredRechecks),
+    ...input.sequentialPlanningHints.flatMap((hint) => hint.requiredRechecks),
+    ...input.combinedReliabilityWarnings.flatMap((warning) => warning.requiredRechecks),
+    "Run fooks check --json in the new session before treating this packet as current authority.",
+    "Run fooks handoff --json again before the next context compression or fresh-agent handoff.",
+  ]);
+  const forbiddenClaims = uniqueStrings([
+    ...input.planBeforeExecuteGuards.flatMap((guard) => guard.forbiddenClaims),
+    ...input.sequentialPlanningHints.flatMap((hint) => hint.forbiddenClaims),
+    ...input.combinedReliabilityWarnings.flatMap((warning) => warning.forbiddenClaims),
+    ...input.planningWarnings.flatMap((warning) => warning.forbiddenClaims),
+    "provider billing/runtime proof",
+    "autonomous CI/merge authority",
+    "frontend runtime behavior change",
+  ]);
+  const staleEntries = input.staleOrHistoricalContextToAvoid.slice(0, RESUME_STALE_ENTRY_LIMIT);
+  const action: AuthoritativeResumePacketAction = stopBeforeMoreExecution ? "stop-before-more-execution" : input.nextRecommendedAction.action;
+  const rationale = stopBeforeMoreExecution
+    ? "plan-before-execute guard is present; a fresh session should recheck current authority and resume from this compact packet before more execution."
+    : input.nextRecommendedAction.rationale;
+
+  return {
+    schemaVersion: AUTHORITATIVE_RESUME_PACKET_SCHEMA_VERSION,
+    issue: AUTHORITATIVE_RESUME_PACKET_ISSUE,
+    status: "advisory",
+    compact: true,
+    beforeNewSession: true,
+    source: AUTHORITATIVE_RESUME_PACKET_SOURCE,
+    claimBoundary: AUTHORITATIVE_RESUME_PACKET_CLAIM_BOUNDARY,
+    derivedFrom: {
+      handoffCommand: SOURCE_OF_TRUTH_HANDOFF_COMMAND,
+      handoffSchemaVersion: SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION,
+      operatorCheckCommand: "check",
+      preflightCommand: "preflight",
+      fields: [
+        "scope",
+        "linkedArtifacts",
+        "currentStatus.operatorCheck",
+        "currentStatus.preflight",
+        "sourceOfTruth.currentAuthority",
+        "sourceOfTruth.authoritativeFilesAndDocs",
+        "staleOrHistoricalContextToAvoid",
+        "nextRecommendedAction",
+        "planningWarnings",
+        "combinedReliabilityWarnings",
+        "sequentialPlanningHints",
+        "planBeforeExecuteGuards",
+      ],
+    },
+    currentSourceOfTruth: {
+      authorityStatus: input.preflight.summary.authorityStatus,
+      currentAuthority: input.preflight.currentAuthority,
+      authoritativeFilesAndDocs: AUTHORITATIVE_FILES_AND_DOCS.map((entry) => path.normalize(entry)).slice(0, RESUME_AUTHORITATIVE_FILE_LIMIT),
+      scope: {
+        cwd: input.cwd,
+        ...(input.branch ? { branch: input.branch } : {}),
+        ...(input.head ? { head: input.head } : {}),
+        ...(input.upstream ? { upstream: input.upstream } : {}),
+        clean: input.clean,
+        changedPathCount: input.changedPaths.length,
+        changedPaths: input.changedPaths.slice(0, RESUME_CHANGED_PATH_LIMIT),
+        changedPathLimit: RESUME_CHANGED_PATH_LIMIT,
+      },
+      linkedArtifacts: {
+        issue: input.issue,
+        pullRequest: input.pullRequest,
+      },
+    },
+    staleHistoricalBoundary: {
+      status: input.staleOrHistoricalContextToAvoid.length > 0 ? "present" : "clear",
+      avoidCount: input.staleOrHistoricalContextToAvoid.length,
+      entries: staleEntries,
+      entryLimit: RESUME_STALE_ENTRY_LIMIT,
+      omittedCount: Math.max(0, input.staleOrHistoricalContextToAvoid.length - staleEntries.length),
+      instruction: input.staleOrHistoricalContextToAvoid.length > 0
+        ? "Treat listed stale/historical/non-authorizing entries as boundaries to avoid until rechecked with fooks check/preflight/stale-context."
+        : "No stale/historical/non-authorizing entries were present in the source handoff; still re-run fooks check before relying on this packet.",
+    },
+    reliabilityBoundary: {
+      planningWarningCount: input.planningWarnings.length,
+      combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+      sequentialPlanningHintCount: input.sequentialPlanningHints.length,
+      planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
+      staleContextReliabilityOverlap: input.combinedReliabilityWarnings.length > 0,
+      stopBeforeMoreExecution,
+    },
+    nextSessionAdvisory: {
+      action,
+      rationale,
+      suggestedCommands: input.nextRecommendedAction.suggestedCommands,
+      requiredRechecks,
+    },
+    forbiddenClaims,
+  };
+}
+
 export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot, preflight: PreflightPacket, options: SourceOfTruthHandoffOptions = {}): SourceOfTruthHandoffPacket {
   const cwd = snapshot.cwd;
   const blockers = [...snapshot.blockers];
@@ -296,6 +500,25 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+  const staleOrHistoricalContextToAvoid = staleAvoidList(snapshot, preflight);
+  const nextRecommendedAction = nextAction(preflight, issue, prResult.artifact, changedPaths.length);
+  const authoritativeResumePacket = buildAuthoritativeResumePacket({
+    cwd,
+    branch,
+    head,
+    upstream,
+    clean: snapshot.activity.worktree.clean,
+    changedPaths,
+    issue,
+    pullRequest: prResult.artifact,
+    preflight,
+    staleOrHistoricalContextToAvoid,
+    nextRecommendedAction,
+    planningWarnings,
+    combinedReliabilityWarnings,
+    sequentialPlanningHints,
+    planBeforeExecuteGuards,
+  });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
@@ -363,12 +586,13 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
       authoritativeFilesAndDocs: AUTHORITATIVE_FILES_AND_DOCS.map((entry) => path.normalize(entry)),
       currentChangedFiles: changedPaths.slice(0, CHANGED_PATH_LIMIT),
     },
-    staleOrHistoricalContextToAvoid: staleAvoidList(snapshot, preflight),
-    nextRecommendedAction: nextAction(preflight, issue, prResult.artifact, changedPaths.length),
+    staleOrHistoricalContextToAvoid,
+    nextRecommendedAction,
     planningWarnings,
     combinedReliabilityWarnings,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
+    authoritativeResumePacket,
     blockers,
   };
 }

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -118,9 +118,92 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.ok(packet.sourceOfTruth.authoritativeFilesAndDocs.includes("src/ops/sequential-planning-hint.ts"));
   assert.equal(packet.staleOrHistoricalContextToAvoid.length, 2);
   assert.equal(packet.nextRecommendedAction.action, "continue-implementation-for-linked-issue");
+  assert.equal(packet.authoritativeResumePacket.issue, "#986");
+  assert.equal(packet.authoritativeResumePacket.compact, true);
+  assert.equal(packet.authoritativeResumePacket.beforeNewSession, true);
+  assert.equal(packet.authoritativeResumePacket.currentSourceOfTruth.authorityStatus, "present");
+  assert.equal(packet.authoritativeResumePacket.staleHistoricalBoundary.status, "present");
+  assert.equal(packet.authoritativeResumePacket.nextSessionAdvisory.action, "continue-implementation-for-linked-issue");
   assert.deepEqual(packet.planningWarnings, []);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
   assert.deepEqual(packet.sequentialPlanningHints, []);
+});
+
+test("authoritative resume packet compacts stale/context/reliability overlap before new session", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.runtimeProvenance.git.branch = "fooks-issue-976-runtime-planning-warning";
+  snapshot.activity.worktree.branch = "fooks-issue-976-runtime-planning-warning";
+  snapshot.activity.worktree.upstream = "origin/fooks-issue-976-runtime-planning-warning";
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return " M src/ops/source-of-truth-handoff.ts\n M test/source-of-truth-handoff.test.mjs\n";
+    if (key === "gh issue view 976 --json number,title,state,url") {
+      return JSON.stringify({ number: 976, title: "runtime planning warning", state: "OPEN", url: "https://github.com/minislively/fooks/issues/976" });
+    }
+    if (key === "gh pr list --head fooks-issue-976-runtime-planning-warning --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-20T10:02:03.000Z" });
+  const resume = packet.authoritativeResumePacket;
+  assert.equal(resume.schemaVersion, 1);
+  assert.equal(resume.status, "advisory");
+  assert.match(resume.claimBoundary, /not provider billing\/runtime proof/);
+  assert.match(resume.claimBoundary, /not autonomous CI\/merge authority/);
+  assert.equal(resume.currentSourceOfTruth.linkedArtifacts.issue.number, 976);
+  assert.equal(resume.currentSourceOfTruth.scope.branch, "fooks-issue-976-runtime-planning-warning");
+  assert.deepEqual(resume.currentSourceOfTruth.scope.changedPaths, ["src/ops/source-of-truth-handoff.ts", "test/source-of-truth-handoff.test.mjs"]);
+  assert.equal(resume.staleHistoricalBoundary.status, "present");
+  assert.equal(resume.staleHistoricalBoundary.avoidCount, 2);
+  assert.match(resume.staleHistoricalBoundary.instruction, /Treat listed stale\/historical\/non-authorizing entries as boundaries/);
+  assert.equal(resume.reliabilityBoundary.planningWarningCount, 1);
+  assert.equal(resume.reliabilityBoundary.combinedReliabilityWarningCount, 1);
+  assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 1);
+  assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 1);
+  assert.equal(resume.reliabilityBoundary.staleContextReliabilityOverlap, true);
+  assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, true);
+  assert.equal(resume.nextSessionAdvisory.action, "stop-before-more-execution");
+  assert.match(resume.nextSessionAdvisory.rationale, /recheck current authority/);
+  assert.ok(resume.nextSessionAdvisory.requiredRechecks.some((line) => /fooks check --json/.test(line)));
+  assert.match(resume.forbiddenClaims.join("\n"), /provider usage\/billing-token proof/);
+  assert.match(resume.forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
+  assert.match(JSON.stringify(resume), /sourceOfTruth.currentAuthority/);
+});
+
+test("authoritative resume packet stays advisory and clear for ordinary non-risk handoff", () => {
+  const cwd = repoRoot;
+  const snapshot = baseSnapshot(cwd);
+  snapshot.contextTrust.nonAuthorizing = [];
+  snapshot.contextTrust.historicalOnly = [];
+  const preflight = basePreflight();
+  preflight.historicalOnly = [];
+  preflight.nonAuthorizing = [];
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 963 --json number,title,state,url") return JSON.stringify({ number: 963, title: "source of truth handoff", state: "OPEN" });
+    if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return JSON.stringify([{ number: 1001, state: "OPEN", headRefName: "fooks-issue-963-source-of-truth-handoff", baseRefName: "main", isDraft: false, statusCheckRollup: [] }]);
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, preflight, { commandRunner: runner, now: () => "2026-05-20T10:03:03.000Z" });
+  const resume = packet.authoritativeResumePacket;
+  assert.equal(resume.staleHistoricalBoundary.status, "clear");
+  assert.equal(resume.staleHistoricalBoundary.avoidCount, 0);
+  assert.equal(resume.reliabilityBoundary.planningWarningCount, 0);
+  assert.equal(resume.reliabilityBoundary.combinedReliabilityWarningCount, 0);
+  assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 0);
+  assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 0);
+  assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, false);
+  assert.equal(resume.nextSessionAdvisory.action, "continue-implementation-for-linked-issue");
+  assert.match(resume.staleHistoricalBoundary.instruction, /No stale\/historical\/non-authorizing entries/);
+  assert.match(resume.claimBoundary, /preserves the full handoff output/);
+  assert.match(resume.forbiddenClaims.join("\n"), /frontend runtime behavior change/);
 });
 
 test("handoff CLI emits JSON packet", () => {


### PR DESCRIPTION
Closes #986

## Summary
- Adds an additive `authoritativeResumePacket` inside the existing source-of-truth handoff output.
- Reuses current authority, stale/historical boundary, reliability warning, sequential planning, and plan-before-execute guard fields.
- Keeps the packet advisory/read-only with explicit non-claims for provider billing/runtime proof, CI/merge authority, and frontend behavior changes.

## Tests
- `npm run build`
- `node --test test/source-of-truth-handoff.test.mjs`
