### PR TITLE
Require concrete child work for clean advisory inventory

### DIFF
--- a/docs/dogfood/clean-epic-advisory-inventory-spawn-child-1046.md
+++ b/docs/dogfood/clean-epic-advisory-inventory-spawn-child-1046.md
@@ -1,0 +1,63 @@
+# Issue #1046 clean epic/advisory inventory spawn-child guard
+
+This is a narrow read-only dogfood docs/test/operator-check/session-whip guard
+for issue #1046. It covers the post-merge state after PR #1048 where fooks can
+be clean with only Epic `#960` plus one concrete but idle child issue in the
+open issue inventory.
+
+## Guard rule
+
+A clean post-merge `session-whip` or `fooks check` snapshot with:
+
+- `open_pr=0`;
+- no active branch;
+- no mapped tmux session;
+- no open PR;
+- no active worktree or mapped process;
+- a clean root worktree on `main` with zero divergence; and
+- open issue inventory containing Epic `#960` plus one concrete but idle child
+  issue
+
+is `clean-epic-plus-idle-child-session-whip-idle`. A status-only check/whip
+receipt must not end on the clean main/CI/dirty/open_pr=0 summary alone and
+must not treat the idle issue inventory as active work by itself.
+
+Before claiming active development, the operator path must spawn or adopt
+concrete child work: active session, active branch, open PR, active worktree, or
+active process. Existing active artifact cases stay active; this guard only
+covers clean main plus advisory/idle inventory with no branch-session-PR work.
+
+This guard is intentionally read-only. It does not mutate GitHub issues
+automatically, change merge policy, provider/runtime hooks, telemetry,
+billing/token proof, detector scope, product claims, or reopen closed PRs or
+issues.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1046",
+  "readOnly": true,
+  "sourceEpic": "#960",
+  "postMergeReceipt": "PR #1048",
+  "operatorDecision": {
+    "classification": "clean-epic-plus-idle-child-session-whip-idle",
+    "statusOnlyCheckMayEndOnCleanEcho": false,
+    "activeDevelopmentAllowed": false,
+    "activeDevelopmentRequiresOneOf": [
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process"
+    ],
+    "rule": "A clean post-merge session-whip/operator-check snapshot with only planning epic #960 plus one idle child issue and no active branch, session, PR, worktree, or process is status-only and must spawn or adopt concrete child work before claiming active development."
+  }
+}
+```
+
+## Focused verification
+
+```sh
+node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
+```

--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -698,12 +698,14 @@ function buildCurrentRunReceipt(input: {
   openPullRequests?: number;
   mainEchoEvidence: boolean;
   advisoryPlanningEpicOnly: boolean;
+  advisoryPlanningEpicPlusSingleChild: boolean;
 }): OperatorActivityCurrentRunReceipt {
   const evidenceKinds: OperatorActivityCurrentRunReceipt["evidenceKinds"] = [];
   const activeParts: string[] = [];
   const idleParts: string[] = [];
 
-  if (typeof input.openIssues === "number" && input.openIssues > 0 && !input.advisoryPlanningEpicOnly) {
+  const advisoryIssueInventory = input.advisoryPlanningEpicOnly || input.advisoryPlanningEpicPlusSingleChild;
+  if (typeof input.openIssues === "number" && input.openIssues > 0 && !advisoryIssueInventory) {
     evidenceKinds.push("issue");
     activeParts.push(plural(input.openIssues, "open issue"));
   }
@@ -731,6 +733,7 @@ function buildCurrentRunReceipt(input: {
   if (input.fooksSessionCount === 0) idleParts.push("no mapped fooks sessions");
   if (input.openIssues === 0 && input.openPullRequests === 0) idleParts.push("zero open issues/PRs");
   if (input.advisoryPlanningEpicOnly) idleParts.push("only planning epic #960 is open");
+  if (input.advisoryPlanningEpicPlusSingleChild) idleParts.push("planning epic #960 plus one idle child issue only");
   if (input.worktree.clean === false && hasOnlyFooksSessionTaskDelta(input.worktree)) {
     idleParts.push(".fooks-session-task.txt-only delta is not active work proof");
   }
@@ -1022,6 +1025,20 @@ export function hasOnlyPlanningEpicOpenIssue(counts: OperatorActivityRemoteCount
     && counts.openIssueNumbers?.length === 1
     && counts.openIssueNumbers[0] === OPERATOR_ACTIVITY_PLANNING_EPIC_ISSUE_NUMBER,
   );
+}
+
+export function hasPlanningEpicPlusSingleChildOpenIssue(counts: OperatorActivityRemoteCounts): boolean {
+  if (
+    !counts.enabled
+    || counts.openIssues !== 2
+    || (counts.openPullRequests ?? 0) !== 0
+    || counts.openIssueNumbers?.length !== 2
+  ) {
+    return false;
+  }
+
+  return counts.openIssueNumbers.includes(OPERATOR_ACTIVITY_PLANNING_EPIC_ISSUE_NUMBER)
+    && counts.openIssueNumbers.some((number) => number !== OPERATOR_ACTIVITY_PLANNING_EPIC_ISSUE_NUMBER);
 }
 
 function readRemoteCounts(cwd: string, options: OperatorActivityOptions): OperatorActivityRemoteCounts {
@@ -1498,7 +1515,9 @@ function buildCurrentRunEvidence(
   const noSessions = fooksSessionCount === 0;
   const zeroRemoteCounts = remoteCountsAvailable && openIssues === 0 && openPullRequests === 0;
   const advisoryPlanningEpicOnly = hasOnlyPlanningEpicOpenIssue(optionalCounts);
-  const remoteCountsIdle = zeroRemoteCounts || advisoryPlanningEpicOnly;
+  const advisoryPlanningEpicPlusSingleChild = hasPlanningEpicPlusSingleChildOpenIssue(optionalCounts);
+  const advisoryIssueInventory = advisoryPlanningEpicOnly || advisoryPlanningEpicPlusSingleChild;
+  const remoteCountsIdle = zeroRemoteCounts || advisoryIssueInventory;
 
   if (!optionalCounts.enabled) {
     blockers.push("remote issue/PR counts disabled; pass --include-remote-counts to prove zero open issue/PR reminder evidence");
@@ -1523,6 +1542,9 @@ function buildCurrentRunEvidence(
   }
   if (zeroRemoteCounts) reasons.push("open issue and pull request counts are both zero");
   if (advisoryPlanningEpicOnly) reasons.push("only open issue is planning epic #960; it is advisory and not active work evidence");
+  if (advisoryPlanningEpicPlusSingleChild) {
+    reasons.push("open issue inventory is planning epic #960 plus one idle child issue; a status-only receipt must spawn or adopt a concrete branch, session, PR, worktree, or process before claiming active work");
+  }
   if (legacyWorktreeEvidence.staleClosedArtifactWorktreeCount > 0) {
     reasons.push("legacy closed-artifact worktree evidence is separated from active current-run evidence");
   }
@@ -1532,7 +1554,7 @@ function buildCurrentRunEvidence(
     (Boolean(worktree.branch) && worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     fooksSessionCount > 0 ||
-    (optionalCounts.enabled && (((openIssues ?? 0) > 0 && !advisoryPlanningEpicOnly) || (openPullRequests ?? 0) > 0));
+    (optionalCounts.enabled && (((openIssues ?? 0) > 0 && !advisoryIssueInventory) || (openPullRequests ?? 0) > 0));
   const receipt = buildCurrentRunReceipt({
     worktree,
     fooksSessionCount,
@@ -1540,6 +1562,7 @@ function buildCurrentRunEvidence(
     openPullRequests,
     mainEchoEvidence,
     advisoryPlanningEpicOnly,
+    advisoryPlanningEpicPlusSingleChild,
   });
 
   return {

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import {
+  hasPlanningEpicPlusSingleChildOpenIssue,
   hasOnlyPlanningEpicOpenIssue,
   readOperatorActivitySnapshot,
   type OperatorActivityOptions,
@@ -1713,7 +1714,9 @@ function buildActiveWorkReceipts(
 
   const baseBlockers = repoIdentity.blockers;
   const counts = activity.optionalCounts;
-  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !hasOnlyPlanningEpicOpenIssue(counts)) {
+  const issueInventoryIsCleanMainAdvisoryOnly = activity.currentRunEvidence.mainEchoEvidence
+    && (hasOnlyPlanningEpicOpenIssue(counts) || hasPlanningEpicPlusSingleChildOpenIssue(counts));
+  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !issueInventoryIsCleanMainAdvisoryOnly) {
     receipts.push({
       kind: "issue",
       classification: "active",
@@ -1973,7 +1976,9 @@ function buildSessionWhipRunReceipt(activeWorkReceipts: Pick<OperatorCheckActive
 function activeArtifactsFrom(activity: OperatorActivitySnapshot): OperatorCheckActiveArtifact[] {
   const artifacts: OperatorCheckActiveArtifact[] = [];
   const counts = activity.optionalCounts;
-  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !hasOnlyPlanningEpicOpenIssue(counts)) {
+  const issueInventoryIsCleanMainAdvisoryOnly = activity.currentRunEvidence.mainEchoEvidence
+    && (hasOnlyPlanningEpicOpenIssue(counts) || hasPlanningEpicPlusSingleChildOpenIssue(counts));
+  if (counts.enabled && typeof counts.openIssues === "number" && counts.openIssues > 0 && !issueInventoryIsCleanMainAdvisoryOnly) {
     artifacts.push({ kind: "issue", count: counts.openIssues, source: counts.source });
   }
   if (counts.enabled && typeof counts.openPullRequests === "number" && counts.openPullRequests > 0) {

--- a/test/epic-only-open-issue-idle-guard.test.mjs
+++ b/test/epic-only-open-issue-idle-guard.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  classifyCleanEpicAdvisoryInventorySessionWhip,
   classifyCleanEpicOnlySessionWhip,
   classifyEpicOnlyOpenIssueState,
 } from "./helpers/stale-epic-checklist-boundary.mjs";
@@ -15,6 +16,9 @@ const compactDoc = doc.replace(/\s+/gu, " ");
 const issue1040DocPath = path.join(repoRoot, "docs", "dogfood", "clean-epic-only-session-whip-1040.md");
 const issue1040Doc = fs.readFileSync(issue1040DocPath, "utf8");
 const compactIssue1040Doc = issue1040Doc.replace(/\s+/gu, " ");
+const issue1046DocPath = path.join(repoRoot, "docs", "dogfood", "clean-epic-advisory-inventory-spawn-child-1046.md");
+const issue1046Doc = fs.readFileSync(issue1046DocPath, "utf8");
+const compactIssue1046Doc = issue1046Doc.replace(/\s+/gu, " ");
 
 function extractJsonFence(markdown) {
   const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
@@ -239,5 +243,127 @@ test("issue #1040 dogfood doc preserves the clean epic-only session-whip boundar
     "product claims",
   ]) {
     assert.ok(compactIssue1040Doc.includes(required), `missing #1040 doc text: ${required}`);
