### PR TITLE
Add reset compact handoff reliability recommendation

### DIFF
--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -24,6 +24,7 @@ import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } fro
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
+import { buildResetCompactHandoffRecommendations, type ResetCompactHandoffRecommendation } from "./reset-compact-handoff-recommendation";
 
 export const OPERATOR_CHECK_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_COMMAND = "check";
@@ -44,9 +45,9 @@ export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE = "operator/check reliability warning visibility projection";
 export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE = "operator/check compact resume handoff projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY =
-  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, and longRunBudgetWarnings fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
+  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY =
-  "Compact advisory/read-only resume handoff projection for issue #992; derived only from existing operator-check contextTrust/source-of-truth, reliability warning visibility, runtime planning, sequential planning, plan-before-execute, and long-run budget fields, and adds no provider/runtime telemetry, CI/merge authority, product claims, or frontend behavior.";
+  "Compact advisory/read-only resume handoff projection for issue #992; derived only from existing operator-check contextTrust/source-of-truth, reliability warning visibility, runtime planning, sequential planning, plan-before-execute, long-run budget, and reset/compact/handoff recommendation fields, and adds no provider/runtime telemetry, CI/merge authority, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SOURCE = "operator/check orphan local-ahead salvage-review queue projection";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_CLAIM_BOUNDARY =
@@ -582,6 +583,7 @@ export type OperatorCheckSnapshot = {
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
+  resetCompactHandoffRecommendations: ResetCompactHandoffRecommendation[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
   resumeHandoffProjection: OperatorCheckResumeHandoffProjection;
   activity: OperatorActivitySnapshot;
@@ -597,6 +599,7 @@ export type OperatorCheckReliabilityWarningVisibility = {
     planningWarningCount: number;
     combinedReliabilityWarningCount: number;
     longRunBudgetWarningCount: number;
+    resetCompactHandoffRecommendationCount: number;
     contextTrustCurrentAuthorityCount: number;
     contextTrustNonAuthorizingCount: number;
     contextTrustHistoricalOnlyCount: number;
@@ -635,12 +638,25 @@ export type OperatorCheckReliabilityWarningVisibility = {
         forbiddenClaims: LongRunBudgetWarning["forbiddenClaims"];
         claimBoundary: LongRunBudgetWarning["claimBoundary"];
       }
+    | {
+        kind: "reset-compact-handoff";
+        issue: ResetCompactHandoffRecommendation["issue"];
+        trigger: ResetCompactHandoffRecommendation["trigger"];
+        status: ResetCompactHandoffRecommendation["status"];
+        riskLevel: ResetCompactHandoffRecommendation["riskLevel"];
+        message: ResetCompactHandoffRecommendation["message"];
+        recommendedActions: ResetCompactHandoffRecommendation["recommendedActions"];
+        requiredRechecks: ResetCompactHandoffRecommendation["requiredRechecks"];
+        forbiddenClaims: ResetCompactHandoffRecommendation["forbiddenClaims"];
+        claimBoundary: ResetCompactHandoffRecommendation["claimBoundary"];
+      }
   >;
   derivedFrom: {
     contextTrustSource: OperatorContextTrustPacket["source"];
     planningWarningsField: "planningWarnings";
     combinedReliabilityWarningsField: "combinedReliabilityWarnings";
     longRunBudgetWarningsField: "longRunBudgetWarnings";
+    resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations";
   };
   claimBoundary: typeof OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY;
 };
@@ -667,6 +683,7 @@ export type OperatorCheckResumeHandoffProjection = {
       "sequentialPlanningHints",
       "planBeforeExecuteGuards",
       "longRunBudgetWarnings",
+      "resetCompactHandoffRecommendations",
       "reliabilityWarningVisibility",
     ];
   };
@@ -678,6 +695,7 @@ export type OperatorCheckResumeHandoffProjection = {
     sequentialPlanningHintCount: number;
     planBeforeExecuteGuardCount: number;
     longRunBudgetWarningCount: number;
+    resetCompactHandoffRecommendationCount: number;
     reliabilityWarningCount: number;
     stopBeforeMoreExecution: boolean;
   };
@@ -1729,7 +1747,9 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
+  resetCompactHandoffRecommendations?: ResetCompactHandoffRecommendation[];
 }): OperatorCheckReliabilityWarningVisibility {
+  const resetCompactHandoffRecommendations = input.resetCompactHandoffRecommendations ?? [];
   const warnings: OperatorCheckReliabilityWarningVisibility["warnings"] = [
     ...input.planningWarnings.map((warning) => ({
       kind: "runtime-planning" as const,
@@ -1764,6 +1784,18 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       forbiddenClaims: warning.forbiddenClaims,
       claimBoundary: warning.claimBoundary,
     })),
+    ...resetCompactHandoffRecommendations.map((recommendation) => ({
+      kind: "reset-compact-handoff" as const,
+      issue: recommendation.issue,
+      trigger: recommendation.trigger,
+      status: recommendation.status,
+      riskLevel: recommendation.riskLevel,
+      message: recommendation.message,
+      recommendedActions: recommendation.recommendedActions,
+      requiredRechecks: recommendation.requiredRechecks,
+      forbiddenClaims: recommendation.forbiddenClaims,
+      claimBoundary: recommendation.claimBoundary,
+    })),
   ];
 
   return {
@@ -1775,6 +1807,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       planningWarningCount: input.planningWarnings.length,
       combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
       longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
+      resetCompactHandoffRecommendationCount: resetCompactHandoffRecommendations.length,
       contextTrustCurrentAuthorityCount: input.contextTrust.sourceOfTruth.current.length,
       contextTrustNonAuthorizingCount: input.contextTrust.nonAuthorizing.length,
       contextTrustHistoricalOnlyCount: input.contextTrust.historicalOnly.length,
@@ -1785,6 +1818,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       planningWarningsField: "planningWarnings",
       combinedReliabilityWarningsField: "combinedReliabilityWarnings",
       longRunBudgetWarningsField: "longRunBudgetWarnings",
+      resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations",
     },
     claimBoundary: OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY,
   };
