### PR TITLE
Add long-run budget warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,3 +343,17 @@ export type {
   CombinedReliabilityWarning,
   CombinedReliabilityWarningContextRisk,
 } from "./ops/combined-reliability-warning";
+export {
+  LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY,
+  LONG_RUN_BUDGET_WARNING_EPIC,
+  LONG_RUN_BUDGET_WARNING_ISSUE,
+  LONG_RUN_BUDGET_WARNING_SCHEMA_VERSION,
+  LONG_RUN_BUDGET_WARNING_SOURCE,
+  buildLongRunBudgetWarnings,
+} from "./ops/long-run-budget-warning";
+export type {
+  LongRunBudgetRiskLevel,
+  LongRunBudgetWarning,
+  LongRunBudgetWarningAction,
+  LongRunBudgetWarningTrigger,
+} from "./ops/long-run-budget-warning";

--- a/src/ops/long-run-budget-warning.ts
+++ b/src/ops/long-run-budget-warning.ts
@@ -1,0 +1,131 @@
+import type { CombinedReliabilityWarning } from "./combined-reliability-warning";
+import type { PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
+import type { RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+import type { SequentialPlanningHint } from "./sequential-planning-hint";
+
+export const LONG_RUN_BUDGET_WARNING_SCHEMA_VERSION = 1;
+export const LONG_RUN_BUDGET_WARNING_ISSUE = "#988";
+export const LONG_RUN_BUDGET_WARNING_EPIC = "#960";
+export const LONG_RUN_BUDGET_WARNING_SOURCE = "deterministic long-run budget advisory";
+export const LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY =
+  "Advisory/read-only long-run budget warning only for issue #988 under epic #960; derived from existing runtime planning, combined reliability, sequential-planning, plan-before-execute, and compact resume packet fields, not provider billing/token/runtime proof, not autonomous CI/merge authority, not provider/runtime hook behavior, not product support expansion, and not frontend behavior change.";
+
+export type LongRunBudgetWarningTrigger =
+  | "plan-before-execute-stop-with-runtime-planning"
+  | "plan-before-execute-stop-with-combined-reliability"
+  | "plan-before-execute-stop-with-sequential-planning";
+
+export type LongRunBudgetRiskLevel = "high";
+
+export type LongRunBudgetWarningAction =
+  | "pause-before-next-long-run"
+  | "refresh-bounded-plan"
+  | "compress-current-source-of-truth"
+  | "handoff-to-fresh-agent";
+
+export type LongRunBudgetWarning = {
+  schemaVersion: typeof LONG_RUN_BUDGET_WARNING_SCHEMA_VERSION;
+  issue: typeof LONG_RUN_BUDGET_WARNING_ISSUE;
+  epic: typeof LONG_RUN_BUDGET_WARNING_EPIC;
+  status: "advisory";
+  source: typeof LONG_RUN_BUDGET_WARNING_SOURCE;
+  trigger: LongRunBudgetWarningTrigger;
+  riskLevel: LongRunBudgetRiskLevel;
+  budgetBoundary: "long-context-window-risk";
+  message: string;
+  recommendedActions: LongRunBudgetWarningAction[];
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  claimBoundary: typeof LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY;
+  derivedFrom: {
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    sequentialPlanningHintCount: number;
+    planBeforeExecuteGuardCount: number;
+    stopBeforeMoreExecution: true;
+    planningWarningsField: "planningWarnings";
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+    sequentialPlanningHintsField: "sequentialPlanningHints";
+    planBeforeExecuteGuardsField: "planBeforeExecuteGuards";
+    compactResumePacketField: "authoritativeResumePacket.reliabilityBoundary";
+  };
+};
+
+function chooseTrigger(input: {
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+}): LongRunBudgetWarningTrigger | undefined {
+  const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
+  if (!stopBeforeMoreExecution) return undefined;
+
+  const hasRuntimePlanningStop = input.planBeforeExecuteGuards.some((guard) => guard.trigger === "long-run-planning-warning-present")
+    && input.planningWarnings.length > 0;
+  if (hasRuntimePlanningStop) return "plan-before-execute-stop-with-runtime-planning";
+
+  if (input.combinedReliabilityWarnings.length > 0) return "plan-before-execute-stop-with-combined-reliability";
+  if (input.sequentialPlanningHints.length > 0) return "plan-before-execute-stop-with-sequential-planning";
+
+  return undefined;
+}
+
+export function buildLongRunBudgetWarnings(input: {
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+}): LongRunBudgetWarning[] {
+  const trigger = chooseTrigger(input);
+  if (!trigger) return [];
+
+  return [
+    {
+      schemaVersion: LONG_RUN_BUDGET_WARNING_SCHEMA_VERSION,
+      issue: LONG_RUN_BUDGET_WARNING_ISSUE,
+      epic: LONG_RUN_BUDGET_WARNING_EPIC,
+      status: "advisory",
+      source: LONG_RUN_BUDGET_WARNING_SOURCE,
+      trigger,
+      riskLevel: "high",
+      budgetBoundary: "long-context-window-risk",
+      message:
+        "Long-run budget risk is high enough to pause before another long context window: refresh a bounded plan, compress current source-of-truth evidence, or hand off to a fresh agent before continuing.",
+      recommendedActions: [
+        "pause-before-next-long-run",
+        "refresh-bounded-plan",
+        "compress-current-source-of-truth",
+        "handoff-to-fresh-agent",
+      ],
+      requiredRechecks: [
+        "Run fooks check --json to inspect current advisory warning fields.",
+        "Run fooks preflight --json before deciding whether to continue normally, split work, compress, or hand off.",
+        "Run fooks handoff --json before context compression or fresh-agent handoff.",
+        "Treat this warning as a deterministic budget-risk boundary only, not token, billing, runtime, CI, merge, or frontend proof.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "provider/runtime hook behavior change",
+        "autonomous CI/merge authority",
+        "merge authority or merge-gate policy change",
+        "runtime/provider support expansion",
+        "frontend runtime behavior change",
+      ],
+      claimBoundary: LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY,
+      derivedFrom: {
+        planningWarningCount: input.planningWarnings.length,
+        combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+        sequentialPlanningHintCount: input.sequentialPlanningHints.length,
+        planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
+        stopBeforeMoreExecution: true,
+        planningWarningsField: "planningWarnings",
+        combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+        sequentialPlanningHintsField: "sequentialPlanningHints",
+        planBeforeExecuteGuardsField: "planBeforeExecuteGuards",
+        compactResumePacketField: "authoritativeResumePacket.reliabilityBoundary",
+      },
+    },
+  ];
+}

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -23,6 +23,7 @@ import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWar
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
+import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -41,7 +42,7 @@ export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VE
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE = "operator/check reliability warning visibility projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY =
-  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, and combinedReliabilityWarnings fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
+  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, and longRunBudgetWarnings fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
@@ -573,6 +574,7 @@ export type OperatorCheckSnapshot = {
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
   activity: OperatorActivitySnapshot;
   blockers: string[];
@@ -586,6 +588,7 @@ export type OperatorCheckReliabilityWarningVisibility = {
     existingWarningCount: number;
     planningWarningCount: number;
     combinedReliabilityWarningCount: number;
+    longRunBudgetWarningCount: number;
     contextTrustCurrentAuthorityCount: number;
     contextTrustNonAuthorizingCount: number;
     contextTrustHistoricalOnlyCount: number;
@@ -611,11 +614,25 @@ export type OperatorCheckReliabilityWarningVisibility = {
         forbiddenClaims: CombinedReliabilityWarning["forbiddenClaims"];
         claimBoundary: CombinedReliabilityWarning["claimBoundary"];
       }
+    | {
+        kind: "long-run-budget";
+        issue: LongRunBudgetWarning["issue"];
+        trigger: LongRunBudgetWarning["trigger"];
+        status: LongRunBudgetWarning["status"];
+        riskLevel: LongRunBudgetWarning["riskLevel"];
+        budgetBoundary: LongRunBudgetWarning["budgetBoundary"];
+        message: LongRunBudgetWarning["message"];
+        recommendedActions: LongRunBudgetWarning["recommendedActions"];
+        requiredRechecks: LongRunBudgetWarning["requiredRechecks"];
+        forbiddenClaims: LongRunBudgetWarning["forbiddenClaims"];
+        claimBoundary: LongRunBudgetWarning["claimBoundary"];
+      }
   >;
   derivedFrom: {
     contextTrustSource: OperatorContextTrustPacket["source"];
     planningWarningsField: "planningWarnings";
     combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+    longRunBudgetWarningsField: "longRunBudgetWarnings";
   };
   claimBoundary: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY;
 };
@@ -1645,6 +1662,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
 }): OperatorCheckReliabilityWarningVisibility {
   const warnings: OperatorCheckReliabilityWarningVisibility["warnings"] = [
     ...input.planningWarnings.map((warning) => ({
@@ -1667,6 +1685,19 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       forbiddenClaims: warning.forbiddenClaims,
       claimBoundary: warning.claimBoundary,
     })),
+    ...input.longRunBudgetWarnings.map((warning) => ({
+      kind: "long-run-budget" as const,
+      issue: warning.issue,
+      trigger: warning.trigger,
+      status: warning.status,
+      riskLevel: warning.riskLevel,
+      budgetBoundary: warning.budgetBoundary,
+      message: warning.message,
+      recommendedActions: warning.recommendedActions,
+      requiredRechecks: warning.requiredRechecks,
+      forbiddenClaims: warning.forbiddenClaims,
+      claimBoundary: warning.claimBoundary,
+    })),
   ];
 
   return {
@@ -1677,6 +1708,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       existingWarningCount: warnings.length,
       planningWarningCount: input.planningWarnings.length,
       combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+      longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
       contextTrustCurrentAuthorityCount: input.contextTrust.sourceOfTruth.current.length,
       contextTrustNonAuthorizingCount: input.contextTrust.nonAuthorizing.length,
       contextTrustHistoricalOnlyCount: input.contextTrust.historicalOnly.length,
@@ -1686,6 +1718,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       contextTrustSource: input.contextTrust.source,
       planningWarningsField: "planningWarnings",
       combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+      longRunBudgetWarningsField: "longRunBudgetWarnings",
     },
     claimBoundary: OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY,
   };
@@ -1719,10 +1752,12 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+  const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
   const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
+    longRunBudgetWarnings,
   });
 
   return {
@@ -1752,6 +1787,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     combinedReliabilityWarnings,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
+    longRunBudgetWarnings,
     reliabilityWarningVisibility,
     activity,
     blockers,

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -7,6 +7,7 @@ import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWar
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
+import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -124,6 +125,7 @@ export type SourceOfTruthHandoffPacket = {
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
   authoritativeResumePacket: AuthoritativeResumePacket;
   blockers: string[];
 };
@@ -158,6 +160,7 @@ export type AuthoritativeResumePacket = {
       "combinedReliabilityWarnings",
       "sequentialPlanningHints",
       "planBeforeExecuteGuards",
+      "longRunBudgetWarnings",
     ];
   };
   currentSourceOfTruth: {
@@ -192,6 +195,8 @@ export type AuthoritativeResumePacket = {
     combinedReliabilityWarningCount: number;
     sequentialPlanningHintCount: number;
     planBeforeExecuteGuardCount: number;
+    longRunBudgetWarningCount: number;
+    longRunBudgetRiskLevel: "high" | "clear";
     staleContextReliabilityOverlap: boolean;
     stopBeforeMoreExecution: boolean;
   };
@@ -387,9 +392,11 @@ function buildAuthoritativeResumePacket(input: {
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
 }): AuthoritativeResumePacket {
   const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
   const requiredRechecks = uniqueStrings([
+    ...input.longRunBudgetWarnings.flatMap((warning) => warning.requiredRechecks),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.requiredRechecks),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.requiredRechecks),
     ...input.combinedReliabilityWarnings.flatMap((warning) => warning.requiredRechecks),
@@ -397,6 +404,7 @@ function buildAuthoritativeResumePacket(input: {
     "Run fooks handoff --json again before the next context compression or fresh-agent handoff.",
   ]);
   const forbiddenClaims = uniqueStrings([
+    ...input.longRunBudgetWarnings.flatMap((warning) => warning.forbiddenClaims),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.forbiddenClaims),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.forbiddenClaims),
     ...input.combinedReliabilityWarnings.flatMap((warning) => warning.forbiddenClaims),
@@ -437,6 +445,7 @@ function buildAuthoritativeResumePacket(input: {
         "combinedReliabilityWarnings",
         "sequentialPlanningHints",
         "planBeforeExecuteGuards",
+        "longRunBudgetWarnings",
       ],
     },
     currentSourceOfTruth: {
@@ -473,6 +482,8 @@ function buildAuthoritativeResumePacket(input: {
       combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
       sequentialPlanningHintCount: input.sequentialPlanningHints.length,
       planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
+      longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
+      longRunBudgetRiskLevel: input.longRunBudgetWarnings.length > 0 ? "high" : "clear",
       staleContextReliabilityOverlap: input.combinedReliabilityWarnings.length > 0,
       stopBeforeMoreExecution,
     },
@@ -500,6 +511,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+  const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
   const staleOrHistoricalContextToAvoid = staleAvoidList(snapshot, preflight);
   const nextRecommendedAction = nextAction(preflight, issue, prResult.artifact, changedPaths.length);
   const authoritativeResumePacket = buildAuthoritativeResumePacket({
@@ -518,6 +530,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     combinedReliabilityWarnings,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
+    longRunBudgetWarnings,
   });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
@@ -592,6 +605,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     combinedReliabilityWarnings,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
+    longRunBudgetWarnings,
     authoritativeResumePacket,
     blockers,
   };

--- a/test/long-run-budget-warning.test.mjs
+++ b/test/long-run-budget-warning.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const {
+  LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY,
+  buildLongRunBudgetWarnings,
+} = require(path.join(repoRoot, "dist", "ops", "long-run-budget-warning.js"));
+const { buildRuntimeTokenCostPlanningWarnings } = require(path.join(repoRoot, "dist", "ops", "runtime-token-cost-planning-warning.js"));
+const { buildCombinedReliabilityWarnings } = require(path.join(repoRoot, "dist", "ops", "combined-reliability-warning.js"));
+const { buildSequentialPlanningHints } = require(path.join(repoRoot, "dist", "ops", "sequential-planning-hint.js"));
+const { buildPlanBeforeExecuteGuards } = require(path.join(repoRoot, "dist", "ops", "plan-before-execute-guard.js"));
+
+const staleContextTrust = {
+  nonAuthorizing: [
+    {
+      kind: "stale-residue-active-boundary",
+      source: "synthetic stale residue",
+      reason: "cleanup-review only",
+      contractScope: "stale-residue-boundary",
+      authority: "insufficient",
+    },
+  ],
+  historicalOnly: [],
+};
+
+test("long-run budget warning appears for bounded high-risk long-run planning inputs", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: { nonAuthorizing: [], historicalOnly: [] }, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch: "fooks-issue-976-runtime-planning-warning", planningWarnings, combinedReliabilityWarnings });
+  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch: "fooks-issue-976-runtime-planning-warning", planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+
+  const warnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
+
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].issue, "#988");
+  assert.equal(warnings[0].epic, "#960");
+  assert.equal(warnings[0].status, "advisory");
+  assert.equal(warnings[0].riskLevel, "high");
+  assert.equal(warnings[0].budgetBoundary, "long-context-window-risk");
+  assert.equal(warnings[0].trigger, "plan-before-execute-stop-with-runtime-planning");
+  assert.ok(warnings[0].recommendedActions.includes("compress-current-source-of-truth"));
+  assert.ok(warnings[0].recommendedActions.includes("handoff-to-fresh-agent"));
+  assert.match(warnings[0].message, /pause before another long context window/);
+  assert.deepEqual(warnings[0].derivedFrom, {
+    planningWarningCount: 1,
+    combinedReliabilityWarningCount: 0,
+    sequentialPlanningHintCount: 0,
+    planBeforeExecuteGuardCount: 1,
+    stopBeforeMoreExecution: true,
+    planningWarningsField: "planningWarnings",
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    sequentialPlanningHintsField: "sequentialPlanningHints",
+    planBeforeExecuteGuardsField: "planBeforeExecuteGuards",
+    compactResumePacketField: "authoritativeResumePacket.reliabilityBoundary",
+  });
+  assert.match(warnings[0].claimBoundary, /Advisory\/read-only long-run budget warning/);
+  assert.match(warnings[0].claimBoundary, /not provider billing\/token\/runtime proof/);
+  assert.match(warnings[0].forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
+  assert.match(warnings[0].forbiddenClaims.join("\n"), /frontend runtime behavior change/);
+});
+
+test("long-run budget warning can derive from stale reliability overlap plus stop guard", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-960-runtime-token-cost-plan" });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: staleContextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch: "fooks-issue-960-runtime-token-cost-plan", planningWarnings, combinedReliabilityWarnings });
+  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch: "fooks-issue-960-runtime-token-cost-plan", planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+
+  const warnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
+
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].trigger, "plan-before-execute-stop-with-combined-reliability");
+  assert.equal(warnings[0].derivedFrom.combinedReliabilityWarningCount, 1);
+  assert.equal(warnings[0].derivedFrom.sequentialPlanningHintCount, 1);
+  assert.equal(warnings[0].derivedFrom.stopBeforeMoreExecution, true);
+});
+
+test("long-run budget warning remains absent for ordinary non-risk boundaries", () => {
+  const warnings = buildLongRunBudgetWarnings({
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+    sequentialPlanningHints: [],
+    planBeforeExecuteGuards: [],
+  });
+
+  assert.deepEqual(warnings, []);
+  assert.match(LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY, /not autonomous CI\/merge authority/);
+  assert.match(LONG_RUN_BUDGET_WARNING_CLAIM_BOUNDARY, /not frontend behavior change/);
+});

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3364,11 +3364,11 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.equal(snapshot.reliabilityWarningVisibility.summary.existingWarningCount, snapshot.planningWarnings.length + snapshot.combinedReliabilityWarnings.length);
   assert.equal(snapshot.reliabilityWarningVisibility.derivedFrom.contextTrustSource, snapshot.contextTrust.source);
   assert.equal(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "runtime-planning" && warning.issue === "#960"), true);
