### PR TITLE
Expose operator-check snapshot timing diagnostics

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { isTmuxNoServerRunningError } from "./tmux-errors";
 import {
   ARTIFACT_AUDIT_CLAIM_BOUNDARY,
@@ -34,6 +35,10 @@ export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE =
   "GitHub Actions run list for exact local origin/main head; read-only and no fetch performed";
 export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY =
   "Read-only post-merge main CI evidence for the exact local origin/main head only; missing exact-head workflow evidence stays unknown or pending and never becomes success.";
+export const OPERATOR_ACTIVITY_TIMING_SCHEMA_VERSION = 1;
+export const OPERATOR_ACTIVITY_TIMING_SOURCE = "fooks status activity diagnostic timing";
+export const OPERATOR_ACTIVITY_TIMING_CLAIM_BOUNDARY =
+  "Diagnostic/read-only operator activity subphase timing only; not current-work authority, not cleanup authority, not provider billing/runtime proof, and not a source-of-truth semantic input.";
 export const OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_ISSUE = "#910";
 export const OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_SOURCE = "operator/activity issue #910 staged OMX prompt pane evidence";
 export const OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_CLAIM_BOUNDARY =
@@ -325,6 +330,22 @@ export type OperatorActivityRuntimeProvenance = {
   };
 };
 