+  }
+});
+
+test("issue #1046 helper treats clean epic plus idle child inventory as status-only", () => {
+  assert.deepEqual(
+    classifyCleanEpicAdvisoryInventorySessionWhip({
+      epic: "#960",
+      branch: "main",
+      clean: true,
+      ahead: 0,
+      behind: 0,
+      openIssueCount: 2,
+      openPullRequestCount: 0,
+      evidence: {
+        issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }],
+        branches: [],
+        worktrees: [],
+        sessions: [],
+        pullRequests: [],
+        processes: [],
+      },
+    }),
+    {
+      issue: "#1046",
+      epic: "#960",
+      classification: "clean-epic-plus-idle-child-session-whip-idle",
+      cleanPostMergeEcho: true,
+      epicPlusSingleIdleChildInventory: true,
+      activeDevelopmentAllowed: false,
+      statusOnlyCheckMayEndOnCleanEcho: false,
+      requiredConcreteChildArtifacts: [
+        "active-session",
+        "active-branch",
+        "open-pull-request",
+        "active-worktree",
+        "active-process",
+      ],
+      activeEvidenceKinds: [],
+      mutationBoundary: {
+        mutatesGitHubIssues: false,
+        changesMergePolicy: false,
+        changesProviderRuntimeHooks: false,
+        changesTelemetry: false,
+        changesBillingTokenProof: false,
+        changesDetectorScope: false,
+        changesProductClaims: false,
+        reopensClosedArtifacts: false,
+      },
+      rule: "A clean post-merge session-whip/operator-check snapshot with only planning epic #960 plus one idle child issue and no active branch, session, PR, worktree, or process is status-only and must spawn or adopt concrete child work before claiming active development.",
+    },
+  );
+});
+
+test("issue #1046 helper keeps active child work artifacts active", () => {
+  for (const [name, evidence, expectedKind] of [
+    ["active session", { issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }], sessions: [{ session: "fooks-issue-1046", active: true }] }, "active-session"],
+    ["active branch", { issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }], branches: [{ name: "fooks-issue-1046-clean-epic-advisory-inventory", active: true }] }, "active-branch"],
+    ["open PR", { issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }], pullRequests: [{ number: 1049, state: "open" }] }, "open-pull-request"],
+    ["active worktree", { issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }], worktrees: [{ path: "/tmp/fooks-1046", active: true }] }, "active-worktree"],
+    ["active process", { issues: [{ number: 960, state: "open" }, { number: 1046, state: "open" }], processes: [{ pid: 1046, active: true }] }, "active-process"],
+  ]) {
+    const result = classifyCleanEpicAdvisoryInventorySessionWhip({
+      epic: "#960",
+      branch: "main",
+      clean: true,
+      ahead: 0,
+      behind: 0,
+      openIssueCount: 2,
+      openPullRequestCount: expectedKind === "open-pull-request" ? 1 : 0,
+      evidence,
+    });
+    assert.equal(result.classification, "active-child-work-adopted", name);
+    assert.equal(result.activeDevelopmentAllowed, true, name);
+    assert.deepEqual(result.activeEvidenceKinds, [expectedKind], name);
+  }
+});
+
+test("issue #1046 dogfood doc preserves the clean epic/advisory inventory spawn-or-adopt guard", () => {
+  const report = extractJsonFence(issue1046Doc);
+
+  assert.equal(report.issue, "#1046");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.sourceEpic, "#960");
+  assert.equal(report.postMergeReceipt, "PR #1048");
+  assert.equal(report.operatorDecision.classification, "clean-epic-plus-idle-child-session-whip-idle");
+  assert.equal(report.operatorDecision.statusOnlyCheckMayEndOnCleanEcho, false);
+  assert.equal(report.operatorDecision.activeDevelopmentAllowed, false);
+  assert.deepEqual(report.operatorDecision.activeDevelopmentRequiresOneOf, [
+    "active-session",
+    "active-branch",
+    "open-pull-request",
+    "active-worktree",
+    "active-process",
+  ]);
+  assert.match(report.operatorDecision.rule, /only planning epic #960 plus one idle child issue/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/operator-check/session-whip guard",
+    "after PR #1048",
+    "Epic `#960` plus one concrete but idle child issue",
+    "`open_pr=0`",
+    "no active branch",
+    "no mapped tmux session",
+    "no open PR",
+    "status-only check/whip receipt",
+    "`clean-epic-plus-idle-child-session-whip-idle`",
+    "must spawn or adopt concrete child work",
+    "active session",
+    "active branch",
+    "open PR",
+    "active worktree",
+    "active process",
+    "does not mutate GitHub issues automatically",
+    "change merge policy",
+    "provider/runtime hooks",
+    "telemetry",
+    "billing/token proof",
+    "detector scope",
+    "product claims",
+    "reopen closed PRs or issues",
+  ]) {
+    assert.ok(compactIssue1046Doc.includes(required), `missing #1046 doc text: ${required}`);
   }
 });

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -150,6 +150,65 @@ export function classifyCleanEpicOnlySessionWhip(input) {
   };
 }
 