-  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, and combinedReliabilityWarnings fields only/);
+  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, and longRunBudgetWarnings fields only/);
   assert.deepEqual(snapshot.sequentialPlanningHints, []);
 });
 
-test("operator check reliability warning visibility surfaces existing planning and combined warnings only", () => {
+test("operator check reliability warning visibility surfaces existing advisory warnings", () => {
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-960-runtime-token-cost-plan" });
   const contextTrust = syntheticPreflightSnapshot({
     nonAuthorizing: [
@@ -3388,6 +3388,7 @@ test("operator check reliability warning visibility surfaces existing planning a
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
+    longRunBudgetWarnings: [],
   });
 
   assert.equal(visibility.schemaVersion, 1);
@@ -3397,6 +3398,7 @@ test("operator check reliability warning visibility surfaces existing planning a
     existingWarningCount: 2,
     planningWarningCount: 1,
     combinedReliabilityWarningCount: 1,
+    longRunBudgetWarningCount: 0,
     contextTrustCurrentAuthorityCount: 0,
     contextTrustNonAuthorizingCount: 1,
     contextTrustHistoricalOnlyCount: 0,
@@ -3409,6 +3411,7 @@ test("operator check reliability warning visibility surfaces existing planning a
     contextTrustSource: OPERATOR_CONTEXT_TRUST_SOURCE,
     planningWarningsField: "planningWarnings",
     combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    longRunBudgetWarningsField: "longRunBudgetWarnings",
   });
   assert.equal(visibility.claimBoundary, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY);
   assert.match(visibility.claimBoundary, /adds no telemetry, provider\/runtime hooks, token\/cost accounting, merge-gate policy, product claims, or frontend behavior/);
@@ -3458,6 +3461,12 @@ test("operator check JSON includes narrow issue #976 long-run planning advisory"
   assert.match(snapshot.planningWarnings[0].message, /plan\/checkpoint\/compression or handoff review/);
   assert.match(snapshot.planningWarnings[0].claimBoundary, /issues #960\/#976/);
   assert.deepEqual(snapshot.sequentialPlanningHints, []);
+  assert.equal(snapshot.planBeforeExecuteGuards.length, 1);
+  assert.equal(snapshot.longRunBudgetWarnings.length, 1);
+  assert.equal(snapshot.longRunBudgetWarnings[0].issue, "#988");
+  assert.equal(snapshot.longRunBudgetWarnings[0].riskLevel, "high");
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.longRunBudgetWarningCount, 1);
+  assert.ok(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "long-run-budget"));
 });
 
 test("operator check JSON includes narrow issue #982 sequential planning hint", () => {

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -127,6 +127,7 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.deepEqual(packet.planningWarnings, []);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
   assert.deepEqual(packet.sequentialPlanningHints, []);
+  assert.deepEqual(packet.longRunBudgetWarnings, []);
 });
 
 test("authoritative resume packet compacts stale/context/reliability overlap before new session", () => {
@@ -163,11 +164,14 @@ test("authoritative resume packet compacts stale/context/reliability overlap bef
   assert.equal(resume.reliabilityBoundary.combinedReliabilityWarningCount, 1);
   assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 1);
   assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 1);
+  assert.equal(resume.reliabilityBoundary.longRunBudgetWarningCount, 1);
+  assert.equal(resume.reliabilityBoundary.longRunBudgetRiskLevel, "high");
   assert.equal(resume.reliabilityBoundary.staleContextReliabilityOverlap, true);
   assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, true);
   assert.equal(resume.nextSessionAdvisory.action, "stop-before-more-execution");
   assert.match(resume.nextSessionAdvisory.rationale, /recheck current authority/);
   assert.ok(resume.nextSessionAdvisory.requiredRechecks.some((line) => /fooks check --json/.test(line)));
+  assert.ok(resume.nextSessionAdvisory.requiredRechecks.some((line) => /budget-risk boundary/.test(line)));
   assert.match(resume.forbiddenClaims.join("\n"), /provider usage\/billing-token proof/);
   assert.match(resume.forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
   assert.match(JSON.stringify(resume), /sourceOfTruth.currentAuthority/);
@@ -199,6 +203,8 @@ test("authoritative resume packet stays advisory and clear for ordinary non-risk
   assert.equal(resume.reliabilityBoundary.combinedReliabilityWarningCount, 0);
   assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 0);
   assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 0);
+  assert.equal(resume.reliabilityBoundary.longRunBudgetWarningCount, 0);
+  assert.equal(resume.reliabilityBoundary.longRunBudgetRiskLevel, "clear");
   assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, false);
   assert.equal(resume.nextSessionAdvisory.action, "continue-implementation-for-linked-issue");
   assert.match(resume.staleHistoricalBoundary.instruction, /No stale\/historical\/non-authorizing entries/);
@@ -319,6 +325,12 @@ test("source-of-truth handoff emits issue #976 long-run runtime planning warning
   assert.equal(packet.sequentialPlanningHints[0].issue, "#982");
   assert.equal(packet.sequentialPlanningHints[0].trigger, "combined-reliability-warning-present");
   assert.match(packet.sequentialPlanningHints[0].message, /write a bounded plan/);
+  assert.equal(packet.planBeforeExecuteGuards.length, 1);
+  assert.equal(packet.longRunBudgetWarnings.length, 1);
+  assert.equal(packet.longRunBudgetWarnings[0].issue, "#988");
+  assert.equal(packet.longRunBudgetWarnings[0].riskLevel, "high");
+  assert.equal(packet.longRunBudgetWarnings[0].trigger, "plan-before-execute-stop-with-runtime-planning");
+  assert.match(packet.longRunBudgetWarnings[0].claimBoundary, /not provider billing\/token\/runtime proof/);
   assert.match(packet.sequentialPlanningHints[0].claimBoundary, /no provider billing-runtime proof|does not prove provider billing\/runtime token usage/);
 });
 


### PR DESCRIPTION
Closes #988

## Summary
- add a bounded advisory long-run budget warning artifact for high-risk #960 reliability runs
- wire longRunBudgetWarnings into operator-check visibility, source-of-truth handoff, and the compact resume packet reliability boundary
- add focused high-risk and ordinary non-risk regression coverage

## Verification
- npm run build
- node --test test/long-run-budget-warning.test.mjs test/source-of-truth-handoff.test.mjs test/operator-activity.test.mjs test/plan-before-execute-guard.test.mjs

## Boundaries
- advisory/read-only only
- no provider billing/token/runtime proof
- no autonomous CI/merge authority
- no frontend behavior expansion