### PR TITLE
Document status activity receipt projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for how these future lanes map to stron
 | `fooks status` | current project inspection | Reads local fooks telemetry/status; it is not a package installer or billing-token report. |
 | `fooks status artifacts` | current project + local git/tmux inspection | Read-only audit of fooks-scoped tmux sessions, git worktrees, and branches that may be merged into the selected base; it does not prove inactivity and never deletes artifacts. |
 | `fooks status activity` | current project + local git/tmux inspection | Compact read-only operator snapshot for dogfood nudges, including bounded current-run and stale closed-artifact worktree evidence; remote issue/PR counts require explicit `--include-remote-counts`. |
+| `fooks status activity --receipt-json` | current project + local git/tmux inspection | Projects only the bounded current-run receipt from `fooks status activity`; read-only/advisory and never creates active work by itself. |
 
 By default, `fooks setup` prints a short readiness summary so the command does not look like a wall of debug JSON. Use `fooks setup --json` when you need the full `scope` object and support/debug paths that show what is project-local versus user-runtime/home scoped.
 
@@ -227,6 +228,7 @@ fooks status claude  # check Claude project-local context hook / handoff health
 fooks status cache   # check local fooks cache health
 fooks status artifacts # read-only fooks tmux/worktree/branch artifact audit
 fooks status activity  # compact read-only operator activity snapshot
+fooks status activity --receipt-json  # current-run receipt projection only; read-only/advisory
 fooks inspect react-web-issues src/components/Form.tsx  # actionable read-only React Web issue report
 fooks compare src/components/Button.tsx --json  # local original-vs-fooks payload estimate
 ```
@@ -238,7 +240,7 @@ fooks extract src/components/Button.tsx --model-payload
 fooks scan
 ```
 
-`fooks status`, `fooks check`, `fooks status activity`, and `fooks status artifacts` are read-only local/operator projections. They report setup, local estimate, activity, branch/worktree/tmux, and artifact evidence without deleting worktrees, pruning branches, proving provider billing, or replacing `ccusage`. Source-checkout dogfood operators should prefer the repo npm aliases (`npm run -s check -- --json`, `npm run -s status:activity -- --json`) when they need built-from-source receipts. Those aliases build first and then run the read-only operator command, so source-checkout handoffs should cite the aliases instead of sending maintainers to `docs/setup.md` or a direct `dist/cli/index.js` path.
+`fooks status`, `fooks check`, `fooks status activity`, and `fooks status artifacts` are read-only local/operator projections. They report setup, local estimate, activity, branch/worktree/tmux, and artifact evidence without deleting worktrees, pruning branches, proving provider billing, or replacing `ccusage`. `fooks status activity --receipt-json` narrows `status activity` to the current-run receipt projection only; it is advisory, read-only, and does not create active work by itself. Source-checkout dogfood operators should prefer the repo npm aliases (`npm run -s check -- --json`, `npm run -s status:activity -- --json`, `npm run -s status:activity -- --receipt-json`) when they need built-from-source receipts. Those aliases build first and then run the read-only operator command, so source-checkout handoffs should cite the aliases instead of sending maintainers to `docs/setup.md` or a direct `dist/cli/index.js` path.
 
 ## opencode support
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -79,6 +79,7 @@ fooks status claude
 fooks status cache
 fooks status artifacts
 fooks status activity [--include-remote-counts]
