### PR TITLE
Keep epic-only issue inventory advisory

### DIFF
--- a/docs/dogfood/epic-only-open-issue-idle-guard-1033.md
+++ b/docs/dogfood/epic-only-open-issue-idle-guard-1033.md
@@ -1,0 +1,68 @@
+# Issue #1033 epic-only open issue idle guard
+
+This is a narrow read-only dogfood docs/test/helper guard for issue #1033 under
+Epic #960 operations reliability. It documents the operator/check and handoff
+boundary for the case where opt-in remote counts report `open_issue=1` but the
+only open issue is the planning epic `#960`.
+
+## Pain captured
+
+After a concrete child closes, the repository can return to a state where the
+only open issue is Epic `#960`. A duplicate/idle check that sees only the
+aggregate count `open_issue=1` can mistake the epic itself for active
+implementation work. That hides the difference between "#960 is the planning
+container" and "a concrete child issue, branch, session, PR, worktree, or
+process exists for current development."
+
+## Guard rule
+
+An `open_issue=1` snapshot that contains only epic `#960` is
+`epic-only-open-issue-advisory`: idle/advisory for active-development purposes.
+It does not satisfy duplicate-session or current-work authority by itself.
+
+The state becomes `concrete-active-artifact-present` only when at least one
+current artifact backs the work:
+
+1. an open child issue distinct from `#960`;
+2. an active branch;
+3. an active worktree;
+4. a live mapped session;
+5. an open pull request; or
+6. a mapped running process.
+
+This guard is intentionally read-only. It distinguishes #960-only open issue
+inventory from active development evidence; it does not mutate GitHub issues,
+change merge policy, provider/runtime hooks, telemetry, billing/token proof,
+detector scope, product claims, or PR/issue closure policy.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1033",
+  "readOnly": true,
+  "sourceEpic": "#960",
+  "openIssueInventory": ["#960"],
+  "operatorDecision": {
+    "openIssueCount": 1,
+    "classification": "epic-only-open-issue-advisory",
+    "epicOnlyOpenIssueState": true,
+    "activeDevelopmentAllowed": false,
+    "activeDevelopmentRequiresOneOf": [
+      "open-child-issue",
+      "active-branch",
+      "active-worktree",
+      "active-session",
+      "open-pull-request",
+      "active-process"
+    ],
+    "rule": "An open_issue=1 snapshot that contains only epic #960 is advisory/idle until backed by a concrete child issue, branch, worktree, session, pull request, or process."
+  }
+}
+```
+
+## Focused verification
+
+```sh
+node --test test/epic-only-open-issue-idle-guard.test.mjs
+```

--- a/test/epic-only-open-issue-idle-guard.test.mjs
+++ b/test/epic-only-open-issue-idle-guard.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyEpicOnlyOpenIssueState } from "./helpers/stale-epic-checklist-boundary.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(repoRoot, "docs", "dogfood", "epic-only-open-issue-idle-guard-1033.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+test("issue #1033 helper treats open_issue=1 with only #960 as idle/advisory", () => {
+  assert.deepEqual(
+    classifyEpicOnlyOpenIssueState({
+      epic: "#960",
+      openIssueCount: 1,
+      evidence: {
+        issues: [{ number: 960, state: "open" }],
+        branches: [],
+        worktrees: [],
+        sessions: [],
+        pullRequests: [],
+        processes: [],
+      },
+    }),
+    {
+      epic: "#960",
+      openIssueCount: 1,
+      epicOnlyOpenIssueState: true,
+      classification: "epic-only-open-issue-advisory",
+      activeDevelopmentAllowed: false,
+      activeEvidenceKinds: [],
+      requiredBeforeActiveDevelopment: [
+        "open-child-issue",
+        "active-branch",
+        "active-worktree",
+        "active-session",
+        "open-pull-request",
+        "active-process",
+      ],
+      rule: "An open_issue=1 snapshot that contains only epic #960 is advisory/idle until backed by a concrete child issue, branch, worktree, session, pull request, or process.",
+    },
+  );
+});
+
+test("issue #1033 helper counts concrete active artifacts normally", () => {
+  for (const [name, evidence, expectedKind] of [
+    ["open child issue", { issues: [{ number: 960, state: "open" }, { number: 1033, state: "open" }] }, "open-child-issue"],
+    ["active branch", { issues: [{ number: 960, state: "open" }], branches: [{ name: "fooks-issue-1033-epic-only-idle-guard", active: true }] }, "active-branch"],
+    ["active worktree", { issues: [{ number: 960, state: "open" }], worktrees: [{ path: "/tmp/fooks-1033", active: true }] }, "active-worktree"],
+    ["live session", { issues: [{ number: 960, state: "open" }], sessions: [{ session: "fooks-issue-1033", state: "active" }] }, "active-session"],
+    ["open PR", { issues: [{ number: 960, state: "open" }], pullRequests: [{ number: 1034, state: "open" }] }, "open-pull-request"],
+    ["mapped process", { issues: [{ number: 960, state: "open" }], processes: [{ pid: 1033, active: true }] }, "active-process"],
+  ]) {
+    const result = classifyEpicOnlyOpenIssueState({ epic: "#960", evidence });
+    assert.equal(result.classification, "concrete-active-artifact-present", name);
+    assert.equal(result.activeDevelopmentAllowed, true, name);
+    assert.deepEqual(result.activeEvidenceKinds, [expectedKind], name);
+  }
+});
+
+test("issue #1033 dogfood doc preserves the epic-only idle boundary", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#1033");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourceEpic, "#960");
+  assert.deepEqual(report.openIssueInventory, ["#960"]);
+  assert.equal(report.operatorDecision.openIssueCount, 1);
+  assert.equal(report.operatorDecision.classification, "epic-only-open-issue-advisory");
+  assert.equal(report.operatorDecision.epicOnlyOpenIssueState, true);
+  assert.equal(report.operatorDecision.activeDevelopmentAllowed, false);
+  assert.deepEqual(report.operatorDecision.activeDevelopmentRequiresOneOf, [
+    "open-child-issue",
+    "active-branch",
+    "active-worktree",
+    "active-session",
+    "open-pull-request",
+    "active-process",
+  ]);
+  assert.match(report.operatorDecision.rule, /open_issue=1 snapshot that contains only epic #960/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/helper guard for issue #1033",
+    "Epic #960 operations reliability",
+    "only open issue is Epic `#960`",
+    "aggregate count `open_issue=1`",
+    "`epic-only-open-issue-advisory`",
+    "idle/advisory for active-development purposes",
+    "open child issue distinct from `#960`",
+    "active branch",
+    "active worktree",
+    "live mapped session",
+    "open pull request",
+    "mapped running process",
+    "does not mutate GitHub issues",
+    "change merge policy",
+    "provider/runtime hooks",
+    "telemetry",
+    "billing/token proof",
+    "detector scope",
+    "product claims",
+  ]) {
+    assert.ok(compactDoc.includes(required), `missing #1033 doc text: ${required}`);
+  }
+});

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -38,6 +38,73 @@ function activeEvidenceKinds(evidence) {
   ].filter(Boolean);
 }
 
