### PR TITLE
Add Codex preflight advisory hook receipts

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -13,6 +13,8 @@ import {
   resolveCodexRuntimeSessionKey,
 } from "./codex-runtime-session";
 import type { CodexRuntimeHookDecision, CodexRuntimeHookInput, ContextMode, ModelFacingPayload } from "../core/schema";
+import { decidePreflightAdvisoryIntent } from "../ops/preflight-advisory-intent";
+import type { PreflightAdvisoryDecision, PreflightAdvisoryRuntimeSignals } from "../ops/preflight-advisory-intent";
 import {
   estimateFileBytes,
   estimateTextBytes,
@@ -27,6 +29,10 @@ import { buildReactWebActivationModeFromRuntimeDecision, summarizeReactWebActiva
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const EDIT_GUIDANCE_CONTEXT_MAX_BYTES = 8_192;
+const PREFLIGHT_ADVISORY_CONTEXT_MARKER = "FOOKS PREFLIGHT ADVISORY";
+const PREFLIGHT_ISSUE_OR_PR_PATTERN = /(?:#\d+\b|\b(?:issue|issues|pr|pull\s+request)\s*#?\d+\b)/iu;
+const PREFLIGHT_TEST_COMMAND_PATTERN = /(?:\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b|\bpytest\b|\bvitest\b|\bjest\b|테스트)/iu;
+const PREFLIGHT_STACK_OR_ERROR_PATTERN = /(?:\b(?:typeerror|referenceerror|syntaxerror|stack\s+trace|traceback|failed|failure|exception|error)\b|에러|오류|실패|스택|이상한데)/iu;
 
 type RuntimeReactWebContext = NonNullable<ModelFacingPayload["reactWebContext"]>;
 type RuntimeReactWebContextArrayKey = Exclude<{
@@ -170,6 +176,65 @@ function compactRuntimeReactWebContext(
 }
 
 type RuntimeReactWebContextPackingSummary = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebContextPacking"]>;
+type CodexRuntimeDebug = NonNullable<CodexRuntimeHookDecision["debug"]>;
+type PreflightAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["preflightAdvisoryIntent"]>;
+
+function preflightAdvisoryDebugReceipt(decision: PreflightAdvisoryDecision): PreflightAdvisoryDebugReceipt {
+  return {
+    shouldAttach: decision.shouldAttach,
+    confidence: decision.confidence,
+    category: decision.category,
+    score: decision.score,
+    reasons: [...decision.reasons],
+    skipReasons: [...decision.skipReasons],
+  };
+}
+
+function buildPreflightAdvisoryRuntimeSignals(
+  prompt: string,
+  target: string | undefined,
+): PreflightAdvisoryRuntimeSignals {
+  return {
+    hasFilePath: Boolean(target),
+    hasRepoAnchor: Boolean(target),
+    hasIssueOrPrReference: PREFLIGHT_ISSUE_OR_PR_PATTERN.test(prompt),
+    hasTestCommand: PREFLIGHT_TEST_COMMAND_PATTERN.test(prompt),
+    hasStackTraceOrError: PREFLIGHT_STACK_OR_ERROR_PATTERN.test(prompt),
+  };
+}
+
+function renderPreflightAdvisoryContext(decision: PreflightAdvisoryDecision): string | undefined {
+  if (!decision.shouldAttach) return undefined;
+
+  return [
+    PREFLIGHT_ADVISORY_CONTEXT_MARKER,
+    "- Source: local preflight advisory intent scorer; no new evidence collection was performed.",
+    `- Intent: ${decision.category} (confidence: ${decision.confidence}, score: ${decision.score}).`,
+    `- Reasons: ${decision.reasons.length > 0 ? decision.reasons.join(", ") : "none"}.`,
+    "- Boundary: advisory-only; does not block, create authority, run cleanup, run commands, or change provider/tool behavior.",
+    "- Reminder: stale/local-only residue is cleanup-review context, not current-work authority unless separately evidenced.",
+  ].join("\n");
+}
+
+function preflightAdvisoryReasons(advisory: string | undefined): string[] {
+  return advisory ? ["preflight-advisory-attached"] : [];
+}
+
+function attachPreflightAdvisoryDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  decision: PreflightAdvisoryDecision,
+): CodexRuntimeHookDecision {
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    preflightAdvisoryIntent: preflightAdvisoryDebugReceipt(decision),
+  };
+  return runtimeDecision;
+}
 
 function summarizeRuntimeReactWebContextPacking(
   reactWebContext: PackedRuntimeReactWebContext | undefined,
@@ -490,13 +555,19 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   const target = promptContext.filePath;
   const policy = promptContext.policy;
   const escapeHatchUsed = hasFullReadEscapeHatch(prompt);
+  const preflightAdvisoryIntent = decidePreflightAdvisoryIntent({
+    prompt,
+    runtime: buildPreflightAdvisoryRuntimeSignals(prompt, target),
+  });
+  const preflightAdvisoryContext = renderPreflightAdvisoryContext(preflightAdvisoryIntent);
 
   if (!target) {
     const runtimeDecision: CodexRuntimeHookDecision = {
       runtime: "codex",
       hookEventName,
       action: "noop",
-      reasons: ["no-eligible-file-in-prompt"],
+      reasons: ["no-eligible-file-in-prompt", ...preflightAdvisoryReasons(preflightAdvisoryContext)],
+      additionalContext: preflightAdvisoryContext,
       contextMode: policy.contextMode,
       contextModeReason: policy.contextModeReason,
       contextBudget: policy.contextBudget,
@@ -508,6 +579,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         escapeHatchUsed,
       },
     };
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision);
     return runtimeDecision;
   }
@@ -531,6 +603,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         escapeHatchUsed,
       },
     };
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision);
     return runtimeDecision;
   }