+fooks status activity --receipt-json
 ```
 
 Good signs:
@@ -93,10 +94,13 @@ Good signs:
 - Activity status reports a compact read-only operator snapshot: current worktree branch/divergence/current dirty-path delta plus active fooks-like tmux panes when tmux is available. Open issue/PR counts are omitted unless `--include-remote-counts` is passed.
 
 From a source checkout, maintainers may use the npm aliases
-`npm run -s check -- --json`, `npm run -s status:activity -- --json`, and
+`npm run -s check -- --json`, `npm run -s status:activity -- --json`,
+`npm run -s status:activity -- --receipt-json`, and
 `npm run -s explain -- status --json`. They are thin build-and-run routes to the
 same built `dist/cli/index.js` `fooks check`, `fooks status activity`, and
-`fooks explain` behavior, so they do not change provider/runtime behavior,
+`fooks explain` behavior. The receipt alias projects only the current-run receipt
+from `status activity`; it is read-only/advisory and does not create active work
+by itself. These aliases do not change provider/runtime behavior,
 merge-gate policy, detector scope, React/RN/TUI/WebView behavior, or
 product/performance claims.
 
@@ -108,7 +112,7 @@ Bare `fooks status` is local telemetry only. It reads `.fooks/sessions` summarie
 
 `fooks check [--json]` is a narrow read-only operator/check artifact for the post-merge main echo versus active work boundary. It projects `fooks status activity --include-remote-counts` into an explicit `verdict`: `activeArtifactPresent` when an open GitHub issue, open GitHub PR, or mapped fooks tmux session exists; `idleRequiresActiveArtifact` when the checkout is otherwise idle and a concrete active artifact must be created or linked; and `blocked` when tmux or GitHub count evidence is unavailable. It does not change runtime/provider behavior, merge-gate policy, detector scope, frontend behavior, cleanup policy, performance claims, or product claims.
 
-`fooks status activity` is read-only and local-first. It does not alter bare `fooks status`, `fooks status worktree`, or `fooks status artifacts` JSON contracts. By default it reads only local git status/local tracking refs and tmux panes, reports current dirty-path counts as a current-status delta rather than a session baseline comparison, and treats missing tmux as a non-fatal blocker. Passing `--include-remote-counts` explicitly opts in to non-blocking GitHub CLI (`gh`) open issue/PR counts with failures captured in JSON; no remote counts are attempted by default. The additive issue #910 `stagedOmxPromptEvidence` artifact is narrow: when a current OMX pane capture has no `UserPromptSubmit`, `Working`, or tool-output evidence, the only dirty path is `.fooks-session-task.txt`, and local ahead is `0`, that pane is reported as staged prompt-only and is not counted as active development proof. The additive `currentRunEvidence` field is the bounded reminder artifact for clean post-merge main echoes: it can classify `mainEchoNonActive` only when the snapshot has `main`, a clean worktree, zero local divergence, zero fooks-like tmux sessions, and opt-in open issue/PR counts of zero. Otherwise it remains `activeOrUnknown` and records blockers/reasons rather than inventing activity. See `docs/post-merge-main-ci-echo-boundary.md` for the read-only operator/check/reminder boundary that ties this field to current-main CI alert echoes and advisory release-report success echoes.
+`fooks status activity` is read-only and local-first. `--receipt-json` returns only `currentRunEvidence.receipt` for handoffs that need the compact current-run receipt projection; it remains advisory and read-only, and the receipt must not be treated as creating active issue/branch/session/PR work by itself. It does not alter bare `fooks status`, `fooks status worktree`, or `fooks status artifacts` JSON contracts. By default it reads only local git status/local tracking refs and tmux panes, reports current dirty-path counts as a current-status delta rather than a session baseline comparison, and treats missing tmux as a non-fatal blocker. Passing `--include-remote-counts` explicitly opts in to non-blocking GitHub CLI (`gh`) open issue/PR counts with failures captured in JSON; no remote counts are attempted by default. The additive issue #910 `stagedOmxPromptEvidence` artifact is narrow: when a current OMX pane capture has no `UserPromptSubmit`, `Working`, or tool-output evidence, the only dirty path is `.fooks-session-task.txt`, and local ahead is `0`, that pane is reported as staged prompt-only and is not counted as active development proof. The additive `currentRunEvidence` field is the bounded reminder artifact for clean post-merge main echoes: it can classify `mainEchoNonActive` only when the snapshot has `main`, a clean worktree, zero local divergence, zero fooks-like tmux sessions, and opt-in open issue/PR counts of zero. Otherwise it remains `activeOrUnknown` and records blockers/reasons rather than inventing activity. See `docs/post-merge-main-ci-echo-boundary.md` for the read-only operator/check/reminder boundary that ties this field to current-main CI alert echoes and advisory release-report success echoes.
 
 `fooks status artifacts` is also read-only. It audits local fooks-scoped tmux panes, git worktrees, and branches against `origin/main` when available, falling back to `main`. It reports conservative statuses (`activeOrUnknown`, `likelyMerged`, `missingPath`, `candidateCleanup`) and a claim boundary that local evidence does not prove inactivity. The command also emits `staleClosedArtifactWorktrees` when an existing non-current worktree has exact local branch-archive evidence and no tmux pane maps to it; that field is evidence to distinguish old closed-artifact worktrees from active OMX work, not cleanup authority, and it adds no cleanup commands. The command never deletes anything and never runs cleanup commands. If JSON includes `manualCleanupCommands`, copy them only after verifying the PR merged and the session/worktree is inactive. Missing worktree paths only suggest `git worktree prune --dry-run`; inspect that output before deciding whether to run any real cleanup manually. If stale tmux panes still point at deleted worktree paths, `staleRuntimeCleanups` documents the safe manual order: verify inactivity, stop the tmux/OMX/Codex session, then run git worktree prune/remove follow-up only after the runtime is stopped.
 

--- a/test/status-activity-receipt-docs.test.mjs
+++ b/test/status-activity-receipt-docs.test.mjs
@@ -1,0 +1,39 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+const setupDoc = fs.readFileSync(path.join(repoRoot, "docs", "setup.md"), "utf8");
+const docs = `${readme}\n${setupDoc}`.replace(/\s+/gu, " ");
+
+function assertDocsInclude(text) {
+  assert.ok(docs.includes(text), `missing receipt docs text: ${text}`);
+}
+
+test("operator docs document status activity receipt projection boundary", () => {
+  for (const required of [
+    "fooks status activity --receipt-json",
+    "current-run receipt projection",
+    "advisory, read-only, and does not create active work by itself",
+    "must not be treated as creating active issue/branch/session/PR work by itself",
+    "returns only `currentRunEvidence.receipt`",
+  ]) {
+    assertDocsInclude(required);
+  }
+});
+
+test("source checkout docs keep receipt-json compatible with npm alias guidance", () => {
+  for (const required of [
+    "`npm run -s status:activity -- --receipt-json`",
+    "Those aliases build first",
+    "same built `dist/cli/index.js`",
+    "source-checkout handoffs should cite the aliases instead of sending maintainers to `docs/setup.md` or a direct `dist/cli/index.js` path",
+  ]) {
+    assertDocsInclude(required);
+  }
+});


### PR DESCRIPTION
Closes #1000

## Summary
- document `fooks status activity --receipt-json` in README/setup operator docs as a current-run receipt projection
- clarify it is read-only/advisory and does not create active work by itself
- add focused docs assertions for receipt-json and source-checkout npm alias guidance

## Tests
- `npm run build && node --test test/status-activity-receipt-docs.test.mjs test/readme-operator-source-aliases.test.mjs test/operator-activity.test.mjs`

## Boundaries
- docs/test-only
- no CLI behavior changes
- no provider/runtime/billing/frontend support expansion