### PR TITLE
Make preflight human-readable by default

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1621,17 +1621,26 @@ async function run(): Promise<void> {
     }
     case "preflight": {
       const allowed = new Set(["--json"]);
+      let json = false;
       for (const arg of rest) {
         if (!allowed.has(arg)) {
           throw new Error(`Unexpected preflight argument: ${arg}`);
         }
+        if (arg === "--json") {
+          json = true;
+        }
       }
-      const [{ readOperatorCheckSnapshot }, { buildPreflightPacket }] = await Promise.all([
+      const [{ readOperatorCheckSnapshot }, { buildPreflightPacket, renderPreflightText }] = await Promise.all([
         import("../ops/operator-check.js"),
         import("../ops/preflight.js"),
       ]);
       const snapshot = readOperatorCheckSnapshot(process.cwd());
-      print(buildPreflightPacket(snapshot));
+      const packet = buildPreflightPacket(snapshot);
+      if (json) {
+        print(packet);
+      } else {
+        process.stdout.write(renderPreflightText(packet));
+      }
       return;
     }
     case "handoff": {

--- a/src/ops/preflight.ts
+++ b/src/ops/preflight.ts
@@ -69,6 +69,75 @@ function summarizeEntries(empty: string, entries: PreflightEvidenceRef[]): strin
   return `${entries.length} entr${entries.length === 1 ? "y" : "ies"}: ${kinds}`;
 }
 
+function headlineFor(packet: PreflightPacket): string {
+  if (packet.summary.authorityStatus === "blocked" || packet.guidance.recommendedAction === "resolve-blockers-first") {
+    return "Preflight: BLOCK - resolve blockers first";
+  }
+
+  if (packet.guidance.recommendedAction === "continue-with-current-authority") {
+    return packet.guidance.riskLevel === "low"
+      ? "Preflight: OK to continue"
+      : "Preflight: WARN - continue with caution";
+  }
+
+  if (packet.guidance.recommendedAction === "adopt-or-report-live-handoff") {
+    return "Preflight: BLOCK - adopt or report live handoff";
+  }
+
+  return "Preflight: BLOCK - active authority needed";
+}
+
+function formatEvidenceLine(entry: PreflightEvidenceRef): string {
+  const details = [
+    entry.count !== undefined ? `count=${entry.count}` : undefined,
+    entry.live !== undefined ? `live=${entry.live}` : undefined,
+    entry.authority ? `authority=${entry.authority}` : undefined,
+    entry.contractScope ? `scope=${entry.contractScope}` : undefined,
+  ].filter((detail): detail is string => Boolean(detail));
+  return `- ${entry.kind}${details.length > 0 ? ` (${details.join(", ")})` : ""}`;
+}
+
+function appendEvidenceSection(lines: string[], title: string, entries: PreflightEvidenceRef[]): void {
+  if (entries.length === 0) return;
+  lines.push("", `${title}:`);
+  for (const entry of entries) {
+    lines.push(formatEvidenceLine(entry));
+  }
+}
+
+function hasStaleOrLocalOnlyResidue(entries: PreflightEvidenceRef[]): boolean {
+  return entries.some((entry) =>
+    entry.contractScope === "stale-residue-boundary"
+    || entry.contractScope === "cleanup-review-boundary"
+    || entry.kind.includes("stale")
+    || entry.kind.includes("local-only")
+  );
+}
+
+function appendNotes(lines: string[], packet: PreflightPacket): void {
+  const notes: string[] = [];
+
+  if (packet.advisoryOnly.length > 0) {
+    notes.push(`advisory guidance present: ${packet.summary.advisorySummary ?? summarizeEntries("no advisory guidance", packet.advisoryOnly)}`);
+  }
+
+  if (packet.historicalOnly.length > 0) {
+    notes.push(`historical receipts present: ${packet.summary.historicalSummary ?? summarizeEntries("no historical receipts", packet.historicalOnly)}`);
+  }
+
+  if (hasStaleOrLocalOnlyResidue(packet.nonAuthorizing)) {
+    notes.push("stale/local-only residue is cleanup-review context, not active-work authority");
+  }
+
+  notes.push("no cleanup, authority creation, hook enforcement, or new evidence collection was performed");
+
+  if (notes.length === 0) return;
+  lines.push("", "Notes:");
+  for (const note of notes) {
+    lines.push(`- ${note}`);
+  }
+}
+
 function hasLiveHandoffCandidate(entries: PreflightEvidenceRef[]): boolean {
   return entries.some((entry) =>
     entry.authority === "handoff-candidate"
@@ -162,4 +231,20 @@ export function buildPreflightPacket(snapshot: OperatorCheckSnapshot): Preflight
     advisoryOnly,
     historicalOnly,
   };
+}
+
+export function renderPreflightText(packet: PreflightPacket): string {
+  const lines = [
+    headlineFor(packet),
+    `Risk: ${packet.guidance.riskLevel}`,
+    `Action: ${packet.guidance.recommendedAction}`,
+    `Authority: ${packet.summary.authorityStatus}`,
+    `Rationale: ${packet.guidance.rationale}`,
+  ];
+
+  appendEvidenceSection(lines, "Current authority", packet.currentAuthority);
+  appendEvidenceSection(lines, "Do not treat as current", packet.nonAuthorizing);
+  appendNotes(lines, packet);
+
+  return `${lines.join("\n")}\n`;
 }

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -64,6 +64,7 @@ const {
   PREFLIGHT_COMMAND,
   PREFLIGHT_SOURCE,
   buildPreflightPacket,
+  renderPreflightText,
 } = require(path.join(repoRoot, "dist", "ops", "preflight.js"));
 
 function runWithCli(cliPath, args, cwd, envOverrides = {}) {
@@ -373,6 +374,13 @@ test("preflight builder projects synthetic contextTrust without evidence reads",
   assert.equal(noAuthority.guidance.recommendedAction, "create-or-link-active-artifact");
   assert.equal(noAuthority.currentAuthority.length, 0);
   assert.equal(noAuthority.nonAuthorizing[0].contractScope, "main-echo-boundary");
+  const noAuthorityText = renderPreflightText(noAuthority);
+  assert.match(noAuthorityText, /Preflight: BLOCK - active authority needed/);
+  assert.match(noAuthorityText, /Risk: high/);
+  assert.match(noAuthorityText, /Action: create-or-link-active-artifact/);
+  assert.match(noAuthorityText, /Do not treat as current:/);
+  assert.match(noAuthorityText, /main-echo-boundary/);
+  assert.match(noAuthorityText, /no cleanup, authority creation, hook enforcement, or new evidence collection was performed/);
 
   const handoff = buildPreflightPacket(syntheticPreflightSnapshot({
     nonAuthorizing: [
@@ -423,6 +431,11 @@ test("preflight builder projects synthetic contextTrust without evidence reads",
   assert.equal(mappedSessionWithCaveat.guidance.recommendedAction, "continue-with-current-authority");
   assert.equal(mappedSessionWithCaveat.currentAuthority[0].contractScope, "top-level-active-artifact");
   assert.equal("number" in mappedSessionWithCaveat.currentAuthority[0], false);
+  const mappedSessionText = renderPreflightText(mappedSessionWithCaveat);
+  assert.match(mappedSessionText, /Preflight: WARN - continue with caution/);
+  assert.match(mappedSessionText, /Current authority:/);
+  assert.match(mappedSessionText, /session \(count=1, authority=current-work, scope=top-level-active-artifact\)/);
+  assert.match(mappedSessionText, /Do not treat as current:/);
 
   const blocked = buildPreflightPacket(syntheticPreflightSnapshot({
     verdict: "blocked",
@@ -431,6 +444,72 @@ test("preflight builder projects synthetic contextTrust without evidence reads",
   assert.equal(blocked.summary.authorityStatus, "blocked");
   assert.equal(blocked.guidance.riskLevel, "high");
   assert.equal(blocked.guidance.recommendedAction, "resolve-blockers-first");
+  assert.match(renderPreflightText(blocked), /Preflight: BLOCK - resolve blockers first/);
+
+  const staleResidue = buildPreflightPacket(syntheticPreflightSnapshot({
+    current: [
+      {
+        kind: "issue",
+        source: "synthetic issue list",
+        reason: "count-only current-work presence",
+        referenceField: "activeArtifacts",
+        count: 3,
+        authority: "current-work",
+        contractScope: "top-level-active-artifact",
+      },
+    ],
+    nonAuthorizing: [
+      {
+        kind: "stale-residue-active-boundary",
+        source: "synthetic stale residue",
+        reason: "cleanup-review context only",
+        referenceField: "activeWorkReceipts.staleResidueActiveBoundary",
+        count: 114,
+        authority: "insufficient",
+        contractScope: "stale-residue-boundary",
+      },
+      {
+        kind: "local-only-residue-active-boundary",
+        source: "synthetic local-only residue",
+        reason: "local-only cleanup-review context only",
+        referenceField: "activeWorkReceipts.localOnlyResidueActiveBoundary",
+        count: 114,
+        authority: "insufficient",
+        contractScope: "cleanup-review-boundary",
+      },
+    ],
+    advisoryOnly: [
+      {
+        kind: "required-active-artifact-guidance",
+        source: "requiredActiveArtifact",
+        reason: "active artifact present",
+        referenceField: "requiredActiveArtifact",
+        authority: "guidance",
+        contractScope: "active-artifact-guidance",
+      },
+    ],
+    historicalOnly: [
+      {
+        kind: "post-merge-main-ci-receipt",
+        source: "synthetic CI receipt",
+        reason: "historical receipt only",
+        referenceField: "postMergeMainCiEvidence",
+        count: 2,
+        authority: "receipt",
+        contractScope: "post-merge-receipt",
+      },
+    ],
+  }));
+  const staleResidueText = renderPreflightText(staleResidue);
+  assert.match(staleResidueText, /Preflight: OK to continue/);
+  assert.match(staleResidueText, /Current authority:/);
+  assert.match(staleResidueText, /issue \(count=3, authority=current-work, scope=top-level-active-artifact\)/);
+  assert.match(staleResidueText, /Do not treat as current:/);
+  assert.match(staleResidueText, /stale-residue-active-boundary \(count=114, authority=insufficient, scope=stale-residue-boundary\)/);
+  assert.match(staleResidueText, /local-only-residue-active-boundary \(count=114, authority=insufficient, scope=cleanup-review-boundary\)/);
+  assert.match(staleResidueText, /Notes:/);
+  assert.match(staleResidueText, /historical receipts present:/);
+  assert.match(staleResidueText, /stale\/local-only residue is cleanup-review context, not active-work authority/);
 });
 
 test("operator reminder docs require a blocker or active artifact after clean CI/React echoes", () => {
@@ -3421,6 +3500,15 @@ test("status activity CLI route preserves existing status contracts", () => {
   assert.equal(Array.isArray(preflight.currentAuthority), true);
   assert.equal(Array.isArray(preflight.nonAuthorizing), true);
   assert.equal(preflight.advisoryOnly.every((entry) => typeof entry.contractScope === "string"), true);
+  assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
+
+  const preflightText = runText(["preflight"], tempDir);
+  assert.doesNotMatch(preflightText.trimStart(), /^\{/);
+  assert.match(preflightText, /^Preflight: /);
+  assert.match(preflightText, /Risk: /);
+  assert.match(preflightText, /Action: /);
+  assert.match(preflightText, /Authority: /);
+  assert.match(preflightText, /no cleanup, authority creation, hook enforcement, or new evidence collection was performed/);
   assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
 
   const activity = run(["status", "activity"], tempDir);


### PR DESCRIPTION
## Summary
- add a pure `renderPreflightText(packet)` renderer for existing preflight packets
- make bare `fooks preflight` print a short human-readable decision summary
- preserve `fooks preflight --json` and `fooks check --json` machine contracts
- add focused renderer/CLI regressions for current authority, blocked state, stale/local-only residue, and JSON preservation

## Boundaries
- no new evidence reads
- no preflight JSON schema change
- no hook automation/enforcement
- no cleanup/mutation/orchestration behavior
- no stale detector or handoff generator expansion
- no new dependency

## Verification
- [x] `npm run build`
- [x] `node --test test/operator-activity.test.mjs` — 49/49
- [x] `node dist/cli/index.js preflight`
- [x] `node dist/cli/index.js preflight --json`
- [x] `node dist/cli/index.js check --json`
- [x] scoped ai-slop-cleaner report: `.omx/ultragoal/ai-slop-cleaner-preflight-human-summary.md`
- [x] code review report: `.omx/ultragoal/code-review-preflight-human-summary.md` — APPROVE / CLEAR

## Notes
This follows the approved ralplan artifacts for the preflight human-summary MVP. Ultragoal bookkeeping was blocked in this thread by a completed legacy Codex goal, but implementation and verification are complete.

Fixes #1002



## Merge-gate acknowledgement
Allowed reviewer/owner comment added: https://github.com/minislively/fooks/pull/1001#issuecomment-4503970330
