### PR TITLE
Isolate init config test from local account env

### DIFF
--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -358,12 +358,14 @@ function withEnv(overrides, fn) {
 
 test("init creates config and cache contract", () => {
   const tempDir = makeTempProject();
-  const result = run(["init"], tempDir);
-  assert.ok(result.config.endsWith(path.join(".fooks", "config.json")));
-  assert.ok(result.cacheDir.endsWith(path.join(".fooks", "cache")));
-  assert.ok(fs.existsSync(path.join(tempDir, ".fooks", "config.json")));
-  const config = JSON.parse(fs.readFileSync(path.join(tempDir, ".fooks", "config.json"), "utf8"));
-  assert.equal(config.targetAccount, "<your-github-org>");
+  withEnv({ FOOKS_TARGET_ACCOUNT: undefined }, () => {
+    const result = run(["init"], tempDir);
+    assert.ok(result.config.endsWith(path.join(".fooks", "config.json")));
+    assert.ok(result.cacheDir.endsWith(path.join(".fooks", "cache")));
+    assert.ok(fs.existsSync(path.join(tempDir, ".fooks", "config.json")));
+    const config = JSON.parse(fs.readFileSync(path.join(tempDir, ".fooks", "config.json"), "utf8"));
+    assert.equal(config.targetAccount, "<your-github-org>");
+  });
 });
 
 test("init prefers FOOKS_TARGET_ACCOUNT for canonical config writes", () => {


### PR DESCRIPTION
## Summary
- Clear `FOOKS_TARGET_ACCOUNT` only around the default `fooks init` placeholder-contract assertion.
- Preserve the separate explicit override test for canonical account writes.

## Verification
- `npm run build && node --test test/fooks.test.mjs && git diff --check` — PASS, 176/176.
- `npm test` — PASS, 931/931.

Closes #1037
