### PR TITLE
Expose React Web reliability handoff cues

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -690,7 +690,7 @@ Everyday commands:
   ${displayCliName} status claude
   ${displayCliName} status cache
   ${displayCliName} status worktree
-  ${displayCliName} status react-web [--json]
+  ${displayCliName} status react-web [--json] [--handoff-resume-json <file>]
   ${displayCliName} status artifacts [--json]
   ${displayCliName} status stale-worktrees [--json]
   ${displayCliName} status orphan-worktrees [--json]
@@ -1018,18 +1018,32 @@ function parseStatusArtifactsArgs(args: string[]): { json: boolean } {
   return { json };
 }
 
-function parseStatusReactWebArgs(args: string[]): { json: boolean } {
+function parseStatusReactWebArgs(args: string[]): { json: boolean; handoffResumeJsonPath?: string } {
   let json = false;
+  let handoffResumeJsonPath: string | undefined;
 
-  for (const arg of args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
     if (arg === "--json") {
       json = true;
+      continue;
+    }
+    if (arg === "--handoff-resume-json") {
+      const value = args[index + 1];
+      if (!value) throw new Error("status react-web --handoff-resume-json requires a file path");
+      handoffResumeJsonPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--handoff-resume-json=")) {
+      handoffResumeJsonPath = arg.slice("--handoff-resume-json=".length);
+      if (!handoffResumeJsonPath) throw new Error("status react-web --handoff-resume-json requires a file path");
       continue;
     }
     throw new Error(`Unexpected status react-web argument: ${arg}`);
   }
 
-  return { json };
+  return { json, ...(handoffResumeJsonPath ? { handoffResumeJsonPath } : {}) };
 }
 
 function parseStatusActivityArgs(args: string[]): { includeRemoteCounts: boolean; receiptJson: boolean } {
@@ -1754,9 +1768,12 @@ async function run(): Promise<void> {
         return;
       }
       if (arg1 === "react-web") {
-        const { json } = parseStatusReactWebArgs(rest.slice(1));
+        const { json, handoffResumeJsonPath } = parseStatusReactWebArgs(rest.slice(1));
         const { readReactWebStatus, renderReactWebStatusText } = await import("../reporting/react-web-status.js");
-        const status = readReactWebStatus(process.cwd());
+        const authoritativeResumePacket = handoffResumeJsonPath
+          ? JSON.parse(fs.readFileSync(path.resolve(process.cwd(), handoffResumeJsonPath), "utf8"))
+          : undefined;
+        const status = readReactWebStatus(process.cwd(), { authoritativeResumePacket });
         if (json) {
           print(status);
         } else {

--- a/src/reporting/react-web-status.ts
+++ b/src/reporting/react-web-status.ts
@@ -12,15 +12,44 @@ import {
 import { buildReactWebActivationMode, summarizeReactWebActivationMode, type ReactWebActivationModeSummary } from "./react-web-activation-mode";
 import { buildReactWebRankedBundle, summarizeReactWebRankedBundle, type ReactWebRankedBundleSummary } from "./react-web-ranked-bundle";
 import type { SourceFingerprint } from "../core/schema";
+import type { AuthoritativeResumePacket } from "../ops/source-of-truth-handoff";
 
 export const REACT_WEB_STATUS_SCHEMA_VERSION = 1;
 export const REACT_WEB_STATUS_COMMAND = "status react-web";
 export const REACT_WEB_STATUS_CLAIM_BOUNDARY =
   "Local React Web source-context decision status only: summarizes existing bounded evidence artifacts without emitting new artifacts, changing runtime behavior, or broadening support or performance claims.";
+export const REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY =
+  "React Web-facing reliability handoff cue only: projects existing authoritativeResumePacket reliability/reset/compact handoff fields without changing stale-context detector scope, provider/runtime hooks, token or billing proof, merge policy, product claims, or frontend behavior.";
 
 export type ReactWebProfileStatus = "ready" | "partial" | "blocked";
 export type ReactWebBoundaryState = "bounded" | "blocked" | "advisory-only";
 export type ReactWebFreshnessState = "current" | "stale" | "missing-source-file" | "unavailable";
+export type ReactWebReliabilityHandoffStatus = "unavailable" | "clear" | "advisory" | "stop-before-more-execution";
+
+export type ReactWebReliabilityHandoffCue = {
+  available: boolean;
+  status: ReactWebReliabilityHandoffStatus;
+  source: "authoritativeResumePacket" | "not-provided";
+  claimBoundary: typeof REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY;
+  derivedFrom: string[];
+  summary: {
+    planningWarningCount: number;
+    combinedReliabilityWarningCount: number;
+    longRunBudgetWarningCount: number;
+    resetCompactHandoffRecommendationCount: number;
+    staleContextReliabilityOverlap: boolean;
+    longRunBudgetRiskLevel: "high" | "clear" | "unknown";
+    stopBeforeMoreExecution: boolean;
+  };
+  recommendedAction: AuthoritativeResumePacket["nextSessionAdvisory"]["action"] | "run-handoff-resume-json";
+  requiredRechecks: string[];
+  forbiddenClaims: string[];
+  operatorCue: string;
+};
+
+export type ReactWebStatusOptions = {
+  authoritativeResumePacket?: AuthoritativeResumePacket | null;
+};
 
 export type ReactWebStatusResult = {
   schemaVersion: typeof REACT_WEB_STATUS_SCHEMA_VERSION;
@@ -55,6 +84,7 @@ export type ReactWebStatusResult = {
   };
   activationMode: ReactWebActivationModeSummary;
   rankedBundle: ReactWebRankedBundleSummary;
+  reliabilityHandoff: ReactWebReliabilityHandoffCue;
   risks: string[];
 };
 
@@ -74,6 +104,84 @@ function currentSourceFingerprint(filePath: string): SourceFingerprint | null {
   return {
     fileHash: hashText(source),
     lineCount: source.split(/\r?\n/u).length,
+  };
+}
+
+function buildReactWebReliabilityHandoffCue(
+  authoritativeResumePacket: AuthoritativeResumePacket | null | undefined,
+): ReactWebReliabilityHandoffCue {
+  if (!authoritativeResumePacket) {
+    return {
+      available: false,
+      status: "unavailable",
+      source: "not-provided",
+      claimBoundary: REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY,
+      derivedFrom: [
+        "authoritativeResumePacket.reliabilityBoundary",
+        "authoritativeResumePacket.nextSessionAdvisory",
+        "authoritativeResumePacket.forbiddenClaims",
+      ],
+      summary: {
+        planningWarningCount: 0,
+        combinedReliabilityWarningCount: 0,
+        longRunBudgetWarningCount: 0,
+        resetCompactHandoffRecommendationCount: 0,
+        staleContextReliabilityOverlap: false,
+        longRunBudgetRiskLevel: "unknown",
+        stopBeforeMoreExecution: false,
+      },
+      recommendedAction: "run-handoff-resume-json",
+      requiredRechecks: ["Run fooks handoff --resume-json, then pass that packet to status react-web --handoff-resume-json <file> for React Web-facing reliability cues."],
+      forbiddenClaims: [
+        "provider billing/runtime proof",
+        "merge-gate policy change",
+        "frontend runtime behavior change",
+      ],
+      operatorCue: "No compact handoff packet was provided; React Web reliability handoff cues are unavailable on this status run.",
+    };
+  }
+
+  const boundary = authoritativeResumePacket.reliabilityBoundary;
+  const hasReliabilityWarnings =
+    boundary.planningWarningCount > 0 ||
+    boundary.combinedReliabilityWarningCount > 0 ||
+    boundary.longRunBudgetWarningCount > 0 ||
+    boundary.resetCompactHandoffRecommendationCount > 0 ||
+    boundary.staleContextReliabilityOverlap;
+  const status: ReactWebReliabilityHandoffStatus = boundary.stopBeforeMoreExecution
+    ? "stop-before-more-execution"
+    : hasReliabilityWarnings
+      ? "advisory"
+      : "clear";
+  const operatorCue = boundary.stopBeforeMoreExecution
+    ? "Stop before more React Web-oriented execution; use the compact handoff packet, recheck current authority, then resume from fresh context."
+    : hasReliabilityWarnings
+      ? "React Web-oriented execution has reliability handoff advisories; reset context, compact current source of truth, or hand off before another long run when indicated."
+      : "No reliability handoff warnings are present in the provided compact handoff packet.";
+
+  return {
+    available: true,
+    status,
+    source: "authoritativeResumePacket",
+    claimBoundary: REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY,
+    derivedFrom: [
+      "authoritativeResumePacket.reliabilityBoundary",
+      "authoritativeResumePacket.nextSessionAdvisory",
+      "authoritativeResumePacket.forbiddenClaims",
+    ],
+    summary: {
+      planningWarningCount: boundary.planningWarningCount,
+      combinedReliabilityWarningCount: boundary.combinedReliabilityWarningCount,
+      longRunBudgetWarningCount: boundary.longRunBudgetWarningCount,
+      resetCompactHandoffRecommendationCount: boundary.resetCompactHandoffRecommendationCount,
+      staleContextReliabilityOverlap: boundary.staleContextReliabilityOverlap,
+      longRunBudgetRiskLevel: boundary.longRunBudgetRiskLevel,
+      stopBeforeMoreExecution: boundary.stopBeforeMoreExecution,
+    },
+    recommendedAction: authoritativeResumePacket.nextSessionAdvisory.action,
+    requiredRechecks: authoritativeResumePacket.nextSessionAdvisory.requiredRechecks,
+    forbiddenClaims: authoritativeResumePacket.forbiddenClaims,
+    operatorCue,
   };
 }
 
@@ -116,6 +224,7 @@ function buildBlockedNoEvidenceStatus(cwd: string, generatedAt: string): ReactWe
     },
     activationMode: summarizeReactWebActivationMode(null),
     rankedBundle: summarizeReactWebRankedBundle(null),
+    reliabilityHandoff: buildReactWebReliabilityHandoffCue(null),
     risks: [
       `no React Web evidence artifact found at ${path.relative(cwd, latestArtifactIndexPath(cwd)) || ".fooks/artifacts/react-web-evidence/latest.json"}`,
     ],
@@ -236,10 +345,13 @@ function deriveProfileStatus(
   return "ready";
 }
 
-export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
+export function readReactWebStatus(cwd = process.cwd(), options: ReactWebStatusOptions = {}): ReactWebStatusResult {
   const generatedAt = new Date().toISOString();
   if (!fs.existsSync(latestArtifactIndexPath(cwd))) {
-    return buildBlockedNoEvidenceStatus(cwd, generatedAt);
+    return {
+      ...buildBlockedNoEvidenceStatus(cwd, generatedAt),
+      reliabilityHandoff: buildReactWebReliabilityHandoffCue(options.authoritativeResumePacket),
+    };
   }
 
   const artifact = readReactWebEvidenceArtifact(cwd, "latest");
@@ -279,6 +391,7 @@ export function readReactWebStatus(cwd = process.cwd()): ReactWebStatusResult {
     freshness,
     activationMode: summarizeReactWebActivationMode(activationMode),
     rankedBundle: summarizeReactWebRankedBundle(rankedBundle),
+    reliabilityHandoff: buildReactWebReliabilityHandoffCue(options.authoritativeResumePacket),
     risks,
   };
 }
@@ -292,6 +405,9 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
   const globMatchReasons = status.activationMode.globMatchReasons.length > 0
     ? status.activationMode.globMatchReasons.join(", ")
     : "none";
+  const requiredRechecks = status.reliabilityHandoff.requiredRechecks.length > 0
+    ? status.reliabilityHandoff.requiredRechecks.map((recheck) => `- ${recheck}`).join("\n")
+    : "- none";
   return [
     "# React Web status",
     "",
@@ -313,9 +429,24 @@ export function renderReactWebStatusText(status: ReactWebStatusResult): string {
     `- profile-gate runtime gate: ${status.activationMode.profileGateVerdict} (${profileGateReasons})`,
     `- glob-match runtime gate: ${status.activationMode.globMatchVerdict} (${globMatchReasons})`,
     `- ranked bundle: ${status.rankedBundle.verdict} (${status.rankedBundle.selectedCount}/${status.rankedBundle.budgetLimit ?? 0} selected, ${status.rankedBundle.deferredCount} deferred)`,
+    `- reliability handoff: ${status.reliabilityHandoff.status} (source=${status.reliabilityHandoff.source})`,
     "",
     "## Risks",
     risks,
+    "",
+    "## Reliability handoff",
+    status.reliabilityHandoff.claimBoundary,
+    "",
+    `- available: ${status.reliabilityHandoff.available ? "yes" : "no"}`,
+    `- operator cue: ${status.reliabilityHandoff.operatorCue}`,
+    `- recommended action: ${status.reliabilityHandoff.recommendedAction}`,
+    `- stale/context overlap: ${status.reliabilityHandoff.summary.staleContextReliabilityOverlap ? "yes" : "no"}`,
+    `- long-run budget risk: ${status.reliabilityHandoff.summary.longRunBudgetRiskLevel}`,
+    `- reset/compact handoff recommendations: ${status.reliabilityHandoff.summary.resetCompactHandoffRecommendationCount}`,
+    `- stop before more execution: ${status.reliabilityHandoff.summary.stopBeforeMoreExecution ? "yes" : "no"}`,
+    "",
+    "### Required rechecks",
+    requiredRechecks,
     "",
   ].join("\n");
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3926,7 +3926,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\|--dry-run-json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\]/);
   assert.match(help, /fooks status claude/);
-  assert.match(help, /fooks status react-web \[--json\]/);
+  assert.match(help, /fooks status react-web \[--json\] \[--handoff-resume-json <file>\]/);
   assert.match(help, /fooks status artifacts/);
   assert.match(help, /Codex: automatic repeated-file runtime hook path/);
   assert.match(help, /Claude: project-local context hooks/);

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -15,6 +15,7 @@ const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters
 const {
   REACT_WEB_STATUS_COMMAND,
   REACT_WEB_STATUS_CLAIM_BOUNDARY,
+  REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY,
   readReactWebStatus,
 } = require(path.join(repoRoot, "dist", "reporting", "react-web-status.js"));
 const { reactWebEvidenceArtifactsDir } = require(path.join(repoRoot, "dist", "reporting", "react-web-evidence-artifact.js"));
@@ -32,6 +33,36 @@ function runRepeatedDecision(tempDir, fileName, secondPrompt) {
   const second = handleCodexRuntimeHook({ hookEventName: "UserPromptSubmit", sessionId, prompt: secondPrompt }, tempDir);
   handleCodexRuntimeHook({ hookEventName: "Stop", sessionId }, tempDir);
   return second;
+}
+
+function highRiskResumePacket() {
+  return {
+    reliabilityBoundary: {
+      planningWarningCount: 1,
+      combinedReliabilityWarningCount: 1,
+      sequentialPlanningHintCount: 1,
+      planBeforeExecuteGuardCount: 1,
+      longRunBudgetWarningCount: 1,
+      resetCompactHandoffRecommendationCount: 1,
+      longRunBudgetRiskLevel: "high",
+      staleContextReliabilityOverlap: true,
+      stopBeforeMoreExecution: true,
+    },
+    nextSessionAdvisory: {
+      action: "stop-before-more-execution",
+      rationale: "plan-before-execute guard is present",
+      suggestedCommands: ["fooks check --json", "fooks handoff --json"],
+      requiredRechecks: [
+        "Run fooks check --json in the new session before treating this packet as current authority.",
+        "Run fooks handoff --json again before the next context compression or fresh-agent handoff.",
+      ],
+    },
+    forbiddenClaims: [
+      "provider billing/runtime proof",
+      "merge-gate policy change",
+      "frontend runtime behavior change",
+    ],
+  };
 }
 
 test("status react-web reports blocked without failing when no latest evidence exists", () => {
@@ -68,6 +99,9 @@ test("status react-web reports blocked without failing when no latest evidence e
     mayBeSummarized: false,
     mayOverrideDecision: false,
   });
+  assert.equal(status.reliabilityHandoff.available, false);
+  assert.equal(status.reliabilityHandoff.status, "unavailable");
+  assert.equal(status.reliabilityHandoff.recommendedAction, "run-handoff-resume-json");
   assert.match(status.claimBoundary, /source-context decision status only/);
   assert.ok(status.risks.some((risk) => /no React Web evidence artifact found/.test(risk)));
 
@@ -114,6 +148,23 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.deepEqual(status.risks, []);
   assert.equal(status.claimBoundary, REACT_WEB_STATUS_CLAIM_BOUNDARY);
 
+  const resumePath = path.join(tempDir, "resume.json");
+  fs.writeFileSync(resumePath, JSON.stringify(highRiskResumePacket()));
+  const statusWithHandoff = readReactWebStatus(tempDir, { authoritativeResumePacket: highRiskResumePacket() });
+  assert.equal(statusWithHandoff.reliabilityHandoff.available, true);
+  assert.equal(statusWithHandoff.reliabilityHandoff.status, "stop-before-more-execution");
+  assert.equal(statusWithHandoff.reliabilityHandoff.claimBoundary, REACT_WEB_RELIABILITY_HANDOFF_CLAIM_BOUNDARY);
+  assert.equal(statusWithHandoff.reliabilityHandoff.summary.staleContextReliabilityOverlap, true);
+  assert.equal(statusWithHandoff.reliabilityHandoff.summary.longRunBudgetRiskLevel, "high");
+  assert.equal(statusWithHandoff.reliabilityHandoff.summary.resetCompactHandoffRecommendationCount, 1);
+  assert.equal(statusWithHandoff.reliabilityHandoff.recommendedAction, "stop-before-more-execution");
+  assert.deepEqual(statusWithHandoff.reliabilityHandoff.derivedFrom, [
+    "authoritativeResumePacket.reliabilityBoundary",
+    "authoritativeResumePacket.nextSessionAdvisory",
+    "authoritativeResumePacket.forbiddenClaims",
+  ]);
+  assert.ok(statusWithHandoff.reliabilityHandoff.requiredRechecks.some((recheck) => /fooks check --json/.test(recheck)));
+
   const cliText = spawnSync(process.execPath, [cliPath, "status", "react-web"], {
     cwd: tempDir,
     encoding: "utf8",
@@ -124,6 +175,25 @@ test("status react-web reports ready from a current repeated same-file use artif
   assert.match(cliText.stdout, /summarized=no/);
   assert.match(cliText.stdout, /profile-gate runtime gate: would-activate/);
   assert.match(cliText.stdout, /glob-match runtime gate: would-activate/);
+
+  const cliHandoffText = spawnSync(process.execPath, [cliPath, "status", "react-web", "--handoff-resume-json", resumePath], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliHandoffText.status, 0, cliHandoffText.stderr);
+  assert.match(cliHandoffText.stdout, /Reliability handoff/);
+  assert.match(cliHandoffText.stdout, /reliability handoff: stop-before-more-execution/);
+  assert.match(cliHandoffText.stdout, /stale\/context overlap: yes/);
+  assert.match(cliHandoffText.stdout, /reset\/compact handoff recommendations: 1/);
+
+  const cliHandoffJson = spawnSync(process.execPath, [cliPath, "status", "react-web", "--json", "--handoff-resume-json", resumePath], {
+    cwd: tempDir,
+    encoding: "utf8",
+  });
+  assert.equal(cliHandoffJson.status, 0, cliHandoffJson.stderr);
+  const parsed = JSON.parse(cliHandoffJson.stdout);
+  assert.equal(parsed.reliabilityHandoff.status, "stop-before-more-execution");
+  assert.equal(parsed.reliabilityHandoff.summary.longRunBudgetRiskLevel, "high");
 });
 
 test("status react-web reports blocked mixed-routing boundary from a deny artifact without failing", () => {


### PR DESCRIPTION
## Summary
- Add a bounded `status react-web --handoff-resume-json <file>` projection over existing `authoritativeResumePacket` reliability/reset/compact handoff fields.
- Surface advisory stale-context/runtime-cost handoff cues in React Web JSON and text output without changing hooks, detector scope, telemetry, token/billing proof, merge policy, or frontend behavior.
- Extend focused React Web status and help tests for unavailable and high-risk handoff cue states.

Closes #1023.

## Verification
- npm run build
- npm run typecheck -- --pretty false
- node --test test/react-web-status-surface.test.mjs
- node --test test/fooks.test.mjs