+export type OperatorDiagnosticTimingPhase = {
+  name: string;
+  elapsedMs: number;
+  status: "ok" | "skipped" | "unavailable";
+};
+
+export type OperatorActivityTimingReceipt = {
+  schemaVersion: typeof OPERATOR_ACTIVITY_TIMING_SCHEMA_VERSION;
+  source: typeof OPERATOR_ACTIVITY_TIMING_SOURCE;
+  status: "diagnostic";
+  claimBoundary: typeof OPERATOR_ACTIVITY_TIMING_CLAIM_BOUNDARY;
+  readOnly: true;
+  totalMs: number;
+  phases: OperatorDiagnosticTimingPhase[];
+};
+
 export type OperatorActivitySnapshot = {
   schemaVersion: typeof OPERATOR_ACTIVITY_SCHEMA_VERSION;
   command: typeof OPERATOR_ACTIVITY_COMMAND;
@@ -341,6 +362,9 @@ export type OperatorActivitySnapshot = {
   currentRunEvidence: OperatorActivityCurrentRunEvidence;
   postMergeMainCiEvidence: OperatorActivityPostMergeMainCiEvidence;
   blockers: string[];
+  diagnostics: {
+    operatorActivityTiming: OperatorActivityTimingReceipt;
+  };
 };
 
 type ParsedTmuxPane = {
@@ -352,6 +376,38 @@ type ParsedTmuxPane = {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function roundDiagnosticMs(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function timeDiagnosticPhase<T>(
+  phases: OperatorDiagnosticTimingPhase[],
+  name: string,
+  callback: () => T,
+): T {
+  const startedAt = performance.now();
+  try {
+    const value = callback();
+    phases.push({ name, elapsedMs: roundDiagnosticMs(performance.now() - startedAt), status: "ok" });
+    return value;
+  } catch (error) {
+    phases.push({ name, elapsedMs: roundDiagnosticMs(performance.now() - startedAt), status: "unavailable" });
+    throw error;
+  }
+}
+
+function buildOperatorActivityTimingReceipt(phases: OperatorDiagnosticTimingPhase[], totalMs: number): OperatorActivityTimingReceipt {
+  return {
+    schemaVersion: OPERATOR_ACTIVITY_TIMING_SCHEMA_VERSION,
+    source: OPERATOR_ACTIVITY_TIMING_SOURCE,
+    status: "diagnostic",
+    claimBoundary: OPERATOR_ACTIVITY_TIMING_CLAIM_BOUNDARY,
+    readOnly: true,
+    totalMs: roundDiagnosticMs(totalMs),
+    phases: phases.map((phase) => ({ ...phase })),
+  };
 }
 
 function uniqueSorted(values: string[]): string[] {
@@ -1471,16 +1527,21 @@ function buildCurrentRunEvidence(
 }
 
 export function readOperatorActivitySnapshot(cwd = process.cwd(), options: OperatorActivityOptions = {}): OperatorActivitySnapshot {
+  const timingStartedAt = performance.now();
+  const timingPhases: OperatorDiagnosticTimingPhase[] = [];
   const generatedAt = options.now?.() ?? nowIso();
-  const worktreeStatus = currentWorktreeEvidenceStatus(cwd, { ...options, now: () => generatedAt });
-  const worktree = buildWorktreeSnapshot(worktreeStatus);
-  const tmux = readTmuxActivity(cwd, worktree, options);
-  const optionalCounts = readRemoteCounts(cwd, options);
-  const legacyWorktreeEvidence = readLegacyWorktreeEvidence(cwd, options, generatedAt);
-  const stagedOmxPromptEvidence = buildStagedOmxPromptEvidence(worktree, tmux);
-  const currentRunEvidence = buildCurrentRunEvidence(worktree, tmux, optionalCounts, legacyWorktreeEvidence);
-  const postMergeMainCiEvidence = readPostMergeMainCiEvidence(cwd, options);
+  const worktreeStatus = timeDiagnosticPhase(timingPhases, "current-worktree-evidence-status", () =>
+    currentWorktreeEvidenceStatus(cwd, { ...options, now: () => generatedAt })
+  );
+  const worktree = timeDiagnosticPhase(timingPhases, "build-worktree-snapshot", () => buildWorktreeSnapshot(worktreeStatus));
+  const tmux = timeDiagnosticPhase(timingPhases, "read-tmux-activity", () => readTmuxActivity(cwd, worktree, options));
+  const optionalCounts = timeDiagnosticPhase(timingPhases, "read-remote-counts", () => readRemoteCounts(cwd, options));
+  const legacyWorktreeEvidence = timeDiagnosticPhase(timingPhases, "read-legacy-worktree-evidence", () => readLegacyWorktreeEvidence(cwd, options, generatedAt));
+  const stagedOmxPromptEvidence = timeDiagnosticPhase(timingPhases, "build-staged-omx-prompt-evidence", () => buildStagedOmxPromptEvidence(worktree, tmux));
+  const currentRunEvidence = timeDiagnosticPhase(timingPhases, "build-current-run-evidence", () => buildCurrentRunEvidence(worktree, tmux, optionalCounts, legacyWorktreeEvidence));
+  const postMergeMainCiEvidence = timeDiagnosticPhase(timingPhases, "read-post-merge-main-ci-evidence", () => readPostMergeMainCiEvidence(cwd, options));
   const optionalCountBlockers = optionalCounts.enabled ? optionalCounts.blockers : [];
+  const runtimeProvenance = timeDiagnosticPhase(timingPhases, "read-operator-activity-runtime-provenance", () => readOperatorActivityRuntimeProvenance(cwd));
 
   return {
     schemaVersion: OPERATOR_ACTIVITY_SCHEMA_VERSION,
@@ -1489,7 +1550,7 @@ export function readOperatorActivitySnapshot(cwd = process.cwd(), options: Opera
     cwd,
     claimBoundary: OPERATOR_ACTIVITY_CLAIM_BOUNDARY,
     readOnly: true,
-    runtimeProvenance: readOperatorActivityRuntimeProvenance(cwd),
+    runtimeProvenance,
     worktree,
     tmux,
     optionalCounts,
@@ -1498,5 +1559,8 @@ export function readOperatorActivitySnapshot(cwd = process.cwd(), options: Opera
     currentRunEvidence,
     postMergeMainCiEvidence,
     blockers: uniqueSorted([...worktree.blockers, ...tmux.blockers, ...optionalCountBlockers]),
+    diagnostics: {
+      operatorActivityTiming: buildOperatorActivityTimingReceipt(timingPhases, performance.now() - timingStartedAt),
+    },
   };
 }

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import {
   readOperatorActivitySnapshot,
   type OperatorActivityOptions,
@@ -32,6 +33,10 @@ export const OPERATOR_CHECK_CLAIM_BOUNDARY =
   "Read-only operator/check artifact for the post-merge main echo versus active work boundary; it requires a concrete issue, PR, or mapped session artifact when the checkout is otherwise idle.";
 export const OPERATOR_CHECK_SOURCE = `status activity ${OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG} projection`;
 export const OPERATOR_CHECK_PROVENANCE_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_TIMING_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_TIMING_SOURCE = "fooks check --json operator-check diagnostic timing";
+export const OPERATOR_CHECK_TIMING_CLAIM_BOUNDARY =
+  "Diagnostic/read-only operator-check subphase timing only; not current-work authority, not cleanup authority, not handoff/source-of-truth authority, not provider billing/runtime proof, and not a semantic input to downstream guidance decisions.";
 export const OPERATOR_CHECK_RELIABILITY_WARNING_VISIBILITY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_RESUME_HANDOFF_PROJECTION_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SCHEMA_VERSION = 1;
@@ -554,6 +559,22 @@ export type OperatorCheckRuntimeProvenance = {
   };
 };
 
+export type OperatorCheckTimingPhase = {
+  name: string;
+  elapsedMs: number;
+  status: "ok" | "skipped" | "unavailable";
+};
+
+export type OperatorCheckTimingReceipt = {
+  schemaVersion: typeof OPERATOR_CHECK_TIMING_SCHEMA_VERSION;
+  source: typeof OPERATOR_CHECK_TIMING_SOURCE;
+  status: "diagnostic";
+  claimBoundary: typeof OPERATOR_CHECK_TIMING_CLAIM_BOUNDARY;
+  readOnly: true;
+  totalMs: number;
+  phases: OperatorCheckTimingPhase[];
+};
+
 export type OperatorCheckSnapshot = {
   schemaVersion: typeof OPERATOR_CHECK_SCHEMA_VERSION;
   command: typeof OPERATOR_CHECK_COMMAND;
@@ -588,6 +609,9 @@ export type OperatorCheckSnapshot = {
   resumeHandoffProjection: OperatorCheckResumeHandoffProjection;
   activity: OperatorActivitySnapshot;
   blockers: string[];
+  diagnostics: {
+    operatorCheckTiming: OperatorCheckTimingReceipt;
+  };
 };
 
 export type OperatorCheckReliabilityWarningVisibility = {
@@ -733,6 +757,39 @@ export type OperatorCheckResumeHandoffProjection = {
   forbiddenClaims: string[];
 };
 
+
+
+function roundDiagnosticMs(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function timeDiagnosticPhase<T>(
+  phases: OperatorCheckTimingPhase[],
+  name: string,
+  callback: () => T,
+): T {
+  const startedAt = performance.now();
+  try {
+    const value = callback();
+    phases.push({ name, elapsedMs: roundDiagnosticMs(performance.now() - startedAt), status: "ok" });
+    return value;
+  } catch (error) {
+    phases.push({ name, elapsedMs: roundDiagnosticMs(performance.now() - startedAt), status: "unavailable" });
+    throw error;
+  }
+}
+
+function buildOperatorCheckTimingReceipt(phases: OperatorCheckTimingPhase[], totalMs: number): OperatorCheckTimingReceipt {
+  return {
+    schemaVersion: OPERATOR_CHECK_TIMING_SCHEMA_VERSION,
+    source: OPERATOR_CHECK_TIMING_SOURCE,
+    status: "diagnostic",
+    claimBoundary: OPERATOR_CHECK_TIMING_CLAIM_BOUNDARY,
+    readOnly: true,
+    totalMs: roundDiagnosticMs(totalMs),
+    phases: phases.map((phase) => ({ ...phase })),
+  };
+}
 
 function uniqueSorted(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))].sort((left, right) => left.localeCompare(right));
@@ -1958,11 +2015,13 @@ export function buildOperatorCheckResumeHandoffProjection(input: {
 }
 
 export function readOperatorCheckSnapshot(cwd = process.cwd(), options: OperatorActivityOptions = {}): OperatorCheckSnapshot {
-  const activity = readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true });
-  const activeArtifacts = activeArtifactsFrom(activity);
-  const activeWorkReceipts = buildActiveWorkReceipts(cwd, activity, options);
+  const timingStartedAt = performance.now();
+  const timingPhases: OperatorCheckTimingPhase[] = [];
+  const activity = timeDiagnosticPhase(timingPhases, "read-operator-activity-snapshot", () => readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true }));
+  const activeArtifacts = timeDiagnosticPhase(timingPhases, "active-artifacts", () => activeArtifactsFrom(activity));
+  const activeWorkReceipts = timeDiagnosticPhase(timingPhases, "build-active-work-receipts", () => buildActiveWorkReceipts(cwd, activity, options));
   const branch = activity.worktree.branch;
-  const blockers = checkProjectionBlockers([...activity.blockers]);
+  const blockers = timeDiagnosticPhase(timingPhases, "check-projection-blockers", () => checkProjectionBlockers([...activity.blockers]));
   const hasActiveArtifact = activeArtifacts.length > 0;
   const optionalCountBlockers = activity.optionalCounts.enabled ? activity.optionalCounts.blockers : [];
   const blocked = activity.currentRunEvidence.blockers.length > 0 || optionalCountBlockers.length > 0 || !activity.tmux.available;
@@ -1973,30 +2032,30 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
       ? "activeArtifactPresent"
       : "idleRequiresActiveArtifact";
 
-  const requiredArtifact = requiredActiveArtifact({ blocked, hasActiveArtifact });
-  const contextTrust = buildOperatorContextTrust({
+  const requiredArtifact = timeDiagnosticPhase(timingPhases, "required-active-artifact", () => requiredActiveArtifact({ blocked, hasActiveArtifact }));
+  const contextTrust = timeDiagnosticPhase(timingPhases, "build-operator-context-trust", () => buildOperatorContextTrust({
     activeArtifacts,
     activeWorkReceipts,
     requiredActiveArtifact: requiredArtifact,
     currentRunEvidence: activity.currentRunEvidence,
     postMergeMainCiEvidence: activity.postMergeMainCiEvidence,
-  });
-  const planningWarnings = buildRuntimeTokenCostPlanningWarnings({ branch });
-  const combinedReliabilityWarnings = buildCombinedReliabilityWarnings({ contextTrust, planningWarnings });
-  const prompt = readSequentialPlanningPrompt(cwd);
-  const sequentialPlanningHints = buildSequentialPlanningHints({ branch, prompt, planningWarnings, combinedReliabilityWarnings });
-  const planBeforeExecuteGuards = buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints });
-  const longRunBudgetWarnings = buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards });
-  const resetCompactHandoffRecommendations = buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings });
-  const reliabilityWarningVisibility = buildOperatorCheckReliabilityWarningVisibility({
+  }));
+  const planningWarnings = timeDiagnosticPhase(timingPhases, "runtime-token-cost-planning-warnings", () => buildRuntimeTokenCostPlanningWarnings({ branch }));
+  const combinedReliabilityWarnings = timeDiagnosticPhase(timingPhases, "combined-reliability-warnings", () => buildCombinedReliabilityWarnings({ contextTrust, planningWarnings }));
+  const prompt = timeDiagnosticPhase(timingPhases, "read-sequential-planning-prompt", () => readSequentialPlanningPrompt(cwd));
+  const sequentialPlanningHints = timeDiagnosticPhase(timingPhases, "sequential-planning-hints", () => buildSequentialPlanningHints({ branch, prompt, planningWarnings, combinedReliabilityWarnings }));
+  const planBeforeExecuteGuards = timeDiagnosticPhase(timingPhases, "plan-before-execute-guards", () => buildPlanBeforeExecuteGuards({ branch, planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints }));
+  const longRunBudgetWarnings = timeDiagnosticPhase(timingPhases, "long-run-budget-warnings", () => buildLongRunBudgetWarnings({ planningWarnings, combinedReliabilityWarnings, sequentialPlanningHints, planBeforeExecuteGuards }));
+  const resetCompactHandoffRecommendations = timeDiagnosticPhase(timingPhases, "reset-compact-handoff-recommendations", () => buildResetCompactHandoffRecommendations({ contextTrust, combinedReliabilityWarnings, longRunBudgetWarnings }));
+  const reliabilityWarningVisibility = timeDiagnosticPhase(timingPhases, "reliability-warning-visibility", () => buildOperatorCheckReliabilityWarningVisibility({
     contextTrust,
     planningWarnings,
     sequentialPlanningHints,
     combinedReliabilityWarnings,
     longRunBudgetWarnings,
     resetCompactHandoffRecommendations,
-  });
-  const resumeHandoffProjection = buildOperatorCheckResumeHandoffProjection({
+  }));
+  const resumeHandoffProjection = timeDiagnosticPhase(timingPhases, "resume-handoff-projection", () => buildOperatorCheckResumeHandoffProjection({
     contextTrust,
     planningWarnings,
     combinedReliabilityWarnings,
@@ -2005,7 +2064,8 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     longRunBudgetWarnings,
     resetCompactHandoffRecommendations,
     reliabilityWarningVisibility,
-  });
+  }));
+  const runtimeProvenance = timeDiagnosticPhase(timingPhases, "read-operator-check-runtime-provenance", () => readOperatorCheckRuntimeProvenance(cwd));
 
   return {
     schemaVersion: OPERATOR_CHECK_SCHEMA_VERSION,
@@ -2015,7 +2075,7 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     claimBoundary: OPERATOR_CHECK_CLAIM_BOUNDARY,
     readOnly: true,
     source: OPERATOR_CHECK_SOURCE,
-    runtimeProvenance: readOperatorCheckRuntimeProvenance(cwd),
+    runtimeProvenance,
     verdict,
     postMergeMainEchoBoundary: {
       explicit: true,
@@ -2041,5 +2101,8 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
     resumeHandoffProjection,
     activity,
     blockers,
+    diagnostics: {
+      operatorCheckTiming: buildOperatorCheckTimingReceipt(timingPhases, performance.now() - timingStartedAt),
+    },
   };
 }

