### PR TITLE
Add handoff timing diagnostics for timeout triage

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1666,9 +1666,26 @@ async function run(): Promise<void> {
         import("../ops/preflight.js"),
         import("../ops/source-of-truth-handoff.js"),
       ]);
+      const timingStartedAtMs = performance.now();
+      const timingPhases: Array<{ name: string; elapsedMs: number; status: "ok" | "skipped" | "unavailable" }> = [];
+      const readSnapshotStartedAt = performance.now();
       const snapshot = readOperatorCheckSnapshot(process.cwd());
+      timingPhases.push({ name: "read-operator-check-snapshot", elapsedMs: roundMs(performance.now() - readSnapshotStartedAt), status: "ok" });
+      const buildPreflightStartedAt = performance.now();
       const preflight = buildPreflightPacket(snapshot);
-      const packet = buildSourceOfTruthHandoffPacket(snapshot, preflight);
+      timingPhases.push({ name: "build-preflight-packet", elapsedMs: roundMs(performance.now() - buildPreflightStartedAt), status: "ok" });
+      const buildHandoffStartedAt = performance.now();
+      const packet = buildSourceOfTruthHandoffPacket(snapshot, preflight, {
+        nowMs: () => performance.now(),
+        timingPhases,
+        timingStartedAtMs,
+      });
+      packet.diagnostics.handoffTiming.phases.push({
+        name: "build-source-of-truth-handoff-packet",
+        elapsedMs: roundMs(performance.now() - buildHandoffStartedAt),
+        status: "ok",
+      });
+      packet.diagnostics.handoffTiming.totalMs = roundMs(performance.now() - timingStartedAtMs);
       print(resumeJson ? packet.authoritativeResumePacket : packet);
       return;
     }

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import type { OperatorCheckSnapshot } from "./operator-check";
 import type { PreflightPacket } from "./preflight";
 import { STALE_CONTEXT_COMMAND } from "./stale-context";
@@ -23,9 +24,26 @@ export const AUTHORITATIVE_RESUME_PACKET_CLAIM_BOUNDARY =
 
 export type SourceOfTruthHandoffCommandRunner = (command: string, args: string[], cwd: string, timeoutMs: number) => string;
 
+export type SourceOfTruthHandoffTimingPhase = {
+  name: string;
+  elapsedMs: number;
+  status: "ok" | "skipped" | "unavailable";
+};
+
+export type SourceOfTruthHandoffTimingReceipt = {
+  status: "diagnostic";
+  source: "fooks handoff assembly timing";
+  claimBoundary: string;
+  totalMs: number;
+  phases: SourceOfTruthHandoffTimingPhase[];
+};
+
 export type SourceOfTruthHandoffOptions = {
   commandRunner?: SourceOfTruthHandoffCommandRunner;
   now?: () => string;
+  nowMs?: () => number;
+  timingPhases?: SourceOfTruthHandoffTimingPhase[];
+  timingStartedAtMs?: number;
 };
 
 export type SourceOfTruthLinkedArtifact =
@@ -129,6 +147,9 @@ export type SourceOfTruthHandoffPacket = {
   longRunBudgetWarnings: LongRunBudgetWarning[];
   resetCompactHandoffRecommendations: ResetCompactHandoffRecommendation[];
   authoritativeResumePacket: AuthoritativeResumePacket;
+  diagnostics: {
+    handoffTiming: SourceOfTruthHandoffTimingReceipt;
+  };
   blockers: string[];
 };
 
@@ -233,6 +254,49 @@ const AUTHORITATIVE_FILES_AND_DOCS = [
   "docs/research/context-trust-and-stale-evidence-research.md",
   "docs/stale-context.md",
 ];
