### PR TITLE
Expose compact operator check resume projection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,11 @@ export {
   OPERATOR_CHECK_COMMAND,
   OPERATOR_CHECK_SCHEMA_VERSION,
   OPERATOR_CHECK_SOURCE,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_ISSUE,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SCHEMA_VERSION,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE,
+  buildOperatorCheckResumeHandoffProjection,
   readOperatorCheckSnapshot,
 } from "./ops/operator-check";
 export type {
@@ -99,6 +104,7 @@ export type {
   OperatorCheckActiveWorkReceipts,
   OperatorCheckPostReceiptNudgeAnchorBoundary,
   OperatorCheckRequiredActiveArtifact,
+  OperatorCheckResumeHandoffProjection,
   OperatorCheckSalvageReviewQueue,
   OperatorCheckSalvageReviewQueueItem,
   OperatorCheckSnapshot,

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -18,7 +18,7 @@ import {
 } from "./orphan-local-worktree-triage";
 import { STALE_WORKTREE_AUDIT_COMMAND, STALE_WORKTREE_AUDIT_ISSUE } from "./stale-worktree-audit";
 import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
-import { buildOperatorContextTrust, type OperatorContextTrustPacket } from "./context-trust";
+import { buildOperatorContextTrust, type OperatorContextTrustEntry, type OperatorContextTrustPacket } from "./context-trust";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
@@ -32,6 +32,7 @@ export const OPERATOR_CHECK_CLAIM_BOUNDARY =
 export const OPERATOR_CHECK_SOURCE = `status activity ${OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG} projection`;
 export const OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_STALE_RESIDUE_ACTIVE_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_WORKTREE_RESIDUE_BOUNDARY_SCHEMA_VERSION = 1;
@@ -41,8 +42,11 @@ export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE = "operator/check reliability warning visibility projection";
+export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE = "operator/check compact resume handoff projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY =
   "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, and longRunBudgetWarnings fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
+export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY =
+  "Compact advisory/read-only resume handoff projection for issue #992; derived only from existing operator-check contextTrust/source-of-truth, reliability warning visibility, runtime planning, sequential planning, plan-before-execute, and long-run budget fields, and adds no provider/runtime telemetry, CI/merge authority, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
@@ -60,6 +64,7 @@ export const OPERATOR_CHECK_POST_RECEIPT_NUDGE_ANCHOR_ISSUE = "#867";
 export const OPERATOR_CHECK_RECEIPT_ONLY_NUDGE_LOOP_BOUNDARY_ISSUE = "#869";
 export const OPERATOR_CHECK_HANDOFF_ARTIFACT_EVIDENCE_ISSUE = "#885";
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE = "#895";
+export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_ISSUE = "#992";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE_URL = "https://github.com/minislively/fooks/issues/736";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE_URL = "https://github.com/minislively/fooks/issues/739";
 export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL = "https://github.com/minislively/fooks/issues/778";
@@ -576,6 +581,7 @@ export type OperatorCheckSnapshot = {
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
+  resumeHandoffProjection: OperatorCheckResumeHandoffProjection;
   activity: OperatorActivitySnapshot;
   blockers: string[];
 };
@@ -635,6 +641,63 @@ export type OperatorCheckReliabilityWarningVisibility = {
     longRunBudgetWarningsField: "longRunBudgetWarnings";
   };
   claimBoundary: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY;
+};
+
+export type OperatorCheckResumeHandoffProjection = {
+  schemaVersion: typeof OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SCHEMA_VERSION;
+  issue: typeof OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_ISSUE;
+  status: "advisory";
+  compact: true;
+  readOnly: true;
+  source: typeof OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE;
+  claimBoundary: typeof OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY;
+  derivedFrom: {
+    operatorCheckCommand: typeof OPERATOR_CHECK_COMMAND;
+    operatorCheckSchemaVersion: typeof OPERATOR_CHECK_SCHEMA_VERSION;
+    contextTrustSchemaVersion: OperatorContextTrustPacket["schemaVersion"];
+    contextTrustSource: OperatorContextTrustPacket["source"];
+    fields: [
+      "contextTrust.sourceOfTruth.current",
+      "contextTrust.nonAuthorizing",
+      "contextTrust.historicalOnly",
+      "planningWarnings",
+      "combinedReliabilityWarnings",
+      "sequentialPlanningHints",
+      "planBeforeExecuteGuards",
+      "longRunBudgetWarnings",
+      "reliabilityWarningVisibility",
+    ];
+  };
+  summary: {
+    currentAuthorityCount: number;
+    staleOrHistoricalBoundaryCount: number;
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    sequentialPlanningHintCount: number;
+    planBeforeExecuteGuardCount: number;
+    longRunBudgetWarningCount: number;
+    reliabilityWarningCount: number;
+    stopBeforeMoreExecution: boolean;
+  };
+  currentAuthority: {
+    status: "present" | "missing";
+    entries: OperatorContextTrustEntry[];
+    entryLimit: number;
+    omittedCount: number;
+  };
+  staleHistoricalBoundary: {
+    status: "clear" | "present";
+    entries: OperatorContextTrustEntry[];
+    entryLimit: number;
+    omittedCount: number;
+    instruction: string;
+  };
+  nextSessionAdvisory: {
+    action: "recheck-current-authority" | "stop-before-more-execution";
+    rationale: string;
+    requiredRechecks: string[];
+  };
+  forbiddenClaims: string[];
 };
 
 
@@ -1724,6 +1787,105 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
   };
 }
 
