### PR TITLE
Expose operator-check receipt subphase bottlenecks

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1671,6 +1671,13 @@ async function run(): Promise<void> {
       const readSnapshotStartedAt = performance.now();
       const snapshot = readOperatorCheckSnapshot(process.cwd());
       timingPhases.push({ name: "read-operator-check-snapshot", elapsedMs: roundMs(performance.now() - readSnapshotStartedAt), status: "ok" });
+      for (const phase of snapshot.diagnostics.operatorCheckTiming.phases) {
+        timingPhases.push({
+          name: `operator-check:${phase.name}`,
+          elapsedMs: phase.elapsedMs,
+          status: phase.status,
+        });
+      }
       const buildPreflightStartedAt = performance.now();
       const preflight = buildPreflightPacket(snapshot);
       timingPhases.push({ name: "build-preflight-packet", elapsedMs: roundMs(performance.now() - buildPreflightStartedAt), status: "ok" });

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -1082,6 +1082,7 @@ function siblingWorktreeReceipts(
   baseIdentifiers: Omit<OperatorCheckActiveWorkReceiptIdentifiers, "session" | "siblingWorktree">,
   baseBlockers: string[],
   options: OperatorActivityOptions,
+  timingPhases?: OperatorCheckTimingPhase[],
 ): {
   receipts: OperatorCheckActiveWorkReceipt[];
   salvageReviewQueue: OperatorCheckSalvageReviewQueue;
@@ -1090,13 +1091,23 @@ function siblingWorktreeReceipts(
   blockers: string[];
 } {
   try {
-    const triage = triageOrphanLocalWorktrees(cwd, {
-      runner: options.commandRunner
-        ? (command, args, runnerCwd) => options.commandRunner?.(command, args, runnerCwd, 3000) ?? ""
-        : undefined,
-      pathExists: options.pathExists,
-      now: options.now,
-    });
+    const triage = timingPhases
+      ? timeDiagnosticPhase(timingPhases, "build-active-work-receipts:sibling-worktree-triage", () =>
+        triageOrphanLocalWorktrees(cwd, {
+          runner: options.commandRunner
+            ? (command, args, runnerCwd) => options.commandRunner?.(command, args, runnerCwd, 3000) ?? ""
+            : undefined,
+          pathExists: options.pathExists,
+          now: options.now,
+        }),
+      )
+      : triageOrphanLocalWorktrees(cwd, {
+        runner: options.commandRunner
+          ? (command, args, runnerCwd) => options.commandRunner?.(command, args, runnerCwd, 3000) ?? ""
+          : undefined,
+        pathExists: options.pathExists,
+        now: options.now,
+      });
     const receipts = triage.entries
       .filter((entry) => !entry.current)
       .map((entry) => ({
@@ -1626,9 +1637,18 @@ function buildActiveWorkReceipts(
   cwd: string,
   activity: OperatorActivitySnapshot,
   options: OperatorActivityOptions,
+  timingPhases?: OperatorCheckTimingPhase[],
 ): OperatorCheckActiveWorkReceipts {
-  const repoIdentity = readRepoIdentifier(cwd, options);
-  const baseIdentifiers = baseReceiptIdentifiers(activity, repoIdentity.repo, repoIdentity.blockers);
+  const repoIdentity = timingPhases
+    ? timeDiagnosticPhase(timingPhases, "build-active-work-receipts:repo-identity", () =>
+      readRepoIdentifier(cwd, options),
+    )
+    : readRepoIdentifier(cwd, options);
+  const baseIdentifiers = timingPhases
+    ? timeDiagnosticPhase(timingPhases, "build-active-work-receipts:base-identifiers", () =>
+      baseReceiptIdentifiers(activity, repoIdentity.repo, repoIdentity.blockers),
+    )
+    : baseReceiptIdentifiers(activity, repoIdentity.repo, repoIdentity.blockers);
   const receipts: OperatorCheckActiveWorkReceipt[] = [];
 
   const baseBlockers = repoIdentity.blockers;
@@ -1713,8 +1733,12 @@ function buildActiveWorkReceipts(
     });
   }
 
-  const siblingReceipts = siblingWorktreeReceipts(cwd, baseIdentifiers, baseBlockers, options);
-  const legacyLocalResidueCleanupReview = buildLegacyLocalResidueCleanupReview(activity.legacyWorktreeEvidence);
+  const siblingReceipts = siblingWorktreeReceipts(cwd, baseIdentifiers, baseBlockers, options, timingPhases);
+  const legacyLocalResidueCleanupReview = timingPhases
+    ? timeDiagnosticPhase(timingPhases, "build-active-work-receipts:legacy-local-residue-cleanup-review", () =>
+      buildLegacyLocalResidueCleanupReview(activity.legacyWorktreeEvidence),
+    )
+    : buildLegacyLocalResidueCleanupReview(activity.legacyWorktreeEvidence);
   receipts.push(...siblingReceipts.receipts);
 
   const blockers = checkProjectionBlockers(uniqueSorted([
@@ -2019,7 +2043,9 @@ export function readOperatorCheckSnapshot(cwd = process.cwd(), options: Operator
   const timingPhases: OperatorCheckTimingPhase[] = [];
   const activity = timeDiagnosticPhase(timingPhases, "read-operator-activity-snapshot", () => readOperatorActivitySnapshot(cwd, { ...options, includeRemoteCounts: true }));
   const activeArtifacts = timeDiagnosticPhase(timingPhases, "active-artifacts", () => activeArtifactsFrom(activity));
-  const activeWorkReceipts = timeDiagnosticPhase(timingPhases, "build-active-work-receipts", () => buildActiveWorkReceipts(cwd, activity, options));
+  const activeWorkReceipts = timeDiagnosticPhase(timingPhases, "build-active-work-receipts", () =>
+    buildActiveWorkReceipts(cwd, activity, options, timingPhases),
+  );
   const branch = activity.worktree.branch;
   const blockers = timeDiagnosticPhase(timingPhases, "check-projection-blockers", () => checkProjectionBlockers([...activity.blockers]));
   const hasActiveArtifact = activeArtifacts.length > 0;

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -953,6 +953,10 @@ test("operator check snapshot emits narrow timing diagnostics without changing a
   const phaseNames = receipt.phases.map((phase) => phase.name);
   assert.ok(phaseNames.includes("read-operator-activity-snapshot"));
   assert.ok(phaseNames.includes("build-active-work-receipts"));
+  assert.ok(phaseNames.includes("build-active-work-receipts:repo-identity"));
+  assert.ok(phaseNames.includes("build-active-work-receipts:base-identifiers"));
+  assert.ok(phaseNames.includes("build-active-work-receipts:sibling-worktree-triage"));
+  assert.ok(phaseNames.includes("build-active-work-receipts:legacy-local-residue-cleanup-review"));
   assert.ok(phaseNames.includes("read-sequential-planning-prompt"));
   assert.ok(phaseNames.includes("read-operator-check-runtime-provenance"));
   assert.ok(snapshot.activity.diagnostics.operatorActivityTiming.phases.some((phase) => phase.name === "read-remote-counts"));


### PR DESCRIPTION
## Summary

- Add nested operator-check timing phases inside the existing diagnostic receipt for active-work receipt construction.
- Surface those operator-check subphases in `fooks handoff --json` timing as `operator-check:*` rows.
- Keep the receipt diagnostic-only: no authority, cleanup, hook, provider billing, or frontend behavior semantics changed.

## Linked issue

Closes #1015

## Evidence

- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/operator-activity.test.mjs test/source-of-truth-handoff.test.mjs`
- `node dist/cli/index.js handoff --json`
  - surfaced `operator-check:build-active-work-receipts:sibling-worktree-triage` as the dominant subphase
- `node dist/cli/index.js check --json`
- `node dist/cli/index.js preflight`
- normalized `TMPDIR` full suite: `npm test` → 914/914 passing

## Boundaries

- No cleanup execution.
- No timeout-only fix.
- No cross-command/session cache.
- No authority/source-of-truth semantics change.
- No hook/preflight behavior change.
