### PR TITLE
Guard active PR cleanup from branch deletion

### DIFF
--- a/docs/dogfood/active-pr-cleanup-branch-deletion-1047.md
+++ b/docs/dogfood/active-pr-cleanup-branch-deletion-1047.md
@@ -1,0 +1,38 @@
+# Dogfood #1047: active PR cleanup is not branch-deletion cleanup
+
+This is a read-only operator guard for the failure mode where dogfood cleanup
+mistakes an active PR branch/worktree for stale branch-deletion residue.
+
+## Boundary
+
+Active PR cleanup is **not** stale branch deletion cleanup while any live PR is
+open for the branch or review worktree. Branch/worktree/remote cleanup may be
+considered only after one of these states is explicit and intentional:
+
+- the PR is `MERGED`, with merge success independently verified; or
+- the PR is `CLOSED` intentionally for recovery/abandonment, with that intent
+  named in the operator handoff.
+
+If the PR is still open and a required check is pending, failing, queued, or
+otherwise non-terminal, cleanup output must keep the branch/worktree as active
+PR evidence. It must not be collapsed into `safe-cleanup`, stale residue, or a
+false idle/no-artifact state.
+
+## Case matrix
+
+| Case | Operator classification |
+| --- | --- |
+| Open PR for the branch, including pending required checks | Keep/adopt as active PR evidence; no branch/worktree/remote deletion from cleanup artifacts. |
+| Current non-main branch | Active branch evidence; not idle. |
+| Mapped fooks tmux/session | Active session evidence; not idle. |
+| Remote branch with no open PR but closed PR evidence | Manual-review cleanup noise; not active by itself and not auto-delete authority. |
+| No open issue/PR/session, clean main, zero divergence | Real idle/no-artifact state, subject to remote-count proof. |
+
+## Operator wording
+
+When a cleanup artifact sees an open PR, the handoff should say:
+
+> Active PR cleanup guard: branch/worktree/remote cleanup is unsafe while this PR remains open; wait for an intentional merged/closed PR state with required checks terminal.
+
+This guard is read-only. It does not change merge policy, required-check policy,
+runtime hooks, telemetry, billing/token proof, detector scope, or product claims.

--- a/src/ops/orphan-local-worktree-triage.ts
+++ b/src/ops/orphan-local-worktree-triage.ts
@@ -10,6 +10,7 @@ export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE = "#711";
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_ISSUE_URL = "https://github.com/minislively/fooks/issues/711";
 export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE = "#843";
 export const ORPHAN_LOCAL_AHEAD_SALVAGE_QUEUE_ISSUE_URL = "https://github.com/minislively/fooks/issues/843";
+export const ORPHAN_LOCAL_WORKTREE_ACTIVE_PR_CLEANUP_GUARD_ISSUE = "#1047";
 export const ORPHAN_LOCAL_WORKTREE_TRIAGE_CLAIM_BOUNDARY =
   "Read-only issue #711 local sibling worktree salvage/delete decision artifact; does not fetch, delete branches/worktrees, open PRs, auto-delete local-only commits, or change runtime/provider/merge-gate policy.";
 export const DEFAULT_ORPHAN_LOCAL_WORKTREE_TRIAGE_TIMEOUT_MS = 3000;