+const RESUME_HANDOFF_ENTRY_LIMIT = 8;
+
+export function buildOperatorCheckResumeHandoffProjection(input: {
+  contextTrust: OperatorContextTrustPacket;
+  planningWarnings: RuntimeTokenCostPlanningWarning[];
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  sequentialPlanningHints: SequentialPlanningHint[];
+  planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
+  reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
+}): OperatorCheckResumeHandoffProjection {
+  const currentAuthority = input.contextTrust.sourceOfTruth.current.slice(0, RESUME_HANDOFF_ENTRY_LIMIT);
+  const staleHistoricalEntries = [
+    ...input.contextTrust.nonAuthorizing,
+    ...input.contextTrust.historicalOnly,
+  ];
+  const staleHistoricalBoundary = staleHistoricalEntries.slice(0, RESUME_HANDOFF_ENTRY_LIMIT);
+  const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
+  const requiredRechecks = uniqueSorted([
+    ...input.longRunBudgetWarnings.flatMap((warning) => warning.requiredRechecks),
+    ...input.planBeforeExecuteGuards.flatMap((guard) => guard.requiredRechecks),
+    ...input.sequentialPlanningHints.flatMap((hint) => hint.requiredRechecks),
+    ...input.combinedReliabilityWarnings.flatMap((warning) => warning.requiredRechecks),
+    "Run fooks check --json in the new session before treating this projection as current authority.",
+  ]);
+  const forbiddenClaims = uniqueSorted([
+    ...input.longRunBudgetWarnings.flatMap((warning) => warning.forbiddenClaims),
+    ...input.planBeforeExecuteGuards.flatMap((guard) => guard.forbiddenClaims),
+    ...input.sequentialPlanningHints.flatMap((hint) => hint.forbiddenClaims),
+    ...input.combinedReliabilityWarnings.flatMap((warning) => warning.forbiddenClaims),
+    ...input.planningWarnings.flatMap((warning) => warning.forbiddenClaims),
+    "provider/runtime telemetry",
+    "provider billing/runtime proof",
+    "autonomous CI/merge authority",
+    "frontend behavior or product-support change",
+  ]);
+
+  return {
+    schemaVersion: OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SCHEMA_VERSION,
+    issue: OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_ISSUE,
+    status: "advisory",
+    compact: true,
+    readOnly: true,
+    source: OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE,
+    claimBoundary: OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY,
+    derivedFrom: {
+      operatorCheckCommand: OPERATOR_CHECK_COMMAND,
+      operatorCheckSchemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
+      contextTrustSchemaVersion: input.contextTrust.schemaVersion,
+      contextTrustSource: input.contextTrust.source,
+      fields: [
+        "contextTrust.sourceOfTruth.current",
+        "contextTrust.nonAuthorizing",
+        "contextTrust.historicalOnly",
+        "planningWarnings",
+        "combinedReliabilityWarnings",
+        "sequentialPlanningHints",
+        "planBeforeExecuteGuards",
+        "longRunBudgetWarnings",
+        "reliabilityWarningVisibility",
+      ],
+    },
+    summary: {
+      currentAuthorityCount: input.contextTrust.sourceOfTruth.current.length,
+      staleOrHistoricalBoundaryCount: staleHistoricalEntries.length,
+      planningWarningCount: input.planningWarnings.length,
+      combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+      sequentialPlanningHintCount: input.sequentialPlanningHints.length,
+      planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
+      longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
+      reliabilityWarningCount: input.reliabilityWarningVisibility.summary.existingWarningCount,
+      stopBeforeMoreExecution,
+    },
+    currentAuthority: {
+      status: input.contextTrust.sourceOfTruth.current.length > 0 ? "present" : "missing",
+      entries: currentAuthority,
+      entryLimit: RESUME_HANDOFF_ENTRY_LIMIT,
+      omittedCount: Math.max(0, input.contextTrust.sourceOfTruth.current.length - currentAuthority.length),
+    },
+    staleHistoricalBoundary: {
+      status: staleHistoricalEntries.length > 0 ? "present" : "clear",
+      entries: staleHistoricalBoundary,
+      entryLimit: RESUME_HANDOFF_ENTRY_LIMIT,
+      omittedCount: Math.max(0, staleHistoricalEntries.length - staleHistoricalBoundary.length),
+      instruction: staleHistoricalEntries.length > 0
+        ? "Treat these non-authorizing or historical entries as boundaries to avoid until rechecked from current source-of-truth evidence."
+        : "No non-authorizing or historical contextTrust entries are present; still re-run fooks check before relying on this projection.",
+    },
+    nextSessionAdvisory: {
+      action: stopBeforeMoreExecution ? "stop-before-more-execution" : "recheck-current-authority",
+      rationale: stopBeforeMoreExecution
+        ? "plan-before-execute guard is present; stop for a bounded plan and current-authority recheck before more execution."
+        : "resume from current source-of-truth entries only after rechecking this operator/check projection in the new session.",
+      requiredRechecks,
+    },
+    forbiddenClaims,
+  };
+}
+
 export function readOperatorCheckSnapshot(cwd = process.cwd(), options: OperatorActivityOptions = {}): OperatorCheckSnapshot {
   const activity = readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true });
   const activeArtifacts = activeArtifactsFrom(activity);