+export function classifyCleanEpicAdvisoryInventorySessionWhip(input) {
+  const epicNumber = issueNumber(input?.epic) ?? 960;
+  const evidence = input?.evidence ?? {};
+  const issues = openIssueNumbers(evidence.issues ?? evidence.childIssues);
+  const openIssueCount = typeof input?.openIssueCount === "number" ? input.openIssueCount : issues.length;
+  const openPullRequestCount = typeof input?.openPullRequestCount === "number"
+    ? input.openPullRequestCount
+    : (evidence.pullRequests ?? []).filter((pr) => isOpenState(pr?.state)).length;
+  const childIssues = issues.filter((number) => number !== epicNumber);
+  const activeKinds = [
+    hasActiveBranch(evidence) ? "active-branch" : null,
+    hasActiveWorktree(evidence) ? "active-worktree" : null,
+    hasActiveSession(evidence) ? "active-session" : null,
+    hasOpenPullRequest(evidence) ? "open-pull-request" : null,
+    (evidence?.processes ?? []).some((process) =>
+      isOpenState(process?.state) || process?.active === true
+    ) ? "active-process" : null,
+  ].filter(Boolean);
+  const cleanPostMergeEcho = Boolean(input?.clean === true && input?.branch === "main" && input?.ahead === 0 && input?.behind === 0);
+  const epicPlusSingleIdleChildInventory =
+    openIssueCount === 2
+    && issues.length === 2
+    && issues.includes(epicNumber)
+    && childIssues.length === 1
+    && openPullRequestCount === 0;
+  const requiresSpawnOrAdoption = cleanPostMergeEcho && epicPlusSingleIdleChildInventory && activeKinds.length === 0;
+
+  return {
+    issue: "#1046",
+    epic: `#${epicNumber}`,
+    classification: requiresSpawnOrAdoption
+      ? "clean-epic-plus-idle-child-session-whip-idle"
+      : "active-child-work-adopted",
+    cleanPostMergeEcho,
+    epicPlusSingleIdleChildInventory,
+    activeDevelopmentAllowed: !requiresSpawnOrAdoption,
+    statusOnlyCheckMayEndOnCleanEcho: false,
+    requiredConcreteChildArtifacts: [
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process",
+    ],
+    activeEvidenceKinds: activeKinds,
+    mutationBoundary: {
+      mutatesGitHubIssues: false,
+      changesMergePolicy: false,
+      changesProviderRuntimeHooks: false,
+      changesTelemetry: false,
+      changesBillingTokenProof: false,
+      changesDetectorScope: false,
+      changesProductClaims: false,
+      reopensClosedArtifacts: false,
+    },
+    rule: "A clean post-merge session-whip/operator-check snapshot with only planning epic #960 plus one idle child issue and no active branch, session, PR, worktree, or process is status-only and must spawn or adopt concrete child work before claiming active development.",
+  };
+}
+
 export function classifyStaleEpicChecklistCandidate(input) {
   const activeKinds = activeEvidenceKinds(input?.evidence ?? {});
   const hasUncheckedEpicChecklistText = Boolean(input?.uncheckedEpicChecklistText);

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1638,6 +1638,69 @@ test("operator check treats clean post-merge epic-only inventory as idle session
   assert.match(snapshot.sessionWhipRunReceipt.noOp.reason, /No created\/adopted issue, PR, non-main branch, mapped session, or adopted worktree evidence/);
 });
 
