### PR TITLE
Surface sequential planning hints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,10 +163,12 @@ export type {
 } from "./ops/orphan-local-worktree-triage";
 export {
   SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY,
+  SEQUENTIAL_PLANNING_HINT_FOLLOWUP_ISSUE,
   SEQUENTIAL_PLANNING_HINT_ISSUE,
   SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION,
   SEQUENTIAL_PLANNING_HINT_SOURCE,
   buildSequentialPlanningHints,
+  readSequentialPlanningPrompt,
 } from "./ops/sequential-planning-hint";
 export type {
   SequentialPlanningHint,

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -21,7 +21,7 @@ import { isTmuxActivityNoServerBlocker } from "./tmux-errors";
 import { buildOperatorContextTrust, type OperatorContextTrustEntry, type OperatorContextTrustPacket } from "./context-trust";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
-import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
+import { buildSequentialPlanningHints, readSequentialPlanningPrompt, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
 import { buildResetCompactHandoffRecommendations, type ResetCompactHandoffRecommendation } from "./reset-compact-handoff-recommendation";
@@ -45,7 +45,7 @@ export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SOURCE = "operator/check reliability warning visibility projection";
 export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SOURCE = "operator/check compact resume handoff projection";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_CLAIM_BOUNDARY =
-  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
+  "Read-only operator/check visibility projection over existing contextTrust/source-of-truth, runtime planning advisory, sequentialPlanningHints, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only; it adds no telemetry, provider/runtime hooks, token/cost accounting, merge-gate policy, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_CLAIM_BOUNDARY =
   "Compact advisory/read-only resume handoff projection for issue #992; derived only from existing operator-check contextTrust/source-of-truth, reliability warning visibility, runtime planning, sequential planning, plan-before-execute, long-run budget, and reset/compact/handoff recommendation fields, and adds no provider/runtime telemetry, CI/merge authority, product claims, or frontend behavior.";
 export const OPERATOR_CHECK_SALVAGE_REVIEW_QUEUE_SCHEMA_VERSION = 1;
@@ -598,6 +598,7 @@ export type OperatorCheckReliabilityWarningVisibility = {
     existingWarningCount: number;
     planningWarningCount: number;
     combinedReliabilityWarningCount: number;
+    sequentialPlanningHintCount: number;
     longRunBudgetWarningCount: number;
     resetCompactHandoffRecommendationCount: number;
     contextTrustCurrentAuthorityCount: number;
@@ -614,6 +615,17 @@ export type OperatorCheckReliabilityWarningVisibility = {
         requiredRechecks: RuntimeTokenCostPlanningWarning["requiredRechecks"];
         forbiddenClaims: RuntimeTokenCostPlanningWarning["forbiddenClaims"];
         claimBoundary: RuntimeTokenCostPlanningWarning["claimBoundary"];
+      }
+    | {
+        kind: "sequential-planning";
+        issue: SequentialPlanningHint["issue"];
+        trigger: SequentialPlanningHint["trigger"];
+        status: SequentialPlanningHint["status"];
+        message: SequentialPlanningHint["message"];
+        recommendations: SequentialPlanningHint["recommendations"];
+        requiredRechecks: SequentialPlanningHint["requiredRechecks"];
+        forbiddenClaims: SequentialPlanningHint["forbiddenClaims"];
+        claimBoundary: SequentialPlanningHint["claimBoundary"];
       }
     | {
         kind: "combined-reliability";
@@ -654,6 +666,7 @@ export type OperatorCheckReliabilityWarningVisibility = {
   derivedFrom: {
     contextTrustSource: OperatorContextTrustPacket["source"];
     planningWarningsField: "planningWarnings";
+    sequentialPlanningHintsField: "sequentialPlanningHints";
     combinedReliabilityWarningsField: "combinedReliabilityWarnings";
     longRunBudgetWarningsField: "longRunBudgetWarnings";
     resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations";
@@ -1745,11 +1758,13 @@ function requiredActiveArtifact(state: { blocked: boolean; hasActiveArtifact: bo
 export function buildOperatorCheckReliabilityWarningVisibility(input: {
   contextTrust: OperatorContextTrustPacket;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
+  sequentialPlanningHints?: SequentialPlanningHint[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
   longRunBudgetWarnings: LongRunBudgetWarning[];
   resetCompactHandoffRecommendations?: ResetCompactHandoffRecommendation[];
 }): OperatorCheckReliabilityWarningVisibility {
   const resetCompactHandoffRecommendations = input.resetCompactHandoffRecommendations ?? [];
+  const sequentialPlanningHints = input.sequentialPlanningHints ?? [];
   const warnings: OperatorCheckReliabilityWarningVisibility["warnings"] = [
     ...input.planningWarnings.map((warning) => ({
       kind: "runtime-planning" as const,
@@ -1760,6 +1775,17 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       requiredRechecks: warning.requiredRechecks,
       forbiddenClaims: warning.forbiddenClaims,
       claimBoundary: warning.claimBoundary,
+    })),
+    ...sequentialPlanningHints.map((hint) => ({
+      kind: "sequential-planning" as const,
+      issue: hint.issue,
+      trigger: hint.trigger,
+      status: hint.status,
+      message: hint.message,
+      recommendations: hint.recommendations,
+      requiredRechecks: hint.requiredRechecks,
+      forbiddenClaims: hint.forbiddenClaims,
+      claimBoundary: hint.claimBoundary,
     })),
     ...input.combinedReliabilityWarnings.map((warning) => ({
       kind: "combined-reliability" as const,
@@ -1806,6 +1832,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
       existingWarningCount: warnings.length,
       planningWarningCount: input.planningWarnings.length,
       combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
+      sequentialPlanningHintCount: sequentialPlanningHints.length,
       longRunBudgetWarningCount: input.longRunBudgetWarnings.length,
       resetCompactHandoffRecommendationCount: resetCompactHandoffRecommendations.length,
       contextTrustCurrentAuthorityCount: input.contextTrust.sourceOfTruth.current.length,
@@ -1816,6 +1843,7 @@ export function buildOperatorCheckReliabilityWarningVisibility(input: {
     derivedFrom: {
       contextTrustSource: input.contextTrust.source,
       planningWarningsField: "planningWarnings",
+      sequentialPlanningHintsField: "sequentialPlanningHints",
       combinedReliabilityWarningsField: "combinedReliabilityWarnings",
       longRunBudgetWarningsField: "longRunBudgetWarnings",
       resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations",
@@ -1955,13 +1983,15 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   });
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
-  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, planningWarnings, combinedReliabilityWarnings });
+  const prompt = readSequentialPlanningPrompt(cwd);
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, prompt, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
   const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
   const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
+    sequentialPlanningHints,
     combinedReliabilityWarnings,
     longRunBudgetWarnings,
     resetCompactHandoffRecommendations,

--- a/src/ops/sequential-planning-hint.ts
+++ b/src/ops/sequential-planning-hint.ts
@@ -1,15 +1,22 @@
 import type { CombinedReliabilityWarning } from "./combined-reliability-warning";
 import type { RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
+import fs from "node:fs";
+import path from "node:path";
 
 export const SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION = 1;
 export const SEQUENTIAL_PLANNING_HINT_ISSUE = "#982";
+export const SEQUENTIAL_PLANNING_HINT_FOLLOWUP_ISSUE = "#1006";
 export const SEQUENTIAL_PLANNING_HINT_SOURCE = "deterministic sequential planning advisory";
 export const SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY =
-  "Advisory sequential-planning hint only for issue #982 under epic #960; does not prove provider billing/runtime token usage, change provider/runtime hooks, grant autonomous execution or merge authority, alter merge-gate policy, expand runtime/provider support, product claims, or frontend behavior.";
+  "Advisory sequential-planning hint only for issues #982/#1006 under epic #960; does not prove provider billing/runtime token usage, change provider/runtime hooks, block execution, grant autonomous execution or merge authority, alter merge-gate policy, expand runtime/provider support, product claims, or frontend behavior.";
 
 export type SequentialPlanningHintTrigger =
   | "branch-issue-982"
   | "linked-issue-982"
+  | "branch-issue-1006"
+  | "linked-issue-1006"
+  | "prompt-implies-sequential-execution"
+  | "run-label-implies-sequential-execution"
   | "combined-reliability-warning-present";
 
 export type SequentialPlanningHintRecommendation =
@@ -20,7 +27,7 @@ export type SequentialPlanningHintRecommendation =
 
 export type SequentialPlanningHint = {
   schemaVersion: typeof SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION;
-  issue: typeof SEQUENTIAL_PLANNING_HINT_ISSUE;
+  issue: typeof SEQUENTIAL_PLANNING_HINT_ISSUE | typeof SEQUENTIAL_PLANNING_HINT_FOLLOWUP_ISSUE;
   status: "advisory";
   source: typeof SEQUENTIAL_PLANNING_HINT_SOURCE;
   trigger: SequentialPlanningHintTrigger;
@@ -35,8 +42,18 @@ export type SequentialPlanningHint = {
     combinedReliabilityWarningCount: number;
     planningWarningsField: "planningWarnings";
     combinedReliabilityWarningsField: "combinedReliabilityWarnings";
+    promptEvidence: "not-provided" | "sequential-intent" | "no-sequential-intent";
+    runLabelEvidence: "not-provided" | "sequential-intent" | "no-sequential-intent";
   };
 };
+
+const SESSION_TASK_FILE = ".fooks-session-task.txt";
+const EXPLICIT_SEQUENTIAL_PATTERN =
+  /\b(?:sequential|sequence\s+of\s+steps|multi[-\s]?step|multi[-\s]?phase|phased\s+(?:work|execution|rollout|implementation)|step[-\s]?by[-\s]?step|several\s+steps|multiple\s+(?:steps|phases|passes|iterations))\b/iu;
+const PHASE_MARKER_PATTERN =
+  /\b(?:first|then|next|after(?:wards)?|finally|before\s+(?:pr|commit|merge|release)|phase\s*\d+|step\s*\d+|plan|implement|test|verify|build|commit|handoff)\b/giu;
+const WORK_INTENT_PATTERN =
+  /\b(?:implement|add|update|change|fix|debug|refactor|build|verify|test|commit|pr|merge|planning|coding\s+run|execution)\b|구현|수정|변경|추가|검증|테스트/iu;
 
 function inferredIssueNumber(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -46,42 +63,97 @@ function inferredIssueNumber(value: string | undefined): number | undefined {
   return Number.isInteger(issue) && issue > 0 ? issue : undefined;
 }
 
+function normalizedEvidence(value: string | undefined): "not-provided" | "sequential-intent" | "no-sequential-intent" {
+  if (!value?.trim()) return "not-provided";
+  return impliesSequentialExecution(value) ? "sequential-intent" : "no-sequential-intent";
+}
+
+function impliesSequentialExecution(value: string | undefined): boolean {
+  const text = value?.trim();
+  if (!text) return false;
+  if (!WORK_INTENT_PATTERN.test(text)) return false;
+  if (EXPLICIT_SEQUENTIAL_PATTERN.test(text)) return true;
+  const markers = [...text.matchAll(PHASE_MARKER_PATTERN)].map((match) => match[0].toLowerCase());
+  return new Set(markers).size >= 3;
+}
+
+export function readSequentialPlanningPrompt(cwd: string): string | undefined {
+  const promptPath = path.join(cwd, SESSION_TASK_FILE);
+  try {
+    if (!fs.existsSync(promptPath)) return undefined;
+    const text = fs.readFileSync(promptPath, "utf8").trim();
+    return text || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildSequentialPlanningHints(input: {
   branch?: string;
   linkedIssueNumber?: number;
+  prompt?: string;
+  runLabel?: string;
   planningWarnings: RuntimeTokenCostPlanningWarning[];
   combinedReliabilityWarnings: CombinedReliabilityWarning[];
 }): SequentialPlanningHint[] {
   const branchIssueNumber = inferredIssueNumber(input.branch);
-  const trigger: SequentialPlanningHintTrigger | undefined = input.linkedIssueNumber === 982
+  const runLabel = [input.runLabel, input.branch].filter(Boolean).join(" ");
+  const promptEvidence = normalizedEvidence(input.prompt);
+  const runLabelEvidence = normalizedEvidence(runLabel);
+  const trigger: SequentialPlanningHintTrigger | undefined = input.linkedIssueNumber === 1006
+    ? "linked-issue-1006"
+    : input.linkedIssueNumber === 982
     ? "linked-issue-982"
+    : branchIssueNumber === 1006
+      ? "branch-issue-1006"
     : branchIssueNumber === 982
       ? "branch-issue-982"
+      : promptEvidence === "sequential-intent"
+        ? "prompt-implies-sequential-execution"
+      : runLabelEvidence === "sequential-intent"
+        ? "run-label-implies-sequential-execution"
       : input.combinedReliabilityWarnings.length > 0
         ? "combined-reliability-warning-present"
         : undefined;
 
   if (!trigger) return [];
 
+  const issue = trigger === "branch-issue-1006"
+    || trigger === "linked-issue-1006"
+    || trigger === "prompt-implies-sequential-execution"
+    || trigger === "run-label-implies-sequential-execution"
+    ? SEQUENTIAL_PLANNING_HINT_FOLLOWUP_ISSUE
+    : SEQUENTIAL_PLANNING_HINT_ISSUE;
+
   const reasons = trigger === "combined-reliability-warning-present"
     ? [
         "combined reliability warning already reports overlapping stale/context risk and runtime-planning risk",
         "long or sequential follow-up work should plan before executing to avoid context drift",
       ]
+    : trigger === "prompt-implies-sequential-execution"
+      ? [
+          "current prompt implies sequential or multi-phase coding execution",
+          "this hint is advisory only and must not block the run or change runtime/provider behavior",
+        ]
+    : trigger === "run-label-implies-sequential-execution"
+      ? [
+          "current run label or branch implies sequential or multi-phase coding execution",
+          "this hint is advisory only and must not block the run or change runtime/provider behavior",
+        ]
     : [
-        "current branch or linked issue targets issue #982 sequential-planning hint work",
+        `current branch or linked issue targets issue ${issue} sequential-planning hint work`,
         "next-agent handoff should include a deterministic plan-before-execute reminder for long or sequential runs",
       ];
 
   return [
     {
       schemaVersion: SEQUENTIAL_PLANNING_HINT_SCHEMA_VERSION,
-      issue: SEQUENTIAL_PLANNING_HINT_ISSUE,
+      issue,
       status: "advisory",
       source: SEQUENTIAL_PLANNING_HINT_SOURCE,
       trigger,
       message:
-        "Before another long or sequential coding run, write a bounded plan, split the work, checkpoint or compress current source-of-truth evidence, and hand off to a fresh agent when context quality is at risk.",
+        "Sequential or multi-phase coding run detected: write a bounded plan, split the work into verifiable steps, checkpoint current source-of-truth evidence, and hand off to a fresh agent when context quality is at risk.",
       reasons,
       recommendations: [
         "write-plan-before-execute",
@@ -110,6 +182,8 @@ export function buildSequentialPlanningHints(input: {
         combinedReliabilityWarningCount: input.combinedReliabilityWarnings.length,
         planningWarningsField: "planningWarnings",
         combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+        promptEvidence,
+        runLabelEvidence,
       },
     },
   ];

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -5,7 +5,7 @@ import type { PreflightPacket } from "./preflight";
 import { STALE_CONTEXT_COMMAND } from "./stale-context";
 import { buildRuntimeTokenCostPlanningWarnings, type RuntimeTokenCostPlanningWarning } from "./runtime-token-cost-planning-warning";
 import { buildCombinedReliabilityWarnings, type CombinedReliabilityWarning } from "./combined-reliability-warning";
-import { buildSequentialPlanningHints, type SequentialPlanningHint } from "./sequential-planning-hint";
+import { buildSequentialPlanningHints, readSequentialPlanningPrompt, type SequentialPlanningHint } from "./sequential-planning-hint";
 import { buildPlanBeforeExecuteGuards, type PlanBeforeExecuteGuard } from "./plan-before-execute-guard";
 import { buildLongRunBudgetWarnings, type LongRunBudgetWarning } from "./long-run-budget-warning";
 import { buildResetCompactHandoffRecommendations, type ResetCompactHandoffRecommendation } from "./reset-compact-handoff-recommendation";
@@ -518,7 +518,12 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
   const linkedIssueNumber = issue.status === "linked" ? issue.number : undefined;
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
   const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
-  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings });
+  const prompt = (snapshot.sequentialPlanningHints ?? []).some((hint) =>
+    hint.trigger === "prompt-implies-sequential-execution" || hint.trigger === "run-label-implies-sequential-execution"
+  )
+    ? readSequentialPlanningPrompt(cwd)
+    : undefined;
+  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, prompt, planningWarnings, combinedReliabilityWarnings });
   const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
   const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
   const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust: snapshot.contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3636,7 +3636,7 @@ test("operator check JSON includes narrow issue #960 runtime/token-cost planning
   assert.equal(snapshot.reliabilityWarningVisibility.summary.existingWarningCount, snapshot.planningWarnings.length + snapshot.combinedReliabilityWarnings.length + snapshot.longRunBudgetWarnings.length + snapshot.resetCompactHandoffRecommendations.length);
   assert.equal(snapshot.reliabilityWarningVisibility.derivedFrom.contextTrustSource, snapshot.contextTrust.source);
   assert.equal(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "runtime-planning" && warning.issue === "#960"), true);
-  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only/);
+  assert.match(snapshot.reliabilityWarningVisibility.claimBoundary, /existing contextTrust\/source-of-truth, runtime planning advisory, sequentialPlanningHints, combinedReliabilityWarnings, longRunBudgetWarnings, and resetCompactHandoffRecommendations fields only/);
   assert.deepEqual(snapshot.sequentialPlanningHints, []);
 });
 
@@ -3740,6 +3740,7 @@ test("operator check reliability warning visibility surfaces existing advisory w
     existingWarningCount: 2,
     planningWarningCount: 1,
     combinedReliabilityWarningCount: 1,
+    sequentialPlanningHintCount: 0,
     longRunBudgetWarningCount: 0,
     resetCompactHandoffRecommendationCount: 0,
     contextTrustCurrentAuthorityCount: 0,
@@ -3753,6 +3754,7 @@ test("operator check reliability warning visibility surfaces existing advisory w
   assert.deepEqual(visibility.derivedFrom, {
     contextTrustSource: OPERATOR_CONTEXT_TRUST_SOURCE,
     planningWarningsField: "planningWarnings",
+    sequentialPlanningHintsField: "sequentialPlanningHints",
     combinedReliabilityWarningsField: "combinedReliabilityWarnings",
     longRunBudgetWarningsField: "longRunBudgetWarnings",
     resetCompactHandoffRecommendationsField: "resetCompactHandoffRecommendations",
@@ -3943,6 +3945,55 @@ test("operator check JSON includes narrow issue #982 sequential planning hint", 
   assert.match(snapshot.sequentialPlanningHints[0].forbiddenClaims.join("\n"), /autonomous execution authority/);
 });
 
+test("operator check JSON includes prompt-derived issue #1006 sequential planning hint without blocking execution", () => {
+  const tempDir = makeTempProject();
+  fs.writeFileSync(
+    path.join(tempDir, ".fooks-session-task.txt"),
+    "Implement this in multiple phases: first inspect, then patch, then test, before PR verify build.",
+  );
+  const branch = "feature-normal";
+  const head = "prompt-sequential-head";
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-21T04:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return `${branch}\n`;
+      if (args[0] === "rev-parse") return `${head}\n`;
+      if (args[0] === "rev-list") return "1\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number,title,url --limit 20") return "[]";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, `HEAD ${head}`, `branch refs/heads/${branch}`, ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return `${branch}\nmain\n`;
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 1\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.sequentialPlanningHints.length, 1);
+  assert.equal(snapshot.sequentialPlanningHints[0].issue, "#1006");
+  assert.equal(snapshot.sequentialPlanningHints[0].trigger, "prompt-implies-sequential-execution");
+  assert.equal(snapshot.sequentialPlanningHints[0].derivedFrom.promptEvidence, "sequential-intent");
+  assert.deepEqual(snapshot.planBeforeExecuteGuards, []);
+  assert.ok(snapshot.reliabilityWarningVisibility.warnings.some((warning) => warning.kind === "sequential-planning" && warning.issue === "#1006"));
+  assert.equal(snapshot.reliabilityWarningVisibility.summary.sequentialPlanningHintCount, 1);
+});
+
 test("sequential planning hint builder is deterministic, bounded, and trigger-gated", () => {
   const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch: "fooks-issue-976-runtime-planning-warning" });
   const contextTrust = syntheticPreflightSnapshot({
@@ -3976,12 +4027,14 @@ test("sequential planning hint builder is deterministic, bounded, and trigger-ga
     "checkpoint-or-compress-current-source-of-truth",
     "handoff-before-burning-another-context-window",
   ]);
-  assert.match(hints[0].message, /Before another long or sequential coding run/);
+  assert.match(hints[0].message, /Sequential or multi-phase coding run detected/);
   assert.deepEqual(hints[0].derivedFrom, {
     planningWarningCount: 1,
     combinedReliabilityWarningCount: 1,
     planningWarningsField: "planningWarnings",
     combinedReliabilityWarningsField: "combinedReliabilityWarnings",
+    promptEvidence: "not-provided",
+    runLabelEvidence: "no-sequential-intent",
   });
   assert.equal(hints[0].claimBoundary, SEQUENTIAL_PLANNING_HINT_CLAIM_BOUNDARY);
   assert.match(hints[0].claimBoundary, /does not prove provider billing\/runtime token usage/);
@@ -3998,4 +4051,31 @@ test("sequential planning hint builder is deterministic, bounded, and trigger-ga
   });
   assert.equal(issueHints.length, 1);
   assert.equal(issueHints[0].trigger, "branch-issue-982");
+
+  const promptHints = buildSequentialPlanningHints({
+    prompt: "Implement Issue #1006 in multiple phases: first inspect, then patch, then test, before PR verify build.",
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+  });
+  assert.equal(promptHints.length, 1);
+  assert.equal(promptHints[0].issue, "#1006");
+  assert.equal(promptHints[0].trigger, "prompt-implies-sequential-execution");
+  assert.equal(promptHints[0].derivedFrom.promptEvidence, "sequential-intent");
+  assert.equal(promptHints[0].derivedFrom.runLabelEvidence, "not-provided");
+  assert.match(promptHints[0].claimBoundary, /block execution/);
+
+  const runHints = buildSequentialPlanningHints({
+    runLabel: "fooks-issue-1006-sequential-planning-hints",
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+  });
+  assert.equal(runHints.length, 1);
+  assert.equal(runHints[0].trigger, "run-label-implies-sequential-execution");
+
+  assert.deepEqual(buildSequentialPlanningHints({
+    prompt: "Explain what a sequence diagram means.",
+    runLabel: "feature-normal-cleanup",
+    planningWarnings: [],
+    combinedReliabilityWarnings: [],
+  }), []);
 });


### PR DESCRIPTION
## Summary
- Detect sequential or multi-phase prompt/run signals for advisory planning hints
- Surface sequential-planning hints through existing `fooks check --json` reliability warning visibility
- Preserve existing runtime/provider behavior and keep the hint non-blocking

## Verification
- `npm test` (907 pass / 0 fail)
- `npm run build && node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs test/long-run-budget-warning.test.mjs test/plan-before-execute-guard.test.mjs test/preflight-advisory-intent.test.mjs` (77 pass / 0 fail)
- `git diff --check`

Closes #1006