@@ -1759,6 +1921,15 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     combinedReliabilityWarnings,
     longRunBudgetWarnings,
   });
+  const resumeHandoffProjection = buildOperatorCheckResumeHandoffProjection({
+    contextTrust,
+    planningWarnings,
+    combinedReliabilityWarnings,
+    sequentialPlanningHints,
+    planBeforeExecuteGuards,
+    longRunBudgetWarnings,
+    reliabilityWarningVisibility,
+  });
 
   return {
     schemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
@@ -1789,6 +1960,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
     reliabilityWarningVisibility,
+    resumeHandoffProjection,
     activity,
     blockers,
   };

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -33,8 +33,11 @@ const {
   OPERATOR_CHECK_CLAIM_BOUNDARY,
   OPERATOR_CHECK_COMMAND,
   OPERATOR_CHECK_SOURCE,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY,
+  OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE,
   OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY,
   OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE,
+  buildOperatorCheckResumeHandoffProjection,
   buildOperatorCheckReliabilityWarningVisibility,
   readOperatorCheckSnapshot,
 } = require(path.join(repoRoot, "dist", "ops", "operator-check.js"));
@@ -3368,6 +3371,75 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.deepEqual(snapshot.sequentialPlanningHints, []);
 });
 
+test("operator check JSON includes compact issue #992 resume handoff projection", () => {
+  const tempDir = makeTempProject();
+  const branch = "fooks-issue-992-operator-check-resume-projection";
+  const head = "issue-992-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-20T14:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return `${branch}\n`;
+      if (args[0] === "rev-parse") return `${head}\n`;
+      if (args[0] === "rev-list") return "1\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number,title,url --limit 20") {
+        return JSON.stringify([{ number: 992, title: "resume projection", url: "https://github.com/minislively/fooks/issues/992" }]);
+      }
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${head}`, `branch refs/heads/${branch}`, ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return `${branch}\nmain\n`;
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 1\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  const projection = snapshot.resumeHandoffProjection;
+  assert.equal(projection.schemaVersion, 1);
+  assert.equal(projection.issue, "#992");
+  assert.equal(projection.status, "advisory");
+  assert.equal(projection.compact, true);
+  assert.equal(projection.readOnly, true);
+  assert.equal(projection.source, OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE);
+  assert.equal(projection.derivedFrom.operatorCheckCommand, OPERATOR_CHECK_COMMAND);
+  assert.deepEqual(projection.derivedFrom.fields, [
+    "contextTrust.sourceOfTruth.current",
+    "contextTrust.nonAuthorizing",
+    "contextTrust.historicalOnly",
+    "planningWarnings",
+    "combinedReliabilityWarnings",
+    "sequentialPlanningHints",
+    "planBeforeExecuteGuards",
+    "longRunBudgetWarnings",
+    "reliabilityWarningVisibility",
+  ]);
+  assert.equal(projection.summary.currentAuthorityCount, snapshot.contextTrust.sourceOfTruth.current.length);
+  assert.equal(projection.summary.staleOrHistoricalBoundaryCount, snapshot.contextTrust.nonAuthorizing.length + snapshot.contextTrust.historicalOnly.length);
+  assert.equal(projection.summary.planningWarningCount, snapshot.planningWarnings.length);
+  assert.equal(projection.summary.combinedReliabilityWarningCount, snapshot.combinedReliabilityWarnings.length);
+  assert.equal(projection.summary.reliabilityWarningCount, snapshot.reliabilityWarningVisibility.summary.existingWarningCount);
+  assert.equal(projection.currentAuthority.status, snapshot.contextTrust.sourceOfTruth.current.length > 0 ? "present" : "missing");
+  assert.match(projection.claimBoundary, /derived only from existing operator-check contextTrust\/source-of-truth/);
+  assert.match(projection.claimBoundary, /adds no provider\/runtime telemetry, CI\/merge authority, product claims, or frontend behavior/);
+  assert.match(projection.forbiddenClaims.join("\n"), /provider\/runtime telemetry/);
+  assert.match(projection.forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
+});
+
 test("operator check reliability warning visibility surfaces existing advisory warnings", () => {
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-960-runtime-token-cost-plan" });
   const contextTrust = syntheticPreflightSnapshot({
@@ -3415,6 +3487,82 @@ test("operator check reliability warning visibility surfaces existing advisory w
   });
   assert.equal(visibility.claimBoundary, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY);
   assert.match(visibility.claimBoundary, /adds no telemetry, provider\/runtime hooks, token\/cost accounting, merge-gate policy, product claims, or frontend behavior/);
+});
+
+test("operator check resume handoff projection is bounded and derived from existing reliability fields", () => {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
+  const contextTrust = syntheticPreflightSnapshot({
+    current: [
+      {
+        kind: "issue",
+        source: "synthetic active artifact",
+        reason: "synthetic current issue",
+        referenceField: "activeArtifacts",
+        count: 1,
+        authority: "current-work",
+        contractScope: "top-level-active-artifact",
+      },
+    ],
+    nonAuthorizing: Array.from({ length: 10 }, (_value, index) => ({
+      kind: `synthetic-stale-${index}`,
+      source: "synthetic stale residue",
+      reason: "synthetic stale residue risk",
+      referenceField: "staleResidueActiveBoundary",
+      contractScope: "stale-residue-boundary",
+      authority: "insufficient",
+    })),
+  }).contextTrust;
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({
+    branch: "fooks-issue-982-sequential-planning-hint",
+    planningWarnings,
+    combinedReliabilityWarnings,
+  });
+  const planBeforeExecuteGuards = [
+    {
+      schemaVersion: 1,
+      issue: "#983",
+      status: "advisory",
+      trigger: "synthetic",
+      stopBeforeMoreExecution: true,
+      message: "synthetic guard",
+      recommendedActions: ["write-plan-before-execute"],
+      requiredRechecks: ["synthetic recheck"],
+      forbiddenClaims: ["synthetic merge authority"],
+      claimBoundary: "synthetic claim boundary",
+    },
+  ];
+  const longRunBudgetWarnings = [];
+  const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
+    contextTrust,
+    planningWarnings,
+    combinedReliabilityWarnings,
+    longRunBudgetWarnings,
+  });
+
+  const projection = buildOperatorCheckResumeHandoffProjection({
+    contextTrust,
+    planningWarnings,
+    combinedReliabilityWarnings,
+    sequentialPlanningHints,
+    planBeforeExecuteGuards,
+    longRunBudgetWarnings,
+    reliabilityWarningVisibility,
+  });
+
+  assert.equal(projection.source, OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE);
+  assert.equal(projection.claimBoundary, OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY);
+  assert.equal(projection.summary.stopBeforeMoreExecution, true);
+  assert.equal(projection.summary.reliabilityWarningCount, reliabilityWarningVisibility.summary.existingWarningCount);
+  assert.equal(projection.summary.staleOrHistoricalBoundaryCount, 10);
+  assert.equal(projection.staleHistoricalBoundary.entries.length, 8);
+  assert.equal(projection.staleHistoricalBoundary.entryLimit, 8);
+  assert.equal(projection.staleHistoricalBoundary.omittedCount, 2);
+  assert.equal(projection.nextSessionAdvisory.action, "stop-before-more-execution");
+  assert.ok(projection.nextSessionAdvisory.requiredRechecks.includes("synthetic recheck"));
+  assert.ok(projection.nextSessionAdvisory.requiredRechecks.includes("Run fooks check --json in the new session before treating this projection as current authority."));
+  assert.ok(projection.forbiddenClaims.includes("provider/runtime telemetry"));
+  assert.ok(projection.forbiddenClaims.includes("frontend behavior or product-support change"));
 });
 
 test("operator check JSON includes narrow issue #976 long-run planning advisory", () => {


### PR DESCRIPTION
Closes #992.

## Summary
- Adds `resumeHandoffProjection` to the operator check JSON as a compact advisory/read-only handoff surface.
- Derives the projection from existing contextTrust/source-of-truth, reliability visibility, runtime planning warnings, sequential planning hints, plan-before-execute guards, and long-run budget warnings.
- Keeps explicit boundaries against provider/runtime telemetry, CI/merge authority, frontend behavior, and product-support claims.

## Verification
- `node --test test/operator-activity.test.mjs` — 51/51 passed
- `npm run build` — passed
- `git diff --check` — passed
- Final review gate: code-review APPROVE; architect CLEAR

## Scope boundary
Advisory/read-only operator-check projection only; no runtime/provider telemetry, CI/merge authority, or frontend behavior/product claims.
