### PR TITLE
Classify interrupted local verification as inconclusive

### DIFF
--- a/docs/dogfood/interrupted-local-verification-inconclusive-1027.md
+++ b/docs/dogfood/interrupted-local-verification-inconclusive-1027.md
@@ -1,0 +1,40 @@
+# Issue #1027 interrupted local verification inconclusive guard
+
+This is a read-only dogfood guard for the #960 reliability/session-handoff lane.
+It documents one operator failure mode only: a local worktree verification command
+that exits `130` because it was interrupted is inconclusive evidence by itself.
+
+## Guarded failure mode
+
+Do not report an interrupted local verifier as a branch blocker when current-head
+CI is passing and no current focused command failure backs the interruption. Exit
+`130` means the verifier was stopped before it produced a pass/fail result; it is
+not the same evidence shape as a focused test, typecheck, or build failure that
+ran to completion.
+
+When an interrupted local verifier is followed by a bounded rerun that passes,
+keep the stale interrupted receipt in the handoff as inconclusive local evidence,
+not as a blocker. Operators should continue to cite the current successful rerun
+and current-head CI state as the branch-health evidence.
+
+## Required operator shape
+
+Classify local verification evidence in this order:
+
+1. Current focused command failure: blocker.
+2. Current-head CI failure: blocker.
+3. Interrupted local command with exit `130`: inconclusive unless item 1 or 2 is
+   also present.
+4. Interrupted exit `130` plus a bounded rerun that passes: inconclusive stale
+   local verifier receipt; cite the rerun as the current local result.
+
+Use the same reliability/session-handoff vocabulary in operator notes: blocked
+requires current focused failure or current-head CI failure; interrupted local
+verification is inconclusive; bounded rerun pass is current local verification
+evidence.
+
+## Boundary
+
+This changes only local operator verification classification guidance and test
+helpers. It does not change merge policy, provider/runtime hooks, telemetry,
+billing/token proof, detector scope, product claims, or frontend behavior.

--- a/test/helpers/local-verification-classifier.mjs
+++ b/test/helpers/local-verification-classifier.mjs
@@ -1,0 +1,39 @@
+export function classifyLocalVerificationEvidence({
+  exitCode,
+  interrupted = exitCode === 130,
+  currentFocusedCommandFailure = false,
+  currentHeadCiFailure = false,
+  boundedRerunPassed = false,
+} = {}) {
+  if (currentFocusedCommandFailure) {
+    return {
+      classification: "blocker",
+      reason: "current-focused-command-failure",
+      operatorCue: "Local verification is blocked by a current focused command failure.",
+    };
+  }
+
+  if (currentHeadCiFailure) {
+    return {
+      classification: "blocker",
+      reason: "current-head-ci-failure",
+      operatorCue: "Branch health is blocked by a current-head CI failure.",
+    };
+  }
+
+  if (interrupted) {
+    return {
+      classification: "inconclusive",
+      reason: boundedRerunPassed ? "interrupted-local-verifier-rerun-passed" : "interrupted-local-verifier",
+      operatorCue: boundedRerunPassed
+        ? "Interrupted local verification exit 130 is stale inconclusive evidence; cite the bounded rerun pass as current local verification."
+        : "Interrupted local verification exit 130 is inconclusive unless backed by current focused command failure or current-head CI failure.",
+    };
+  }
+
+  return {
+    classification: "current-local-result",
+    reason: exitCode === 0 ? "local-verifier-passed" : "local-verifier-completed",
+    operatorCue: "Use the completed local verifier result as current local verification evidence.",
+  };
+}

--- a/test/interrupted-local-verification-inconclusive.test.mjs
+++ b/test/interrupted-local-verification-inconclusive.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyLocalVerificationEvidence } from "./helpers/local-verification-classifier.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(repoRoot, "docs", "dogfood", "interrupted-local-verification-inconclusive-1027.md");
+
+test("issue #1027 classifies interrupted local verification as inconclusive without current failure evidence", () => {
+  assert.deepEqual(classifyLocalVerificationEvidence({ exitCode: 130 }), {
+    classification: "inconclusive",
+    reason: "interrupted-local-verifier",
+    operatorCue: "Interrupted local verification exit 130 is inconclusive unless backed by current focused command failure or current-head CI failure.",
+  });
+
+  assert.deepEqual(classifyLocalVerificationEvidence({ exitCode: 130, boundedRerunPassed: true }), {
+    classification: "inconclusive",
+    reason: "interrupted-local-verifier-rerun-passed",
+    operatorCue: "Interrupted local verification exit 130 is stale inconclusive evidence; cite the bounded rerun pass as current local verification.",
+  });
+});
+
+test("issue #1027 keeps true blockers tied to current focused failure or current-head CI failure", () => {
+  assert.equal(
+    classifyLocalVerificationEvidence({ exitCode: 130, currentFocusedCommandFailure: true }).classification,
+    "blocker",
+  );
+  assert.equal(
+    classifyLocalVerificationEvidence({ exitCode: 130, currentHeadCiFailure: true }).classification,
+    "blocker",
+  );
+  assert.equal(classifyLocalVerificationEvidence({ exitCode: 0 }).classification, "current-local-result");
+});
+
+test("issue #1027 dogfood doc preserves the interrupted-verifier boundary", () => {
+  const doc = fs.readFileSync(docPath, "utf8");
+
+  assert.match(doc, /# Issue #1027 interrupted local verification inconclusive guard/);
+  assert.match(doc, /#960 reliability\/session-handoff lane/);
+  assert.match(doc, /exits `130` because it was interrupted is inconclusive evidence by itself/);
+  assert.match(doc, /Do not report an interrupted local verifier as a branch blocker/);
+  assert.match(doc, /current-head\s+CI is passing/);
+  assert.match(doc, /Current focused command failure: blocker/);
+  assert.match(doc, /Current-head CI failure: blocker/);
+  assert.match(doc, /Interrupted local command with exit `130`: inconclusive/);
+  assert.match(doc, /bounded rerun that passes/);
+  assert.match(doc, /bounded rerun pass is current local verification\s+evidence/);
+  assert.match(doc, /does not change merge policy, provider\/runtime hooks, telemetry,\s+billing\/token proof, detector scope, product claims, or frontend behavior/);
+});


### PR DESCRIPTION
## Summary
- Adds a read-only Issue #1027 dogfood guard for interrupted local verification exit 130.
- Adds a test helper that classifies interrupted local verification as inconclusive unless backed by a current focused command failure or current-head CI failure.
- Locks the boundary with focused doc/helper tests and no merge policy/provider/runtime/detector/product-claim changes.

Closes #1027

## Verification
- git diff --check
- npm run typecheck
- npm run build
- node --test test/interrupted-local-verification-inconclusive.test.mjs