@@ -1799,8 +1833,10 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
+  resetCompactHandoffRecommendations?: ResetCompactHandoffRecommendation[];
   reliabilityWarningVisibility: OperatorCheckReliabilityWarningVisibility;
 }): OperatorCheckResumeHandoffProjection {
+  const resetCompactHandoffRecommendations = input.resetCompactHandoffRecommendations ?? [];
   const currentAuthority = input.contextTrust.sourceOfTruth.current.slice(0, RESUME_HANDOFF_ENTRY_LIMIT);
   const staleHistoricalEntries = [
     ...input.contextTrust.nonAuthorizing,
@@ -1809,6 +1845,7 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
   const staleHistoricalBoundary = staleHistoricalEntries.slice(0, RESUME_HANDOFF_ENTRY_LIMIT);
   const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
   const requiredRechecks = uniqueSorted([
+    ...resetCompactHandoffRecommendations.flatMap((recommendation) => recommendation.requiredRechecks),
     ...input.longRunBudgetWarnings.flatMap((warning) => warning.requiredRechecks),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.requiredRechecks),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.requiredRechecks),
@@ -1816,6 +1853,7 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
     "Run fooks check --json in the new session before treating this projection as current authority.",
   ]);
   const forbiddenClaims = uniqueSorted([
+    ...resetCompactHandoffRecommendations.flatMap((recommendation) => recommendation.forbiddenClaims),
     ...input.longRunBudgetWarnings.flatMap((warning) => warning.forbiddenClaims),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.forbiddenClaims),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.forbiddenClaims),
@@ -1849,6 +1887,7 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
         "sequentialPlanningHints",
         "planBeforeExecuteGuards",
         "longRunBudgetWarnings",
+        "resetCompactHandoffRecommendations",
         "reliabilityWarningVisibility",
       ],
     },
@@ -1860,6 +1899,7 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
       sequentialPlanningHintCount: input.sequentialPlanningHints.length,
       planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
       longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
+      resetCompactHandoffRecommendationCount: resetCompactHandoffRecommendations.length,
       reliabilityWarningCount: input.reliabilityWarningVisibility.summary.existingWarningCount,
       stopBeforeMoreExecution,
     },
@@ -1918,11 +1958,13 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
+  const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
   const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
     longRunBudgetWarnings,
