### PR TITLE
Guard focused React Web status tests against root-cwd worktree runs

### DIFF
--- a/docs/dogfood/worktree-cwd-focused-test-guard-1025.md
+++ b/docs/dogfood/worktree-cwd-focused-test-guard-1025.md
@@ -1,0 +1,41 @@
+# Issue #1025 worktree cwd focused-test guard
+
+This is a read-only dogfood guard for the #960 reliability/session-handoff lane.
+It documents one operator failure mode only: a focused React Web status test in an
+issue worktree must be invoked from that same worktree's repository root.
+
+## Guarded failure mode
+
+Do not run a focused test by staying in the root checkout and passing an absolute
+path into an issue worktree, for example:
+
+```sh
+# Wrong for worktree verification: cwd is the root checkout, test path is another worktree.
+node --test /path/to/issue-worktree/test/react-web-status-surface.test.mjs
+```
+
+`react-web-status-surface.test.mjs` intentionally treats `process.cwd()` as the
+repo root under verification so it reads the `dist/` build output for that cwd.
+A root-cwd cross-worktree invocation can therefore test the root checkout's
+`dist/` while loading the issue worktree's test file, creating a false local
+failure that should not be classified against the issue branch.
+
+## Required operator shape
+
+Run the build and focused test from the worktree cwd being verified:
+
+```sh
+cd /path/to/issue-worktree
+npm run build
+node --test test/react-web-status-surface.test.mjs
+```
+
+If the guard trips, rerun from the expected cwd before reporting branch health,
+writing a handoff, or deciding whether the #960 reliability/session-handoff
+surface regressed.
+
+## Boundary
+
+This changes only test/operator verification guidance. It does not change product
+runtime behavior, provider hooks, merge policy, telemetry, billing/token proof,
+or frontend detector scope.