@@ -549,6 +622,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       "escape-hatch-full-read",
       policy,
     );
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
       actualEstimatedBytes: originalEstimatedBytes,
@@ -569,8 +643,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       hookEventName,
       action: "record",
       filePath: target,
-      reasons: ["first-seen-file", "context-mode:no-op"],
+      reasons: ["first-seen-file", "context-mode:no-op", ...preflightAdvisoryReasons(preflightAdvisoryContext)],
       statePath,
+      additionalContext: preflightAdvisoryContext,
       contextMode: "no-op",
       contextModeReason: policy.promptSpecificity === "file-hinted" ? "first-turn-file-hinted-record-only" : "first-turn-exact-file-record-only",
       contextBudget: { ...policy.contextBudget, selectedFiles: 0, totalBytes: 0, skippedFiles: policy.contextBudget.selectedFiles },
@@ -582,8 +657,15 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         escapeHatchUsed: false,
       },
     };
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
       observedOriginalEstimatedBytes: originalEstimatedBytes,
+      ...(preflightAdvisoryContext
+        ? {
+            actualEstimatedBytes: estimateTextBytes(preflightAdvisoryContext),
+            comparableForSavings: false,
+          }
+        : {}),
     });
     return runtimeDecision;
   }
@@ -605,6 +687,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       "payload-build-failed",
       policy,
     );
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
       actualEstimatedBytes: originalEstimatedBytes,
