### PR TITLE
Clarify current authority before users continue

### DIFF
--- a/src/core/work-item-dashboard.ts
+++ b/src/core/work-item-dashboard.ts
@@ -14,6 +14,7 @@ export type WorkItemEvidenceClass = "Source evidence" | "Local command evidence"
 export type WorkItemState = "uninspected" | "evidence-ready" | "fallback-required" | "context-issued" | "receipt-recorded" | "active-work" | "blocked";
 export type WorkItemNextActionKind = "inspect" | "verify" | "link" | "open-pr" | "continue" | "fallback";
 export type WorkItemDomainJudgmentConfidence = "high" | "medium" | "low";
+export type WorkItemCurrentAuthorityStatus = "ready-to-continue" | "needs-recheck" | "stop-before-execution";
 
 export type WorkItemEvidence = {
   kind: WorkItemEvidenceKind;
@@ -65,6 +66,16 @@ export type WorkItemArchitectureAudit = {
   firstPassAction: string;
 };
 
+export type WorkItemCurrentAuthoritySummary = {
+  status: WorkItemCurrentAuthorityStatus;
+  statusLabel: "Ready to continue" | "Needs recheck" | "Stop before execution";
+  sourceOfTruth: string;
+  staleBoundary: string;
+  nextAction: string;
+  reasons: string[];
+  nonClaims: string[];
+};
+
 export type WorkItemDashboard = {
   schemaVersion: typeof WORK_ITEM_DASHBOARD_SCHEMA_VERSION;
   source: typeof WORK_ITEM_DASHBOARD_SOURCE;
@@ -86,6 +97,7 @@ export type WorkItemDashboard = {
     pullRequestUrl?: string;
   };
   architectureAudit: WorkItemArchitectureAudit[];
+  currentAuthoritySummary: WorkItemCurrentAuthoritySummary;
   workItems: WorkItem[];
   nextActions: WorkItemNextAction[];
   frontendDomainTaxonomy: WorkItemFrontendDomain[];
@@ -414,6 +426,81 @@ function nextActionFor(snapshot: GitSnapshot, anchors: WorkItemDashboard["anchor
   };
 }
 
+function statusLabel(status: WorkItemCurrentAuthorityStatus): WorkItemCurrentAuthoritySummary["statusLabel"] {
+  switch (status) {
+    case "ready-to-continue":
+      return "Ready to continue";
+    case "needs-recheck":
+      return "Needs recheck";
+    case "stop-before-execution":
+      return "Stop before execution";
+  }
+}
+
+function sourceOfTruthFor(item: WorkItem, anchors: WorkItemDashboard["anchors"]): string {
+  const submittedSession = item.state !== "evidence-ready" ? anchors.session : undefined;
+  const anchorsText = [
+    anchors.issue ? `issue ${anchors.issue}` : undefined,
+    anchors.pullRequest ? `PR ${anchors.pullRequest}` : undefined,
+    submittedSession ? `session ${submittedSession}` : undefined,
+  ].filter(Boolean).join(", ");
+  if (anchorsText) return `Current authority derives from ${anchorsText}.`;
+  if (item.state === "blocked") return "No current authority is available because local worktree evidence is blocked.";
+  return "No issue, PR, or submitted-session authority is linked for this checkout.";
+}
+
+function staleBoundaryFor(status: WorkItemCurrentAuthorityStatus): string {
+  if (status === "stop-before-execution") {
+    return "Treat stale, historical, and advisory context as non-authorizing until current authority is refreshed.";
+  }
+  if (status === "needs-recheck") {
+    return "No stale stop boundary is represented here, but current authority or closeout evidence needs recheck.";
+  }
+  return "No blocking stale or historical boundary is represented in this WorkItem projection.";
+}
+
+function authorityStatusFor(item: WorkItem, anchors: WorkItemDashboard["anchors"]): WorkItemCurrentAuthorityStatus {
+  const hasSubmittedSession = Boolean(anchors.session && item.state !== "evidence-ready");
+  const hasAuthority = Boolean(anchors.issue || anchors.pullRequest || hasSubmittedSession);
+  if (item.state === "blocked" || !hasAuthority) return "stop-before-execution";
+  if (item.requiredNextAction.kind === "continue" || item.requiredNextAction.kind === "verify") return "ready-to-continue";
+  return "needs-recheck";
+}
+
+function authorityReasonsFor(item: WorkItem, anchors: WorkItemDashboard["anchors"], status: WorkItemCurrentAuthorityStatus): string[] {
+  const hasSubmittedSession = Boolean(anchors.session && item.state !== "evidence-ready");
+  const reasons = [
+    `work item state is ${item.state}`,
+    `next action kind is ${item.requiredNextAction.kind}`,
+  ];
+  if (anchors.issue) reasons.push(`issue anchor ${anchors.issue} is present`);
+  if (anchors.pullRequest) reasons.push(`pull request anchor ${anchors.pullRequest} is present`);
+  if (hasSubmittedSession) reasons.push(`submitted-session anchor ${anchors.session} is present`);
+  if (anchors.session && !hasSubmittedSession) reasons.push(`ambient session ${anchors.session} is advisory only for this clean unlinked checkout`);
+  if (!anchors.issue && !anchors.pullRequest && !hasSubmittedSession) reasons.push("no issue, PR, or submitted-session authority anchor is present");
+  if (status === "ready-to-continue") reasons.push("existing evidence points to verification/continuation instead of inspection/linking/fallback");
+  if (status === "needs-recheck") reasons.push("existing evidence still asks for linking, PR creation, inspection, or fallback before a continue claim");
+  if (status === "stop-before-execution") reasons.push("current authority is absent or blocked, so execution should pause for source-of-truth refresh");
+  return reasons;
+}
+
+export function buildWorkItemCurrentAuthoritySummary(item: WorkItem, anchors: WorkItemDashboard["anchors"]): WorkItemCurrentAuthoritySummary {
+  const status = authorityStatusFor(item, anchors);
+  return {
+    status,
+    statusLabel: statusLabel(status),
+    sourceOfTruth: sourceOfTruthFor(item, anchors),
+    staleBoundary: staleBoundaryFor(status),
+    nextAction: item.requiredNextAction.label,
+    reasons: authorityReasonsFor(item, anchors, status),
+    nonClaims: [
+      "This summary is an advisory projection over existing WorkItem evidence, not a new authority source.",
+      "This summary does not prove release readiness, merge authority, autonomous CI success, provider billing, provider token usage, charged cost, benchmark performance, or runtime UI correctness.",
+      "A stop-before-execution status is operator guidance only; it does not enforce or block unrelated CLI commands.",
+    ],
+  };
+}
+
 export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMetricStatus): WorkItemDashboard {
   const snapshot = readGitSnapshot(cwd);
   const issue = issueFromBranch(snapshot.branch);
@@ -453,6 +540,28 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
       doesNotSupport: "submitted work or review completion by itself",
     });
   }