+    resetCompactHandoffRecommendations,
   });
   const resumeHandoffProjection = buildOperatorCheckResumeHandoffProjection({
     contextTrust,
@@ -1931,6 +1973,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     sequentialPlanningHints,
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
+    resetCompactHandoffRecommendations,
     reliabilityWarningVisibility,
   });
 
@@ -1963,6 +2006,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     sequentialPlanningHints,
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
+    resetCompactHandoffRecommendations,
     reliabilityWarningVisibility,
     resumeHandoffProjection,
     activity,

--- a/src/ops/reset-compact-handoff-recommendation.ts
+++ b/src/ops/reset-compact-handoff-recommendation.ts
@@ -1,0 +1,116 @@
+import type { OperatorContextTrustEntry, OperatorContextTrustPacket } from "./context-trust";
+import type { CombinedReliabilityWarning } from "./combined-reliability-warning";
+import type { LongRunBudgetWarning } from "./long-run-budget-warning";
+
+export const RESET_COMPACT_HANDOFF_RECOMMENDATION_SCHEMA_VERSION = 1;
+export const RESET_COMPACT_HANDOFF_RECOMMENDATION_ISSUE = "#996";
+export const RESET_COMPACT_HANDOFF_RECOMMENDATION_EPIC = "#960";
+export const RESET_COMPACT_HANDOFF_RECOMMENDATION_SOURCE = "deterministic reset/compact/handoff advisory";
+export const RESET_COMPACT_HANDOFF_RECOMMENDATION_CLAIM_BOUNDARY =
+  "Advisory/read-only reset, compact, or handoff recommendation for issue #996 under epic #960; derived only from existing contextTrust/source-of-truth, combined reliability, and long-run budget warning fields, not provider billing/token/runtime proof, not autonomous CI/merge authority, not provider/runtime hook behavior, not product support expansion, and not frontend behavior change.";
+
+export type ResetCompactHandoffRecommendationAction =
+  | "reset-context"
+  | "compact-current-source-of-truth"
+  | "handoff-to-fresh-agent";
+
+export type ResetCompactHandoffRecommendationContextRisk = Pick<
+  OperatorContextTrustEntry,
+  "kind" | "source" | "reason" | "referenceField" | "contractScope" | "authority" | "count" | "live"
+>;
+
+export type ResetCompactHandoffRecommendation = {
+  schemaVersion: typeof RESET_COMPACT_HANDOFF_RECOMMENDATION_SCHEMA_VERSION;
+  issue: typeof RESET_COMPACT_HANDOFF_RECOMMENDATION_ISSUE;
+  epic: typeof RESET_COMPACT_HANDOFF_RECOMMENDATION_EPIC;
+  status: "advisory";
+  source: typeof RESET_COMPACT_HANDOFF_RECOMMENDATION_SOURCE;
+  trigger: "stale-context-and-high-cost-pressure";
+  riskLevel: "high";
+  message: string;
+  recommendedActions: ResetCompactHandoffRecommendationAction[];
+  requiredOverlap: {
+    contextRisk: ResetCompactHandoffRecommendationContextRisk[];
+    combinedReliabilityWarningCount: number;
+    longRunBudgetWarningCount: number;
+  };
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  derivedFrom: {
+    contextTrustSource: OperatorContextTrustPacket["source"];
+    contextTrustNonAuthorizingCount: number;
+    contextTrustHistoricalOnlyCount: number;
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+    longRunBudgetWarningsField: "longRunBudgetWarnings";
+  };
+  claimBoundary: typeof RESET_COMPACT_HANDOFF_RECOMMENDATION_CLAIM_BOUNDARY;
+};
+
+function contextRiskRef(entry: OperatorContextTrustEntry): ResetCompactHandoffRecommendationContextRisk {
+  return {
+    kind: entry.kind,
+    source: entry.source,
+    reason: entry.reason,
+    ...(entry.referenceField ? { referenceField: entry.referenceField } : {}),
+    contractScope: entry.contractScope,
+    ...(entry.authority ? { authority: entry.authority } : {}),
+    ...(entry.count !== undefined ? { count: entry.count } : {}),
+    ...(entry.live !== undefined ? { live: entry.live } : {}),
+  };
+}
+
+export function buildResetCompactHandoffRecommendations(input: {
+  contextTrust: Pick<OperatorContextTrustPacket, "source" | "nonAuthorizing" | "historicalOnly">;
+  combinedReliabilityWarnings: CombinedReliabilityWarning[];
+  longRunBudgetWarnings: LongRunBudgetWarning[];
+}): ResetCompactHandoffRecommendation[] {
+  const highCostWarnings = input.longRunBudgetWarnings.filter((warning) => warning.riskLevel === "high");
+  if (input.combinedReliabilityWarnings.length === 0 || highCostWarnings.length === 0) return [];
+
+  const contextRisk = [...input.contextTrust.nonAuthorizing, ...input.contextTrust.historicalOnly].map(contextRiskRef);
+  if (contextRisk.length === 0) return [];
+
+  return [
+    {
+      schemaVersion: RESET_COMPACT_HANDOFF_RECOMMENDATION_SCHEMA_VERSION,
+      issue: RESET_COMPACT_HANDOFF_RECOMMENDATION_ISSUE,
+      epic: RESET_COMPACT_HANDOFF_RECOMMENDATION_EPIC,
+      status: "advisory",
+      source: RESET_COMPACT_HANDOFF_RECOMMENDATION_SOURCE,
+      trigger: "stale-context-and-high-cost-pressure",
+      riskLevel: "high",
+      message:
+        "Stale/non-authorizing context evidence overlaps high long-run budget pressure; before continuing, reset context, compact only current source-of-truth evidence, or hand off to a fresh agent with current check/preflight/handoff output.",
+      recommendedActions: ["reset-context", "compact-current-source-of-truth", "handoff-to-fresh-agent"],
+      requiredOverlap: {
+        contextRisk,
+        combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+        longRunBudgetWarningCount: highCostWarnings.length,
+      },
+      requiredRechecks: [
+        "Run fooks check --json to re-read contextTrust current authority and stale/non-authorizing boundaries.",
+        "Run fooks preflight --json before deciding to continue, reset, compact, or hand off.",
+        "Run fooks handoff --json before context compression or fresh-agent handoff.",
+        "Run fooks stale-context --stdin --json on pasted prompt or handoff text before treating it as current authority.",
+      ],
+      forbiddenClaims: [
+        "provider usage/billing-token proof",
+        "invoice/dashboard/charged-cost proof",
+        "runtime-token savings proof",
+        "provider/runtime hook behavior change",
+        "autonomous CI/merge authority",
+        "merge-gate policy change",
+        "runtime/provider support expansion",
+        "frontend runtime behavior change",
+      ],
+      derivedFrom: {
+        contextTrustSource: input.contextTrust.source,
+        contextTrustNonAuthorizingCount: input.contextTrust.nonAuthorizing.length,
+        contextTrustHistoricalOnlyCount: input.contextTrust.historicalOnly.length,
+        combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+        longRunBudgetWarningsField: "longRunBudgetWarnings",
+      },
+      claimBoundary: RESET_COMPACT_HANDOFF_RECOMMENDATION_CLAIM_BOUNDARY,
+    },
+  ];
+}

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -8,6 +8,7 @@ import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } fro
 import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
