### PR TITLE
Require concrete child for clean epic-only whip

### DIFF
--- a/docs/dogfood/clean-epic-only-session-whip-1040.md
+++ b/docs/dogfood/clean-epic-only-session-whip-1040.md
@@ -1,0 +1,59 @@
+# Issue #1040 clean epic-only session-whip child artifact guard
+
+This is a narrow read-only dogfood docs/test/helper/operator-check-adjacent
+artifact for issue #1040. It covers the post-merge state after PR #1039 where
+live fooks evidence can be clean and idle while the only open GitHub issue is
+planning Epic `#960`.
+
+## Guard rule
+
+A clean post-merge `session-whip` snapshot with:
+
+- `open_pr=0`;
+- no mapped tmux session;
+- no mapped process;
+- no active sibling worktree;
+- a clean root worktree on `main` with zero divergence; and
+- open issue inventory containing only Epic `#960`
+
+is `clean-epic-only-session-whip-idle`. It must not end as a clean echo or treat
+Epic `#960` as the child artifact for active development.
+
+Before claiming active work, the next report must name one concrete child
+artifact: an open child issue distinct from `#960`, active session, active
+branch, open PR, active worktree, or active process.
+
+This guard is intentionally read-only. It does not mutate GitHub issues
+automatically, change merge policy, provider/runtime hooks, telemetry,
+billing/token proof, detector scope, product claims, or PR/issue closure policy.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1040",
+  "readOnly": true,
+  "sourceEpic": "#960",
+  "postMergeReceipt": "PR #1039",
+  "operatorDecision": {
+    "classification": "clean-epic-only-session-whip-idle",
+    "sessionWhipMayEndOnCleanEcho": false,
+    "activeDevelopmentAllowed": false,
+    "activeDevelopmentRequiresOneOf": [
+      "open-child-issue",
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process"
+    ],
+    "rule": "A clean post-merge session-whip snapshot with only planning epic #960 open is idle and must name a concrete child issue, session, branch, PR, worktree, or process before claiming active work."
+  }
+}
+```
+
+## Focused verification
+
+```sh
+node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
+```

--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -45,6 +45,7 @@ export const OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_CLAIM_BOUNDARY =
   "Read-only issue #910 operator artifact; a current OMX pane with only a staged prompt placeholder, no submitted/working/tool-output evidence, only .fooks-session-task.txt delta, and ahead=0 is not active development proof.";
 export const OPERATOR_ACTIVITY_TMUX_CAPTURE_COMMAND = "tmux capture-pane -pt <pane_id> -S -200";
 export const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_WORKFLOWS = ["CI", "React Web Release Report"] as const;
+export const OPERATOR_ACTIVITY_PLANNING_EPIC_ISSUE_NUMBER = 960;
 const OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_GH_RUN_LIST_ARGS = [
   "run",
   "list",
@@ -162,6 +163,7 @@ export type OperatorActivityRemoteCounts =
       enabled: true;
       source: typeof OPERATOR_ACTIVITY_REMOTE_SOURCE;
       openIssues?: number;
+      openIssueNumbers?: number[];
       openPullRequests?: number;
       blockers: string[];
     };
@@ -695,12 +697,13 @@ function buildCurrentRunReceipt(input: {
   openIssues?: number;
   openPullRequests?: number;
   mainEchoEvidence: boolean;
+  advisoryPlanningEpicOnly: boolean;
 }): OperatorActivityCurrentRunReceipt {
   const evidenceKinds: OperatorActivityCurrentRunReceipt["evidenceKinds"] = [];
   const activeParts: string[] = [];
   const idleParts: string[] = [];
 
-  if (typeof input.openIssues === "number" && input.openIssues > 0) {
+  if (typeof input.openIssues === "number" && input.openIssues > 0 && !input.advisoryPlanningEpicOnly) {
     evidenceKinds.push("issue");
     activeParts.push(plural(input.openIssues, "open issue"));
   }
@@ -727,6 +730,7 @@ function buildCurrentRunReceipt(input: {
   if (input.worktree.ahead === 0 && input.worktree.behind === 0) idleParts.push("zero divergence");
   if (input.fooksSessionCount === 0) idleParts.push("no mapped fooks sessions");
   if (input.openIssues === 0 && input.openPullRequests === 0) idleParts.push("zero open issues/PRs");
+  if (input.advisoryPlanningEpicOnly) idleParts.push("only planning epic #960 is open");
   if (input.worktree.clean === false && hasOnlyFooksSessionTaskDelta(input.worktree)) {
     idleParts.push(".fooks-session-task.txt-only delta is not active work proof");
   }
@@ -993,6 +997,33 @@ function parseGhJsonCount(output: string): number | undefined {
   }
 }
 
+function parseGhIssueNumbers(output: string): number[] | undefined {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    if (!Array.isArray(parsed)) return undefined;
+    const numbers: number[] = [];
+    for (const entry of parsed) {
+      if (typeof entry !== "object" || entry === null) return undefined;
+      const number = (entry as { number?: unknown }).number;
+      if (typeof number !== "number" || !Number.isInteger(number)) return undefined;
+      numbers.push(number);
+    }
+    return numbers;
+  } catch {
+    return undefined;
+  }
+}
+
+export function hasOnlyPlanningEpicOpenIssue(counts: OperatorActivityRemoteCounts): boolean {
+  return Boolean(
+    counts.enabled
+    && counts.openIssues === 1
+    && (counts.openPullRequests ?? 0) === 0
+    && counts.openIssueNumbers?.length === 1
+    && counts.openIssueNumbers[0] === OPERATOR_ACTIVITY_PLANNING_EPIC_ISSUE_NUMBER,
+  );
+}
+
 function readRemoteCounts(cwd: string, options: OperatorActivityOptions): OperatorActivityRemoteCounts {
   if (!options.includeRemoteCounts) {
     return { enabled: false, source: "disabled; pass --include-remote-counts to opt in" };
@@ -1001,11 +1032,16 @@ function readRemoteCounts(cwd: string, options: OperatorActivityOptions): Operat
   const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
   const blockers: string[] = [];
   let openIssues: number | undefined;
+  const returnOpenIssueNumbers: number[] = [];
   let openPullRequests: number | undefined;
 
   try {
     const output = runner("gh", ["issue", "list", "--state", "open", "--json", "number", "--limit", "1000"], cwd, DEFAULT_OPERATOR_ACTIVITY_REMOTE_TIMEOUT_MS);
     openIssues = parseGhJsonCount(output);
+    const openIssueNumbers = parseGhIssueNumbers(output);
+    if (openIssueNumbers !== undefined && openIssueNumbers.length > 0) {
+      returnOpenIssueNumbers.push(...openIssueNumbers);
+    }
     if (openIssues === undefined) blockers.push("GitHub open issue count unavailable: unable to parse gh issue list JSON");
   } catch (error) {
     blockers.push(`GitHub open issue count unavailable: ${errorDetail(error)}`);
@@ -1023,6 +1059,7 @@ function readRemoteCounts(cwd: string, options: OperatorActivityOptions): Operat
     enabled: true,
     source: OPERATOR_ACTIVITY_REMOTE_SOURCE,
     openIssues,
+    ...(returnOpenIssueNumbers.length > 0 ? { openIssueNumbers: returnOpenIssueNumbers } : {}),
     openPullRequests,
     blockers: uniqueSorted(blockers),
   };
@@ -1460,6 +1497,8 @@ function buildCurrentRunEvidence(
   const noLocalDivergence = localDivergenceKnown && worktree.ahead === 0 && worktree.behind === 0;
   const noSessions = fooksSessionCount === 0;
   const zeroRemoteCounts = remoteCountsAvailable && openIssues === 0 && openPullRequests === 0;
+  const advisoryPlanningEpicOnly = hasOnlyPlanningEpicOpenIssue(optionalCounts);
+  const remoteCountsIdle = zeroRemoteCounts || advisoryPlanningEpicOnly;
 
   if (!optionalCounts.enabled) {
     blockers.push("remote issue/PR counts disabled; pass --include-remote-counts to prove zero open issue/PR reminder evidence");
@@ -1483,22 +1522,24 @@ function buildCurrentRunEvidence(
     reasons.push(`${ancestorMaintenanceSessionCount} ancestor maintenance tmux session(s) were not counted as active work evidence`);
   }
   if (zeroRemoteCounts) reasons.push("open issue and pull request counts are both zero");
+  if (advisoryPlanningEpicOnly) reasons.push("only open issue is planning epic #960; it is advisory and not active work evidence");
   if (legacyWorktreeEvidence.staleClosedArtifactWorktreeCount > 0) {
     reasons.push("legacy closed-artifact worktree evidence is separated from active current-run evidence");
   }
 
-  const mainEchoEvidence = blockers.length === 0 && onMain && clean && noLocalDivergence && noSessions && zeroRemoteCounts;
+  const mainEchoEvidence = blockers.length === 0 && onMain && clean && noLocalDivergence && noSessions && remoteCountsIdle;
   const activeWorkEvidence =
     (Boolean(worktree.branch) && worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     fooksSessionCount > 0 ||
-    (optionalCounts.enabled && ((openIssues ?? 0) > 0 || (openPullRequests ?? 0) > 0));
+    (optionalCounts.enabled && (((openIssues ?? 0) > 0 && !advisoryPlanningEpicOnly) || (openPullRequests ?? 0) > 0));
   const receipt = buildCurrentRunReceipt({
     worktree,
     fooksSessionCount,
     openIssues,
     openPullRequests,
     mainEchoEvidence,
+    advisoryPlanningEpicOnly,
   });
 
   return {

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import {
+  hasOnlyPlanningEpicOpenIssue,
   readOperatorActivitySnapshot,
   type OperatorActivityOptions,
   type OperatorActivitySnapshot,
@@ -1712,7 +1713,7 @@ function buildActiveWorkReceipts(
 
   const baseBlockers = repoIdentity.blockers;
   const counts = activity.optionalCounts;
-  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0) {
+  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !hasOnlyPlanningEpicOpenIssue(counts)) {
     receipts.push({
       kind: "issue",
       classification: "active",
@@ -1972,7 +1973,7 @@ function buildSessionWhipRunReceipt(activeWorkReceipts: Pick<OperatorCheckActive
 function activeArtifactsFrom(activity: OperatorActivitySnapshot): OperatorCheckActiveArtifact[] {
   const artifacts: OperatorCheckActiveArtifact[] = [];
   const counts = activity.optionalCounts;
-  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0) {
+  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !hasOnlyPlanningEpicOpenIssue(counts)) {
     artifacts.push({ kind: "issue", count: counts.openIssues, source: counts.source });
   }
   if (counts.enabled && typeof counts.openPullRequests === "number" && counts.openPullRequests > 0) {

--- a/test/epic-only-open-issue-idle-guard.test.mjs
+++ b/test/epic-only-open-issue-idle-guard.test.mjs
@@ -3,12 +3,18 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { classifyEpicOnlyOpenIssueState } from "./helpers/stale-epic-checklist-boundary.mjs";
+import {
+  classifyCleanEpicOnlySessionWhip,
+  classifyEpicOnlyOpenIssueState,
+} from "./helpers/stale-epic-checklist-boundary.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const docPath = path.join(repoRoot, "docs", "dogfood", "epic-only-open-issue-idle-guard-1033.md");
 const doc = fs.readFileSync(docPath, "utf8");
 const compactDoc = doc.replace(/\s+/gu, " ");
+const issue1040DocPath = path.join(repoRoot, "docs", "dogfood", "clean-epic-only-session-whip-1040.md");
+const issue1040Doc = fs.readFileSync(issue1040DocPath, "utf8");
+const compactIssue1040Doc = issue1040Doc.replace(/\s+/gu, " ");
 
 function extractJsonFence(markdown) {
   const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
@@ -109,5 +115,129 @@ test("issue #1033 dogfood doc preserves the epic-only idle boundary", () => {
     "product claims",
   ]) {
     assert.ok(compactDoc.includes(required), `missing #1033 doc text: ${required}`);