+  const workItem: WorkItem = {
+    id: issue ? `work-item-${issue.slice(1)}` : "work-item-unlinked",
+    title: issue ? `Active ${displayFrontendDomain(frontendDomain)} work ${issue}` : "Unlinked work item candidate",
+    state: workItemStateFor(snapshot, anchors),
+    frontendDomain,
+    domainJudgment,
+    observed: [...evidence.map((item) => item.observed), domainJudgment.rationale],
+    inferred: [
+      issue ? `${issue} is the local issue anchor inferred from branch naming.` : "No issue anchor was inferred from branch naming.",
+      snapshot.clean === false ? "The worktree has uncommitted local changes and still needs verification/closeout." : "Clean worktree evidence still needs a scoped receipt before active work is complete.",
+      `Domain judgment recommends state ${domainJudgment.recommendedState} and next action ${domainJudgment.nextAction.kind}.`,
+    ],
+    requiredNextAction: action,
+    evidence,
+    nonClaims: [
+      "This dashboard does not prove provider usage or billing-token savings.",
+      "This dashboard does not prove runtime UI correctness.",
+      "A TUI-domain work item means a user-developed terminal UI target, not fooks' own rendering surface.",
+      "This dashboard does not close active work without test/review/PR receipt evidence.",
+      ...domainJudgment.nonClaims,
+    ],
+  };
 
   return {
     schemaVersion: WORK_ITEM_DASHBOARD_SCHEMA_VERSION,
@@ -489,30 +598,8 @@ export function buildWorkItemDashboard(cwd: string, metricStatus: FooksProjectMe
         firstPassAction: "export shared model types, include the TUI frontend domain, and do not rewrite fooks' own TUI board",
       },
     ],