+import { buildResetCompactHandoffRecommendations, type ResetCompactHandoffRecommendation } from "./reset-compact-handoff-recommendation";
 
 export const SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION = 1;
 export const SOURCE_OF_TRUTH_HANDOFF_COMMAND = "handoff";
@@ -126,6 +127,7 @@ export type SourceOfTruthHandoffPacket = {
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
+  resetCompactHandoffRecommendations: ResetCompactHandoffRecommendation[];
   authoritativeResumePacket: AuthoritativeResumePacket;
   blockers: string[];
 };
@@ -161,6 +163,7 @@ export type AuthoritativeResumePacket = {
       "sequentialPlanningHints",
       "planBeforeExecuteGuards",
       "longRunBudgetWarnings",
+      "resetCompactHandoffRecommendations",
     ];
   };
   currentSourceOfTruth: {
@@ -196,6 +199,7 @@ export type AuthoritativeResumePacket = {
     sequentialPlanningHintCount: number;
     planBeforeExecuteGuardCount: number;
     longRunBudgetWarningCount: number;
+    resetCompactHandoffRecommendationCount: number;
     longRunBudgetRiskLevel: "high" | "clear";
     staleContextReliabilityOverlap: boolean;
     stopBeforeMoreExecution: boolean;
@@ -393,9 +397,11 @@ function buildAuthoritativeResumePacket(input: {
   sequentialPlanningHints: SequentialPlanningHint[];
   planBeforeExecuteGuards: PlanBeforeExecuteGuard[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
+  resetCompactHandoffRecommendations: ResetCompactHandoffRecommendation[];
 }): AuthoritativeResumePacket {
   const stopBeforeMoreExecution = input.planBeforeExecuteGuards.some((guard) => guard.stopBeforeMoreExecution);
   const requiredRechecks = uniqueStrings([
+    ...input.resetCompactHandoffRecommendations.flatMap((recommendation) => recommendation.requiredRechecks),
     ...input.longRunBudgetWarnings.flatMap((warning) => warning.requiredRechecks),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.requiredRechecks),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.requiredRechecks),
@@ -404,6 +410,7 @@ function buildAuthoritativeResumePacket(input: {
     "Run fooks handoff --json again before the next context compression or fresh-agent handoff.",
   ]);
   const forbiddenClaims = uniqueStrings([
+    ...input.resetCompactHandoffRecommendations.flatMap((recommendation) => recommendation.forbiddenClaims),
     ...input.longRunBudgetWarnings.flatMap((warning) => warning.forbiddenClaims),
     ...input.planBeforeExecuteGuards.flatMap((guard) => guard.forbiddenClaims),
     ...input.sequentialPlanningHints.flatMap((hint) => hint.forbiddenClaims),
@@ -446,6 +453,7 @@ function buildAuthoritativeResumePacket(input: {
         "sequentialPlanningHints",
         "planBeforeExecuteGuards",
         "longRunBudgetWarnings",
+        "resetCompactHandoffRecommendations",
       ],
     },
     currentSourceOfTruth: {
@@ -483,6 +491,7 @@ function buildAuthoritativeResumePacket(input: {
       sequentialPlanningHintCount: input.sequentialPlanningHints.length,
       planBeforeExecuteGuardCount: input.planBeforeExecuteGuards.length,
       longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
+      resetCompactHandoffRecommendationCount: input.resetCompactHandoffRecommendations.length,
       longRunBudgetRiskLevel: input.longRunBudgetWarnings.length > 0 ? "high" : "clear",
       staleContextReliabilityOverlap: input.combinedReliabilityWarnings.length > 0,
       stopBeforeMoreExecution,
@@ -512,6 +521,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
+  const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust: snapshot.contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
   const staleOrHistoricalContextToAvoid = staleAvoidList(snapshot, preflight);
   const nextRecommendedAction = nextAction(preflight, issue, prResult.artifact, changedPaths.length);
   const authoritativeResumePacket = buildAuthoritativeResumePacket({
@@ -531,6 +541,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
+    resetCompactHandoffRecommendations,
   });
   const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
@@ -606,6 +617,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     sequentialPlanningHints,
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
+    resetCompactHandoffRecommendations,
     authoritativeResumePacket,
     blockers,
   };

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3426,10 +3426,10 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.equal(snapshot.reliabilityWarningVisibility.source, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE);
   assert.equal(snapshot.reliabilityWarningVisibility.status, "advisory");
   assert.equal(snapshot.reliabilityWarningVisibility.summary.planningWarningCount, 1);
-  assert.equal(snapshot.reliabilityWarningVisibility.summary.existingWarningCount, snapshot.planningWarnings.length + snapshot.combinedReliabilityWarnings.length);
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.existingWarningCount, snapshot.planningWarnings.length + snapshot.combinedReliabilityWarnings.length + snapshot.longRunBudgetWarnings.length + snapshot.resetCompactHandoffRecommendations.length);
   assert.equal(snapshot.reliabilityWarningVisibility.derivedFrom.contextTrustSource, snapshot.contextTrust.source);
   assert.equal(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "runtime-planning" && warning.issue === "#960"), true);
-  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, and longRunBudgetWarnings fields only/);
+  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only/);
   assert.deepEqual(snapshot.sequentialPlanningHints, []);
 });
 
@@ -3488,6 +3488,7 @@ test("operator check JSON includes compact issue #992 resume handoff projection"
     "sequentialPlanningHints",
     "planBeforeExecuteGuards",
     "longRunBudgetWarnings",
+    "resetCompactHandoffRecommendations",
     "reliabilityWarningVisibility",
   ]);
   assert.equal(projection.summary.currentAuthorityCount, snapshot.contextTrust.sourceOfTruth.current.length);
@@ -3533,6 +3534,7 @@ test("operator check reliability warning visibility surfaces existing advisory w
     planningWarningCount: 1,
     combinedReliabilityWarningCount: 1,
     longRunBudgetWarningCount: 0,
+    resetCompactHandoffRecommendationCount: 0,
     contextTrustCurrentAuthorityCount: 0,
     contextTrustNonAuthorizingCount: 1,
     contextTrustHistoricalOnlyCount: 0,
@@ -3546,6 +3548,7 @@ test("operator check reliability warning visibility surfaces existing advisory w
     planningWarningsField: "planningWarnings",
     combinedReliabilityWarningsField: "combinedReliabilityWarnings",
     longRunBudgetWarningsField: "longRunBudgetWarnings",
+    resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations",
   });
   assert.equal(visibility.claimBoundary, OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY);
   assert.match(visibility.claimBoundary, /adds no telemetry, provider\/runtime hooks, token\/cost accounting, merge-gate policy, product claims, or frontend behavior/);
@@ -3676,6 +3679,7 @@ test("operator check JSON includes narrow issue #976 long-run planning advisory"
   assert.equal(snapshot.longRunBudgetWarnings[0].issue, "#988");
   assert.equal(snapshot.longRunBudgetWarnings[0].riskLevel, "high");
   assert.equal(snapshot.reliabilityWarningVisibility.summary.longRunBudgetWarningCount, 1);
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.resetCompactHandoffRecommendationCount, 0);
   assert.ok(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "long-run-budget"));
 });
 