--- a/src/ops/source-of-truth-handoff.ts
+++ b/src/ops/source-of-truth-handoff.ts
@@ -109,6 +109,7 @@ export type SourceOfTruthHandoffPacket = {
       generatedAt: string;
       blockers: string[];
       source: OperatorCheckSnapshot["source"];
+      diagnostics?: OperatorCheckSnapshot["diagnostics"];
     };
     preflight: PreflightPacket["guidance"] & { authorityStatus: PreflightPacket["summary"]["authorityStatus"] };
     ci: {
@@ -662,6 +663,7 @@ export function buildSourceOfTruthHandoffPacket(snapshot: OperatorCheckSnapshot,
         generatedAt: snapshot.generatedAt,
         blockers: snapshot.blockers,
         source: snapshot.source,
+        ...(snapshot.diagnostics ? { diagnostics: snapshot.diagnostics } : {}),
       },
       preflight: {
         ...preflight.guidance,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -863,6 +863,107 @@ test("operator activity reports exact-head post-merge main CI and release-report
   assert.equal(calls.some((call) => /fetch|delete/.test(call)), false);
 });
 
+
+test("operator activity snapshot emits read-only subphase timing diagnostics", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-21T08:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "activity-main-head\n";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD activity-main-head", "branch refs/heads/main", ""].join("\n");
+      }
+      throw new Error(`unexpected command: ${command} ${joined}`);
+    },
+  });
+
+  const receipt = snapshot.diagnostics.operatorActivityTiming;
+  assert.equal(receipt.status, "diagnostic");
+  assert.equal(receipt.readOnly, true);
+  assert.match(receipt.claimBoundary, /Diagnostic\/read-only/);
+  assert.match(receipt.claimBoundary, /not current-work authority/);
+  assert.ok(Number.isFinite(receipt.totalMs));
+  assert.ok(receipt.totalMs >= 0);
+  const phaseNames = receipt.phases.map((phase) => phase.name);
+  assert.ok(phaseNames.includes("current-worktree-evidence-status"));
+  assert.ok(phaseNames.includes("read-tmux-activity"));
+  assert.ok(phaseNames.includes("read-remote-counts"));
+  assert.ok(phaseNames.includes("read-legacy-worktree-evidence"));
+  assert.ok(phaseNames.includes("read-post-merge-main-ci-evidence"));
+  for (const phase of receipt.phases) {
+    assert.equal(phase.status, "ok");
+    assert.ok(Number.isFinite(phase.elapsedMs));
+    assert.ok(phase.elapsedMs >= 0);
+  }
+});
+
+test("operator check snapshot emits narrow timing diagnostics without changing authority fields", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-21T08:05:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "check-main-head\n";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD check-main-head", "branch refs/heads/main", ""].join("\n");
+      }
+      throw new Error(`unexpected command: ${command} ${joined}`);
+    },
+  });
+
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.command, OPERATOR_CHECK_COMMAND);
+  assert.equal(snapshot.readOnly, true);
+  assert.equal(snapshot.source, OPERATOR_CHECK_SOURCE);
+  assert.equal(snapshot.contextTrust.source, OPERATOR_CONTEXT_TRUST_SOURCE);
+
+  const receipt = snapshot.diagnostics.operatorCheckTiming;
+  assert.equal(receipt.status, "diagnostic");
+  assert.equal(receipt.readOnly, true);
+  assert.match(receipt.claimBoundary, /not current-work authority/);
+  assert.match(receipt.claimBoundary, /not handoff\/source-of-truth authority/);
+  assert.ok(Number.isFinite(receipt.totalMs));
+  assert.ok(receipt.totalMs >= 0);
+  const phaseNames = receipt.phases.map((phase) => phase.name);
+  assert.ok(phaseNames.includes("read-operator-activity-snapshot"));
+  assert.ok(phaseNames.includes("build-active-work-receipts"));
+  assert.ok(phaseNames.includes("read-sequential-planning-prompt"));
+  assert.ok(phaseNames.includes("read-operator-check-runtime-provenance"));
+  assert.ok(snapshot.activity.diagnostics.operatorActivityTiming.phases.some((phase) => phase.name === "read-remote-counts"));
+  assert.ok(snapshot.activity.diagnostics.operatorActivityTiming.phases.some((phase) => phase.name === "read-post-merge-main-ci-evidence"));
+  for (const phase of receipt.phases) {
+    assert.equal(phase.status, "ok");
+    assert.ok(Number.isFinite(phase.elapsedMs));
+    assert.ok(phase.elapsedMs >= 0);
+  }
+});
+
 test("operator check keeps missing exact-head workflow evidence unknown instead of success", () => {
   const tempDir = makeTempProject();
   const mainHead = "new-main-head";

--- a/test/source-of-truth-handoff.test.mjs
+++ b/test/source-of-truth-handoff.test.mjs
@@ -299,6 +299,39 @@ test("source-of-truth handoff packet emits JSON-ready diagnostic timing shape wi
   assert.ok(phaseNames.includes("build-source-of-truth-handoff-packet"));
 });
 
+
+test("source-of-truth handoff surfaces operator-check timing under operator status only", () => {
+  const snapshot = baseSnapshot(repoRoot);
+  snapshot.diagnostics = {
+    operatorCheckTiming: {
+      schemaVersion: 1,
+      source: "fooks check --json operator-check diagnostic timing",
+      status: "diagnostic",
+      claimBoundary: "Diagnostic/read-only operator-check subphase timing only; not current-work authority",
+      readOnly: true,
+      totalMs: 12,
+      phases: [
+        { name: "read-operator-activity-snapshot", elapsedMs: 10, status: "ok" },
+        { name: "build-active-work-receipts", elapsedMs: 2, status: "ok" },
+      ],
+    },
+  };
+
+  const packet = buildSourceOfTruthHandoffPacket(snapshot, basePreflight(), {
+    commandRunner: (command, args) => {
+      const key = `${command} ${args.join(" ")}`;
+      if (key === "git status --porcelain=v1") return "";
+      if (key === "gh pr list --head fooks-issue-963-source-of-truth-handoff --state all --json number,title,state,url,headRefName,baseRefName,isDraft,statusCheckRollup --limit 1") return "[]";
+      throw new Error(`unexpected command: ${key}`);
+    },
+    nowMs: () => 1,
+  });
+
+  assert.equal(packet.currentStatus.operatorCheck.diagnostics.operatorCheckTiming.status, "diagnostic");
+  assert.ok(packet.currentStatus.operatorCheck.diagnostics.operatorCheckTiming.phases.some((phase) => phase.name === "read-operator-activity-snapshot"));
+  assert.equal(packet.diagnostics.handoffTiming.phases.some((phase) => phase.name === "read-operator-activity-snapshot"), false);
+});
+
 test("handoff compact authoritative resume packet excludes diagnostic timing", () => {
   const cwd = repoRoot;
   const runner = (command, args) => {


### PR DESCRIPTION
## Summary
- Add read-only operator activity and operator-check timing receipts so the slow snapshot path is broken into local subphases.
- Surface operator-check timing under handoff currentStatus.operatorCheck without adding more handoffTiming phases.
- Preserve schema versions and authority semantics; timing remains diagnostic-only and non-authorizing.

## Evidence
- Local handoff evidence now shows operator timing under currentStatus.operatorCheck while diagnostics.handoffTiming stays handoff-scoped.
- Observed local sample: read-operator-activity-snapshot ~3266ms, build-active-work-receipts ~1721ms in this worktree.

## Verification
- npm run build
- node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs
- npm run lint

Closes #1015