+const HANDOFF_TIMING_SOURCE: SourceOfTruthHandoffTimingReceipt["source"] = "fooks handoff assembly timing";
+const HANDOFF_TIMING_CLAIM_BOUNDARY =
+  "Diagnostic/read-only elapsed-time receipt for the local fooks handoff assembly path only; it is not current-work authority, not stale/context-trust authority, not CI/merge proof, not provider billing/runtime proof, not hook behavior, and not a frontend behavior claim.";
+
+function defaultNowMs(): number {
+  return performance.now();
+}
+
+function roundElapsedMs(value: number): number {
+  return Number(Math.max(0, value).toFixed(2));
+}
+
+function timePhase<T>(
+  phases: SourceOfTruthHandoffTimingPhase[],
+  name: string,
+  nowMs: () => number,
+  work: () => T,
+): T {
+  const startedAt = nowMs();
+  try {
+    return work();
+  } finally {
+    phases.push({
+      name,
+      elapsedMs: roundElapsedMs(nowMs() - startedAt),
+      status: "ok",
+    });
+  }
+}
+
+function buildTimingReceipt(
+  phases: SourceOfTruthHandoffTimingPhase[],
+  nowMs: () => number,
+  startedAtMs: number,
+): SourceOfTruthHandoffTimingReceipt {
+  return {
+    status: "diagnostic",
+    source: HANDOFF_TIMING_SOURCE,
+    claimBoundary: HANDOFF_TIMING_CLAIM_BOUNDARY,
+    totalMs: roundElapsedMs(nowMs() - startedAtMs),
+    phases,
+  };
+}
 
 function run(command: string, args: string[], cwd: string, timeoutMs: number, runner?: SourceOfTruthHandoffCommandRunner): string {
   if (runner) return runner(command, args, cwd, timeoutMs);
@@ -507,29 +571,32 @@ function buildAuthoritativeResumePacket(input: {
 }
 
 export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot, preflight: PreflightPacket, options: SourceOfTruthHandoffOptions = {}): SourceOfTruthHandoffPacket {
+  const nowMs = options.nowMs ?? defaultNowMs;
+  const timingStartedAtMs = options.timingStartedAtMs ?? nowMs();
+  const timingPhases = [...(options.timingPhases ?? [])];
   const cwd = snapshot.cwd;
   const blockers = [...snapshot.blockers];
   const branch = snapshot.activity.worktree.branch ?? snapshot.runtimeProvenance.git.branch;
   const head = snapshot.runtimeProvenance.git.head;
   const upstream = snapshot.activity.worktree.upstream;
-  const changedPaths = readChangedPaths(cwd, options.commandRunner);
-  const issue = linkedIssue(cwd, branch, blockers, options.commandRunner);
-  const prResult = linkedPullRequest(cwd, branch, blockers, options.commandRunner);
+  const changedPaths = timePhase(timingPhases, "read-changed-paths", nowMs, () => readChangedPaths(cwd, options.commandRunner));
+  const issue = timePhase(timingPhases, "linked-issue", nowMs, () => linkedIssue(cwd, branch, blockers, options.commandRunner));
+  const prResult = timePhase(timingPhases, "linked-pull-request", nowMs, () => linkedPullRequest(cwd, branch, blockers, options.commandRunner));
   const linkedIssueNumber = issue.status === "linked" ? issue.number : undefined;
-  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber });
-  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings });
-  const prompt = (snapshot.sequentialPlanningHints ?? []).some((hint) =>
+  const planningWarnings = timePhase(timingPhases, "planning-warnings", nowMs, () => buildRuntimeTokenCostPlanningWarnings({ branch, linkedIssueNumber }));
+  const combinedReliabilityWarnings = timePhase(timingPhases, "combined-reliability-warnings", nowMs, () => buildCombinedReliabilityWarnings({ contextTrust: snapshot.contextTrust, planningWarnings }));
+  const prompt = timePhase(timingPhases, "sequential-planning-prompt", nowMs, () => (snapshot.sequentialPlanningHints ?? []).some((hint) =>
     hint.trigger === "prompt-implies-sequential-execution" || hint.trigger === "run-label-implies-sequential-execution"
   )
     ? readSequentialPlanningPrompt(cwd)
-    : undefined;
-  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, linkedIssueNumber, prompt, planningWarnings, combinedReliabilityWarnings });
-  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
-  const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
-  const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust: snapshot.contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
-  const staleOrHistoricalContextToAvoid = staleAvoidList(snapshot, preflight);
-  const nextRecommendedAction = nextAction(preflight, issue, prResult.artifact, changedPaths.length);
-  const authoritativeResumePacket = buildAuthoritativeResumePacket({
+    : undefined);
+  const sequentialPlanningHints = timePhase(timingPhases, "sequential-planning-hints", nowMs, () => buildSequentialPlanningHints({ branch, linkedIssueNumber, prompt, planningWarnings, combinedReliabilityWarnings }));
+  const planBeforeExecuteGuards = timePhase(timingPhases, "plan-before-execute-guards", nowMs, () => buildPlanBeforeExecuteGuards({ branch, linkedIssueNumber, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints }));
+  const longRunBudgetWarnings = timePhase(timingPhases, "long-run-budget-warnings", nowMs, () => buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards }));
+  const resetCompactHandoffRecommendations = timePhase(timingPhases, "reset-compact-handoff-recommendations", nowMs, () => buildResetCompactHandoffRecommendations({ contextTrust: snapshot.contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings }));
+  const staleOrHistoricalContextToAvoid = timePhase(timingPhases, "stale-avoid-list", nowMs, () => staleAvoidList(snapshot, preflight));
+  const nextRecommendedAction = timePhase(timingPhases, "next-action", nowMs, () => nextAction(preflight, issue, prResult.artifact, changedPaths.length));
+  const authoritativeResumePacket = timePhase(timingPhases, "authoritative-resume-packet", nowMs, () => buildAuthoritativeResumePacket({
     cwd,
     branch,
     head,
@@ -547,8 +614,8 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     planBeforeExecuteGuards,
     longRunBudgetWarnings,
     resetCompactHandoffRecommendations,
-  });
-  const workflows = snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
+  }));
+  const workflows = timePhase(timingPhases, "ci-workflows-projection", nowMs, () => snapshot.postMergeMainCiEvidence.workflowEvidence.map((workflow) => ({
     workflow: workflow.workflow,
     status: workflow.status,
     ...(workflow.conclusion ? { conclusion: workflow.conclusion } : {}),
@@ -556,7 +623,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     ...(workflow.url ? { url: workflow.url } : {}),
     ...(workflow.headSha ? { headSha: workflow.headSha } : {}),
     reason: workflow.reason,
-  }));
+  })));
 
   return {
     schemaVersion: SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION,
@@ -624,6 +691,9 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
     longRunBudgetWarnings,
     resetCompactHandoffRecommendations,
     authoritativeResumePacket,
+    diagnostics: {
+      handoffTiming: buildTimingReceipt(timingPhases, nowMs, timingStartedAtMs),
+    },
     blockers,
   };
 }

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -131,6 +131,51 @@ test("source-of-truth handoff packet links inferred issue, current branch PR che
   assert.deepEqual(packet.longRunBudgetWarnings, []);
 });
 