@@ -672,25 +755,27 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         ...(reactWebContextPacking ? { reactWebContextPacking } : {}),
       },
     };
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
 
     if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
       const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
       const promoted =
         activationMode?.profileGate.verdict === "would-activate" || activationMode?.globMatch.verdict === "would-activate";
       if (!activationMode || !promoted) {
+        const activationFallbackBase = fallbackDecision(
+          hookEventName,
+          target,
+          statePath,
+          ["repeated-file", "activation-mode-not-promoted"],
+          true,
+          true,
+          false,
+          "activation-mode-not-promoted",
+          policy,
+          decision,
+        );
         const activationFallback = attachReactWebActivationDebug(
-          fallbackDecision(
-            hookEventName,
-            target,
-            statePath,
-            ["repeated-file", "activation-mode-not-promoted"],
-            true,
-            true,
-            false,
-            "activation-mode-not-promoted",
-            policy,
-            decision,
-          ),
+          attachPreflightAdvisoryDebug(activationFallbackBase, preflightAdvisoryIntent),
           { promoted: false },
           cwd,
         );
@@ -726,6 +811,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     policy,
     decision,
   );
+  attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
   recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
     originalEstimatedBytes,
     actualEstimatedBytes: originalEstimatedBytes,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -742,6 +742,14 @@ export type CodexRuntimeHookDecision = {
       deferredTriggers: string[];
       blockedReasons: string[];
     };