+  }
+});
+
+test("issue #1040 helper treats clean post-merge epic-only session whip as idle", () => {
+  assert.deepEqual(
+    classifyCleanEpicOnlySessionWhip({
+      epic: "#960",
+      branch: "main",
+      clean: true,
+      ahead: 0,
+      behind: 0,
+      openIssueCount: 1,
+      openPullRequestCount: 0,
+      evidence: {
+        issues: [{ number: 960, state: "open" }],
+        branches: [],
+        worktrees: [],
+        sessions: [],
+        pullRequests: [],
+        processes: [],
+      },
+    }),
+    {
+      issue: "#1040",
+      epic: "#960",
+      classification: "clean-epic-only-session-whip-idle",
+      cleanPostMergeEcho: true,
+      epicOnlyOpenIssueState: true,
+      activeDevelopmentAllowed: false,
+      sessionWhipMayEndOnCleanEcho: false,
+      requiredConcreteChildArtifacts: [
+        "open-child-issue",
+        "active-session",
+        "active-branch",
+        "open-pull-request",
+        "active-worktree",
+        "active-process",
+      ],
+      activeEvidenceKinds: [],
+      mutationBoundary: {
+        mutatesGitHubIssues: false,
+        changesMergePolicy: false,
+        changesProviderRuntimeHooks: false,
+        changesTelemetry: false,
+        changesBillingTokenProof: false,
+        changesDetectorScope: false,
+        changesProductClaims: false,
+      },
+      rule: "A clean post-merge session-whip snapshot with only planning epic #960 open is idle and must name a concrete child issue, session, branch, PR, worktree, or process before claiming active work.",
+    },
+  );
+});
+
+test("issue #1040 helper counts concrete child artifacts normally", () => {
+  for (const [name, evidence, expectedKind] of [
+    ["open child issue", { issues: [{ number: 960, state: "open" }, { number: 1040, state: "open" }] }, "open-child-issue"],
+    ["active session", { issues: [{ number: 960, state: "open" }], sessions: [{ session: "fooks-issue-1040", active: true }] }, "active-session"],
+    ["active branch", { issues: [{ number: 960, state: "open" }], branches: [{ name: "fooks-issue-1040-clean-epic-only-whip", active: true }] }, "active-branch"],
+    ["open PR", { issues: [{ number: 960, state: "open" }], pullRequests: [{ number: 1041, state: "open" }] }, "open-pull-request"],
+    ["active worktree", { issues: [{ number: 960, state: "open" }], worktrees: [{ path: "/tmp/fooks-1040", active: true }] }, "active-worktree"],
+    ["active process", { issues: [{ number: 960, state: "open" }], processes: [{ pid: 1040, active: true }] }, "active-process"],
+  ]) {
+    const result = classifyCleanEpicOnlySessionWhip({
+      epic: "#960",
+      branch: "main",
+      clean: true,
+      ahead: 0,
+      behind: 0,
+      openIssueCount: 1,
+      openPullRequestCount: 0,
+      evidence,
+    });
+    assert.equal(result.classification, "concrete-child-artifact-present", name);
+    assert.equal(result.activeDevelopmentAllowed, true, name);
+    assert.deepEqual(result.activeEvidenceKinds, [expectedKind], name);
+  }
+});
+
+test("issue #1040 dogfood doc preserves the clean epic-only session-whip boundary", () => {
+  const report = extractJsonFence(issue1040Doc);
+
+  assert.equal(report.issue, "#1040");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourceEpic, "#960");
+  assert.equal(report.postMergeReceipt, "PR #1039");
+  assert.equal(report.operatorDecision.classification, "clean-epic-only-session-whip-idle");
+  assert.equal(report.operatorDecision.sessionWhipMayEndOnCleanEcho, false);
+  assert.equal(report.operatorDecision.activeDevelopmentAllowed, false);
+  assert.deepEqual(report.operatorDecision.activeDevelopmentRequiresOneOf, [
+    "open-child-issue",
+    "active-session",
+    "active-branch",
+    "open-pull-request",
+    "active-worktree",
+    "active-process",
+  ]);
+  assert.match(report.operatorDecision.rule, /clean post-merge session-whip snapshot with only planning epic #960 open/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/helper/operator-check-adjacent",
+    "after PR #1039",
+    "only open GitHub issue is planning Epic `#960`",
+    "`open_pr=0`",
+    "no mapped tmux session",
+    "no mapped process",
+    "no active sibling worktree",
+    "clean root worktree on `main`",
+    "`clean-epic-only-session-whip-idle`",
+    "must not end as a clean echo",
+    "open child issue distinct from `#960`",
+    "active session",
+    "active branch",
+    "open PR",
+    "active worktree",
+    "active process",
+    "does not mutate GitHub issues automatically",
+    "change merge policy",
+    "provider/runtime hooks",
+    "telemetry",
+    "billing/token proof",
+    "detector scope",
+    "product claims",
+  ]) {
+    assert.ok(compactIssue1040Doc.includes(required), `missing #1040 doc text: ${required}`);
   }
 });

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -105,6 +105,51 @@ export function classifyEpicOnlyOpenIssueState(input) {
   };
 }
 