--- a/test/reset-compact-handoff-recommendation.test.mjs
+++ b/test/reset-compact-handoff-recommendation.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+const { buildRuntimeTokenCostPlanningWarnings } = require(path.join(repoRoot, "dist", "ops", "runtime-token-cost-planning-warning.js"));
+const { buildCombinedReliabilityWarnings } = require(path.join(repoRoot, "dist", "ops", "combined-reliability-warning.js"));
+const { buildSequentialPlanningHints } = require(path.join(repoRoot, "dist", "ops", "sequential-planning-hint.js"));
+const { buildPlanBeforeExecuteGuards } = require(path.join(repoRoot, "dist", "ops", "plan-before-execute-guard.js"));
+const { buildLongRunBudgetWarnings } = require(path.join(repoRoot, "dist", "ops", "long-run-budget-warning.js"));
+const {
+  RESET_COMPACT_HANDOFF_RECOMMENDATION_CLAIM_BOUNDARY,
+  buildResetCompactHandoffRecommendations,
+} = require(path.join(repoRoot, "dist", "ops", "reset-compact-handoff-recommendation.js"));
+
+const contextTrust = {
+  source: "fooks check --json operator-check projection",
+  nonAuthorizing: [
+    {
+      kind: "stale-residue-active-boundary",
+      source: "synthetic stale residue",
+      reason: "cleanup-review only",
+      referenceField: "activeWorkReceipts.staleResidueActiveBoundary",
+      contractScope: "stale-residue-boundary",
+      authority: "insufficient",
+    },
+  ],
+  historicalOnly: [],
+};
+
+function highCostInputs() {
+  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
+  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch: "fooks-issue-976-runtime-planning-warning", planningWarnings, combinedReliabilityWarnings });
+  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch: "fooks-issue-976-runtime-planning-warning", planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
+  const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
+  return { combinedReliabilityWarnings, longRunBudgetWarnings };
+}
+
+test("reset/compact/handoff recommendation appears only for stale context plus high-cost pressure", () => {
+  const { combinedReliabilityWarnings, longRunBudgetWarnings } = highCostInputs();
+  const recommendations = buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
+
+  assert.equal(recommendations.length, 1);
+  assert.equal(recommendations[0].issue, "#996");
+  assert.equal(recommendations[0].epic, "#960");
+  assert.equal(recommendations[0].status, "advisory");
+  assert.equal(recommendations[0].riskLevel, "high");
+  assert.equal(recommendations[0].trigger, "stale-context-and-high-cost-pressure");
+  assert.deepEqual(recommendations[0].recommendedActions, ["reset-context", "compact-current-source-of-truth", "handoff-to-fresh-agent"]);
+  assert.equal(recommendations[0].requiredOverlap.contextRisk[0].contractScope, "stale-residue-boundary");
+  assert.equal(recommendations[0].requiredOverlap.combinedReliabilityWarningCount, 1);
+  assert.equal(recommendations[0].requiredOverlap.longRunBudgetWarningCount, 1);
+  assert.deepEqual(recommendations[0].derivedFrom, {
+    contextTrustSource: contextTrust.source,
+    contextTrustNonAuthorizingCount: 1,
+    contextTrustHistoricalOnlyCount: 0,
+    combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    longRunBudgetWarningsField: "longRunBudgetWarnings",
+  });
+  assert.match(recommendations[0].message, /reset context, compact only current source-of-truth evidence, or hand off/);
+  assert.match(recommendations[0].claimBoundary, /Advisory\/read-only reset, compact, or handoff recommendation/);
+  assert.match(recommendations[0].claimBoundary, /not provider billing\/token\/runtime proof/);
+  assert.match(recommendations[0].forbiddenClaims.join("\n"), /autonomous CI\/merge authority/);
+  assert.match(recommendations[0].forbiddenClaims.join("\n"), /frontend runtime behavior change/);
+});
+
+test("reset/compact/handoff recommendation does not overwarn for low-risk inputs", () => {
+  assert.deepEqual(buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings: [], longRunBudgetWarnings: [] }), []);
+
+  const { combinedReliabilityWarnings, longRunBudgetWarnings } = highCostInputs();
+  assert.deepEqual(buildResetCompactHandoffRecommendations({
+    contextTrust: { ...contextTrust, nonAuthorizing: [], historicalOnly: [] },
+    combinedReliabilityWarnings,
+    longRunBudgetWarnings,
+  }), []);
+
+  assert.deepEqual(buildResetCompactHandoffRecommendations({
+    contextTrust,
+    combinedReliabilityWarnings,
+    longRunBudgetWarnings: [],
+  }), []);
+  assert.match(RESET_COMPACT_HANDOFF_RECOMMENDATION_CLAIM_BOUNDARY, /not autonomous CI\/merge authority/);
+});

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -126,6 +126,7 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.equal(packet.authoritativeResumePacket.nextSessionAdvisory.action, "continue-implementation-for-linked-issue");
   assert.deepEqual(packet.planningWarnings, []);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