-    workItems: [
-      {
-        id: issue ? `work-item-${issue.slice(1)}` : "work-item-unlinked",
-        title: issue ? `Active ${displayFrontendDomain(frontendDomain)} work ${issue}` : "Unlinked work item candidate",
-        state: workItemStateFor(snapshot, anchors),
-        frontendDomain,
-        domainJudgment,
-        observed: [...evidence.map((item) => item.observed), domainJudgment.rationale],
-        inferred: [
-          issue ? `${issue} is the local issue anchor inferred from branch naming.` : "No issue anchor was inferred from branch naming.",
-          snapshot.clean === false ? "The worktree has uncommitted local changes and still needs verification/closeout." : "Clean worktree evidence still needs a scoped receipt before active work is complete.",
-          `Domain judgment recommends state ${domainJudgment.recommendedState} and next action ${domainJudgment.nextAction.kind}.`,
-        ],
-        requiredNextAction: action,
-        evidence,
-        nonClaims: [
-          "This dashboard does not prove provider usage or billing-token savings.",
-          "This dashboard does not prove runtime UI correctness.",
-          "A TUI-domain work item means a user-developed terminal UI target, not fooks' own rendering surface.",
-          "This dashboard does not close active work without test/review/PR receipt evidence.",
-          ...domainJudgment.nonClaims,
-        ],
-      },
-    ],
+    currentAuthoritySummary: buildWorkItemCurrentAuthoritySummary(workItem, anchors),
+    workItems: [workItem],
     nextActions: [action],
     tuiCompatibility: {
       modelOnly: true,

--- a/src/core/work-item-explain.ts
+++ b/src/core/work-item-explain.ts
@@ -1,5 +1,5 @@
-import type { WorkItem, WorkItemDashboard, WorkItemDomainJudgment, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
-import { WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY } from "./work-item-dashboard";
+import type { WorkItem, WorkItemCurrentAuthoritySummary, WorkItemDashboard, WorkItemDomainJudgment, WorkItemEvidence, WorkItemNextAction } from "./work-item-dashboard";
+import { WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY, buildWorkItemCurrentAuthoritySummary } from "./work-item-dashboard";
 
 export const WORK_ITEM_EXPLAIN_SCHEMA_VERSION = 2;
 export const WORK_ITEM_EXPLAIN_CLAIM_BOUNDARY =
@@ -27,6 +27,7 @@ export type WorkItemExplainResult = {
     frontendDomain: WorkItem["frontendDomain"];
     domainJudgment: WorkItemDomainJudgment;
   };
+  currentAuthoritySummary: WorkItemCurrentAuthoritySummary;
   why: string[];
   evidence: WorkItemEvidence[];
   rejectedEvidence: WorkItemExplainRejectedEvidence[];
@@ -155,6 +156,11 @@ function rejectedEvidenceFor(item: WorkItem): WorkItemExplainRejectedEvidence[] 
 
 export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboard: WorkItemDashboard): WorkItemExplainResult {
   const item = evidenceForArtifact(artifact, dashboard);
+  const currentAuthoritySummary = artifact === "sample"
+    ? buildWorkItemCurrentAuthoritySummary(item, { worktree: "static-sample" })
+    : dashboard.workItems[0] === item
+      ? dashboard.currentAuthoritySummary
+      : buildWorkItemCurrentAuthoritySummary(item, dashboard.anchors);
   return {
     schemaVersion: WORK_ITEM_EXPLAIN_SCHEMA_VERSION,
     command: "explain",
@@ -170,6 +176,7 @@ export function buildWorkItemExplain(artifact: WorkItemExplainArtifact, dashboar
       frontendDomain: item.frontendDomain,
       domainJudgment: item.domainJudgment,
     },
+    currentAuthoritySummary,
     why: whyFor(item, dashboard, artifact),
     evidence: item.evidence,
     rejectedEvidence: rejectedEvidenceFor(item),
@@ -213,6 +220,7 @@ export function renderWorkItemExplainText(explain: WorkItemExplainResult): strin
   const domainLabel = displayFrontendDomain(explain.workItem.frontendDomain);
   const judgmentAction = explain.workItem.domainJudgment.nextAction;
   const judgmentCommandLine = judgmentAction.command ? `\n- domain command: ${judgmentAction.command}` : "";
+  const summary = explain.currentAuthoritySummary;
 
-  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${domainLabel} (${explain.workItem.frontendDomain})\n- domain judgment: ${explain.workItem.domainJudgment.recommendedState} / ${judgmentAction.kind} (${explain.workItem.domainJudgment.confidence} confidence)\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Domain judgment\n\n- frontend domain: ${domainLabel} (${explain.workItem.domainJudgment.frontendDomain})\n- recommended state: ${explain.workItem.domainJudgment.recommendedState}\n- confidence: ${explain.workItem.domainJudgment.confidence}\n- rationale: ${explain.workItem.domainJudgment.rationale}\n- evidence focus: ${explain.workItem.domainJudgment.evidenceFocus.join(", ")}\n- required evidence: ${explain.workItem.domainJudgment.requiredEvidence.join(", ")}\n- domain next action kind: ${judgmentAction.kind}\n- domain next action: ${judgmentAction.label}${judgmentCommandLine}\n- domain reason: ${judgmentAction.reason}\n- domain closes when: ${judgmentAction.closesWhen}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList(explain.nonClaims)}\n`;
+  return `# fooks explain ${explain.artifact}\n\n${explain.claimBoundary}\n\n## Current authority summary\n\n- status: ${summary.statusLabel}\n- source of truth: ${summary.sourceOfTruth}\n- stale boundary: ${summary.staleBoundary}\n- next action: ${summary.nextAction}\n\n## Work item\n\n- id: ${explain.workItem.id}\n- title: ${explain.workItem.title}\n- state: ${explain.workItem.state}\n- frontend domain: ${domainLabel} (${explain.workItem.frontendDomain})\n- domain judgment: ${explain.workItem.domainJudgment.recommendedState} / ${judgmentAction.kind} (${explain.workItem.domainJudgment.confidence} confidence)\n\n## Why\n\n${bulletList(explain.why)}\n\n## Evidence\n\n${evidence}\n\n## Rejected evidence / non-claims\n\n${rejected}\n\n## Domain judgment\n\n- frontend domain: ${domainLabel} (${explain.workItem.domainJudgment.frontendDomain})\n- recommended state: ${explain.workItem.domainJudgment.recommendedState}\n- confidence: ${explain.workItem.domainJudgment.confidence}\n- rationale: ${explain.workItem.domainJudgment.rationale}\n- evidence focus: ${explain.workItem.domainJudgment.evidenceFocus.join(", ")}\n- required evidence: ${explain.workItem.domainJudgment.requiredEvidence.join(", ")}\n- domain next action kind: ${judgmentAction.kind}\n- domain next action: ${judgmentAction.label}${judgmentCommandLine}\n- domain reason: ${judgmentAction.reason}\n- domain closes when: ${judgmentAction.closesWhen}\n\n## Next action\n\n- kind: ${explain.nextAction.kind}\n- label: ${explain.nextAction.label}${commandLine}\n- reason: ${explain.nextAction.reason}\n- closes when: ${explain.nextAction.closesWhen}\n\n## Non-claims\n\n${bulletList([...summary.nonClaims, ...explain.nonClaims])}\n`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,6 +295,8 @@ export {
   WORK_ITEM_DASHBOARD_CLAIM_BOUNDARY,
   buildWorkItemDashboard,
   type WorkItem,
+  type WorkItemCurrentAuthorityStatus,
+  type WorkItemCurrentAuthoritySummary,
   type WorkItemEvidence,
   type WorkItemNextAction,
   type WorkItemDashboard,

--- a/test/work-item-dashboard.test.mjs
+++ b/test/work-item-dashboard.test.mjs
@@ -74,7 +74,7 @@ test("bare status includes docs-backed WorkItem dashboard while preserving metri
   assert.equal(dashboard.anchors.issueUrl, "https://github.com/minislively/fooks/issues/922");
   assert.equal(dashboard.anchors.branch, "feature/issue-922-docs-backed-work-item-action-dashboard");
   assert.equal(dashboard.anchors.session, "omx-test-session");
-  assert.equal(dashboard.anchors.worktree, tempDir);
+  assert.equal(fs.realpathSync(dashboard.anchors.worktree), fs.realpathSync(tempDir));
   assert.equal(dashboard.workItems[0].requiredNextAction.kind, "open-pr");
   assert.deepEqual(dashboard.tuiCompatibility.sharedTypes, ["WorkItem", "Evidence", "NextAction"]);
   assert.equal(dashboard.tuiCompatibility.modelOnly, true);
@@ -83,6 +83,55 @@ test("bare status includes docs-backed WorkItem dashboard while preserving metri
   assert.ok(dashboard.architectureAudit.some((item) => item.scope === "tui" && /do not rewrite/.test(item.firstPassAction)));
   assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "architectureDoc" && item.supports.includes("WorkItem/Evidence/NextAction")));
   assert.ok(dashboard.workItems[0].nonClaims.some((item) => item.includes("provider usage")));
+  assert.equal(dashboard.currentAuthoritySummary.status, "needs-recheck");
+  assert.equal(dashboard.currentAuthoritySummary.statusLabel, "Needs recheck");
+  assert.match(dashboard.currentAuthoritySummary.sourceOfTruth, /issue #922/);
+  assert.match(dashboard.currentAuthoritySummary.staleBoundary, /needs recheck/);
+  assert.match(dashboard.currentAuthoritySummary.nextAction, /Open or link the PR/);
+  assert.ok(dashboard.currentAuthoritySummary.reasons.some((item) => /next action kind is open-pr/.test(item)));
+  assert.ok(dashboard.currentAuthoritySummary.nonClaims.some((item) => /advisory projection/.test(item)));
+});
+
+test("WorkItem current authority summary marks ready when issue and PR anchors are present", () => {
+  const tempDir = makeRepo();
+  const status = runStatus(tempDir, { FOOOKS_UNUSED: "ignored", PR_NUMBER: "123", PR_URL: "https://github.com/minislively/fooks/pull/123" });
+  const summary = status.workItemDashboard.currentAuthoritySummary;
+
+  assert.equal(summary.status, "ready-to-continue");
+  assert.equal(summary.statusLabel, "Ready to continue");
+  assert.match(summary.sourceOfTruth, /issue #922/);
+  assert.match(summary.sourceOfTruth, /PR #123/);
+  assert.match(summary.staleBoundary, /No blocking stale or historical boundary/);
+  assert.match(summary.nextAction, /Verify and close active work/);
+  assert.ok(summary.reasons.some((item) => /verification\/continuation/.test(item)));
+  assert.ok(summary.nonClaims.some((item) => /does not prove release readiness/));
+});
+
+test("WorkItem current authority summary stops when no current authority is linked", () => {
+  const tempDir = makeRepo();
+  git(tempDir, ["checkout", "main"]);
+  const previousFooksSession = process.env.FOOKS_SESSION_ID;
+  const previousOmxSession = process.env.OMX_SESSION_ID;
+  const previousTmuxPane = process.env.TMUX_PANE;
+  delete process.env.FOOKS_SESSION_ID;
+  delete process.env.OMX_SESSION_ID;
+  delete process.env.TMUX_PANE;
+  try {
+    const status = runStatus(tempDir, { FOOKS_SESSION_ID: "", OMX_SESSION_ID: "", TMUX_PANE: "" });
+    const summary = status.workItemDashboard.currentAuthoritySummary;
+
+    assert.equal(summary.status, "stop-before-execution");
+    assert.equal(summary.statusLabel, "Stop before execution");
+    assert.match(summary.sourceOfTruth, /No issue, PR, or submitted-session authority/);
+    assert.match(summary.staleBoundary, /non-authorizing/);
+    assert.match(summary.nextAction, /Link an open issue/);
+    assert.ok(summary.reasons.some((item) => /no issue, PR, or submitted-session authority/.test(item)));
+    assert.ok(summary.nonClaims.some((item) => /does not enforce or block unrelated CLI commands/));
+  } finally {
+    if (previousFooksSession === undefined) delete process.env.FOOKS_SESSION_ID; else process.env.FOOKS_SESSION_ID = previousFooksSession;
+    if (previousOmxSession === undefined) delete process.env.OMX_SESSION_ID; else process.env.OMX_SESSION_ID = previousOmxSession;
+    if (previousTmuxPane === undefined) delete process.env.TMUX_PANE; else process.env.TMUX_PANE = previousTmuxPane;
+  }
 });
 
 test("shared WorkItem dashboard builder is importable for non-CLI consumers", () => {
@@ -247,6 +296,9 @@ test("ambient session alone does not make a clean unlinked checkout active work"
     assert.equal(dashboard.workItems[0].state, "evidence-ready");
     assert.equal(dashboard.nextActions[0].kind, "link");
     assert.ok(dashboard.workItems[0].evidence.some((item) => item.kind === "session"));
+    assert.equal(dashboard.currentAuthoritySummary.status, "stop-before-execution");
+    assert.match(dashboard.currentAuthoritySummary.sourceOfTruth, /No issue, PR, or submitted-session authority/);
+    assert.ok(dashboard.currentAuthoritySummary.reasons.some((item) => /ambient session ambient-session-only is advisory only/.test(item)));
   } finally {
     if (previousFooksSession === undefined) delete process.env.FOOKS_SESSION_ID;
     else process.env.FOOKS_SESSION_ID = previousFooksSession;
@@ -263,6 +315,11 @@ test("fooks explain status renders WorkItem evidence, rejected evidence, and nex
 
   assert.match(text, /^# fooks explain status/m);
   assert.match(text, /CLI-only WorkItem evidence explanation/);
+  assert.match(text, /## Current authority summary/);
+  assert.match(text, /- status: Needs recheck/);
+  assert.match(text, /- source of truth: Current authority derives from issue #922/);
+  assert.match(text, /- stale boundary: No stale stop boundary is represented here, but current authority or closeout evidence needs recheck\./);
+  assert.match(text, /- next action: Open or link the PR after focused verification passes/);
   assert.match(text, /## Why/);
   assert.match(text, /artifact 'status' resolves to WorkItem 'work-item-922' in state 'active-work'/);
   assert.match(text, /## Evidence/);
@@ -287,6 +344,9 @@ test("fooks explain work-item --json exposes machine-readable WorkItem explanati
   assert.equal(explanation.readOnly, true);
   assert.equal(explanation.workItem.id, "work-item-922");
   assert.equal(explanation.workItem.state, "active-work");
+  assert.equal(explanation.currentAuthoritySummary.status, "needs-recheck");
+  assert.equal(explanation.currentAuthoritySummary.statusLabel, "Needs recheck");
+  assert.match(explanation.currentAuthoritySummary.sourceOfTruth, /issue #922/);
   assert.ok(explanation.why.some((line) => line.includes("next action:")));
   assert.ok(explanation.evidence.some((item) => item.kind === "worktree"));
   assert.ok(explanation.rejectedEvidence.some((item) => item.reason.includes("provider usage")));
@@ -325,6 +385,8 @@ test("fooks explain current defaults to the current repository WorkItem artifact
   assert.equal(explicit.workItem.id, "work-item-922");
   assert.equal(implicit.workItem.id, "work-item-922");
   assert.equal(explicit.nextAction.kind, "open-pr");
+  assert.equal(explicit.currentAuthoritySummary.status, "needs-recheck");
+  assert.equal(implicit.currentAuthoritySummary.status, "needs-recheck");
 });
 
 test("fooks explain exposes command help without reading live WorkItem evidence", () => {


### PR DESCRIPTION
## Summary
- Add an advisory `currentAuthoritySummary` projection to the existing WorkItem dashboard/status JSON.
- Surface the same current-authority summary at the top of `fooks explain current` / explain text.
- Keep clean unlinked checkouts non-authorizing when only an ambient session is present.

## Constraints preserved
- No new command.
- No JSON breaking change; status remains JSON-compatible and fields are additive.
- No new evidence collection; summary derives from existing WorkItem anchors/evidence.
- No automation/enforcement block.
- No release, CI, provider billing/token, cost, benchmark, or runtime UI correctness claims.

## Verification
- `npm run build && node --test test/work-item-dashboard.test.mjs test/source-of-truth-handoff.test.mjs && git diff --check` — PASS, focused tests 34/34.
- `npm test` — build PASS, 930/931 pass. Remaining failure is unrelated/pre-existing environment account-default assertion in `test/fooks.test.mjs` (`expected <your-github-org>`, actual `minislively`).

## Notes
- Bare `fooks status` intentionally remains JSON-shaped because existing tests lock it as equivalent to `fooks status --json`.

Closes #1035

Closes #1036