+function issueNumber(value) {
+  const raw = typeof value === "object" && value !== null ? value.number : value;
+  const normalized = normalizeRef(raw).replace(/^#/u, "");
+  if (!/^\d+$/u.test(normalized)) return undefined;
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function openIssueNumbers(issues) {
+  return (issues ?? [])
+    .filter((issue) => isOpenState(typeof issue === "object" && issue !== null ? issue.state : "open"))
+    .map(issueNumber)
+    .filter((number) => Number.isInteger(number));
+}
+
+function hasConcreteChildIssue(evidence, epicNumber) {
+  return openIssueNumbers(evidence?.issues ?? evidence?.childIssues)
+    .some((number) => number !== epicNumber);
+}
+
+function hasActiveWorktree(evidence) {
+  return (evidence?.worktrees ?? []).some((worktree) => isOpenState(worktree?.state) || worktree?.active === true);
+}
+
+function epicOnlyActiveEvidenceKinds(evidence, epicNumber) {
+  return [
+    hasConcreteChildIssue(evidence, epicNumber) ? "open-child-issue" : null,
+    hasActiveBranch(evidence) ? "active-branch" : null,
+    hasActiveWorktree(evidence) ? "active-worktree" : null,
+    hasActiveSession(evidence) ? "active-session" : null,
+    hasOpenPullRequest(evidence) ? "open-pull-request" : null,
+    (evidence?.processes ?? []).some((process) =>
+      isOpenState(process?.state) || process?.active === true
+    ) ? "active-process" : null,
+  ].filter(Boolean);
+}
+
+export function classifyEpicOnlyOpenIssueState(input) {
+  const epicNumber = issueNumber(input?.epic) ?? 960;
+  const issues = openIssueNumbers(input?.evidence?.issues ?? input?.evidence?.childIssues);
+  const openIssueCount = typeof input?.openIssueCount === "number" ? input.openIssueCount : issues.length;
+  const activeKinds = epicOnlyActiveEvidenceKinds(input?.evidence ?? {}, epicNumber);
+  const epicOnlyOpenIssueState = openIssueCount === 1 && issues.length === 1 && issues[0] === epicNumber;
+  const concreteActiveArtifactPresent = activeKinds.length > 0;
+  const classification = epicOnlyOpenIssueState && !concreteActiveArtifactPresent
+    ? "epic-only-open-issue-advisory"
+    : "concrete-active-artifact-present";
+
+  return {
+    epic: `#${epicNumber}`,
+    openIssueCount,
+    epicOnlyOpenIssueState,
+    classification,
+    activeDevelopmentAllowed: classification === "concrete-active-artifact-present",
+    activeEvidenceKinds: activeKinds,
+    requiredBeforeActiveDevelopment: [
+      "open-child-issue",
+      "active-branch",
+      "active-worktree",
+      "active-session",
+      "open-pull-request",
+      "active-process",
+    ],
+    rule: "An open_issue=1 snapshot that contains only epic #960 is advisory/idle until backed by a concrete child issue, branch, worktree, session, pull request, or process.",
+  };
+}
+
 export function classifyStaleEpicChecklistCandidate(input) {
   const activeKinds = activeEvidenceKinds(input?.evidence ?? {});
   const hasUncheckedEpicChecklistText = Boolean(input?.uncheckedEpicChecklistText);


### PR DESCRIPTION
Closes #1033.

## Summary
- Added a read-only dogfood guard documenting that `open_issue=1` with only Epic `#960` is `epic-only-open-issue-advisory`.
- Added a focused helper regression that keeps #960-only inventory idle/advisory until backed by a concrete child issue, branch, worktree, session, PR, or process.
- Preserved concrete active artifact classification for child issue, branch, worktree, session, PR, and process evidence.

## Validation
- `npm run build`
- `npm run typecheck`
- `node --test test/epic-only-open-issue-idle-guard.test.mjs test/stale-epic-checklist-boundary.test.mjs`
- `npm test` (934 passing)

## Boundaries
- Docs/test/helper-only read-only guard.
- Does not mutate GitHub issues automatically.
- Does not change merge policy, provider/runtime hooks, telemetry, billing/token proof, detector scope, product claims, or PR/issue closure policy.
- Do not merge automatically.
