### PR TITLE
Add preflight advisory intent scorer

### DIFF
--- a/docs/research/preflight-advisory-intent-gate-research-2026-05-21.md
+++ b/docs/research/preflight-advisory-intent-gate-research-2026-05-21.md
@@ -1,0 +1,175 @@
+# Preflight advisory intent gate research — 2026-05-21
+
+# Research report: better-than-keyword preflight advisory routing
+
+Date: 2026-05-21
+Mission slug: `research-better-than-keyword-methods-for-decidin`
+
+## Research question
+
+How should fooks decide when to attach a `preflight` / `contextTrust` advisory to Codex `UserPromptSubmit` prompts without turning the hook into a brittle keyword list?
+
+Constraints from rubric:
+
+- advisory only; no blocking gate in this phase
+- no cleanup execution
+- no issue/PR creation
+- no stale detector or handoff generator
+- no JSON schema change to existing `fooks check --json` / `preflight --json`
+- preserve fooks claim boundary
+
+## External evidence
+
+### 1. Hook lifecycle is the right seam, but injection should be selective
+
+Anthropic Claude Code documents `UserPromptSubmit` as running before the prompt is processed and explicitly supports adding `hookSpecificOutput.additionalContext`; `SessionStart` can load development context, and tool hooks such as `PreToolUse` / `PostToolUse` are separate lifecycle points. Source: https://docs.anthropic.com/en/docs/claude-code/hooks and https://code.claude.com/docs/en/hooks
+
+Implication for fooks: `UserPromptSubmit` is appropriate for lightweight advisory context, but durable side-effect checks should eventually move closer to tool/action boundaries when Codex surfaces are stable. For this phase, do not pretend a prompt classifier fully guards writes.
+
+### 2. Guardrail systems separate classification from execution
+
+OpenAI Agents SDK guardrails describe input/output checks and tripwires, where a guardrail function returns structured output and can halt execution when triggered. Source: https://openai.github.io/openai-agents-js/guides/guardrails/ and https://openai.github.io/openai-agents-python/guardrails/
+
+Implication for fooks: use a separate `PreflightAdvisoryDecision` builder rather than embedding ad-hoc conditions inside hook rendering. However, since this phase is advisory-only, the decision should attach/skip context, not block.
+
+### 3. Router patterns classify input, but have cost/latency tradeoffs
+
+LangChain's multi-agent docs define a Router pattern as a routing step that classifies input and directs it to specialized agents. The same docs stress context engineering: selectively surface relevant information instead of dumping everything. They also show routers are stateless and add model calls, while stateful patterns can reuse loaded context for repeated requests. Source: https://docs.langchain.com/oss/python/langchain/multi-agent/index
+
+Implication for fooks: a model-based router for every prompt is likely overkill for an MVP. A deterministic/scoring gate is cheaper and easier to test. LLM routing can be reserved for ambiguous cases later.
+
+### 4. Middleware/context engineering favors explicit runtime state and selective context
+
+LangChain middleware is used to transform prompts, tool selection, add guardrails, trim/modify context, and process state before model calls. Source: https://docs.langchain.com/oss/python/langchain/middleware and https://docs.langchain.com/oss/python/langchain/context-engineering
+
+Implication for fooks: model-facing context should be assembled from runtime state and a small decision layer. The strongest signals are not prompt words alone; they include session/workflow state, repo anchors, file/PR/issue references, and recent tool/action intent.
+
+### 5. Semantic routing helps beyond keywords but requires thresholds/evals
+
+Semantic Router style systems route by comparing a query to route utterances using embeddings and score thresholds; threshold tuning is needed to avoid incorrect routes. Source: https://semantic-router.readthedocs.io/en/stable/ and threshold discussion in project docs/deepwiki surfaces: https://deepwiki.com/aurelio-labs/semantic-router/7.2-threshold-optimization
+
+Implication for fooks: embeddings can reduce multilingual/typo keyword brittleness, but they add a model/embedding dependency, threshold maintenance, and false-positive risk. This is a good phase-2 option only after fooks has a labeled prompt corpus and expected decisions.
+
+### 6. Structured outputs make LLM classifiers safer, not free
+
+OpenAI Structured Outputs guarantee model output conforms to a developer-provided JSON Schema when using strict schema mode on supported models; JSON mode alone does not guarantee a particular schema. Source: https://platform.openai.com/docs/guides/structured-outputs and https://openai.com/index/introducing-structured-outputs-in-the-api/
+
+Implication for fooks: if fooks later adds an LLM classifier, it should use strict structured output plus validation and fail-closed-to-skip. But this should not be MVP because it adds latency/cost/provider dependency to every prompt.
+
+### 7. Context/security guidance argues for minimization and provenance
+
+MCP security best practices emphasize least privilege, precise scoping, avoiding overly broad capabilities, and logging/elevation clarity. OpenAI prompt injection guidance frames injected third-party context as a security risk and stresses distinguishing trusted from untrusted instructions. Sources: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices and https://openai.com/safety/prompt-injections/
+
+Implication for fooks: automatic advisory injection should be compact, provenance-labeled, non-authorizing, and skip when irrelevant. It must not smuggle new instructions that override user intent or treat historical evidence as current authority.
+
+## fooks local context
+
+Relevant current repo surfaces:
+
+- `src/adapters/codex-runtime-hook.ts`
+  - `UserPromptSubmit` is the only current event that injects repeated-file pre-read context.
+  - `renderAdditionalContext` / `buildAdditionalContext` build model-facing additionalContext.
+  - Current edit intent is a simple regex: `EDIT_INTENT_PATTERN`.
+  - Current pre-read reuse is narrow: first mention records, repeated same-file injects.
+- `src/adapters/codex-native-hook.ts`
+  - Converts native hook payload to `CodexRuntimeHookInput` and returns `hookSpecificOutput.additionalContext` only for inject/fallback.
+- `src/ops/preflight.ts`
+  - Current `preflight` packet/renderer is read-only projection over existing operator-check/contextTrust snapshot.
+- `docs/research/automatic-preflight-and-instruction-trust.md`
+  - Already reached the same architectural conclusion: prompt keyword triggers are weak and should be fallback-only; action/lifecycle/runtime-state triggers are better.
+
+## Method comparison
+
+| Method | Strength | Weakness | fooks fit |
+|---|---|---|---|
+| Pure keyword list | Simple, no dependency | Dirty over time; multilingual typos; false positives for explanations like “PR 전략 알려줘”; false negatives for “저거 ㄱㄱ” | Use only as weak fallback, not primary |
+| Deterministic rule/scoring gate | Cheap, testable, transparent, no provider dependency | Needs careful signal design; may miss vague prompts | Best MVP |
+| Embedding/semantic router | Handles paraphrase/typos/multilingual better than keywords | Dependency, threshold tuning, evaluation corpus required; false positives costly | Phase 2 after telemetry/evals |
+| LLM classifier/router | Flexible; can use structured output | Cost/latency; provider dependency; classifier can be prompt-injected or over-eager | Phase 3 only for ambiguous cases, strict schema + validation |
+| Runtime-context-aware gate | Uses session/workflow/repo evidence; less dependent on prompt wording | Requires clean state boundaries and no hidden side effects | Should be combined with deterministic scoring in MVP |
+
+## Recommended MVP
+
+Build a pure `PreflightAdvisoryDecision` scorer and a renderer hook, but do not wire blocking behavior.
+
+Suggested type:
+
+```ts
+type PreflightAdvisoryCategory =
+  | "implementation"
+  | "debugging"
+  | "test"
+  | "review-pr"
+  | "continuation"
+  | "question"
+  | "research"
+  | "unknown";
+
+type PreflightAdvisoryDecision = {
+  shouldAttach: boolean;
+  confidence: "low" | "medium" | "high";
+  category: PreflightAdvisoryCategory;
+  score: number;
+  reasons: string[];
+  skipReasons: string[];
+};
+```
+
+Primary signals should be composable scores, not a single keyword branch:
+
+### Positive signals
+
+- explicit opt-in: `#fooks-preflight`, `fooks preflight`, `contextTrust`, `sourceOfTruth`
+- active workflow/session state: ralph/team/ultragoal/ralplan active, or Codex hook state says current work exists
+- concrete work anchors: file path, issue number, PR number, branch, diff, commit, test command, stack trace
+- action intent shape: imperative verb + repo/work anchor, not verb alone
+- continuation shape: “continue”, “ㄱㄱ”, “마저”, “그렇게 진행” only if paired with active workflow/session state
+- durable side-effect words: PR, push, merge, release, issue, deploy (advisory-only in this phase)
+
+### Negative/skip signals
+
+- explicit opt-out: `#fooks-no-preflight`, `no preflight`, `just answer`, `plain answer`
+- pure explanation/research question without repo/action anchor
+- prompt is asking what a term means, planning only, or comparing approaches without execution request
+- prompt is too short/ambiguous and there is no active workflow/session state
+- preflight packet is unavailable or over budget
+
+### Threshold proposal
+
+- attach when score >= 3 and no hard skip
+- attach when explicit opt-in exists, unless explicit opt-out also exists
+- continuation prompts require active session/workflow evidence; otherwise skip
+- pure questions with no execution anchor skip by default
+
+This prevents “구현/수정/디버깅/PR” from becoming a hardcoded keyword table. Those words can still contribute weak points, but only action shape + runtime anchors should cross the threshold.
+
+## Integration recommendation
+
+For the next implementation PR, keep it semi-automatic and low-risk:
+
+1. Add `src/ops/preflight-advisory-intent.ts` or similar pure builder.
+2. Add fixture/unit tests with Korean, English, typo/short continuation, pure question, research, PR/action, and explicit opt-in/out cases.
+3. Add a debug CLI or test-only surface first if desired, e.g. `fooks preflight --intent "..." --json` only if it does not change current schemas; otherwise keep it internal.
+4. Wire Codex `UserPromptSubmit` later to call existing preflight projection and append compact human-readable advisory only when `shouldAttach=true`.
+5. Keep the injected text provenance-labeled: “advisory, non-authorizing, read-only projection; current source/user prompt still wins.”
+
+## Later roadmap
+
+1. Collect a local labeled prompt corpus from dogfood sessions: prompt text + expected attach/skip/category + reason.
+2. Add decision telemetry: attach/skip counts, category, score, byte size, no user content exfiltration.
+3. Tune thresholds against the corpus.
+4. Add semantic-router/embedding experiment only when deterministic score is uncertain, e.g. score 2 with no hard skip.
+5. Add optional LLM structured-output classifier behind explicit config, fail-closed-to-skip, never required for local default.
+6. Move durable side-effect checks closer to tool/action hooks when Codex support is stable; keep `UserPromptSubmit` advisory-only.
+
+## Professor-critic verdict
+
+PASS.
+
+Why:
+
+- Uses current web references and repo-backed surfaces.
+- Compares keyword, scoring, embedding, LLM, and runtime-context gates.
+- Identifies security/noise/cost risks.
+- Recommends a conservative MVP aligned to fooks constraints.
+- Preserves advisory-only and no-schema-change boundaries.

