### PR TITLE
Bound stale epic checklist text before next-work adoption

### DIFF
--- a/docs/dogfood/stale-epic-checklist-boundary-1031.md
+++ b/docs/dogfood/stale-epic-checklist-boundary-1031.md
@@ -1,0 +1,77 @@
+# Issue #1031 stale epic checklist boundary
+
+This is a narrow read-only dogfood docs/test/helper guard for issue #1031. It
+bounds stale unchecked checklist text in the open #960 epic so it cannot be used
+as active next-work authority by itself after PR #1030.
+
+## Pain captured
+
+After PR #1030, only epic `#960` is open, but the epic body can still contain
+unchecked or possible slices that were already represented by closed child issues
+such as long-run budget warning `#988`. A dogfood nudge that treats that old
+unchecked prose as current work has to manually re-search siblings and can start
+a duplicate session for work that is already closed.
+
+## Guard rule
+
+Unchecked epic checklist text is **advisory** unless the candidate slice is
+backed by at least one current evidence source:
+
+1. an open child issue for the slice;
+2. a non-stale active branch or worktree for the slice;
+3. a live mapped session for the slice;
+4. an open PR for the slice; or
+5. an exact duplicate search showing whether the same slice already exists or
+   closed under the same wording.
+
+Closed child issues are receipts, not active next-work anchors. For example,
+closed issue `#988` may explain why a long-run budget warning checklist item is
+already covered, but it does not make unchecked #960 body text current work.
+
+When none of the five current evidence sources exists, report the checklist row
+as `epic-checklist-advisory-only`, perform sibling/duplicate inspection before
+choosing next work, and do not spawn a new duplicate branch/session from the epic
+body text alone.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1031",
+  "readOnly": true,
+  "question": "bound stale unchecked #960 checklist text before selecting active next work",
+  "sourceEpic": "#960",
+  "postPr1030OpenIssueInventory": ["#960"],
+  "staleChecklistExample": {
+    "text": "long-run budget warning slice",
+    "closedChildIssue": "#988",
+    "closedChildIssueIsActiveNextWork": false
+  },
+  "operatorDecision": {
+    "classification": "epic-checklist-advisory-only",
+    "uncheckedEpicChecklistTextIsAdvisory": true,
+    "activeNextWorkRequiresOneOf": [
+      "open-child-issue",
+      "active-branch-or-worktree",
+      "live-mapped-session",
+      "open-pull-request",
+      "exact-duplicate-search"
+    ],
+    "duplicateSessionRisk": "elevated-until-sibling-search",
+    "rule": "Unchecked epic checklist text is advisory unless backed by an open child issue, active branch/session, open PR, or exact duplicate search."
+  }
+}
+```
+
+## Non-goals
+
+This guard changes only read-only dogfood operator classification docs, a test,
+and a helper. It does not mutate GitHub issues automatically, change merge
+policy, provider/runtime hooks, telemetry, billing/token proof, detector scope,
+frontend behavior, product claims, issue closure policy, or release criteria.
+
+## Focused verification
+
+```sh
+node --test test/stale-epic-checklist-boundary.test.mjs
+```

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -1,0 +1,58 @@
+const ACTIVE_STATES = new Set(["open", "active", "current"]);
+
+function normalizeRef(ref) {
+  return String(ref ?? "").trim();
+}
+
+function isOpenState(value) {
+  return ACTIVE_STATES.has(String(value ?? "").toLowerCase());
+}
+
+function hasOpenChildIssue(evidence) {
+  return (evidence?.childIssues ?? []).some((issue) => isOpenState(issue?.state));
+}
+
+function hasActiveBranch(evidence) {
+  return (evidence?.branches ?? []).some((branch) => isOpenState(branch?.state) || branch?.active === true);
+}
+
+function hasActiveSession(evidence) {
+  return (evidence?.sessions ?? []).some((session) => isOpenState(session?.state) || session?.active === true);
+}
+
+function hasOpenPullRequest(evidence) {
+  return (evidence?.pullRequests ?? []).some((pr) => isOpenState(pr?.state));
+}
+
+function hasExactDuplicateSearch(evidence) {
+  return Boolean(evidence?.exactDuplicateSearch?.performed === true && normalizeRef(evidence.exactDuplicateSearch.query));
+}
+
+function activeEvidenceKinds(evidence) {
+  return [
+    hasOpenChildIssue(evidence) ? "open-child-issue" : null,
+    hasActiveBranch(evidence) ? "active-branch" : null,
+    hasActiveSession(evidence) ? "active-session" : null,
+    hasOpenPullRequest(evidence) ? "open-pull-request" : null,
+    hasExactDuplicateSearch(evidence) ? "exact-duplicate-search" : null,
+  ].filter(Boolean);
+}
+
+export function classifyStaleEpicChecklistCandidate(input) {
+  const activeKinds = activeEvidenceKinds(input?.evidence ?? {});
+  const hasUncheckedEpicChecklistText = Boolean(input?.uncheckedEpicChecklistText);
+  const backedByActiveEvidence = activeKinds.length > 0;
+  const classification = hasUncheckedEpicChecklistText && !backedByActiveEvidence
+    ? "epic-checklist-advisory-only"
+    : "active-next-work-candidate";
+
+  return {
+    epic: normalizeRef(input?.epic) || "#960",
+    checklistTextAuthority: classification === "epic-checklist-advisory-only" ? "advisory" : "backed",
+    classification,
+    activeNextWorkAllowed: classification === "active-next-work-candidate",
+    activeEvidenceKinds: activeKinds,
+    duplicateSessionRisk: classification === "epic-checklist-advisory-only" ? "elevated-until-sibling-search" : "bounded",
+    rule: "Unchecked epic checklist text is advisory unless backed by an open child issue, active branch/session, open PR, or exact duplicate search.",
+  };
+}

--- a/test/stale-epic-checklist-boundary.test.mjs
+++ b/test/stale-epic-checklist-boundary.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyStaleEpicChecklistCandidate } from "./helpers/stale-epic-checklist-boundary.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(repoRoot, "docs", "dogfood", "stale-epic-checklist-boundary-1031.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #1031 helper treats unchecked epic text without current evidence as advisory only", () => {
+  assert.deepEqual(
+    classifyStaleEpicChecklistCandidate({
+      epic: "#960",
+      uncheckedEpicChecklistText: "long-run budget warning slice",
+      evidence: {
+        childIssues: [{ number: 988, state: "closed", title: "Long-run budget warning" }],
+        branches: [],
+        sessions: [],
+        pullRequests: [],
+      },
+    }),
+    {
+      epic: "#960",
+      checklistTextAuthority: "advisory",
+      classification: "epic-checklist-advisory-only",
+      activeNextWorkAllowed: false,
+      activeEvidenceKinds: [],
+      duplicateSessionRisk: "elevated-until-sibling-search",
+      rule: "Unchecked epic checklist text is advisory unless backed by an open child issue, active branch/session, open PR, or exact duplicate search.",
+    },
+  );
+});
+
+test("issue #1031 helper allows active next work only when a current anchor or exact duplicate search backs the slice", () => {
+  for (const [name, evidence, expectedKind] of [
+    ["open child issue", { childIssues: [{ number: 1031, state: "open" }] }, "open-child-issue"],
+    ["active branch", { branches: [{ name: "dogfood/issue-1031-stale-epic-checklist-boundary", active: true }] }, "active-branch"],
+    ["live session", { sessions: [{ session: "fooks-dogfood-issue-1031", state: "active" }] }, "active-session"],
+    ["open PR", { pullRequests: [{ number: 1032, state: "open" }] }, "open-pull-request"],
+    ["exact duplicate search", { exactDuplicateSearch: { performed: true, query: '"long-run budget warning" repo:minislively/fooks' } }, "exact-duplicate-search"],
+  ]) {
+    const result = classifyStaleEpicChecklistCandidate({
+      epic: "#960",
+      uncheckedEpicChecklistText: "possible follow-up slice",
+      evidence,
+    });
+
+    assert.equal(result.classification, "active-next-work-candidate", name);
+    assert.equal(result.checklistTextAuthority, "backed", name);
+    assert.equal(result.activeNextWorkAllowed, true, name);
+    assert.deepEqual(result.activeEvidenceKinds, [expectedKind], name);
+    assert.equal(result.duplicateSessionRisk, "bounded", name);
+  }
+});
+
+test("issue #1031 dogfood doc preserves the stale epic checklist boundary", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#1031");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourceEpic, "#960");
+  assert.deepEqual(report.postPr1030OpenIssueInventory, ["#960"]);
+  assert.equal(report.staleChecklistExample.closedChildIssue, "#988");
+  assert.equal(report.staleChecklistExample.closedChildIssueIsActiveNextWork, false);
+  assert.equal(report.operatorDecision.classification, "epic-checklist-advisory-only");
+  assert.equal(report.operatorDecision.uncheckedEpicChecklistTextIsAdvisory, true);
+  assert.deepEqual(report.operatorDecision.activeNextWorkRequiresOneOf, [
+    "open-child-issue",
+    "active-branch-or-worktree",
+    "live-mapped-session",
+    "open-pull-request",
+    "exact-duplicate-search",
+  ]);
+  assert.equal(report.operatorDecision.duplicateSessionRisk, "elevated-until-sibling-search");
+  assert.match(report.operatorDecision.rule, /Unchecked epic checklist text is advisory/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/helper guard for issue #1031",
+    "bounds stale unchecked checklist text in the open #960 epic",
+    "after PR #1030",
+    "only epic `#960` is open",
+    "closed child issues such as long-run budget warning `#988`",
+    "Unchecked epic checklist text is **advisory**",
+    "an open child issue for the slice",
+    "a non-stale active branch or worktree",
+    "a live mapped session",
+    "an open PR",
+    "an exact duplicate search",
+    "Closed child issues are receipts, not active next-work anchors",
+    "`epic-checklist-advisory-only`",
+    "do not spawn a new duplicate branch/session from the epic body text alone",
+    "does not mutate GitHub issues automatically",
+    "change merge policy",
+    "provider/runtime hooks",
+    "telemetry",
+    "billing/token proof",
+    "detector scope",
+    "product claims",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #1031 doc text: ${required}`);
+  }
+});


### PR DESCRIPTION
Closes #1031.

## Summary
- Add a read-only dogfood guard documenting that unchecked #960 epic checklist text is advisory unless backed by an open child issue, active branch/session, open PR, or exact duplicate search.
- Add a focused helper classifier for stale epic checklist candidates.
- Add tests for the advisory-only closed-child case (#988) and each current-evidence backing path.

## Verification
- git diff --check
- npm run typecheck
- npm run build
- node --test test/stale-epic-checklist-boundary.test.mjs