### PR TITLE
Expose current-run dogfood receipt

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -163,6 +163,16 @@ export type OperatorActivityRemoteCounts =
 
 export type OperatorActivityCurrentRunClassification = "mainEchoNonActive" | "activeOrUnknown";
 
+export type OperatorActivityCurrentRunReceipt = {
+  status: "active" | "idle";
+  active: boolean;
+  oneLine: string;
+  evidenceKinds: Array<"issue" | "pullRequest" | "branch" | "session" | "delta">;
+  advisoryOnly: true;
+  readOnly: true;
+  claimBoundary: typeof OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY;
+};
+
 export type OperatorActivityStagedOmxPromptEvidence = {
   issue: typeof OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_ISSUE;
   source: typeof OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_SOURCE;
@@ -200,6 +210,7 @@ export type OperatorActivityCurrentRunEvidence = {
     openPullRequests?: number;
     legacyStaleClosedArtifactWorktreeCount: number;
   };
+  receipt: OperatorActivityCurrentRunReceipt;
   reasons: string[];
   blockers: string[];
 };
@@ -610,6 +621,74 @@ function buildWorktreeSnapshot(status: WorktreeCurrentStatus): OperatorActivityW
 
 function hasOnlyFooksSessionTaskDelta(worktree: OperatorActivityWorktree): boolean {
   return worktree.delta.changedPathCount === 1 && worktree.delta.changedPaths[0] === ".fooks-session-task.txt";
+}
+
+function reportToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/[^A-Za-z0-9._/#:-]+/gu, "-").slice(0, 80);
+}
+
+function plural(count: number, singular: string, pluralValue = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralValue}`;
+}
+
+function buildCurrentRunReceipt(input: {
+  worktree: OperatorActivityWorktree;
+  fooksSessionCount: number;
+  openIssues?: number;
+  openPullRequests?: number;
+  mainEchoEvidence: boolean;
+}): OperatorActivityCurrentRunReceipt {
+  const evidenceKinds: OperatorActivityCurrentRunReceipt["evidenceKinds"] = [];
+  const activeParts: string[] = [];
+  const idleParts: string[] = [];
+
+  if (typeof input.openIssues === "number" && input.openIssues > 0) {
+    evidenceKinds.push("issue");
+    activeParts.push(plural(input.openIssues, "open issue"));
+  }
+  if (typeof input.openPullRequests === "number" && input.openPullRequests > 0) {
+    evidenceKinds.push("pullRequest");
+    activeParts.push(plural(input.openPullRequests, "open PR"));
+  }
+  if (input.worktree.branch && input.worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(input.worktree)) {
+    evidenceKinds.push("branch");
+    activeParts.push(`branch ${reportToken(input.worktree.branch) ?? "non-main"}`);
+  }
+  if (input.fooksSessionCount > 0) {
+    evidenceKinds.push("session");
+    activeParts.push(plural(input.fooksSessionCount, "mapped fooks session"));
+  }
+  if (input.worktree.clean === false && !hasOnlyFooksSessionTaskDelta(input.worktree)) {
+    evidenceKinds.push("delta");
+    activeParts.push(`dirty worktree with ${plural(input.worktree.delta.changedPathCount, "changed path")}`);
+  }
+
+  if (input.worktree.branch === "main") idleParts.push("clean main");
+  else if (input.worktree.branch) idleParts.push(`branch ${reportToken(input.worktree.branch)}`);
+  else idleParts.push("unknown branch");
+  if (input.worktree.ahead === 0 && input.worktree.behind === 0) idleParts.push("zero divergence");
+  if (input.fooksSessionCount === 0) idleParts.push("no mapped fooks sessions");
+  if (input.openIssues === 0 && input.openPullRequests === 0) idleParts.push("zero open issues/PRs");
+  if (input.worktree.clean === false && hasOnlyFooksSessionTaskDelta(input.worktree)) {
+    idleParts.push(".fooks-session-task.txt-only delta is not active work proof");
+  }
+
+  const active = evidenceKinds.length > 0 && !input.mainEchoEvidence;
+  const oneLine = active
+    ? `Current fooks run appears active: ${activeParts.join(", ")}.`
+    : `Current fooks run is idle/non-active: ${idleParts.join(", ")}.`;
+
+  return {
+    status: active ? "active" : "idle",
+    active,
+    oneLine,
+    evidenceKinds: [...new Set(evidenceKinds)] as OperatorActivityCurrentRunReceipt["evidenceKinds"],
+    advisoryOnly: true,
+    readOnly: true,
+    claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
+  };
 }
 
 function hasOmxSignal(pane: ParsedTmuxPane, cleanPanePath: string): boolean {
@@ -1354,9 +1433,17 @@ function buildCurrentRunEvidence(
 
   const mainEchoEvidence = blockers.length === 0 && onMain && clean && noLocalDivergence && noSessions && zeroRemoteCounts;
   const activeWorkEvidence =
+    (Boolean(worktree.branch) && worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     fooksSessionCount > 0 ||
     (optionalCounts.enabled && ((openIssues ?? 0) > 0 || (openPullRequests ?? 0) > 0));
+  const receipt = buildCurrentRunReceipt({
+    worktree,
+    fooksSessionCount,
+    openIssues,
+    openPullRequests,
+    mainEchoEvidence,
+  });
 
   return {
     available: blockers.length === 0,
@@ -1377,6 +1464,7 @@ function buildCurrentRunEvidence(
       openPullRequests,
       legacyStaleClosedArtifactWorktreeCount: legacyWorktreeEvidence.staleClosedArtifactWorktreeCount,
     },
+    receipt,
     reasons,
     blockers: uniqueSorted(blockers),
   };

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -502,6 +502,7 @@ export type OperatorCheckActiveWorkReceipts = {
   postReceiptNudgeAnchorBoundary: OperatorCheckPostReceiptNudgeAnchorBoundary;
   receiptOnlyNudgeLoopBoundary: OperatorCheckReceiptOnlyNudgeLoopBoundary;
   handoffArtifactEvidence: OperatorCheckHandoffArtifactEvidence;
+  currentRunReceipt: OperatorActivitySnapshot["currentRunEvidence"]["receipt"];
   blockers: string[];
 };
 
@@ -573,6 +574,7 @@ export type OperatorCheckSnapshot = {
   postMergeMainCiEvidence: OperatorActivitySnapshot["postMergeMainCiEvidence"];
   activeArtifacts: OperatorCheckActiveArtifact[];
   activeWorkReceipts: OperatorCheckActiveWorkReceipts;
+  currentRunReceipt: OperatorActivitySnapshot["currentRunEvidence"]["receipt"];
   requiredActiveArtifact: OperatorCheckRequiredActiveArtifact;
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
@@ -1677,6 +1679,7 @@ function buildActiveWorkReceipts(
     postReceiptNudgeAnchorBoundary: buildPostReceiptNudgeAnchorBoundary(activity),
     receiptOnlyNudgeLoopBoundary: buildReceiptOnlyNudgeLoopBoundary(activity),
     handoffArtifactEvidence: buildHandoffArtifactEvidence(activity, receipts),
+    currentRunReceipt: activity.currentRunEvidence.receipt,
     blockers,
   };
 }
@@ -1952,6 +1955,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
     activeArtifacts,
     activeWorkReceipts,
+    currentRunReceipt: activity.currentRunEvidence.receipt,
     requiredActiveArtifact: requiredArtifact,
     contextTrust,
     planningWarnings,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -564,7 +564,7 @@ test("idle activity snapshot remains zero and read-only with opt-in remote count
     claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
     classification: "activeOrUnknown",
     mainEchoEvidence: false,
-    activeWorkEvidence: false,
+    activeWorkEvidence: true,
     remoteCountsRequired: true,
     evidence: {
       branch: "dogfood/issue-428-idle-activity-snapshot",
@@ -576,6 +576,15 @@ test("idle activity snapshot remains zero and read-only with opt-in remote count
       openIssues: 0,
       openPullRequests: 0,
       legacyStaleClosedArtifactWorktreeCount: 0,
+    },
+    receipt: {
+      status: "active",
+      active: true,
+      oneLine: "Current fooks run appears active: branch dogfood/issue-428-idle-activity-snapshot.",
+      evidenceKinds: ["branch"],
+      advisoryOnly: true,
+      readOnly: true,
+      claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
     },
     reasons: [
       "current branch is dogfood/issue-428-idle-activity-snapshot, not main",
@@ -1084,7 +1093,50 @@ test("operator activity marks clean current main with zero counts and no session
     "no fooks-like tmux sessions are mapped to this snapshot",
     "open issue and pull request counts are both zero",
   ]);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt, {
+    status: "idle",
+    active: false,
+    oneLine: "Current fooks run is idle/non-active: clean main, zero divergence, no mapped fooks sessions, zero open issues/PRs.",
+    evidenceKinds: [],
+    advisoryOnly: true,
+    readOnly: true,
+    claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
+  });
   assert.deepEqual(snapshot.currentRunEvidence.blockers, []);
+});
+
+test("operator activity current-run receipt names dirty delta as active dogfood evidence", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-20T12:00:00.000Z",
+    runner: () => " M src/index.ts\0?? notes.md\0",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      if (command === "tmux") return "not-related\t/tmp/no-active-pane\tzsh\n";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${args.join(" ")}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.currentRunEvidence.mainEchoEvidence, false);
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, true);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt, {
+    status: "active",
+    active: true,
+    oneLine: "Current fooks run appears active: dirty worktree with 2 changed paths.",
+    evidenceKinds: ["delta"],
+    advisoryOnly: true,
+    readOnly: true,
+    claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
+  });
 });
 
 test("operator activity does not count ancestor tmux panes as current active work for nested checkouts", () => {
@@ -1632,6 +1684,16 @@ test("operator check treats issue, PR, or mapped session as the concrete active 
     { kind: "session", count: 1, source: OPERATOR_ACTIVITY_TMUX_COMMAND },
   ]);
   assert.equal(snapshot.postMergeMainEchoBoundary.echoOnly, false);
+  assert.deepEqual(snapshot.currentRunReceipt, {
+    status: "active",
+    active: true,
+    oneLine: "Current fooks run appears active: 1 open issue, 1 open PR, branch dogfood/issue-705-post-merge-echo-idle-boundary, 1 mapped fooks session.",
+    evidenceKinds: ["issue", "pullRequest", "branch", "session"],
+    advisoryOnly: true,
+    readOnly: true,
+    claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
+  });
+  assert.deepEqual(snapshot.activeWorkReceipts.currentRunReceipt, snapshot.currentRunReceipt);
 
   assert.equal(snapshot.activeWorkReceipts.schemaVersion, 1);
   assert.equal(snapshot.activeWorkReceipts.readOnly, true);


### PR DESCRIPTION
## Summary
- Add a narrow `currentRunEvidence.receipt` for one-line dogfood/operator responses.
- Project the receipt through operator-check and active-work receipts without adding authority.
- Cover idle clean main, branch/session/issue/PR active evidence, dirty delta wording, and the staged `.fooks-session-task.txt` prompt-only safeguard.

Closes #994

## Verification
- `npm run build`
- `node --test test/operator-activity.test.mjs`
- `npm test`
- `git diff --check`

## Boundaries
- Advisory/read-only only.
- No cleanup authority.
- No merge/CI authority.
- No provider runtime or billing proof.
- No product support expansion.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