+export function classifyCleanEpicOnlySessionWhip(input) {
+  const epicNumber = issueNumber(input?.epic) ?? 960;
+  const evidence = input?.evidence ?? {};
+  const issues = openIssueNumbers(evidence.issues ?? evidence.childIssues);
+  const openIssueCount = typeof input?.openIssueCount === "number" ? input.openIssueCount : issues.length;
+  const openPullRequestCount = typeof input?.openPullRequestCount === "number"
+    ? input.openPullRequestCount
+    : (evidence.pullRequests ?? []).filter((pr) => isOpenState(pr?.state)).length;
+  const activeKinds = epicOnlyActiveEvidenceKinds(evidence, epicNumber);
+  const cleanPostMergeEcho = Boolean(input?.clean === true && input?.branch === "main" && input?.ahead === 0 && input?.behind === 0);
+  const epicOnlyOpenIssueState = openIssueCount === 1 && issues.length === 1 && issues[0] === epicNumber && openPullRequestCount === 0;
+  const requiresConcreteChildArtifact = cleanPostMergeEcho && epicOnlyOpenIssueState && activeKinds.length === 0;
+
+  return {
+    issue: "#1040",
+    epic: `#${epicNumber}`,
+    classification: requiresConcreteChildArtifact
+      ? "clean-epic-only-session-whip-idle"
+      : "concrete-child-artifact-present",
+    cleanPostMergeEcho,
+    epicOnlyOpenIssueState,
+    activeDevelopmentAllowed: !requiresConcreteChildArtifact,
+    sessionWhipMayEndOnCleanEcho: false,
+    requiredConcreteChildArtifacts: [
+      "open-child-issue",
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process",
+    ],
+    activeEvidenceKinds: activeKinds,
+    mutationBoundary: {
+      mutatesGitHubIssues: false,
+      changesMergePolicy: false,
+      changesProviderRuntimeHooks: false,
+      changesTelemetry: false,
+      changesBillingTokenProof: false,
+      changesDetectorScope: false,
+      changesProductClaims: false,
+    },
+    rule: "A clean post-merge session-whip snapshot with only planning epic #960 open is idle and must name a concrete child issue, session, branch, PR, worktree, or process before claiming active work.",
+  };
+}
+
 export function classifyStaleEpicChecklistCandidate(input) {
   const activeKinds = activeEvidenceKinds(input?.evidence ?? {});
   const hasUncheckedEpicChecklistText = Boolean(input?.uncheckedEpicChecklistText);

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1574,6 +1574,70 @@ test("operator check forces a concrete active artifact when post-merge main echo
   assert.deepEqual(snapshot.blockers, []);
 });
 
