### PR TITLE
Fix Node 20 status artifact JSON output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,24 @@ function print(value: unknown): void {
   console.log(JSON.stringify(value));
 }
 
+async function printAndFlush(value: unknown): Promise<void> {
+  const serialized = `${JSON.stringify(value)}\n`;
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      reject(error);
+    };
+    process.stdout.once("error", onError);
+    process.stdout.write(serialized, (error) => {
+      process.stdout.off("error", onError);
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 function roundMs(value: number): number {
   return Number(value.toFixed(2));
 }
@@ -1745,7 +1763,7 @@ async function run(): Promise<void> {
       if (arg1 === "artifacts") {
         parseStatusArtifactsArgs(rest.slice(1));
         const { auditArtifacts } = await import("../ops/artifact-audit.js");
-        print(auditArtifacts(process.cwd()));
+        await printAndFlush(auditArtifacts(process.cwd()));
         return;
       }
       if (arg1 === "stale-worktrees") {

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4024,6 +4024,28 @@ test("status artifacts route reports read-only audit JSON", () => {
   assert.match(output, /artifacts/);
 });
 
+test("status artifacts drains large JSON stdout before exit", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-status-artifacts-large-"));
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "fooks@example.invalid"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "fooks test"], { cwd: tempDir, stdio: "ignore" });
+  fs.writeFileSync(path.join(tempDir, "README.md"), "# fooks status artifacts large stdout fixture\n");
+  execFileSync("git", ["add", "README.md"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "fixture"], { cwd: tempDir, stdio: "ignore" });
+  for (let index = 0; index < 800; index += 1) {
+    execFileSync("git", ["update-ref", `refs/heads/fooks-artifact-${index}`, "HEAD"], { cwd: tempDir, stdio: "ignore" });
+  }
+
+  const output = runText(["status", "artifacts"], tempDir);
+  assert.ok(output.length > 65536, `expected large stdout fixture, got ${output.length} bytes`);
+  const result = JSON.parse(output);
+
+  assert.equal(result.command, "status artifacts");
+  assert.equal(result.scope, "fooks");
+  assert.match(result.claimBoundary, /never deletes/);
+  assert.ok(result.branches.length >= 800);
+});
+
 test("doctor rejects unknown targets and exposes bounded command help", () => {
   const help = runText(["doctor", "--help"]);
   assert.match(help, /Usage: fooks doctor \[codex\|claude\] \[--json\]/);


### PR DESCRIPTION
## Summary
- Fixes large `fooks status artifacts` JSON output truncation on Node 20 by awaiting the status-artifacts stdout write callback.
- Keeps the artifact audit path read-only and scoped to JSON delivery only.
- Adds a large stdout regression fixture that parses the complete JSON payload.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test --test-name-pattern "status artifacts" test/fooks.test.mjs`
- `~/.nvm/versions/node/v20.20.2/bin/node --test --test-name-pattern "status artifacts" test/fooks.test.mjs`

Closes #1012

— *[repo owner's gaebal-gajae (clawdbot) 🦞]*
