### PR TITLE
Expose compact resume handoff projection

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -645,7 +645,7 @@ Everyday commands:
   ${displayCliName} preflight [--json]
       Compact read-only agent guidance projected from the existing operator-check/contextTrust snapshot.
 
-  ${displayCliName} handoff [--json]
+  ${displayCliName} handoff [--json|--resume-json]
       Compact source-of-truth handoff packet for fresh agent sessions, bounded to the current branch/worktree.
 
   ${displayCliName} stale-context <prompt-or-handoff.md> [--json]
@@ -1613,11 +1613,22 @@ async function run(): Promise<void> {
       return;
     }
     case "handoff": {
-      const allowed = new Set(["--json"]);
+      const allowed = new Set(["--json", "--resume-json"]);
+      let json = false;
+      let resumeJson = false;
       for (const arg of rest) {
         if (!allowed.has(arg)) {
           throw new Error(`Unexpected handoff argument: ${arg}`);
         }
+        if (arg === "--json") {
+          json = true;
+        }
+        if (arg === "--resume-json") {
+          resumeJson = true;
+        }
+      }
+      if (json && resumeJson) {
+        throw new Error("handoff accepts either --json or --resume-json, not both");
       }
       const [{ readOperatorCheckSnapshot }, { buildPreflightPacket }, { buildSourceOfTruthHandoffPacket }] = await Promise.all([
         import("../ops/operator-check.js"),
@@ -1626,7 +1637,8 @@ async function run(): Promise<void> {
       ]);
       const snapshot = readOperatorCheckSnapshot(process.cwd());
       const preflight = buildPreflightPacket(snapshot);
-      print(buildSourceOfTruthHandoffPacket(snapshot, preflight));
+      const packet = buildSourceOfTruthHandoffPacket(snapshot, preflight);
+      print(resumeJson ? packet.authoritativeResumePacket : packet);
       return;
     }
     case "status": {

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -218,6 +218,44 @@ test("handoff CLI emits JSON packet", () => {
   assert.ok(packet.currentStatus.operatorCheck.verdict);
 });
 
+test("handoff CLI emits compact authoritative resume packet only", () => {
+  const fullStdout = execFileSync(process.execPath, [cli, "handoff", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
+  const resumeStdout = execFileSync(process.execPath, [cli, "handoff", "--resume-json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
+  const fullPacket = JSON.parse(fullStdout);
+  const resumePacket = JSON.parse(resumeStdout);
+
+  assert.deepEqual(resumePacket, fullPacket.authoritativeResumePacket);
+  assert.equal(resumePacket.schemaVersion, 1);
+  assert.equal(resumePacket.status, "advisory");
+  assert.equal(resumePacket.compact, true);
+  assert.equal(resumePacket.beforeNewSession, true);
+  assert.equal(resumePacket.derivedFrom.handoffCommand, "handoff");
+  assert.equal(resumePacket.derivedFrom.handoffSchemaVersion, fullPacket.schemaVersion);
+  assert.equal(resumePacket.currentSourceOfTruth.scope.cwd, fullPacket.scope.cwd);
+  assert.equal(resumePacket.currentSourceOfTruth.scope.changedPathCount, fullPacket.scope.changedPathCount);
+  assert.equal(resumePacket.staleHistoricalBoundary.avoidCount, fullPacket.staleOrHistoricalContextToAvoid.length);
+  assert.equal(resumePacket.reliabilityBoundary.planningWarningCount, fullPacket.planningWarnings.length);
+  assert.equal(resumePacket.reliabilityBoundary.combinedReliabilityWarningCount, fullPacket.combinedReliabilityWarnings.length);
+  assert.equal(resumePacket.reliabilityBoundary.sequentialPlanningHintCount, fullPacket.sequentialPlanningHints.length);
+  assert.equal(resumePacket.reliabilityBoundary.planBeforeExecuteGuardCount, fullPacket.planBeforeExecuteGuards.length);
+  assert.equal(Object.hasOwn(resumePacket, "currentStatus"), false);
+  assert.equal(Object.hasOwn(resumePacket, "sourceOfTruth"), false);
+  assert.match(resumePacket.claimBoundary, /not provider billing\/runtime proof/);
+  assert.match(resumePacket.claimBoundary, /not autonomous CI\/merge authority/);
+  assert.match(resumePacket.claimBoundary, /not provider\/runtime hook behavior/);
+  assert.match(resumePacket.claimBoundary, /not product support expansion/);
+  assert.match(resumePacket.claimBoundary, /not frontend behavior change/);
+  assert.match(resumePacket.forbiddenClaims.join("\n"), /provider billing\/runtime proof/);
+  assert.match(resumePacket.forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
+});
+
+test("handoff CLI rejects ambiguous full and resume JSON projection flags", () => {
+  assert.throws(
+    () => execFileSync(process.execPath, [cli, "handoff", "--json", "--resume-json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000, stdio: ["ignore", "pipe", "pipe"] }),
+    /handoff accepts either --json or --resume-json, not both/,
+  );
+});
+
 test("source-of-truth handoff emits narrow issue #960 runtime/token-cost planning warning only", () => {
   const cwd = repoRoot;
   const snapshot = baseSnapshot(cwd);


### PR DESCRIPTION
Closes #989.

## Summary
- Add `fooks handoff --resume-json` as a narrow read-only CLI projection.
- Reuse the existing `packet.authoritativeResumePacket` from the source-of-truth handoff builder.
- Preserve existing full `fooks handoff --json` output behavior.
- Keep the surface advisory/claim-bounded with no provider/runtime hook, frontend, docs, release, CI, or merge-authority changes.

## Verification
- `npm run build`
- `node --test test/source-of-truth-handoff.test.mjs`
- `npm test`
- AI slop cleanup pass on changed files: no-op/clean
- Code review: APPROVE; architecture review: CLEAR