+test("operator check treats clean post-merge epic-only inventory as idle session-whip requiring a concrete child", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-22T06:40:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: /** @param {string} command @param {string[]} args */ (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[{\"number\":960}]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD post-merge-main-head", "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "post-merge-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: /** @param {string} targetPath */ (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.activity.optionalCounts.openIssues, 1);
+  assert.deepEqual(snapshot.activity.optionalCounts.openIssueNumbers, [960]);
+  assert.equal(snapshot.activity.optionalCounts.openPullRequests, 0);
+  assert.equal(snapshot.activity.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.activity.currentRunEvidence.activeWorkEvidence, false);
+  assert.match(snapshot.activity.currentRunEvidence.reasons.join("\n"), /only open issue is planning epic #960/);
+  assert.match(snapshot.activity.currentRunEvidence.receipt.oneLine, /only planning epic #960 is open/);
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.deepEqual(snapshot.activeArtifacts, []);
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.status, "requires-live-artifact");
+  assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
+  assert.equal(snapshot.activeWorkReceipts.receipts.some((receipt) => receipt.kind === "issue"), false);
+  assert.equal(snapshot.sessionWhipRunReceipt.status, "idle");
+  assert.equal(snapshot.sessionWhipRunReceipt.noOp.empty, true);
+  assert.deepEqual(snapshot.sessionWhipRunReceipt.counts, {
+    createdOrAdoptedIssues: 0,
+    adoptedPullRequests: 0,
+    adoptedBranches: 0,
+    mappedSessions: 0,
+    adoptedWorktrees: 0,
+    staleOrReviewOnly: 0,
+    mainEchoes: 1,
+    blockers: 0,
+  });
+  assert.deepEqual(snapshot.sessionWhipRunReceipt.evidence.issues, []);
+  assert.match(snapshot.sessionWhipRunReceipt.noOp.reason, /No created\/adopted issue, PR, non-main branch, mapped session, or adopted worktree evidence/);
+});
+
 
 test("operator check treats absent tmux server as zero mapped sessions and keeps CI uncertainty separate", () => {
   const tempDir = makeTempProject();


### PR DESCRIPTION
## Summary
- Preserve open issue numbers in opt-in operator activity counts.
- Treat sole planning Epic #960 as advisory/non-active for clean post-merge session-whip/operator-check snapshots.
- Add #1040 dogfood doc/helper/test coverage requiring a concrete child issue/session/branch/PR/worktree/proc before active-work claims.

Closes #1040.

## Verification
- `git diff --check HEAD`
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs`