--- a/test/helpers/worktree-cwd-guard.mjs
+++ b/test/helpers/worktree-cwd-guard.mjs
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function resolveTestRepoRoot(testFileUrl) {
+  return path.resolve(path.dirname(fileURLToPath(testFileUrl)), "..");
+}
+
+export function buildWorktreeCwdGuardMessage({
+  expectedRepoRoot,
+  actualCwd,
+  testFilePath,
+  issue = "#1025",
+  command = "node --test test/react-web-status-surface.test.mjs",
+}) {
+  return [
+    `${issue} worktree-local focused test cwd guard: run this focused verification from the worktree repo root.`,
+    `Expected cwd: ${expectedRepoRoot}`,
+    `Actual cwd: ${actualCwd}`,
+    `Test file: ${testFilePath}`,
+    `Use: cd ${expectedRepoRoot} && ${command}`,
+    "Do not classify the target worktree as failing from a root-cwd cross-worktree absolute test invocation; process.cwd() selects the repo build output under test.",
+  ].join("\n");
+}
+
+function realpathIfPresent(value) {
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+export function assertWorktreeCwdForFocusedTest({ testFileUrl, issue, command, cwd = process.cwd() }) {
+  const expectedRepoRoot = resolveTestRepoRoot(testFileUrl);
+  const actualCwd = path.resolve(cwd);
+  if (realpathIfPresent(actualCwd) !== realpathIfPresent(expectedRepoRoot)) {
+    throw new Error(
+      buildWorktreeCwdGuardMessage({
+        expectedRepoRoot,
+        actualCwd,
+        testFilePath: fileURLToPath(testFileUrl),
+        issue,
+        command,
+      }),
+    );
+  }
+  return expectedRepoRoot;
+}

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -8,8 +8,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { assertWorktreeCwdForFocusedTest } from "./helpers/worktree-cwd-guard.mjs";
 
-const repoRoot = process.cwd();
+const repoRoot = assertWorktreeCwdForFocusedTest({
+  testFileUrl: import.meta.url,
+  issue: "#1025",
+  command: "npm run build && node --test test/react-web-status-surface.test.mjs",
+});
 const require = createRequire(import.meta.url);
 const { handleCodexRuntimeHook } = require(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const {

--- a/test/worktree-cwd-focused-test-guard-doc.test.mjs
+++ b/test/worktree-cwd-focused-test-guard-doc.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(repoRoot, "docs", "dogfood", "worktree-cwd-focused-test-guard-1025.md");
+
+test("issue #1025 dogfood doc keeps focused React Web status verification tied to worktree cwd", () => {
+  const doc = fs.readFileSync(docPath, "utf8");
+
+  assert.match(doc, /# Issue #1025 worktree cwd focused-test guard/);
+  assert.match(doc, /#960 reliability\/session-handoff lane/);
+  assert.match(doc, /`process\.cwd\(\)` as the\s+repo root under verification/);
+  assert.match(doc, /root-cwd cross-worktree invocation/);
+  assert.match(doc, /false local\s+failure/);
+  assert.match(doc, /cd \/path\/to\/issue-worktree/);
+  assert.match(doc, /node --test test\/react-web-status-surface\.test\.mjs/);
+  assert.match(doc, /rerun from the expected cwd before reporting branch health/);
+  assert.match(doc, /does not change product\s+runtime behavior, provider hooks, merge policy, telemetry, billing\/token proof,\s+or frontend detector scope/);
+});

--- a/test/worktree-cwd-guard.test.mjs
+++ b/test/worktree-cwd-guard.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertWorktreeCwdForFocusedTest,
+  buildWorktreeCwdGuardMessage,
+  resolveTestRepoRoot,
+} from "./helpers/worktree-cwd-guard.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("worktree cwd guard returns the test worktree root when focused verification starts there", () => {
+  assert.equal(assertWorktreeCwdForFocusedTest({ testFileUrl: import.meta.url, cwd: repoRoot }), repoRoot);
+  assert.equal(resolveTestRepoRoot(import.meta.url), repoRoot);
+});
+
+test("worktree cwd guard explains root-cwd cross-worktree absolute test invocation risk", () => {
+  const rootCwd = path.dirname(repoRoot);
+  assert.throws(
+    () =>
+      assertWorktreeCwdForFocusedTest({
+        testFileUrl: import.meta.url,
+        issue: "#1025",
+        command: "node --test test/react-web-status-surface.test.mjs",
+        cwd: rootCwd,
+      }),
+    (error) => {
+      assert.match(error.message, /#1025 worktree-local focused test cwd guard/);
+      assert.match(error.message, /Expected cwd:/);
+      assert.match(error.message, /Actual cwd:/);
+      assert.match(error.message, /root-cwd cross-worktree absolute test invocation/);
+      assert.match(error.message, /process\.cwd\(\) selects the repo build output under test/);
+      return true;
+    },
+  );
+});
+
+test("worktree cwd guard message preserves the operator rerun command", () => {
+  const message = buildWorktreeCwdGuardMessage({
+    expectedRepoRoot: "/worktrees/issue-1025",
+    actualCwd: "/repo-root",
+    testFilePath: "/worktrees/issue-1025/test/react-web-status-surface.test.mjs",
+    issue: "#1025",
+    command: "npm run build && node --test test/react-web-status-surface.test.mjs",
+  });
+
+  assert.match(message, /cd \/worktrees\/issue-1025 && npm run build && node --test test\/react-web-status-surface\.test\.mjs/);
+  assert.match(message, /Do not classify the target worktree as failing/);
+});


### PR DESCRIPTION
## Summary
- add a test-only worktree cwd guard for focused React Web status verification
- document the #1025 root-cwd cross-worktree false-failure mode for the #960 reliability/session-handoff lane
- add helper/doc regressions covering the operator rerun guidance and non-goal boundary

## Verification
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run build`
- `node --test test/worktree-cwd-guard.test.mjs test/worktree-cwd-focused-test-guard-doc.test.mjs test/react-web-status-surface.test.mjs`

Closes #1025