+    preflightAdvisoryIntent?: {
+      shouldAttach: boolean;
+      confidence: "low" | "medium" | "high";
+      category: string;
+      score: number;
+      reasons: string[];
+      skipReasons: string[];
+    };
   };
   fallback?: {
     action: "full-read";

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -17,6 +17,7 @@ import { cleanupMetricSessions } from "./metric-cleanup.mjs";
 const repoRoot = process.cwd();
 const cli = path.join(repoRoot, "dist", "cli", "index.js");
 const require = createRequire(import.meta.url);
+const PREFLIGHT_ADVISORY_CONTEXT_MARKER = "FOOKS PREFLIGHT ADVISORY";
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -29,6 +30,7 @@ function readReactWebIssueGoldenText(name) {
 function readReactWebIssueGoldenJson(name) {
   return JSON.parse(fs.readFileSync(path.join(repoRoot, "test", "fixtures", "react-web-issues-golden", name), "utf8"));
 }
+
 const { extractFile } = require(path.join(repoRoot, "dist", "core", "extract.js"));
 const {
   DESIGN_REVIEW_METADATA_ITEM_CAPS,
@@ -2045,6 +2047,91 @@ test("codex runtime hook keeps matching no-target claim-boundary prompts as no-o
   assert.equal("matchReasons" in lastEvent, false);
 });
 
+test("codex runtime hook attaches preflight advisory context for anchored work prompts", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-preflight-advisory-attach-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  const decision = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please update ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(decision.action, "record");
+  assert.equal(decision.filePath, target);
+  assert.ok(decision.additionalContext.includes(PREFLIGHT_ADVISORY_CONTEXT_MARKER));
+  assert.ok(decision.reasons.includes("preflight-advisory-attached"));
+  assert.equal(decision.debug.preflightAdvisoryIntent.shouldAttach, true);
+  assert.equal(decision.debug.preflightAdvisoryIntent.category, "implementation");
+  assert.equal(typeof decision.debug.preflightAdvisoryIntent.score, "number");
+  assert.ok(decision.debug.preflightAdvisoryIntent.reasons.includes("repo-anchor"));
+  assert.ok(decision.debug.preflightAdvisoryIntent.reasons.includes("runtime-repo-anchor"));
+  assert.ok(decision.debug.preflightAdvisoryIntent.reasons.includes("work-intent:implementation"));
+  assert.deepEqual(decision.debug.preflightAdvisoryIntent.skipReasons, []);
+});
+
+test("codex runtime hook skips preflight advisory for pure questions and vague unanchored work", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-preflight-advisory-skip-${Date.now()}`;
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  const question = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "이 구조가 뭐야?",
+    },
+    tempDir,
+  );
+  assert.equal(question.action, "noop");
+  assert.equal(question.additionalContext, undefined);
+  assert.equal(question.debug.preflightAdvisoryIntent.shouldAttach, false);
+  assert.equal(question.debug.preflightAdvisoryIntent.category, "question");
+  assert.ok(question.debug.preflightAdvisoryIntent.skipReasons.includes("pure-question"));
+
+  const vagueWork = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: "구현해줘",
+    },
+    tempDir,
+  );
+  assert.equal(vagueWork.action, "noop");
+  assert.equal(vagueWork.additionalContext, undefined);
+  assert.equal(vagueWork.debug.preflightAdvisoryIntent.shouldAttach, false);
+  assert.equal(vagueWork.debug.preflightAdvisoryIntent.category, "implementation");
+  assert.ok(vagueWork.debug.preflightAdvisoryIntent.reasons.includes("work-intent:implementation"));
+  assert.ok(vagueWork.debug.preflightAdvisoryIntent.skipReasons.includes("work-intent-without-anchor"));
+});
+
+test("codex runtime hook lets preflight advisory opt-out win", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-preflight-advisory-optout-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+
+  const decision = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `no preflight, please update ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(decision.action, "record");
+  assert.equal(decision.additionalContext, undefined);
+  assert.equal(decision.debug.preflightAdvisoryIntent.shouldAttach, false);
+  assert.ok(decision.debug.preflightAdvisoryIntent.skipReasons.includes("explicit-opt-out"));
+  assert.equal(decision.reasons.includes("preflight-advisory-attached"), false);
+});
+
 test("codex runtime hook records first matching exact-file prompt without project knowledge and injects it on repeated file", () => {
   const tempDir = makeTempProject();
   writeProjectKnowledgeFixture(tempDir);
@@ -2314,7 +2401,8 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(first.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
   assert.equal(first.contextMode, "no-op");
   assert.equal(first.promptSpecificity, "exact-file");
-  assert.equal(first.additionalContext, undefined);
+  assert.ok(first.additionalContext.includes(PREFLIGHT_ADVISORY_CONTEXT_MARKER));
+  assert.equal(first.debug.preflightAdvisoryIntent.shouldAttach, true);
   assert.match(first.statePath, /\.fooks\/state\/codex-runtime/);
 
   const second = handleCodexRuntimeHook(
@@ -2339,7 +2427,9 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.additionalContext.includes("\"editGuidance\""), true);
   assert.equal(second.additionalContext.includes("\"reactWebContext\""), true);
   assert.ok(second.reasons.includes("edit-guidance-opt-in"));
+  assert.equal(second.reasons.includes("preflight-advisory-attached"), false);
   assert.equal(second.debug.repeatedFile, true);
+  assert.equal(second.debug.preflightAdvisoryIntent.shouldAttach, true);
   assert.deepEqual(second.debug.decision.payload.editGuidance.freshness, second.debug.decision.payload.sourceFingerprint);
   assert.ok(second.debug.decision.payload.editGuidance.patchTargets.length <= 12);
   assert.equal(second.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");


### PR DESCRIPTION
## Linked issue
Related epic: #960

## Summary
- Add Codex UserPromptSubmit preflight advisory scoring from local prompt/target facts.
- Attach bounded `FOOKS PREFLIGHT ADVISORY` context for anchored first/no-target advisory paths.
- Preserve repeated React Web same-file inject visible payload shape by keeping preflight advisory debug-only on repeated injects.

## Boundaries
- Codex runtime hook only.
- No Claude runtime changes.
- No public CLI/check/preflight JSON schema changes.
- No hook-side command orchestration, cleanup, authority creation, or new evidence reads.
- No new dependencies.

## Verification
- `npm run build`
- `npm run typecheck`
- `node --test test/preflight-advisory-intent.test.mjs`
- `env -u FOOKS_TARGET_ACCOUNT node --test test/fooks.test.mjs`
- `git diff --check`

## Notes
- Negative-path stack traces in `test/fooks.test.mjs` are expected test fixtures; final suite result was 175/175.
- Full `npm test` was run successfully earlier during Ralph verification (909/909) before rebasing onto latest `origin/main`; after branch refresh, targeted runtime/build/typecheck verification was rerun.

Fixes #1009
