### PR TITLE
Classify superseded investigation residue as non-active

### DIFF
--- a/src/ops/orphan-local-worktree-triage.ts
+++ b/src/ops/orphan-local-worktree-triage.ts
@@ -337,10 +337,10 @@ function closedPullRequestEvidence(
     : { state: "none", source: ORPHAN_LOCAL_WORKTREE_TRIAGE_CLOSED_PR_SOURCE };
 }
 
-function worktreeStatus(runner: OrphanLocalWorktreeCommandRunner, worktreePath: string): { dirty: boolean | "unknown"; changedPathCount?: number; blocker?: string } {
+function worktreeStatus(runner: OrphanLocalWorktreeCommandRunner, worktreePath: string): { dirty: boolean | "unknown"; changedPathCount?: number; changedPaths?: string[]; blocker?: string } {
   try {
     const summary = parseAndSummarizeWorktreeStatus(runner("git", ["status", "--porcelain=v1", "-z"], worktreePath), { nulTerminated: true });
-    return { dirty: !summary.clean, changedPathCount: summary.changedPaths.length };
+    return { dirty: !summary.clean, changedPathCount: summary.changedPaths.length, changedPaths: summary.changedPaths };
   } catch (error) {
     return { dirty: "unknown", blocker: `git status unavailable for ${worktreePath}: ${errorDetail(error)}` };
   }
@@ -498,6 +498,7 @@ function classifyEntry(input: {
   exists: boolean;
   branch?: string;
   dirty: boolean | "unknown";
+  changedPaths?: string[];
   ahead?: number;
   remoteBranchExists: boolean | "unknown";
   openPullRequest: OrphanLocalWorktreePullRequestEvidence;
@@ -509,6 +510,7 @@ function classifyEntry(input: {
   const manualCleanupCommands: string[] = [];
   const manualReviewCommands: string[] = [];
   const detachedReviewWorktree = !input.branch && isDetachedReviewWorktreePath(input.path);
+  const onlyFooksSessionTaskResidue = input.changedPaths?.length === 1 && input.changedPaths[0] === ".fooks-session-task.txt";
 
   if (input.current) reasons.push("worktree is the current working directory");
   if (!input.exists) reasons.push("worktree path is missing from the filesystem");
@@ -533,6 +535,9 @@ function classifyEntry(input: {
   if (input.dirty === "unknown") reasons.push("worktree cleanliness is unknown");
   if (input.ahead !== undefined && input.ahead > 0) reasons.push(`HEAD has ${input.ahead} commit(s) not reachable from ${input.baseRef ?? "the selected base"}`);
   if (input.ahead === 0) reasons.push(`HEAD has no commits ahead of ${input.baseRef ?? "the selected base"}`);
+  if (onlyFooksSessionTaskResidue) {
+    reasons.push("only .fooks-session-task.txt residue is present; treat as superseded investigation cleanup evidence, not active development");
+  }
 
   const closedPrRemoteResidue =
     input.remoteBranchExists === true &&
@@ -574,7 +579,13 @@ function classifyEntry(input: {
     return { category: "salvage-review", reasons: uniqueSorted(reasons), manualCleanupCommands, manualReviewCommands: uniqueSorted(manualReviewCommands) };
   }
 
-  if (input.remoteBranchExists === false && input.openPullRequest.state === "none" && input.dirty === false && input.ahead === 0) {
+  if (
+    input.remoteBranchExists === false &&
+    input.openPullRequest.state === "none" &&
+    (input.dirty === false || onlyFooksSessionTaskResidue) &&
+    input.ahead === 0 &&
+    input.activeTmuxPaneCount === 0
+  ) {
     manualCleanupCommands.push("git worktree remove <path>");
     if (input.branch) manualCleanupCommands.push(`git branch -d ${shellQuote(input.branch)}`);
     return { category: "safe-cleanup", reasons: uniqueSorted(reasons), manualCleanupCommands: uniqueSorted(manualCleanupCommands), manualReviewCommands };
@@ -630,6 +641,7 @@ export function triageOrphanLocalWorktrees(cwd = process.cwd(), options: OrphanL
       exists,
       branch,
       dirty: status.dirty,
+      changedPaths: status.changedPaths,
       ahead: divergence.ahead,
       remoteBranchExists,
       openPullRequest,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -2443,6 +2443,98 @@ test("operator check receipt marks closed-PR remote worktree residue as non-acti
   assert.equal(calls.some((call) => /fetch|worktree remove|branch -d/.test(call)), false);
 });
 
+test("operator check classifies superseded investigation taskfile-only residue as cleanup evidence for #1021", () => {
+  const tempDir = makeTempProject();
+  const siblingRoot = path.dirname(tempDir);
+  const supersededWorktree = path.join(siblingRoot, "fooks-issue-1011-superseded-investigation");
+  const calls = [];
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-21T14:10:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args, cwd) => {
+      calls.push([command, ...args].join(" "));
+      const joined = args.join(" ");
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [
+          `worktree ${tempDir}`,
+          "HEAD main-head",
+          "branch refs/heads/main",
+          "",
+          `worktree ${supersededWorktree}`,
+          "HEAD issue-1011-head",
+          "branch refs/heads/fooks-issue-1011-superseded-investigation",
+          "",
+        ].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\nfooks-issue-1011-superseded-investigation\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return cwd === supersededWorktree ? "?? .fooks-session-task.txt\0" : "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") return "[]";
+      if (command === "gh" && joined.startsWith("run list ")) return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => [tempDir, supersededWorktree].includes(targetPath),
+  });
+
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.deepEqual(snapshot.activeArtifacts, []);
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.equal(snapshot.activeWorkReceipts.classification, "closedOrStale");
+  const receipt = snapshot.activeWorkReceipts.receipts.find(
+    (item) => item.kind === "worktree" && item.identifiers.worktree.branch === "fooks-issue-1011-superseded-investigation",
+  );
+  assert.equal(receipt?.classification, "closedOrStale");
+  assert.equal(receipt?.identifiers.siblingWorktree?.category, "safe-cleanup");
+  assert.equal(receipt?.identifiers.siblingWorktree?.dirty, true);
+  assert.equal(receipt?.identifiers.siblingWorktree?.aheadOfBase, 0);
+  assert.equal(receipt?.identifiers.siblingWorktree?.activeTmuxPaneCount, 0);
+  assert.equal(receipt?.identifiers.siblingWorktree?.remoteBranchExists, false);
+  assert.equal(receipt?.identifiers.siblingWorktree?.openPullRequestState, "none");
+  assert.match(receipt?.reasons.join("\n") ?? "", /superseded investigation cleanup evidence/);
+  assert.match(snapshot.activeWorkReceipts.reportLine, /closedOrStale=1/);
+  assert.match(snapshot.activeWorkReceipts.reportLine, /staleResidueLedger=1/);
+  assert.equal(snapshot.activeWorkReceipts.salvageReviewQueue.itemCount, 0);
+  assert.deepEqual(snapshot.activeWorkReceipts.staleResidueLedger.counts, {
+    "safe-cleanup": 1,
+    "salvage-review": 0,
+    "manual-review-noise": 0,
+  });
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueCount, 1);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.staleResidueIsActiveWorkEvidence, false);
+  assert.equal(snapshot.activeWorkReceipts.staleResidueActiveBoundary.satisfiesActiveArtifactRequirement, false);
+  assert.equal(snapshot.sessionWhipRunReceipt.status, "idle");
+  assert.equal(snapshot.sessionWhipRunReceipt.counts.adoptedWorktrees, 0);
+  assert.equal(snapshot.sessionWhipRunReceipt.counts.staleOrReviewOnly, 1);
+  assert.equal(snapshot.contextTrust.nonAuthorizing.some((entry) =>
+    entry.kind === "stale-residue-active-boundary" &&
+    entry.referenceField === "activeWorkReceipts.staleResidueActiveBoundary"
+  ), true);
+
+  const receiptJson = JSON.stringify([
+    receipt,
+    snapshot.activeWorkReceipts.cleanupReviewManifest,
+    snapshot.sessionWhipRunReceipt,
+  ]);
+  assert.equal(receiptJson.includes(supersededWorktree), false);
+  assert.equal(/worktree remove|branch -d|deleteCommand|manualCleanupCommands|cleanupOrder|kill-session/.test(receiptJson), false);
+  assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|kill-session/.test(call)), false);
+});
+
 test("operator check receipt marks detached PR review worktree leftovers as non-active cleanup-review noise", () => {
   const tempDir = makeTempProject();
   const siblingRoot = path.dirname(tempDir);


### PR DESCRIPTION
Closes #1021.

## Summary
- treat sibling worktrees with only `.fooks-session-task.txt`, zero ahead commits, no open PR, no remote branch, and no mapped tmux pane as safe cleanup residue
- keep operator-check/session-whip receipts non-authorizing: closedOrStale, idle session-whip receipt, no adopted worktree
- add a focused operator-check regression for the #1011 superseded-investigation shape

## Verification
- `npm run typecheck -- --pretty false`
- `npm run build`
- `node --test test/operator-activity.test.mjs`

## Mutation boundary
- receipt assertions ensure no worktree/GitHub/tmux cleanup commands are rendered or invoked for this evidence path
