### PR TITLE
Guard stale gate rerun echoes

### DIFF
--- a/docs/dogfood/stale-gate-rerun-echo-1029.md
+++ b/docs/dogfood/stale-gate-rerun-echo-1029.md
@@ -1,0 +1,89 @@
+# Issue #1029 stale gate rerun echo guard
+
+This is a narrow read-only dogfood docs/test/helper guard for issue #1029. It
+keeps the original approval/linked-issue gate failure relay from PR #1028
+separate from the latest rerun result for the same current head.
+
+## Captured PR #1028 evidence
+
+- Source PR: `#1028` (`Classify interrupted local verification as inconclusive`)
+- Current head SHA: `55384c5c08814c182677f6ef981b05233a535b24`
+- Original failed approval/linked-issue gate relay: run `26250077038`, attempt
+  `1`, job `77258573169`, conclusion `failure`
+- Latest rerun result for the same current head: run `26250077038`, attempt `2`,
+  job `77258696992`, conclusion `success`
+- Live `gh pr checks 1028` after the rerun showed `Validate approval review and
+  linked issue` and the other current-head checks passing.
+- PR #1028 merged at `d42f971ad6101938a64033afce3768552977e8b2` after the live
+  current-head checks passed.
+
+## Guard rule
+
+When an alert or relay repeats the attempt-1 failed approval/linked-issue gate
+after a later rerun on the same current head has passed, classify the repeated
+failure as `stale-approval-gate-failure-echo`. It is audit provenance for the
+old failed attempt, not the latest current-head gate result and not a fresh
+blocker by itself.
+
+Do not skip the live merge gate. The operator still has to verify live
+current-head checks and mergeability before merge:
+
+1. Confirm the relay points to the original failed approval gate.
+2. Confirm the latest approval-gate rerun is for the same current head SHA.
+3. Confirm the latest rerun concluded `success` and supersedes the failed relay.
+4. Confirm all live current-head checks pass.
+5. Confirm mergeability is clean before merging.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1029",
+  "readOnly": true,
+  "question": "distinguish stale approval-gate failure echo from latest current-head rerun pass for PR #1028",
+  "sourcePullRequest": "#1028",
+  "currentHeadSha": "55384c5c08814c182677f6ef981b05233a535b24",
+  "relay": {
+    "workflow": "Merge Gate",
+    "name": "Validate approval review and linked issue",
+    "runId": "26250077038",
+    "attempt": 1,
+    "jobId": "77258573169",
+    "headSha": "55384c5c08814c182677f6ef981b05233a535b24",
+    "conclusion": "failure",
+    "classification": "original-failed-approval-gate-relay"
+  },
+  "latest": {
+    "workflow": "Merge Gate",
+    "name": "Validate approval review and linked issue",
+    "runId": "26250077038",
+    "attempt": 2,
+    "jobId": "77258696992",
+    "headSha": "55384c5c08814c182677f6ef981b05233a535b24",
+    "conclusion": "success",
+    "classification": "latest-current-head-rerun-pass"
+  },
+  "operatorDecision": {
+    "classification": "stale-approval-gate-failure-echo",
+    "relayIsCurrentHeadBlocker": false,
+    "latestResultIsAuthoritativeForCurrentHead": true,
+    "eligibleToMergeRequiresLiveChecksPass": true,
+    "eligibleToMergeRequiresCleanMergeability": true,
+    "rule": "The attempt-1 approval-gate failure relay is stale after attempt 2 passed for the same current head. Treat the failure as audit provenance, then merge only after live current-head checks pass and mergeability is clean."
+  }
+}
+```
+
+## Non-goals
+
+This guard changes only read-only dogfood operator classification docs and a test
+helper. It does not change merge policy, approval requirements,
+provider/runtime hooks, telemetry, billing/token proof, detector scope, product
+claims, frontend behavior, CI workflow behavior, issue closure policy, or release
+criteria.
+
+## Focused verification
+
+```sh
+node --test test/stale-gate-rerun-echo.test.mjs test/merge-gate-workflow.test.mjs test/pr-merge-gate.test.mjs
+```

--- a/test/helpers/stale-gate-rerun-classifier.mjs
+++ b/test/helpers/stale-gate-rerun-classifier.mjs
@@ -1,0 +1,64 @@
+const APPROVAL_GATE_WORKFLOW = "Merge Gate";
+const APPROVAL_GATE_CHECK = "Validate approval review and linked issue";
+
+function isApprovalGate(entry) {
+  return entry?.workflow === APPROVAL_GATE_WORKFLOW && entry?.name === APPROVAL_GATE_CHECK;
+}
+
+function isSuccess(entry) {
+  return String(entry?.conclusion ?? entry?.state ?? "").toLowerCase() === "success";
+}
+
+function isFailure(entry) {
+  return String(entry?.conclusion ?? entry?.state ?? "").toLowerCase() === "failure";
+}
+
+function numericAttempt(entry) {
+  return Number.isInteger(entry?.attempt) ? entry.attempt : Number(entry?.attempt ?? entry?.runAttempt ?? 0);
+}
+
+function sameHead(input) {
+  return Boolean(
+    input?.currentHeadSha
+      && input?.relay?.headSha === input.currentHeadSha
+      && input?.latest?.headSha === input.currentHeadSha,
+  );
+}
+
+function latestSupersedesRelay(relay, latest) {
+  if (!relay || !latest) return false;
+  if (relay.runId && latest.runId && relay.runId === latest.runId) {
+    return numericAttempt(latest) > numericAttempt(relay);
+  }
+  if (relay.completedAt && latest.completedAt) {
+    return Date.parse(latest.completedAt) > Date.parse(relay.completedAt);
+  }
+  return false;
+}
+
+export function classifyStaleApprovalGateRerunEcho(input) {
+  const relay = input?.relay;
+  const latest = input?.latest;
+  const relayIsOriginalFailedApprovalGate = isApprovalGate(relay) && isFailure(relay);
+  const latestIsPassingApprovalGate = isApprovalGate(latest) && isSuccess(latest);
+  const currentHeadMatchesBoth = sameHead(input);
+  const latestSupersedesOriginal = latestSupersedesRelay(relay, latest);
+  const staleFailureEcho = Boolean(
+    relayIsOriginalFailedApprovalGate
+      && latestIsPassingApprovalGate
+      && currentHeadMatchesBoth
+      && latestSupersedesOriginal,
+  );
+  const liveCurrentHeadChecksPass = Boolean(input?.liveCurrentHeadChecksPass);
+  const mergeabilityClean = Boolean(input?.mergeabilityClean);
+
+  return {
+    classification: staleFailureEcho ? "stale-approval-gate-failure-echo" : "current-or-unresolved-approval-gate-evidence",
+    staleFailureEcho,
+    relayIsCurrentHeadBlocker: !staleFailureEcho && relayIsOriginalFailedApprovalGate && relay?.headSha === input?.currentHeadSha,
+    currentHeadGateResult: staleFailureEcho ? "latest-rerun-pass" : latestIsPassingApprovalGate ? "latest-pass" : "unresolved",
+    latestResultIsAuthoritativeForCurrentHead: staleFailureEcho || (latestIsPassingApprovalGate && latest?.headSha === input?.currentHeadSha),
+    eligibleToMerge: liveCurrentHeadChecksPass && mergeabilityClean,
+    mergeRule: "Merge only after live current-head checks pass and mergeability is clean.",
+  };
+}

--- a/test/stale-gate-rerun-echo.test.mjs
+++ b/test/stale-gate-rerun-echo.test.mjs
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyStaleApprovalGateRerunEcho } from "./helpers/stale-gate-rerun-classifier.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(repoRoot, "docs", "dogfood", "stale-gate-rerun-echo-1029.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+const pr1028GateEvidence = {
+  currentHeadSha: "55384c5c08814c182677f6ef981b05233a535b24",
+  relay: {
+    workflow: "Merge Gate",
+    name: "Validate approval review and linked issue",
+    runId: "26250077038",
+    attempt: 1,
+    jobId: "77258573169",
+    headSha: "55384c5c08814c182677f6ef981b05233a535b24",
+    conclusion: "failure",
+    completedAt: "2026-05-21T20:04:27Z",
+  },
+  latest: {
+    workflow: "Merge Gate",
+    name: "Validate approval review and linked issue",
+    runId: "26250077038",
+    attempt: 2,
+    jobId: "77258696992",
+    headSha: "55384c5c08814c182677f6ef981b05233a535b24",
+    conclusion: "success",
+    completedAt: "2026-05-21T20:05:11Z",
+  },
+};
+
+test("issue #1029 classifies the original PR #1028 approval-gate failure relay as stale after same-head rerun pass", () => {
+  assert.deepEqual(
+    classifyStaleApprovalGateRerunEcho({
+      ...pr1028GateEvidence,
+      liveCurrentHeadChecksPass: true,
+      mergeabilityClean: true,
+    }),
+    {
+      classification: "stale-approval-gate-failure-echo",
+      staleFailureEcho: true,
+      relayIsCurrentHeadBlocker: false,
+      currentHeadGateResult: "latest-rerun-pass",
+      latestResultIsAuthoritativeForCurrentHead: true,
+      eligibleToMerge: true,
+      mergeRule: "Merge only after live current-head checks pass and mergeability is clean.",
+    },
+  );
+});
+
+test("issue #1029 helper does not convert live merge requirements into stale-echo permission", () => {
+  const withoutCleanMergeability = classifyStaleApprovalGateRerunEcho({
+    ...pr1028GateEvidence,
+    liveCurrentHeadChecksPass: true,
+    mergeabilityClean: false,
+  });
+  assert.equal(withoutCleanMergeability.staleFailureEcho, true);
+  assert.equal(withoutCleanMergeability.relayIsCurrentHeadBlocker, false);
+  assert.equal(withoutCleanMergeability.eligibleToMerge, false);
+
+  const withoutPassingLatest = classifyStaleApprovalGateRerunEcho({
+    ...pr1028GateEvidence,
+    latest: { ...pr1028GateEvidence.latest, conclusion: "failure" },
+    liveCurrentHeadChecksPass: false,
+    mergeabilityClean: true,
+  });
+  assert.equal(withoutPassingLatest.classification, "current-or-unresolved-approval-gate-evidence");
+  assert.equal(withoutPassingLatest.relayIsCurrentHeadBlocker, true);
+  assert.equal(withoutPassingLatest.latestResultIsAuthoritativeForCurrentHead, false);
+  assert.equal(withoutPassingLatest.eligibleToMerge, false);
+});
+
+test("issue #1029 dogfood doc preserves the stale gate echo boundary", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#1029");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourcePullRequest, "#1028");
+  assert.equal(report.currentHeadSha, "55384c5c08814c182677f6ef981b05233a535b24");
+  assert.equal(report.relay.classification, "original-failed-approval-gate-relay");
+  assert.equal(report.relay.runId, "26250077038");
+  assert.equal(report.relay.attempt, 1);
+  assert.equal(report.relay.jobId, "77258573169");
+  assert.equal(report.latest.classification, "latest-current-head-rerun-pass");
+  assert.equal(report.latest.attempt, 2);
+  assert.equal(report.latest.jobId, "77258696992");
+  assert.equal(report.operatorDecision.classification, "stale-approval-gate-failure-echo");
+  assert.equal(report.operatorDecision.relayIsCurrentHeadBlocker, false);
+  assert.equal(report.operatorDecision.latestResultIsAuthoritativeForCurrentHead, true);
+  assert.equal(report.operatorDecision.eligibleToMergeRequiresLiveChecksPass, true);
+  assert.equal(report.operatorDecision.eligibleToMergeRequiresCleanMergeability, true);
+  assert.match(report.operatorDecision.rule, /same current head/);
+  assert.match(report.operatorDecision.rule, /live current-head checks pass/);
+  assert.match(report.operatorDecision.rule, /mergeability is clean/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/helper guard for issue #1029",
+    "original approval/linked-issue gate failure relay from PR #1028",
+    "Latest rerun result for the same current head",
+    "stale-approval-gate-failure-echo",
+    "not the latest current-head gate result and not a fresh blocker by itself",
+    "Confirm all live current-head checks pass",
+    "Confirm mergeability is clean before merging",
+    "does not change merge policy, approval requirements",
+    "provider/runtime hooks",
+    "telemetry",
+    "billing/token proof",
+    "detector scope",
+    "product claims",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #1029 doc text: ${required}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a read-only Issue #1029 dogfood guard for stale approval-gate failure echoes after a same-head rerun pass.
- Adds a focused helper/test that classifies the original PR #1028 failed approval-gate relay as stale once the latest same-head rerun passes.
- Preserves the live merge rule: merge only after current-head checks pass and mergeability is clean, with no merge policy/approval/provider/runtime/telemetry/billing/detector/product-claim changes.

Closes #1029

## Verification
- git diff --check
- npm run typecheck
- npm run build
- node --test test/stale-gate-rerun-echo.test.mjs test/merge-gate-workflow.test.mjs test/pr-merge-gate.test.mjs