+test("operator check treats clean epic plus idle child issue inventory as status-only and requires spawned or adopted child work", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-22T12:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: /** @param {string} command @param {string[]} args */ (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[{\"number\":960},{\"number\":1046}]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") return "[]";
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD post-pr-1048-main-head", "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "post-pr-1048-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: /** @param {string} targetPath */ (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.activity.optionalCounts.openIssues, 2);
+  assert.deepEqual(snapshot.activity.optionalCounts.openIssueNumbers, [960, 1046]);
+  assert.equal(snapshot.activity.optionalCounts.openPullRequests, 0);
+  assert.equal(snapshot.activity.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.activity.currentRunEvidence.activeWorkEvidence, false);
+  assert.match(snapshot.activity.currentRunEvidence.reasons.join("\n"), /planning epic #960 plus one idle child issue/);
+  assert.match(snapshot.activity.currentRunEvidence.receipt.oneLine, /planning epic #960 plus one idle child issue only/);
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.deepEqual(snapshot.activeArtifacts, []);
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.equal(snapshot.requiredActiveArtifact.dogfoodHandoff.status, "requires-live-artifact");
+  assert.equal(snapshot.activeWorkReceipts.classification, "mainEcho");
+  assert.equal(snapshot.activeWorkReceipts.receipts.some((receipt) => receipt.kind === "issue"), false);
+  assert.equal(snapshot.sessionWhipRunReceipt.status, "idle");
+  assert.equal(snapshot.sessionWhipRunReceipt.noOp.empty, true);
+  assert.deepEqual(snapshot.sessionWhipRunReceipt.counts, {
+    createdOrAdoptedIssues: 0,
+    adoptedPullRequests: 0,
+    adoptedBranches: 0,
+    mappedSessions: 0,
+    adoptedWorktrees: 0,
+    staleOrReviewOnly: 0,
+    mainEchoes: 1,
+    blockers: 0,
+  });
+  assert.deepEqual(snapshot.sessionWhipRunReceipt.evidence.issues, []);
+});
+
 
 test("operator check treats absent tmux server as zero mapped sessions and keeps CI uncertainty separate", () => {
   const tempDir = makeTempProject();


### PR DESCRIPTION
Closes #1046

## Scope
- Constrain clean main + Epic #960 + idle child issue snapshots so status-only inventory does not satisfy session-whip/operator-check activity.
- Keep live branch/session/PR/work evidence as the active path.

## Constraints
- Read-only helper/docs/test/operator-check/session-whip surface only.
- No GitHub mutation automation.
- No merge policy, provider/runtime hook, telemetry, billing/token proof, detector-scope, or product-claim changes.

## Verification
- npm run build
- node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
- npm run typecheck
- npm test