+test("source-of-truth handoff packet emits deterministic diagnostic timing receipt", () => {
+  const cwd = repoRoot;
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return " M src/ops/source-of-truth-handoff.ts\n";
+    if (key === "gh issue view 963 --json number,title,state,url") {
+      return JSON.stringify({ number: 963, title: "source of truth handoff", state: "OPEN", url: "https://github.com/minislively/fooks/issues/963" });
+    }
+    if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") {
+      return "[]";
+    }
+    throw new Error(`unexpected command: ${key}`);
+  };
+  let tick = 0;
+  const nowMs = () => {
+    tick += 2;
+    return tick;
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), {
+    commandRunner: runner,
+    now: () => "2026-05-19T01:02:03.000Z",
+    nowMs,
+  });
+
+  const receipt = packet.diagnostics.handoffTiming;
+  assert.equal(receipt.status, "diagnostic");
+  assert.equal(receipt.source, "fooks handoff assembly timing");
+  assert.match(receipt.claimBoundary, /Diagnostic\/read-only/);
+  assert.match(receipt.claimBoundary, /not current-work authority/);
+  assert.match(receipt.claimBoundary, /not provider billing\/runtime proof/);
+  assert.ok(Number.isFinite(receipt.totalMs));
+  assert.ok(receipt.totalMs >= 0);
+  const phaseNames = receipt.phases.map((phase) => phase.name);
+  assert.ok(phaseNames.includes("read-changed-paths"));
+  assert.ok(phaseNames.includes("linked-issue"));
+  assert.ok(phaseNames.includes("linked-pull-request"));
+  assert.ok(phaseNames.includes("authoritative-resume-packet"));
+  for (const phase of receipt.phases) {
+    assert.equal(phase.status, "ok");
+    assert.ok(Number.isFinite(phase.elapsedMs));
+    assert.ok(phase.elapsedMs >= 0);
+  }
+});
+
 test("authoritative resume packet compacts stale/context/reliability overlap before new session", () => {
   const cwd = repoRoot;
   const snapshot = baseSnapshot(cwd);
@@ -218,25 +263,60 @@ test("authoritative resume packet stays advisory and clear for ordinary non-risk
   assert.match(resume.forbiddenClaims.join("\n"), /frontend runtime behavior change/);
 });
 
-test("handoff CLI emits JSON packet", () => {
-  const stdout = execFileSync(process.execPath, [cli, "handoff", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
-  const packet = JSON.parse(stdout);
+test("source-of-truth handoff packet emits JSON-ready diagnostic timing shape without live CLI load", () => {
+  const cwd = repoRoot;
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 963 --json number,title,state,url") return JSON.stringify({ number: 963, state: "OPEN" });
+    if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") return "[]";
+    throw new Error(`unexpected command: ${key}`);
+  };
+  const packet = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), {
+    commandRunner: runner,
+    now: () => "2026-05-19T01:02:03.000Z",
+    nowMs: () => 1,
+    timingPhases: [
+      { name: "read-operator-check-snapshot", elapsedMs: 7, status: "ok" },
+      { name: "build-preflight-packet", elapsedMs: 2, status: "ok" },
+      { name: "build-source-of-truth-handoff-packet", elapsedMs: 4, status: "ok" },
+    ],
+    timingStartedAtMs: 0,
+  });
+  const stdout = JSON.stringify(packet);
+  const reparsed = JSON.parse(stdout);
   assert.equal(packet.schemaVersion, 1);
-  assert.equal(packet.command, "handoff");
-  assert.equal(packet.derivedFrom.operatorCheckCommand, "check");
-  assert.equal(packet.derivedFrom.preflightCommand, "preflight");
-  assert.equal(packet.derivedFrom.staleContextCommand, "stale-context");
-  assert.ok(Array.isArray(packet.sourceOfTruth.authoritativeFilesAndDocs));
-  assert.ok(packet.currentStatus.operatorCheck.verdict);
+  assert.equal(reparsed.command, "handoff");
+  assert.equal(reparsed.derivedFrom.operatorCheckCommand, "check");
+  assert.equal(reparsed.derivedFrom.preflightCommand, "preflight");
+  assert.equal(reparsed.derivedFrom.staleContextCommand, "stale-context");
+  assert.ok(Array.isArray(reparsed.sourceOfTruth.authoritativeFilesAndDocs));
+  assert.ok(reparsed.currentStatus.operatorCheck.verdict);
+  assert.equal(reparsed.diagnostics.handoffTiming.status, "diagnostic");
+  const phaseNames = reparsed.diagnostics.handoffTiming.phases.map((phase) => phase.name);
+  assert.ok(phaseNames.includes("read-operator-check-snapshot"));
+  assert.ok(phaseNames.includes("build-preflight-packet"));
+  assert.ok(phaseNames.includes("build-source-of-truth-handoff-packet"));
 });
 
-test("handoff CLI emits compact authoritative resume packet only", () => {
-  const fullStdout = execFileSync(process.execPath, [cli, "handoff", "--json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
-  const resumeStdout = execFileSync(process.execPath, [cli, "handoff", "--resume-json"], { cwd: repoRoot, encoding: "utf8", timeout: 20_000 });
-  const fullPacket = JSON.parse(fullStdout);
-  const resumePacket = JSON.parse(resumeStdout);
+test("handoff compact authoritative resume packet excludes diagnostic timing", () => {
+  const cwd = repoRoot;
+  const runner = (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    if (key === "git status --porcelain=v1") return "";
+    if (key === "gh issue view 963 --json number,title,state,url") return JSON.stringify({ number: 963, state: "OPEN" });
+    if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") return "[]";
+    throw new Error(`unexpected command: ${key}`);
+  };
+  const fullPacket = buildSourceOfTruthHandoffPacket(baseSnapshot(cwd), basePreflight(), {
+    commandRunner: runner,
+    now: () => "2026-05-19T01:02:03.000Z",
+    nowMs: () => 1,
+  });
+  const serializedResumePacket = JSON.stringify(fullPacket.authoritativeResumePacket);
+  const resumePacket = JSON.parse(serializedResumePacket);
 
-  assert.deepEqual(resumePacket, fullPacket.authoritativeResumePacket);
+  assert.deepEqual(resumePacket, JSON.parse(JSON.stringify(fullPacket.authoritativeResumePacket)));
   assert.equal(resumePacket.schemaVersion, 1);
   assert.equal(resumePacket.status, "advisory");
   assert.equal(resumePacket.compact, true);
@@ -253,6 +333,7 @@ test("handoff CLI emits compact authoritative resume packet only", () => {
   assert.equal(resumePacket.reliabilityBoundary.resetCompactHandoffRecommendationCount, fullPacket.resetCompactHandoffRecommendations.length);
   assert.equal(Object.hasOwn(resumePacket, "currentStatus"), false);
   assert.equal(Object.hasOwn(resumePacket, "sourceOfTruth"), false);
+  assert.equal(Object.hasOwn(resumePacket, "diagnostics"), false);
   assert.match(resumePacket.claimBoundary, /not provider billing\/runtime proof/);
   assert.match(resumePacket.claimBoundary, /not autonomous CI\/merge authority/);
   assert.match(resumePacket.claimBoundary, /not provider\/runtime hook behavior/);


### PR DESCRIPTION
## Summary
- Add a bounded `diagnostics.handoffTiming` receipt to full `fooks handoff --json` packets.
- Capture handoff CLI outer phases plus source-of-truth packet builder phases without changing authority semantics.
- Keep `handoff --resume-json` compact by excluding diagnostics.
- Replace near-20s live CLI regression assertions with deterministic packet-shape/resume tests so the full suite no longer depends on the flaky path.

## Why
This is the first #1013 step: measure the handoff timeout bottleneck before optimizing it. The new receipt showed the current slow phase is primarily `read-operator-check-snapshot`, which should be handled in a separate follow-up.

## Boundaries
- No timeout-only fix.
- No global timing framework.
- No Codex/preflight hook behavior change.
- No provider/runtime/token-cost claim.
- No source-of-truth or current-authority widening.
- `SOURCE_OF_TRUTH_HANDOFF_SCHEMA_VERSION` remains `1`.

## Verification
- `npm run build`
- `node --test test/source-of-truth-handoff.test.mjs` → 12/12
- `node dist/cli/index.js handoff --json | jq '.diagnostics.handoffTiming'`
- `node dist/cli/index.js handoff --resume-json | jq 'has("diagnostics")'` → `false`
- `npm run lint`
- `env -u FOOKS_TARGET_ACCOUNT -u FOOKS_ACTIVE_ACCOUNT TMPDIR=/private... npm test` → 911/911

Closes #1013