+  assert.deepEqual(packet.resetCompactHandoffRecommendations, []);
   assert.deepEqual(packet.sequentialPlanningHints, []);
   assert.deepEqual(packet.longRunBudgetWarnings, []);
 });
@@ -165,6 +166,9 @@ test("authoritative resume packet compacts stale/context/reliability overlap bef
   assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 1);
   assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 1);
   assert.equal(resume.reliabilityBoundary.longRunBudgetWarningCount, 1);
+  assert.equal(resume.reliabilityBoundary.resetCompactHandoffRecommendationCount, 1);
+  assert.equal(packet.resetCompactHandoffRecommendations.length, 1);
+  assert.deepEqual(packet.resetCompactHandoffRecommendations[0].recommendedActions, ["reset-context", "compact-current-source-of-truth", "handoff-to-fresh-agent"]);
   assert.equal(resume.reliabilityBoundary.longRunBudgetRiskLevel, "high");
   assert.equal(resume.reliabilityBoundary.staleContextReliabilityOverlap, true);
   assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, true);
@@ -204,6 +208,8 @@ test("authoritative resume packet stays advisory and clear for ordinary non-risk
   assert.equal(resume.reliabilityBoundary.sequentialPlanningHintCount, 0);
   assert.equal(resume.reliabilityBoundary.planBeforeExecuteGuardCount, 0);
   assert.equal(resume.reliabilityBoundary.longRunBudgetWarningCount, 0);
+  assert.equal(resume.reliabilityBoundary.resetCompactHandoffRecommendationCount, 0);
+  assert.deepEqual(packet.resetCompactHandoffRecommendations, []);
   assert.equal(resume.reliabilityBoundary.longRunBudgetRiskLevel, "clear");
   assert.equal(resume.reliabilityBoundary.stopBeforeMoreExecution, false);
   assert.equal(resume.nextSessionAdvisory.action, "continue-implementation-for-linked-issue");
@@ -244,6 +250,7 @@ test("handoff CLI emits compact authoritative resume packet only", () => {
   assert.equal(resumePacket.reliabilityBoundary.combinedReliabilityWarningCount, fullPacket.combinedReliabilityWarnings.length);
   assert.equal(resumePacket.reliabilityBoundary.sequentialPlanningHintCount, fullPacket.sequentialPlanningHints.length);
   assert.equal(resumePacket.reliabilityBoundary.planBeforeExecuteGuardCount, fullPacket.planBeforeExecuteGuards.length);
+  assert.equal(resumePacket.reliabilityBoundary.resetCompactHandoffRecommendationCount, fullPacket.resetCompactHandoffRecommendations.length);
   assert.equal(Object.hasOwn(resumePacket, "currentStatus"), false);
   assert.equal(Object.hasOwn(resumePacket, "sourceOfTruth"), false);
   assert.match(resumePacket.claimBoundary, /not provider billing\/runtime proof/);
@@ -308,6 +315,7 @@ test("source-of-truth handoff emits narrow issue #960 runtime/token-cost plannin
   });
   assert.deepEqual(nonTargetPacket.planningWarnings, []);
   assert.deepEqual(nonTargetPacket.combinedReliabilityWarnings, []);
+  assert.deepEqual(nonTargetPacket.resetCompactHandoffRecommendations, []);
   assert.deepEqual(nonTargetPacket.sequentialPlanningHints, []);
 });
 