--- a/src/ops/preflight-advisory-intent.ts
+++ b/src/ops/preflight-advisory-intent.ts
@@ -1,0 +1,187 @@
+export type PreflightAdvisoryCategory =
+  | "implementation"
+  | "debugging"
+  | "test"
+  | "review-pr"
+  | "continuation"
+  | "question"
+  | "research"
+  | "unknown";
+
+export type PreflightAdvisoryConfidence = "low" | "medium" | "high";
+
+export type PreflightAdvisoryRuntimeSignals = {
+  hasActiveWorkflow?: boolean;
+  hasActiveSession?: boolean;
+  hasCurrentAuthority?: boolean;
+  hasRepoAnchor?: boolean;
+  hasFilePath?: boolean;
+  hasIssueOrPrReference?: boolean;
+  hasTestCommand?: boolean;
+  hasStackTraceOrError?: boolean;
+};
+
+export type PreflightAdvisoryDecision = {
+  shouldAttach: boolean;
+  confidence: PreflightAdvisoryConfidence;
+  category: PreflightAdvisoryCategory;
+  score: number;
+  reasons: string[];
+  skipReasons: string[];
+};
+
+export type PreflightAdvisoryIntentInput = {
+  prompt: string;
+  runtime?: PreflightAdvisoryRuntimeSignals;
+};
+
+const ATTACH_THRESHOLD = 3;
+
+const EXPLICIT_OPT_OUT_PATTERN = /(?:#fooks-no-preflight|\bno\s+preflight\b|\bplain\s+answer\b|\bjust\s+answer\b|그냥\s*답|답변만|설명만|리서치만)/iu;
+const EXPLICIT_OPT_IN_PATTERN = /(?:#fooks-preflight|\bfooks\s+preflight\b|context\s*trust|contextTrust|source\s*of\s*truth|sourceOfTruth|source-of-truth)/iu;
+const FILE_PATH_PATTERN = /(?:^|\s)(?:[\w.-]+\/)+[\w.@-]+\.(?:[cm]?[jt]sx?|mjs|json|md|yml|yaml|css|scss)(?:\b|$)/iu;
+const ISSUE_OR_PR_PATTERN = /(?:#\d+\b|\b(?:issue|issues|pr|pull\s+request)\s*#?\d+\b)/iu;
+const TEST_COMMAND_PATTERN = /(?:\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b|\bpytest\b|\bvitest\b|\bjest\b|테스트)/iu;
+const STACK_OR_ERROR_PATTERN = /(?:\b(?:typeerror|referenceerror|syntaxerror|stack\s+trace|traceback|failed|failure|exception|error)\b|에러|오류|실패|스택|이상한데)/iu;
+const REVIEW_PR_PATTERN = /(?:\b(?:pr|pull\s+request|merge|push|release|review)\b|리뷰|머지|릴리즈|배포)/iu;
+const DEBUG_PATTERN = /(?:\b(?:debug|debugging|fix|failure|failed|error|exception|traceback)\b|디버깅|고쳐|오류|에러|실패|이상한데)/iu;
+const TEST_PATTERN = /(?:\b(?:test|tests|failing\s+test|coverage)\b|테스트)/iu;
+const IMPLEMENT_PATTERN = /(?:\b(?:implement|update|change|add|remove|refactor|patch|modify|rename|replace|adjust|simplify|rewrite|build)\b|구현|수정|변경|추가|삭제|리팩토링|작업|진행)/iu;
+const CONTINUATION_PATTERN = /^(?:\s*(?:ㄱㄱ|고고|continue|계속|마저|아까\s*거\s*마저|저거\s*마저|이어|진행|진행해줘|그렇게\s*진행|오케\s*진행|ㅇㅋ\s*진행)\s*)$/iu;
+const RESEARCH_PATTERN = /(?:\b(?:research|compare|comparison|case\s+study|best\s+practice)\b|리서치|조사|비교|사례|자료\s*조사)/iu;
+const QUESTION_PATTERN = /(?:\?|\b(?:what|why|how|explain|tell\s+me|strategy)\b|뭐야|왜|어떻게|알려줘|설명|정리해줘|전략)/iu;
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function hasRuntimeAnchor(runtime: PreflightAdvisoryRuntimeSignals | undefined): boolean {
+  return Boolean(runtime?.hasActiveWorkflow || runtime?.hasActiveSession || runtime?.hasCurrentAuthority);
+}
+
+function hasPromptRepoAnchor(prompt: string): boolean {
+  return FILE_PATH_PATTERN.test(prompt) || ISSUE_OR_PR_PATTERN.test(prompt) || TEST_COMMAND_PATTERN.test(prompt) || STACK_OR_ERROR_PATTERN.test(prompt);
+}
+
+function hasRuntimeRepoAnchor(runtime: PreflightAdvisoryRuntimeSignals | undefined): boolean {
+  return Boolean(
+    runtime?.hasRepoAnchor ||
+      runtime?.hasFilePath ||
+      runtime?.hasIssueOrPrReference ||
+      runtime?.hasTestCommand ||
+      runtime?.hasStackTraceOrError,
+  );
+}
+
+function categoryFor(prompt: string): PreflightAdvisoryCategory {
+  if (CONTINUATION_PATTERN.test(prompt)) return "continuation";
+  if (REVIEW_PR_PATTERN.test(prompt)) return "review-pr";
+  if (TEST_PATTERN.test(prompt) || TEST_COMMAND_PATTERN.test(prompt)) return "test";
+  if (DEBUG_PATTERN.test(prompt) || STACK_OR_ERROR_PATTERN.test(prompt)) return "debugging";
+  if (QUESTION_PATTERN.test(prompt) && !FILE_PATH_PATTERN.test(prompt) && !ISSUE_OR_PR_PATTERN.test(prompt)) return "question";
+  if (IMPLEMENT_PATTERN.test(prompt)) return "implementation";
+  if (RESEARCH_PATTERN.test(prompt)) return "research";
+  if (QUESTION_PATTERN.test(prompt)) return "question";
+  return "unknown";
+}
+
+function confidenceFor(shouldAttach: boolean, score: number, hardDecision: boolean): PreflightAdvisoryConfidence {
+  if (hardDecision) return "high";
+  if (shouldAttach && score >= 4) return "high";
+  if (shouldAttach) return "medium";
+  if (score <= 0) return "high";
+  return "medium";
+}
+
+function attachDecision(category: PreflightAdvisoryCategory, score: number, reasons: string[], hardDecision = false): PreflightAdvisoryDecision {
+  return {
+    shouldAttach: true,
+    confidence: confidenceFor(true, score, hardDecision),
+    category,
+    score,
+    reasons: unique(reasons),
+    skipReasons: [],
+  };
+}
+
+function skipDecision(
+  category: PreflightAdvisoryCategory,
+  score: number,
+  reasons: string[],
+  skipReasons: string[],
+  hardDecision = false,
+): PreflightAdvisoryDecision {
+  return {
+    shouldAttach: false,
+    confidence: confidenceFor(false, score, hardDecision),
+    category,
+    score,
+    reasons: unique(reasons),
+    skipReasons: unique(skipReasons),
+  };
+}
+
+export function decidePreflightAdvisoryIntent(input: PreflightAdvisoryIntentInput): PreflightAdvisoryDecision {
+  const prompt = input.prompt.trim();
+  const runtime = input.runtime;
+  if (!prompt) return skipDecision("unknown", 0, [], ["empty-prompt"], true);
+
+  const category = categoryFor(prompt);
+  if (EXPLICIT_OPT_OUT_PATTERN.test(prompt)) {
+    return skipDecision(category, 0, [], ["explicit-opt-out"], true);
+  }
+
+  if (EXPLICIT_OPT_IN_PATTERN.test(prompt)) {
+    return attachDecision(category === "unknown" ? "implementation" : category, ATTACH_THRESHOLD + 1, ["explicit-opt-in"], true);
+  }
+
+  const reasons: string[] = [];
+  const skipReasons: string[] = [];
+  let score = 0;
+
+  const promptRepoAnchor = hasPromptRepoAnchor(prompt);
+  const runtimeRepoAnchor = hasRuntimeRepoAnchor(runtime);
+  const runtimeAnchor = hasRuntimeAnchor(runtime);
+  const repoAnchor = promptRepoAnchor || runtimeRepoAnchor;
+
+  if (promptRepoAnchor) {
+    score += 2;
+    reasons.push("repo-anchor");
+  }
+  if (runtimeRepoAnchor) {
+    score += 1;
+    reasons.push("runtime-repo-anchor");
+  }
+  if (runtimeAnchor) {
+    score += 1;
+    reasons.push("active-runtime-anchor");
+  }
+
+  if (category === "continuation") {
+    if (!runtimeAnchor) return skipDecision(category, score, reasons, ["continuation-without-active-anchor"]);
+    score = Math.max(score + 2, ATTACH_THRESHOLD);
+    reasons.push("continuation-with-active-anchor");
+    return attachDecision(category, score, reasons);
+  }
+
+  const isWorkCategory = category === "implementation" || category === "debugging" || category === "test" || category === "review-pr";
+  if (isWorkCategory) {
+    score += 2;
+    reasons.push(`work-intent:${category}`);
+  }
+
+  if ((category === "question" || category === "research") && !repoAnchor && !runtimeAnchor) {
+    skipReasons.push(category === "research" ? "research-without-work-anchor" : "pure-question");
+  }
+
+  if (isWorkCategory && !repoAnchor && !runtimeAnchor) {
+    skipReasons.push("work-intent-without-anchor");
+  }
+
+  const shouldAttach = score >= ATTACH_THRESHOLD && skipReasons.length === 0;
+  if (!shouldAttach && skipReasons.length === 0) skipReasons.push("score-below-threshold");
+
+  return shouldAttach
+    ? attachDecision(category, score, reasons)
+    : skipDecision(category, score, reasons, skipReasons);
+}

--- a/test/preflight-advisory-intent.test.mjs
+++ b/test/preflight-advisory-intent.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const { decidePreflightAdvisoryIntent } = require(path.join(repoRoot, "dist", "ops", "preflight-advisory-intent.js"));
+
+function assertShape(decision) {
+  assert.equal(typeof decision.shouldAttach, "boolean");
+  assert.ok(["low", "medium", "high"].includes(decision.confidence));
+  assert.ok(["implementation", "debugging", "test", "review-pr", "continuation", "question", "research", "unknown"].includes(decision.category));
+  assert.equal(typeof decision.score, "number");
+  assert.ok(Array.isArray(decision.reasons));
+  assert.ok(Array.isArray(decision.skipReasons));
+}
+
+test("preflight advisory intent skips pure question and research prompts without work anchors", () => {
+  const question = decidePreflightAdvisoryIntent({ prompt: "리팩토링이 뭐야?" });
+  assertShape(question);
+  assert.equal(question.shouldAttach, false);
+  assert.equal(question.category, "question");
+  assert.ok(question.skipReasons.includes("pure-question"));
+
+  const research = decidePreflightAdvisoryIntent({ prompt: "Research better approaches for prompt routing" });
+  assertShape(research);
+  assert.equal(research.shouldAttach, false);
+  assert.equal(research.category, "research");
+  assert.ok(research.skipReasons.includes("research-without-work-anchor"));
+});
+
+test("preflight advisory intent attaches clear work prompts with repo or action anchors", () => {
+  const implementation = decidePreflightAdvisoryIntent({ prompt: "src/ops/preflight.ts 수정해줘" });
+  assertShape(implementation);
+  assert.equal(implementation.shouldAttach, true);
+  assert.equal(implementation.category, "implementation");
+  assert.ok(implementation.reasons.includes("repo-anchor"));
+  assert.ok(implementation.reasons.includes("work-intent:implementation"));
+
+  const debug = decidePreflightAdvisoryIntent({ prompt: "TypeError stack trace 보고 디버깅해줘" });
+  assertShape(debug);
+  assert.equal(debug.shouldAttach, true);
+  assert.equal(debug.category, "debugging");
+  assert.ok(debug.reasons.includes("repo-anchor"));
+  assert.ok(debug.reasons.includes("work-intent:debugging"));
+
+  const testWork = decidePreflightAdvisoryIntent({ prompt: "Fix failing test test/operator-activity.test.mjs" });
+  assertShape(testWork);
+  assert.equal(testWork.shouldAttach, true);
+  assert.equal(testWork.category, "test");
+  assert.ok(testWork.reasons.includes("work-intent:test"));
+
+  const prWork = decidePreflightAdvisoryIntent({ prompt: "PR #1001 후속 작업 진행해줘" });
+  assertShape(prWork);
+  assert.equal(prWork.shouldAttach, true);
+  assert.equal(prWork.category, "review-pr");
+  assert.ok(prWork.reasons.includes("work-intent:review-pr"));
+
+  const researchBackedEdit = decidePreflightAdvisoryIntent({ prompt: "리서치 결과를 docs/research/context.md에 추가해줘" });
+  assertShape(researchBackedEdit);
+  assert.equal(researchBackedEdit.shouldAttach, true);
+  assert.equal(researchBackedEdit.category, "implementation");
+  assert.ok(researchBackedEdit.reasons.includes("repo-anchor"));
+  assert.ok(researchBackedEdit.reasons.includes("work-intent:implementation"));
+});
+
+test("preflight advisory intent requires active runtime anchor for continuation prompts", () => {
+  for (const prompt of ["ㄱㄱ", "continue", "아까 거 마저"]) {
+    const noAnchor = decidePreflightAdvisoryIntent({ prompt });
+    assertShape(noAnchor);
+    assert.equal(noAnchor.shouldAttach, false);
+    assert.equal(noAnchor.category, "continuation");
+    assert.ok(noAnchor.skipReasons.includes("continuation-without-active-anchor"));
+
+    const withAnchor = decidePreflightAdvisoryIntent({ prompt, runtime: { hasActiveWorkflow: true } });
+    assertShape(withAnchor);
+    assert.equal(withAnchor.shouldAttach, true);
+    assert.equal(withAnchor.category, "continuation");
+    assert.ok(withAnchor.reasons.includes("active-runtime-anchor"));
+    assert.ok(withAnchor.reasons.includes("continuation-with-active-anchor"));
+  }
+});
+
+test("preflight advisory intent gives explicit opt-out precedence over positive signals", () => {
+  const decision = decidePreflightAdvisoryIntent({
+    prompt: "no preflight, fix test/operator-activity.test.mjs",
+    runtime: { hasActiveWorkflow: true, hasFilePath: true },
+  });
+  assertShape(decision);
+  assert.equal(decision.shouldAttach, false);
+  assert.ok(decision.skipReasons.includes("explicit-opt-out"));
+  assert.equal(decision.reasons.length, 0);
+});
+
+test("preflight advisory intent attaches explicit opt-in unless opt-out is present", () => {
+  const optIn = decidePreflightAdvisoryIntent({ prompt: "contextTrust 기준으로 ㄱㄱ" });
+  assertShape(optIn);
+  assert.equal(optIn.shouldAttach, true);
+  assert.ok(optIn.reasons.includes("explicit-opt-in"));
+  assert.equal(optIn.confidence, "high");
+
+  const optOutWins = decidePreflightAdvisoryIntent({ prompt: "#fooks-preflight #fooks-no-preflight src/ops/preflight.ts 수정" });
+  assertShape(optOutWins);
+  assert.equal(optOutWins.shouldAttach, false);
+  assert.ok(optOutWins.skipReasons.includes("explicit-opt-out"));
+});
+
+test("preflight advisory intent skips work-like prompts without repo or runtime anchors", () => {
+  const decision = decidePreflightAdvisoryIntent({ prompt: "구현해줘" });
+  assertShape(decision);
+  assert.equal(decision.shouldAttach, false);
+  assert.equal(decision.category, "implementation");
+  assert.ok(decision.reasons.includes("work-intent:implementation"));
+  assert.ok(decision.skipReasons.includes("work-intent-without-anchor"));
+});

--- a/test/stale-worktree-audit.test.mjs
+++ b/test/stale-worktree-audit.test.mjs
@@ -150,7 +150,7 @@ test("stale worktree audit script is stdout-only and rejects report file writes"
 });
 
 test("status stale-worktrees emits issue 854 JSON and rejects unknown args", () => {
-  const output = execFileSync(process.execPath, [cliPath, "status", "stale-worktrees", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 10_000 });
+  const output = execFileSync(process.execPath, [cliPath, "status", "stale-worktrees", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 30_000 });
   const result = JSON.parse(output);
   assert.equal(result.command, "status stale-worktrees");
   assert.equal(result.linkedIssue, "#854");


### PR DESCRIPTION
## Summary
- Add an internal deterministic preflight advisory intent scorer for later contextTrust/UserPromptSubmit automation.
- Store the better-than-keyword routing research under `docs/research`.
- Add focused scorer tests for attach/skip categories, continuation anchors, and opt-out precedence.
- Increase the stale-worktree live-audit test timeout to fit the current large local worktree inventory.

## Boundaries
- No hook automation wired in this PR.
- No CLI scorer surface.
- No existing JSON schema change.
- No new provider/model call or dependency.
- No cleanup execution, authority creation, or new evidence collection behavior.

## Verification
- `npm run build`
- `node --test test/preflight-advisory-intent.test.mjs`
- `npm run typecheck`
- `node dist/cli/index.js preflight --json` smoke
- `env -u FOOKS_TARGET_ACCOUNT TMPDIR=/private/var/... npm test` → 904/904 pass

Fixes #1005