@@ -519,7 +520,10 @@ function classifyEntry(input: {
   if (input.activeTmuxPaneCount > 0) reasons.push("one or more tmux panes are mapped inside this worktree");
   if (input.remoteBranchExists === true) reasons.push("a local remote-tracking branch exists for this branch");
   if (input.remoteBranchExists === false) reasons.push("no local remote-tracking branch exists for this branch");
-  if (input.openPullRequest.state === "open") reasons.push("an open pull request exists for this branch");
+  if (input.openPullRequest.state === "open") {
+    reasons.push("an open pull request exists for this branch");
+    reasons.push(`active PR cleanup guard: branch/worktree/remote cleanup is unsafe while this PR remains open; wait for an intentional merged/closed PR state with required checks terminal (${ORPHAN_LOCAL_WORKTREE_ACTIVE_PR_CLEANUP_GUARD_ISSUE})`);
+  }
   if (input.openPullRequest.state === "none") reasons.push("no open pull request was found for this branch");
   if (input.openPullRequest.state === "unknown") reasons.push("open pull request evidence is unavailable");
   if (input.closedPullRequest.state === "closed") {

--- a/test/active-pr-cleanup-branch-deletion-doc.test.mjs
+++ b/test/active-pr-cleanup-branch-deletion-doc.test.mjs
@@ -1,0 +1,22 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "active-pr-cleanup-branch-deletion-1047.md");
+
+test("issue #1047 doc distinguishes active PR cleanup from branch deletion cleanup", () => {
+  const doc = fs.readFileSync(docPath, "utf8");
+
+  assert.match(doc, /active PR cleanup is not branch-deletion cleanup/i);
+  assert.match(doc, /PR is still open and a required check is pending/i);
+  assert.match(doc, /must not be collapsed into `safe-cleanup`, stale residue, or a\s+false idle\/no-artifact state/i);
+  assert.match(doc, /Current non-main branch \| Active branch evidence/i);
+  assert.match(doc, /Mapped fooks tmux\/session \| Active session evidence/i);
+  assert.match(doc, /No open issue\/PR\/session, clean main, zero divergence \| Real idle\/no-artifact state/i);
+  assert.match(doc, /does not change merge policy/i);
+});

--- a/test/orphan-local-worktree-triage.test.mjs
+++ b/test/orphan-local-worktree-triage.test.mjs
@@ -315,6 +315,66 @@ test("orphan local worktree triage keeps detached PR review worktrees when match
   assert.match(decision?.decisionLabel ?? "", /KEEP/);
 });
 
+test("orphan local worktree triage keeps open PR branches with pending checks out of branch-deletion cleanup", () => {
+  const cwd = "/work/fooks.omx-worktrees/current";
+  const activePr = "/work/fooks.omx-worktrees/fooks-issue-1047-active-pr-cleanup";
+  const calls = [];
+  const result = triageOrphanLocalWorktrees(cwd, {
+    now: () => "2026-05-22T12:00:00.000Z",
+    pathExists: (target) => [cwd, activePr].includes(target),
+    runner: makeRunner({
+      "git worktree list --porcelain": [
+        `worktree ${cwd}`,
+        "HEAD main-head",
+        "branch refs/heads/main",
+        "",
+        `worktree ${activePr}`,
+        "HEAD active-pr-head",
+        "branch refs/heads/fooks-issue-1047-active-pr-cleanup",
+        "",
+      ].join("\n"),
+      "git rev-parse --verify origin/main": "origin-main-sha\n",
+      "git branch -r --format=%(refname:short)": "origin/main\n",
+      "tmux list-panes -a -F #{session_name}	#{pane_current_path}": "",
+      [`${cwd} :: git status --porcelain=v1 -z`]: "",
+      [`${activePr} :: git status --porcelain=v1 -z`]: "",
+      [`${cwd} :: git rev-list --left-right --count origin/main...HEAD`]: "0 0\n",
+      [`${activePr} :: git rev-list --left-right --count origin/main...HEAD`]: "0 0\n",
+      [`${cwd} :: git diff --shortstat origin/main...HEAD`]: "",
+      [`${activePr} :: git diff --shortstat origin/main...HEAD`]: "",
+      "gh pr list --state open --json number,url,headRefName --limit 200": JSON.stringify([
+        {
+          number: 1045,
+          url: "https://github.com/minislively/fooks/pull/1045",
+          headRefName: "fooks-issue-1047-active-pr-cleanup",
+          mergeStateStatus: "UNSTABLE",
+          statusCheckRollup: [{ name: "Node", status: "PENDING", conclusion: null }],
+        },
+      ]),
+      "gh pr list --state closed --json number,url,headRefName,state,closedAt --limit 200": "[]",
+    }, calls),
+  });
+
+  const entry = result.entries.find((item) => item.branch === "fooks-issue-1047-active-pr-cleanup");
+  assert.equal(entry?.category, "keep");
+  assert.equal(entry?.remoteBranchExists, false);
+  assert.equal(entry?.openPullRequest.state, "open");
+  assert.equal(entry?.openPullRequest.pullRequests[0]?.number, 1045);
+  assert.equal(entry?.openPullRequest.pullRequests[0]?.statusCheckRollup?.[0]?.status, "PENDING");
+  assert.deepEqual(entry?.manualCleanupCommands, []);
+  assert.match(entry?.manualReviewCommands.join("\n") ?? "", /inspect active worktree\/PR\/remote evidence before cleanup/i);
+  assert.match(entry?.reasons.join("\n") ?? "", /active PR cleanup guard/i);
+  assert.match(entry?.reasons.join("\n") ?? "", /required checks terminal/i);
+  assert.deepEqual(result.categories["safe-cleanup"].map((item) => item.branch), []);
+
+  const decision = result.decisionTable.find((item) => item.branch === "fooks-issue-1047-active-pr-cleanup");
+  assert.equal(decision?.decision, "keep-active-evidence");
+  assert.equal(decision?.deleteCommand, "none from this artifact");
+  assert.match(decision?.decisionLabel ?? "", /KEEP because active PR/);
+  assert.match(decision?.evidenceSummary ?? "", /open-pr:#1045/);
+  assert.equal(calls.some(([command, args]) => command === "git" && /fetch|worktree remove|branch -d|push/.test(args.join(" "))), false);
+});
+
 test("status orphan-worktrees emits parseable JSON", () => {
   const stdout = execFileSync(process.execPath, [cli, "status", "orphan-worktrees", "--json"], {
     cwd: repoRoot,


### PR DESCRIPTION
## Summary
- add a read-only #1047 dogfood doc for the active-PR cleanup vs branch-deletion boundary
- make orphan-local-worktree triage explain that open PR branches must be kept and not cleaned while required checks are non-terminal
- add focused regression coverage for the triage decision and doc contract

Closes #1047

## Validation
- `git diff --check`
- `node --test test/orphan-local-worktree-triage.test.mjs test/active-pr-cleanup-branch-deletion-doc.test.mjs`
- `npm run typecheck -- --pretty false`
- `npm run build`

## Boundaries
- no merge-policy change
- no GitHub issue mutation automation
- no runtime/provider hook, detector scope, telemetry, billing/token proof, or product-claim change