@@ -330,6 +338,7 @@ test("source-of-truth handoff does not emit combined reliability warning for run
   const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-19T01:02:03.000Z" });
   assert.equal(packet.planningWarnings.length, 1);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
+  assert.deepEqual(packet.resetCompactHandoffRecommendations, []);
 });
 
 test("source-of-truth handoff emits issue #976 long-run runtime planning warning", () => {
@@ -368,6 +377,8 @@ test("source-of-truth handoff emits issue #976 long-run runtime planning warning
   assert.equal(packet.longRunBudgetWarnings[0].issue, "#988");
   assert.equal(packet.longRunBudgetWarnings[0].riskLevel, "high");
   assert.equal(packet.longRunBudgetWarnings[0].trigger, "plan-before-execute-stop-with-runtime-planning");
+  assert.equal(packet.resetCompactHandoffRecommendations.length, 1);
+  assert.equal(packet.resetCompactHandoffRecommendations[0].issue, "#996");
   assert.match(packet.longRunBudgetWarnings[0].claimBoundary, /not provider billing\/token\/runtime proof/);
   assert.match(packet.sequentialPlanningHints[0].claimBoundary, /no provider billing-runtime proof|does not prove provider billing\/runtime token usage/);
 });
@@ -394,6 +405,7 @@ test("source-of-truth handoff emits issue #982 sequential planning hint without 
   const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), { commandRunner: runner, now: () => "2026-05-20T04:02:03.000Z" });
   assert.deepEqual(packet.planningWarnings, []);
   assert.deepEqual(packet.combinedReliabilityWarnings, []);
+  assert.deepEqual(packet.resetCompactHandoffRecommendations, []);
   assert.equal(packet.sequentialPlanningHints.length, 1);
   assert.equal(packet.sequentialPlanningHints[0].trigger, "linked-issue-982");
   assert.deepEqual(packet.sequentialPlanningHints[0].recommendations, [


### PR DESCRIPTION
## Summary\n- Adds an advisory/read-only #996 reset/compact/handoff recommendation gated on existing stale/non-authorizing context evidence plus high long-run budget pressure.\n- Projects the recommendation/count through existing operator-check and source-of-truth handoff outputs.\n- Adds focused coverage for stale+high-cost emission and low-risk non-overwarning.\n\nCloses #996.\n\n## Verification\n- npm run build\n- node --test test/reset-compact-handoff-recommendation.test.mjs test/long-run-budget-warning.test.mjs test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs\n- git diff --check\n\n## Boundaries\n- Advisory/read-only only.\n- No CI/merge enforcement or autonomous authority.\n- No provider billing/runtime proof claims.\n- No frontend behavior broadening.