### PR TITLE
Add domain-memory receipt freshness verifier

### DIFF
--- a/docs/context-decision-contract.md
+++ b/docs/context-decision-contract.md
@@ -1,0 +1,36 @@
+# Context decision contract
+
+`context-decision.v1` is an explicit report-only CLI appendix for inspecting how fooks would classify a one-file context planning situation.
+
+Command:
+
+```sh
+fooks inspect-domain <file> --json --context-decision
+```
+
+The appendix is emitted as top-level `contextDecision` only when `--context-decision` is passed. Plain `inspect-domain --json` output remains unchanged. `--context-decision` requires `--json`.
+
+## What it records
+
+`contextDecision` keeps the architecture axes that were previously at risk of becoming many separate `react-web-*.ts` cases:
+
+- `scope`: exact file prompt specificity, selected files, and `sourceFingerprint.fileHash` / `sourceFingerprint.lineCount` freshness anchors.
+- `environment`: report surface, runtime name, capability lane, and a small context-budget summary.
+- `evidence`: detected domain, concern ids, freshness state, and risk flags such as fallback-first, mixed-domain, WebView, or policy-denied evidence.
+- `decision`: one of `full-read`, `report-only`, `compact-context`, `narrow-payload`, or `defer`.
+- `policy`: always `allowed: false` in this first slice.
+- `nonClaims`: explicit boundaries for runtime, pre-read, cache, setup-readiness, model-facing reuse, support expansion, browser runtime proof, accessibility audit, multi-file correctness, and provider-token/cost/latency claims.
+
+## Decision meanings
+
+- `full-read`: fallback-first boundary; current source should be read directly.
+- `report-only`: evidence exists, but the current slice does not authorize reuse.
+- `compact-context`: diagnostic React Web compact-context shape only; `diagnosticOnly: true` and `policy.allowed: false` mean it does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse.
+- `narrow-payload`: diagnostic React Native narrow-payload shape only; `diagnosticOnly: true` and `policy.allowed: false` mean it does not expand React Native support.
+- `defer`: insufficient or evidence-only lane such as unknown/shared/TUI should not be promoted.
+
+## Boundary
+
+`context-decision.v1` is a planning/reporting contract, not an execution policy. It does not change detector behavior, runtime adapters, pre-read behavior, cache storage, setup readiness, model-facing payload schemas, React Native support, WebView support, broad TUI semantics, or provider-token/cost/latency claims.
+
+Policy remains the permission owner. A diagnostic `compact-context` or `narrow-payload` decision is useful metadata for later planning, but it is not permission to reuse context unless a separate payload-policy/runtime path explicitly authorizes it.

--- a/docs/domain-memory-contract.md
+++ b/docs/domain-memory-contract.md
@@ -147,3 +147,22 @@ That flag may add a top-level `domainMemoryReceipt` to the existing `inspect-dom
 3. `policy.allowed` in this lane is `false`, and `allowedMeaning` says the receipt does not authorize runtime, pre-read, cache, or compact-payload reuse.
 4. `receipt.runtimeOrCacheReuse` is `false`, and `nonClaims` preserves the no-support-expansion and no-token/cost/performance-claim boundaries.
 5. Runtime or payload-shape changes remain deferred until a separate plan names exact files, fixtures, policy gates, and verification commands.
+
+## Receipt freshness verifier lane
+
+The next implementation lane is an explicit CLI-only verifier:
+
+```bash
+fooks domain-memory verify --receipt receipt.json --file src/Foo.tsx --json
+```
+
+The verifier checks whether a saved `domain-memory.v1` receipt still matches the current source fingerprint, file scope, domain lane, claim boundary, and report-only policy boundary. Its `fresh` status means **fresh for report-only evidence only**. It does not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims.
+
+Verifier statuses are fail-closed:
+
+- `fresh` means the receipt matches the current file and may be quoted as report-only evidence.
+- `stale` means source freshness changed or is missing; rerun `inspect-domain`.
+- `incompatible` means file scope, domain lane, or claim boundary no longer matches; full-read the current source.
+- `unsupported` means the receipt is malformed, from an unsupported schema, or attempts to claim runtime/cache reuse.
+
+For this lane, any receipt with `policy.allowed: true` or `receipt.runtimeOrCacheReuse: true` is unsupported. Runtime/cache/pre-read consumers remain deferred until a later plan names the exact consumer, freshness gates, policy boundaries, and verification evidence.

--- a/docs/domain-payload-architecture.md
+++ b/docs/domain-payload-architecture.md
@@ -270,3 +270,7 @@ When in doubt:
 - describe TUI/Ink as measured syntax/payload evidence, not terminal behavior support;
 - describe Mixed/Unknown as safety states;
 - keep provider-token, billing, runtime-token, cost, performance, bridge-safety, and terminal-correctness claims out of this architecture layer.
+
+## Context decision planning appendix
+
+`context-decision.v1` (`context-decision-contract.md`) keeps context-planning metadata separate from payload authorization. Diagnostic `compact-context` or `narrow-payload` decisions remain report-only in this slice; scanner evidence and concern metadata remain observations, while policy remains the permission owner.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -247,3 +247,7 @@ fooks scan
 fooks extract <file> --model-payload
 fooks compare src/components/Button.tsx --json
 ```
+
+## Context decision report
+
+`fooks inspect-domain <file> --json --context-decision` emits an explicit report-only `context-decision.v1` appendix. It is local CLI metadata for domain/concern/freshness/risk planning and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing payload reuse. Plain `inspect-domain --json` output remains unchanged, and `--context-decision` requires `--json`.

--- a/docs/state-contract.md
+++ b/docs/state-contract.md
@@ -96,3 +96,7 @@ Evidence cannot choose a next action without state, and state cannot be assigned
 ## State to next-action mapping
 
 `architecture_blocked`, `idle_clean`, `active_session`, `active_branch`, `pr_ready`, `receipt_only`, and `blocked` are report-facing state terms. State to next-action mapping keeps active work, receipts, and architecture blockers separate.
+
+## Context decision report boundary
+
+`context-decision.v1` is documented in `context-decision-contract.md`. It records report-only domain, concern, freshness, environment, risk, and diagnostic decision metadata. It does not change cache storage, detector logic, runtime adapters, pre-read behavior, setup-readiness behavior, or implementation behavior.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { performance } from "node:perf_hooks";
 import type { ExtractionResult } from "../core/schema";
 import type { ContextDecision } from "../core/context-decision";
 import type { DomainMemoryReceipt } from "../core/domain-memory-receipt";
+import type { DomainMemoryVerifyResult } from "../core/domain-memory-verify";
 import type { InspectDomainReactNativeSourceAnchorBeta } from "../core/react-native-proof-surface";
 
 function print(value: unknown): void {
@@ -646,7 +647,7 @@ async function runSetup(displayCliName: string, cwd = process.cwd()): Promise<Re
 }
 
 function printHelp(displayCliName: string): void {
-  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|handoff|stale-context|run|scan|extract|compare|decide|explain|inspect|inspect-domain|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
+  console.log(`Usage: ${displayCliName} <init|setup|doctor|check|preflight|handoff|stale-context|run|scan|extract|compare|decide|explain|inspect|inspect-domain|domain-memory|attach|install|status|codex-pre-read|codex-runtime-hook|claude-runtime-hook>
 
 Everyday commands:
   ${displayCliName} setup
@@ -683,6 +684,7 @@ Everyday commands:
   ${displayCliName} inspect react-web-label-preview <file> [--json]
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
+  ${displayCliName} domain-memory verify --receipt <receipt.json> --file <file> --json
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
@@ -835,6 +837,48 @@ function parseInspectDomainArgs(args: string[]): { filePath: string; json: boole
   }
 
   return { filePath: requireFilePath(filePath), json, domainMemoryReceipt, contextDecision };
+}
+
+function parseDomainMemoryArgs(args: string[]): {
+  receiptPath: string;
+  filePath: string;
+} {
+  const [action, ...rest] = args;
+  if (action !== "verify") {
+    throw new Error("domain-memory expects 'verify'");
+  }
+
+  let receiptPath: string | undefined;
+  let filePath: string | undefined;
+  let json = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--receipt") {
+      receiptPath = rest[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--file") {
+      filePath = rest[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unexpected domain-memory verify argument: ${arg}`);
+  }
+
+  if (!json) {
+    throw new Error("domain-memory verify requires --json");
+  }
+
+  return {
+    receiptPath: requireFilePath(receiptPath),
+    filePath: requireFilePath(filePath),
+  };
 }
 
 function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode: "text" | "json" | "summary-json" | "dry-run-json" } {
@@ -1572,6 +1616,48 @@ async function run(): Promise<void> {
         reactNativeSourceAnchorBeta,
         domainMemoryReceipt,
         contextDecision,
+      }));
+      return;
+    }
+    case "domain-memory": {
+      let options: ReturnType<typeof parseDomainMemoryArgs>;
+      try {
+        options = parseDomainMemoryArgs(rest);
+      } catch (error) {
+        console.error(`fooks domain-memory: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const [
+        { detectDomainFromSource },
+        { verifyDomainMemoryReceipt, unsupportedDomainMemoryVerifyResult },
+      ] = await Promise.all([
+        import("../core/domain-detector.js"),
+        import("../core/domain-memory-verify.js"),
+      ]);
+      const sourceText = fs.readFileSync(options.filePath, "utf8");
+      let receipt: unknown;
+      try {
+        receipt = JSON.parse(fs.readFileSync(options.receiptPath, "utf8"));
+      } catch (error) {
+        const result: DomainMemoryVerifyResult = unsupportedDomainMemoryVerifyResult({
+          filePath: options.filePath,
+          receiptPath: options.receiptPath,
+          cwd: process.cwd(),
+          reason: `receipt JSON could not be parsed: ${error instanceof Error ? error.message : String(error)}`,
+        });
+        print(result);
+        return;
+      }
+
+      print(verifyDomainMemoryReceipt({
+        receipt,
+        receiptPath: options.receiptPath,
+        filePath: options.filePath,
+        cwd: process.cwd(),
+        sourceText,
+        domainDetection: detectDomainFromSource(sourceText, options.filePath),
       }));
       return;
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ExtractionResult } from "../core/schema";
+import type { ContextDecision } from "../core/context-decision";
 import type { DomainMemoryReceipt } from "../core/domain-memory-receipt";
 import type { InspectDomainReactNativeSourceAnchorBeta } from "../core/react-native-proof-surface";
 
@@ -681,7 +682,7 @@ Everyday commands:
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
-  ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt]
+  ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
@@ -800,10 +801,11 @@ function parseCompareArgs(args: string[]): { filePath: string; json: boolean } {
   return { filePath: requireFilePath(filePath), json };
 }
 
-function parseInspectDomainArgs(args: string[]): { filePath: string; json: boolean; domainMemoryReceipt: boolean } {
+function parseInspectDomainArgs(args: string[]): { filePath: string; json: boolean; domainMemoryReceipt: boolean; contextDecision: boolean } {
   let filePath: string | undefined;
   let json = false;
   let domainMemoryReceipt = false;
+  let contextDecision = false;
 
   for (const arg of args) {
     if (arg === "--json") {
@@ -812,6 +814,10 @@ function parseInspectDomainArgs(args: string[]): { filePath: string; json: boole
     }
     if (arg === "--domain-memory-receipt") {
       domainMemoryReceipt = true;
+      continue;
+    }
+    if (arg === "--context-decision") {
+      contextDecision = true;
       continue;
     }
     if (!filePath) {
@@ -824,8 +830,11 @@ function parseInspectDomainArgs(args: string[]): { filePath: string; json: boole
   if (domainMemoryReceipt && !json) {
     throw new Error("inspect-domain --domain-memory-receipt requires --json");
   }
+  if (contextDecision && !json) {
+    throw new Error("inspect-domain --context-decision requires --json");
+  }
 
-  return { filePath: requireFilePath(filePath), json, domainMemoryReceipt };
+  return { filePath: requireFilePath(filePath), json, domainMemoryReceipt, contextDecision };
 }
 
 function parseReactWebIssuesArgs(args: string[]): { filePath: string; outputMode: "text" | "json" | "summary-json" | "dry-run-json" } {
@@ -962,6 +971,7 @@ type InspectDomainCliResult = {
   };
   reactNativeSourceAnchorBeta?: InspectDomainReactNativeSourceAnchorBeta;
   domainMemoryReceipt?: DomainMemoryReceipt;
+  contextDecision?: ContextDecision;
 };
 
 function hasWebViewEvidence(evidence: Array<{ domain: string }>): boolean {
@@ -1010,6 +1020,7 @@ function buildInspectDomainResult(options: {
   tuiSourceMetadata?: NonNullable<InspectDomainCliResult["tuiSourceMetadata"]>;
   reactNativeSourceAnchorBeta?: InspectDomainCliResult["reactNativeSourceAnchorBeta"];
   domainMemoryReceipt?: InspectDomainCliResult["domainMemoryReceipt"];
+  contextDecision?: InspectDomainCliResult["contextDecision"];
 }): InspectDomainCliResult {
   const relative = path.relative(options.cwd, options.filePath) || path.basename(options.filePath);
   const webViewFallbackFirst = hasWebViewEvidence(options.detection.evidence);
@@ -1033,6 +1044,9 @@ function buildInspectDomainResult(options: {
   }
   if (options.json && options.domainMemoryReceipt) {
     result.domainMemoryReceipt = options.domainMemoryReceipt;
+  }
+  if (options.json && options.contextDecision) {
+    result.contextDecision = options.contextDecision;
   }
   return result;
 }
@@ -1462,6 +1476,8 @@ async function run(): Promise<void> {
         { assessFrontendPayloadPolicy },
         { inspectDomainReactNativeSourceAnchorBetaFor },
         { buildDomainMemoryReceipt },
+        { buildContextDecision },
+        { collectFrontendConcernProfiles },
       ] = await Promise.all([
         import("../core/domain-detector.js"),
         import("../core/tui-source-metadata.js"),
@@ -1470,6 +1486,8 @@ async function run(): Promise<void> {
         import("../core/payload-policy/registry.js"),
         import("../core/react-native-proof-surface.js"),
         import("../core/domain-memory-receipt.js"),
+        import("../core/context-decision.js"),
+        import("../core/concern-profiles/index.js"),
       ]);
       let inspectDomainOptions: ReturnType<typeof parseInspectDomainArgs>;
       try {
@@ -1479,9 +1497,19 @@ async function run(): Promise<void> {
         process.exitCode = 1;
         return;
       }
-      const { filePath: file, json, domainMemoryReceipt: includeDomainMemoryReceipt } = inspectDomainOptions;
+      const {
+        filePath: file,
+        json,
+        domainMemoryReceipt: includeDomainMemoryReceipt,
+        contextDecision: includeContextDecision,
+      } = inspectDomainOptions;
       const sourceText = fs.readFileSync(file, "utf8");
       const detection = detectDomainFromSource(sourceText, file);
+      let extractedForInspectDomain: ExtractionResult | undefined;
+      const getExtractedForInspectDomain = (): ExtractionResult => {
+        extractedForInspectDomain ??= extractFile(file);
+        return extractedForInspectDomain;
+      };
       const tuiSourceMetadata =
         json && hasTuiInkEvidence(detection.evidence)
           ? toInspectDomainTuiSourceMetadata(
@@ -1495,7 +1523,7 @@ async function run(): Promise<void> {
       const reactNativeSourceAnchorBeta =
         json && detection.classification === "react-native"
           ? (() => {
-              const extracted = extractFile(file);
+              const extracted = getExtractedForInspectDomain();
               const frontendPayloadPolicy = extracted.domainDetection
                 ? assessFrontendPayloadPolicy(extracted.domainDetection)
                 : undefined;
@@ -1515,6 +1543,26 @@ async function run(): Promise<void> {
             domainDetection: detection,
           })
         : undefined;
+      const contextDecision = includeContextDecision
+        ? (() => {
+            const extracted = getExtractedForInspectDomain();
+            const frontendPayloadPolicy = extracted.domainDetection
+              ? assessFrontendPayloadPolicy(extracted.domainDetection)
+              : assessFrontendPayloadPolicy(detection);
+            return buildContextDecision({
+              filePath: file,
+              cwd: process.cwd(),
+              sourceText,
+              domainDetection: detection,
+              extraction: extracted,
+              concerns: collectFrontendConcernProfiles(extracted),
+              payloadPolicy: frontendPayloadPolicy,
+              surface: "cli-report",
+              runtime: "cli",
+              capability: "unknown",
+            });
+          })()
+        : undefined;
       print(buildInspectDomainResult({
         filePath: file,
         cwd: process.cwd(),
@@ -1523,6 +1571,7 @@ async function run(): Promise<void> {
         tuiSourceMetadata,
         reactNativeSourceAnchorBeta,
         domainMemoryReceipt,
+        contextDecision,
       }));
       return;
     }

--- a/src/core/context-decision.ts
+++ b/src/core/context-decision.ts
@@ -1,0 +1,211 @@
+import path from "node:path";
+import type { FrontendConcernProfile } from "./concern-profiles/types";
+import type { DomainDetectionResult } from "./domain-detector";
+import type { FrontendPayloadPolicyDecision } from "./payload-policy/types";
+import type { ExtractionResult, SourceFingerprint } from "./schema";
+
+export const CONTEXT_DECISION_SCHEMA_VERSION = "context-decision.v1" as const;
+
+export type ContextDecisionKind = "full-read" | "report-only" | "compact-context" | "narrow-payload" | "defer";
+export type ContextDecisionPromptSpecificity = "exact-file" | "file-hinted" | "ambiguous";
+export type ContextDecisionSurface = "cli-report" | "pre-read" | "runtime-repeat" | "status-report";
+export type ContextDecisionRuntime = "codex" | "claude" | "opencode" | "cli" | "unknown";
+export type ContextDecisionCapability = "react-only" | "codex-ts-js-beta" | "unknown";
+export type ContextDecisionFreshness = "fresh" | "stale" | "unknown";
+
+export type ContextDecisionPolicy = {
+  allowed: false;
+  allowedMeaning: "context-decision.v1 is report-only in this slice and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse";
+};
+
+export type ContextDecision = {
+  schemaVersion: typeof CONTEXT_DECISION_SCHEMA_VERSION;
+  scope: {
+    promptSpecificity: ContextDecisionPromptSpecificity;
+    files: string[];
+    sourceFingerprint?: SourceFingerprint;
+  };
+  environment: {
+    surface: ContextDecisionSurface;
+    runtime: ContextDecisionRuntime;
+    capability: ContextDecisionCapability;
+    contextBudget: {
+      maxFiles: number;
+      selectedFiles: number;
+      totalBytes?: number;
+    };
+  };
+  evidence: {
+    domain: DomainDetectionResult["classification"];
+    concerns: string[];
+    freshness: ContextDecisionFreshness;
+    risk: string[];
+  };
+  decision:
+    | { kind: "full-read"; reason: string }
+    | { kind: "report-only"; reason: string }
+    | { kind: "compact-context"; policy: string; retainedAxes: string[]; diagnosticOnly: true }
+    | { kind: "narrow-payload"; policy: string; retainedAxes: string[]; diagnosticOnly: true }
+    | { kind: "defer"; reason: string };
+  policy: ContextDecisionPolicy;
+  nonClaims: string[];
+};
+
+export type BuildContextDecisionOptions = {
+  filePath: string;
+  cwd: string;
+  sourceText: string;
+  domainDetection: DomainDetectionResult;
+  extraction?: ExtractionResult;
+  concerns?: FrontendConcernProfile[];
+  payloadPolicy?: FrontendPayloadPolicyDecision;
+  surface?: ContextDecisionSurface;
+  runtime?: ContextDecisionRuntime;
+  capability?: ContextDecisionCapability;
+  promptSpecificity?: ContextDecisionPromptSpecificity;
+  maxFiles?: number;
+};
+
+const CONTEXT_DECISION_ALLOWED_MEANING: ContextDecisionPolicy["allowedMeaning"] =
+  "context-decision.v1 is report-only in this slice and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse";
+
+const BASE_NON_CLAIMS = [
+  "does not authorize runtime reuse",
+  "does not authorize pre-read reuse",
+  "does not authorize cache reuse",
+  "does not authorize setup-readiness reuse",
+  "does not authorize model-facing payload reuse",
+  "does not expand React Native, WebView, or TUI support",
+  "does not claim browser runtime proof",
+  "does not claim accessibility audit",
+  "does not claim cross-file correctness",
+  "does not claim provider-token, billing, cost, latency, or runtime-token savings",
+] as const;
+
+const REACT_WEB_RETAINED_AXES = [
+  "editTargetRouting",
+  "formStateFlow",
+  "a11yAnchors",
+  "layoutRegionHints",
+  "componentApiHints",
+  "stylingVariantHints",
+  "importRoleHints",
+] as const;
+
+const REACT_NATIVE_RETAINED_AXES = ["sourceAnchorBeta", "primitiveInteractions"] as const;
+
+function sourceFingerprintFor(options: BuildContextDecisionOptions): SourceFingerprint | undefined {
+  if (!options.extraction) return undefined;
+  const extractedHash = options.extraction.fileHash.startsWith("sha256:")
+    ? options.extraction.fileHash
+    : `sha256:${options.extraction.fileHash}`;
+  return {
+    fileHash: extractedHash,
+    lineCount: options.sourceText.split(/\r\n|\r|\n/u).length,
+  };
+}
+
+function relativeFilePath(filePath: string, cwd: string): string {
+  return path.relative(cwd, filePath) || path.basename(filePath);
+}
+
+function unique(values: Array<string | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+function risksFor(domainDetection: DomainDetectionResult, payloadPolicy?: FrontendPayloadPolicyDecision): string[] {
+  return unique([
+    "report-only-first-slice",
+    domainDetection.profile.fallbackFirst ? "fallback-first-domain-boundary" : undefined,
+    domainDetection.classification === "mixed" ? "mixed-domain-evidence" : undefined,
+    domainDetection.classification === "webview" ? "webview-boundary" : undefined,
+    domainDetection.classification === "unknown" ? "unknown-domain" : undefined,
+    payloadPolicy?.allowed === false ? `payload-policy-denied:${payloadPolicy.reason ?? payloadPolicy.name}` : undefined,
+    ...(payloadPolicy?.evidenceGates?.map((gate) => `payload-policy-gate:${gate}`) ?? []),
+  ]);
+}
+
+function reportOnlyReason(domainDetection: DomainDetectionResult, payloadPolicy?: FrontendPayloadPolicyDecision): string {
+  return payloadPolicy?.reason ?? domainDetection.reason ?? `${domainDetection.classification}-evidence-only-report-boundary`;
+}
+
+function decide(options: BuildContextDecisionOptions): ContextDecision["decision"] {
+  const { domainDetection, payloadPolicy } = options;
+
+  if (domainDetection.classification === "webview" || domainDetection.classification === "mixed") {
+    return {
+      kind: "full-read",
+      reason: domainDetection.profile.boundaryReason ?? domainDetection.reason ?? "fallback-first-domain-boundary",
+    };
+  }
+
+  if (domainDetection.classification === "unknown" || domainDetection.classification === "shared") {
+    return { kind: "defer", reason: `${domainDetection.classification}-domain-evidence` };
+  }
+
+  if (domainDetection.classification === "tui-ink") {
+    return { kind: "defer", reason: "tui-evidence-only-report-boundary" };
+  }
+
+  if (domainDetection.classification === "react-native") {
+    if (payloadPolicy?.allowed === true) {
+      return {
+        kind: "narrow-payload",
+        policy: payloadPolicy.name,
+        retainedAxes: [...REACT_NATIVE_RETAINED_AXES],
+        diagnosticOnly: true,
+      };
+    }
+    return { kind: "report-only", reason: reportOnlyReason(domainDetection, payloadPolicy) };
+  }
+
+  if (domainDetection.classification === "react-web") {
+    if (payloadPolicy?.allowed === true) {
+      return {
+        kind: "compact-context",
+        policy: payloadPolicy.name,
+        retainedAxes: [...REACT_WEB_RETAINED_AXES],
+        diagnosticOnly: true,
+      };
+    }
+    return { kind: "report-only", reason: reportOnlyReason(domainDetection, payloadPolicy) };
+  }
+
+  return { kind: "report-only", reason: reportOnlyReason(domainDetection, payloadPolicy) };
+}
+
+export function buildContextDecision(options: BuildContextDecisionOptions): ContextDecision {
+  const sourceFingerprint = sourceFingerprintFor(options);
+  const concerns = unique(options.concerns?.map((concern) => concern.id) ?? []);
+  const selectedFiles = 1;
+  return {
+    schemaVersion: CONTEXT_DECISION_SCHEMA_VERSION,
+    scope: {
+      promptSpecificity: options.promptSpecificity ?? "exact-file",
+      files: [relativeFilePath(options.filePath, options.cwd)],
+      ...(sourceFingerprint ? { sourceFingerprint } : {}),
+    },
+    environment: {
+      surface: options.surface ?? "cli-report",
+      runtime: options.runtime ?? "cli",
+      capability: options.capability ?? "unknown",
+      contextBudget: {
+        maxFiles: options.maxFiles ?? 1,
+        selectedFiles,
+        totalBytes: Buffer.byteLength(options.sourceText, "utf8"),
+      },
+    },
+    evidence: {
+      domain: options.domainDetection.classification,
+      concerns,
+      freshness: sourceFingerprint ? "fresh" : "unknown",
+      risk: risksFor(options.domainDetection, options.payloadPolicy),
+    },
+    decision: decide(options),
+    policy: {
+      allowed: false,
+      allowedMeaning: CONTEXT_DECISION_ALLOWED_MEANING,
+    },
+    nonClaims: [...BASE_NON_CLAIMS],
+  };
+}

--- a/src/core/domain-memory-verify.ts
+++ b/src/core/domain-memory-verify.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { DomainDetectionResult } from "./domain-profiles/types";
+
+export const DOMAIN_MEMORY_VERIFY_SCHEMA_VERSION = "domain-memory-verify.v1" as const;
+
+export type DomainMemoryVerifyStatus = "fresh" | "stale" | "incompatible" | "unsupported";
+export type DomainMemoryVerifyCheck = "match" | "mismatch" | "missing";
+export type DomainMemoryVerifySafeNextAction = "reuse-for-report-only" | "rerun-inspect-domain" | "full-read";
+
+export type DomainMemoryVerifyResult = {
+  schemaVersion: typeof DOMAIN_MEMORY_VERIFY_SCHEMA_VERSION;
+  command: "domain-memory verify";
+  filePath: string;
+  receiptPath: string;
+  status: DomainMemoryVerifyStatus;
+  checks: {
+    receiptSchema: DomainMemoryVerifyCheck;
+    fileScope: DomainMemoryVerifyCheck;
+    sourceFingerprint: DomainMemoryVerifyCheck;
+    domainLane: DomainMemoryVerifyCheck;
+    claimBoundary: DomainMemoryVerifyCheck;
+    policyBoundary: "report-only" | "mismatch" | "missing";
+    runtimeOrCacheReuse: false;
+  };
+  reasons: string[];
+  nonClaims: string[];
+  safeNextAction: DomainMemoryVerifySafeNextAction;
+};
+
+export type VerifyDomainMemoryReceiptOptions = {
+  receipt: unknown;
+  receiptPath: string;
+  filePath: string;
+  cwd: string;
+  sourceText: string;
+  domainDetection: DomainDetectionResult;
+};
+
+const NON_CLAIMS = [
+  "does not authorize runtime reuse",
+  "does not authorize pre-read reuse",
+  "does not authorize cache reuse",
+  "does not authorize model-facing payload reuse",
+  "does not expand React Native, WebView, or TUI support",
+  "does not use concern or domain evidence as authorization",
+  "does not claim provider-token, billing, cost, latency, or runtime-token savings",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sourceFingerprintFor(sourceText: string): { fileHash: string; lineCount: number } {
+  return {
+    fileHash: `sha256:${createHash("sha256").update(sourceText).digest("hex")}`,
+    lineCount: sourceText.length === 0 ? 0 : sourceText.split(/\r\n|\r|\n/u).length,
+  };
+}
+
+function relativeFilePath(filePath: string, cwd: string): string {
+  return path.relative(cwd, filePath) || path.basename(filePath);
+}
+
+function normalizeReceiptFilePath(receiptFilePath: unknown, cwd: string): string | undefined {
+  if (typeof receiptFilePath !== "string" || receiptFilePath.trim() === "") return undefined;
+  return path.resolve(cwd, receiptFilePath);
+}
+
+function checkFromBoolean(value: boolean | undefined): DomainMemoryVerifyCheck {
+  if (value === undefined) return "missing";
+  return value ? "match" : "mismatch";
+}
+
+function statusFor(checks: DomainMemoryVerifyResult["checks"]): DomainMemoryVerifyStatus {
+  if (checks.receiptSchema !== "match" || checks.policyBoundary !== "report-only") return "unsupported";
+  if (checks.fileScope === "mismatch" || checks.domainLane === "mismatch" || checks.claimBoundary === "mismatch") return "incompatible";
+  if (
+    checks.fileScope === "missing" ||
+    checks.domainLane === "missing" ||
+    checks.claimBoundary === "missing"
+  ) {
+    return "incompatible";
+  }
+  if (checks.sourceFingerprint !== "match") return "stale";
+  return "fresh";
+}
+
+function safeNextActionFor(status: DomainMemoryVerifyStatus): DomainMemoryVerifySafeNextAction {
+  if (status === "fresh") return "reuse-for-report-only";
+  if (status === "stale") return "rerun-inspect-domain";
+  return "full-read";
+}
+
+function reasonsFor(checks: DomainMemoryVerifyResult["checks"]): string[] {
+  const reasons: string[] = [];
+  if (checks.receiptSchema === "missing") reasons.push("missing domain-memory.v1 receipt schema");
+  if (checks.receiptSchema === "mismatch") reasons.push("unsupported receipt schema");
+  if (checks.fileScope === "missing") reasons.push("missing receipt file scope");
+  if (checks.fileScope === "mismatch") reasons.push("receipt file scope does not match requested file");
+  if (checks.sourceFingerprint === "missing") reasons.push("missing receipt source fingerprint");
+  if (checks.sourceFingerprint === "mismatch") reasons.push("receipt source fingerprint is stale");
+  if (checks.domainLane === "missing") reasons.push("missing receipt domain lane");
+  if (checks.domainLane === "mismatch") reasons.push("receipt domain lane does not match current source");
+  if (checks.claimBoundary === "missing") reasons.push("missing receipt claim boundary");
+  if (checks.claimBoundary === "mismatch") reasons.push("receipt claim boundary does not match current source");
+  if (checks.policyBoundary === "missing") reasons.push("missing report-only policy boundary");
+  if (checks.policyBoundary === "mismatch") reasons.push("receipt attempts to exceed report-only runtime/cache boundary");
+  if (reasons.length === 0) reasons.push("receipt is fresh for report-only evidence");
+  return reasons;
+}
+
+function policyBoundaryFor(receipt: Record<string, unknown>): "report-only" | "mismatch" | "missing" {
+  const policy = isRecord(receipt.policy) ? receipt.policy : undefined;
+  const receiptMeta = isRecord(receipt.receipt) ? receipt.receipt : undefined;
+  if (!policy || !receiptMeta) return "missing";
+
+  const allowed = policy.allowed;
+  const allowedMeaning = typeof policy.allowedMeaning === "string" ? policy.allowedMeaning : "";
+  const runtimeOrCacheReuse = receiptMeta.runtimeOrCacheReuse;
+  if (allowed !== false || runtimeOrCacheReuse !== false) return "mismatch";
+  if (
+    !/report-only/i.test(allowedMeaning) ||
+    !/runtime/i.test(allowedMeaning) ||
+    !/pre-read/i.test(allowedMeaning) ||
+    !/cache/i.test(allowedMeaning)
+  ) {
+    return "mismatch";
+  }
+  return "report-only";
+}
+
+export function verifyDomainMemoryReceipt(options: VerifyDomainMemoryReceiptOptions): DomainMemoryVerifyResult {
+  const receipt = isRecord(options.receipt) ? options.receipt : undefined;
+  const scope = receipt && isRecord(receipt.scope) ? receipt.scope : undefined;
+  const domain = receipt && isRecord(receipt.domain) ? receipt.domain : undefined;
+  const receiptFingerprint = scope && isRecord(scope.sourceFingerprint) ? scope.sourceFingerprint : undefined;
+  const currentFingerprint = sourceFingerprintFor(options.sourceText);
+  const receiptFilePath = normalizeReceiptFilePath(scope?.filePath, options.cwd);
+  const currentFilePath = path.resolve(options.filePath);
+
+  const receiptSchema = receipt?.schemaVersion === undefined
+    ? "missing"
+    : receipt.schemaVersion === "domain-memory.v1"
+      ? "match"
+      : "mismatch";
+  const fileScope = checkFromBoolean(receiptFilePath ? receiptFilePath === currentFilePath : undefined);
+  const sourceFingerprint = checkFromBoolean(
+    receiptFingerprint
+      ? receiptFingerprint.fileHash === currentFingerprint.fileHash && receiptFingerprint.lineCount === currentFingerprint.lineCount
+      : undefined,
+  );
+  const domainLane = checkFromBoolean(typeof domain?.lane === "string" ? domain.lane === options.domainDetection.classification : undefined);
+  const claimBoundary = checkFromBoolean(
+    typeof domain?.claimBoundary === "string" ? domain.claimBoundary === options.domainDetection.profile.claimBoundary : undefined,
+  );
+  const policyBoundary = receipt ? policyBoundaryFor(receipt) : "missing";
+
+  const checks: DomainMemoryVerifyResult["checks"] = {
+    receiptSchema,
+    fileScope,
+    sourceFingerprint,
+    domainLane,
+    claimBoundary,
+    policyBoundary,
+    runtimeOrCacheReuse: false,
+  };
+  const status = statusFor(checks);
+
+  return {
+    schemaVersion: DOMAIN_MEMORY_VERIFY_SCHEMA_VERSION,
+    command: "domain-memory verify",
+    filePath: relativeFilePath(options.filePath, options.cwd),
+    receiptPath: relativeFilePath(options.receiptPath, options.cwd),
+    status,
+    checks,
+    reasons: reasonsFor(checks),
+    nonClaims: [...NON_CLAIMS],
+    safeNextAction: safeNextActionFor(status),
+  };
+}
+
+export function unsupportedDomainMemoryVerifyResult(options: {
+  filePath: string;
+  receiptPath: string;
+  cwd: string;
+  reason: string;
+}): DomainMemoryVerifyResult {
+  return {
+    schemaVersion: DOMAIN_MEMORY_VERIFY_SCHEMA_VERSION,
+    command: "domain-memory verify",
+    filePath: relativeFilePath(options.filePath, options.cwd),
+    receiptPath: relativeFilePath(options.receiptPath, options.cwd),
+    status: "unsupported",
+    checks: {
+      receiptSchema: "missing",
+      fileScope: "missing",
+      sourceFingerprint: "missing",
+      domainLane: "missing",
+      claimBoundary: "missing",
+      policyBoundary: "missing",
+      runtimeOrCacheReuse: false,
+    },
+    reasons: [options.reason],
+    nonClaims: [...NON_CLAIMS],
+    safeNextAction: "full-read",
+  };
+}

--- a/test/context-decision-contract-docs.test.mjs
+++ b/test/context-decision-contract-docs.test.mjs
@@ -1,0 +1,82 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readDoc(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function assertContains(label, doc, phrases) {
+  for (const phrase of phrases) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${label} missing ${phrase}`);
+  }
+}
+
+const contract = readDoc("docs/context-decision-contract.md");
+const setup = readDoc("docs/setup.md");
+const stateContract = readDoc("docs/state-contract.md");
+const domainPayloadArchitecture = readDoc("docs/domain-payload-architecture.md");
+
+test("context-decision contract documents the explicit report-only CLI appendix", () => {
+  assertContains("context decision", contract, [
+    "# Context decision contract",
+    "context-decision.v1",
+    "fooks inspect-domain <file> --json --context-decision",
+    "top-level `contextDecision` only when `--context-decision` is passed",
+    "Plain `inspect-domain --json` output remains unchanged",
+    "`--context-decision` requires `--json`",
+  ]);
+});
+
+test("context-decision contract preserves decision metadata versus permission boundary", () => {
+  assertContains("context decision", contract, [
+    "full-read",
+    "report-only",
+    "compact-context",
+    "narrow-payload",
+    "defer",
+    "policy.allowed: false",
+    "Policy remains the permission owner",
+    "not permission to reuse context",
+  ]);
+});
+
+test("context-decision contract forbids runtime, support, and provider-cost expansion", () => {
+  assertContains("context decision", contract, [
+    "does not change detector behavior",
+    "runtime adapters",
+    "pre-read behavior",
+    "cache storage",
+    "setup readiness",
+    "model-facing payload schemas",
+    "React Native support",
+    "WebView support",
+    "broad TUI semantics",
+    "provider-token/cost/latency claims",
+  ]);
+});
+
+test("related docs link context-decision without widening behavior", () => {
+  assertContains("setup", setup, [
+    "context-decision.v1",
+    "--context-decision",
+    "does not authorize runtime, pre-read, cache, setup-readiness, or model-facing payload reuse",
+  ]);
+  assertContains("state contract", stateContract, [
+    "context-decision.v1",
+    "context-decision-contract.md",
+    "does not change cache storage, detector logic, runtime adapters, pre-read behavior, setup-readiness behavior, or implementation behavior",
+  ]);
+  assertContains("domain payload architecture", domainPayloadArchitecture, [
+    "context-decision.v1",
+    "context-decision-contract.md",
+    "Diagnostic `compact-context` or `narrow-payload` decisions remain report-only",
+    "policy remains the permission owner",
+  ]);
+});

--- a/test/context-decision.test.mjs
+++ b/test/context-decision.test.mjs
@@ -1,0 +1,97 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { buildContextDecision } from "../dist/core/context-decision.js";
+import { detectDomainFromSource } from "../dist/core/domain-detector.js";
+import { extractFile } from "../dist/core/extract.js";
+import { collectFrontendConcernProfiles } from "../dist/core/concern-profiles/index.js";
+import { assessFrontendPayloadPolicy } from "../dist/core/payload-policy/registry.js";
+
+const repoRoot = process.cwd();
+const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
+
+function decisionFor(relativeFixture) {
+  const filePath = path.join(fixtureRoot, relativeFixture);
+  const sourceText = fs.readFileSync(filePath, "utf8");
+  const domainDetection = detectDomainFromSource(sourceText, filePath);
+  const extraction = extractFile(filePath);
+  return buildContextDecision({
+    filePath,
+    cwd: repoRoot,
+    sourceText,
+    domainDetection,
+    extraction,
+    concerns: collectFrontendConcernProfiles(extraction),
+    payloadPolicy: assessFrontendPayloadPolicy(domainDetection),
+    surface: "cli-report",
+    runtime: "cli",
+    capability: "unknown",
+  });
+}
+
+test("context-decision.v1 reports React Web as diagnostic compact context without authorizing reuse", () => {
+  const decision = decisionFor("react-web/custom-form-shell.tsx");
+
+  assert.equal(decision.schemaVersion, "context-decision.v1");
+  assert.equal(decision.evidence.domain, "react-web");
+  assert.equal(decision.decision.kind, "compact-context");
+  assert.equal(decision.decision.diagnosticOnly, true);
+  assert.equal(decision.policy.allowed, false);
+  assert.match(decision.policy.allowedMeaning, /report-only/);
+  assert.ok(decision.decision.retainedAxes.includes("formStateFlow"));
+  assert.ok(decision.decision.retainedAxes.includes("a11yAnchors"));
+  assert.ok(decision.scope.sourceFingerprint?.fileHash.startsWith("sha256:"));
+  assert.ok(decision.scope.sourceFingerprint?.lineCount > 0);
+  assert.ok(decision.nonClaims.includes("does not authorize runtime reuse"));
+  assert.ok(decision.nonClaims.includes("does not authorize model-facing payload reuse"));
+});
+
+test("context-decision.v1 keeps WebView and mixed evidence on full-read fallback", () => {
+  const webview = decisionFor("webview-boundary-basic.tsx");
+  assert.equal(webview.evidence.domain, "webview");
+  assert.equal(webview.decision.kind, "full-read");
+  assert.ok(webview.evidence.risk.includes("fallback-first-domain-boundary"));
+  assert.ok(webview.evidence.risk.includes("webview-boundary"));
+  assert.equal(webview.policy.allowed, false);
+
+  const mixed = decisionFor("tui-ink-web-dom-mixed.tsx");
+  assert.equal(mixed.evidence.domain, "mixed");
+  assert.equal(mixed.decision.kind, "full-read");
+  assert.ok(mixed.evidence.risk.includes("mixed-domain-evidence"));
+});
+
+test("context-decision.v1 can expose RN narrow-payload diagnostics without expanding support", () => {
+  const decision = decisionFor("rn-primitive-basic.tsx");
+
+  assert.equal(decision.evidence.domain, "react-native");
+  assert.equal(decision.decision.kind, "narrow-payload");
+  assert.equal(decision.decision.diagnosticOnly, true);
+  assert.ok(decision.decision.retainedAxes.includes("sourceAnchorBeta"));
+  assert.equal(decision.policy.allowed, false);
+  assert.ok(decision.nonClaims.includes("does not expand React Native, WebView, or TUI support"));
+});
+
+test("context-decision.v1 defers TUI and unknown evidence", () => {
+  const tui = decisionFor("tui-ink-basic.tsx");
+  assert.equal(tui.evidence.domain, "tui-ink");
+  assert.equal(tui.decision.kind, "defer");
+  assert.match(tui.decision.reason, /tui/);
+
+  const unknownFile = path.join(repoRoot, "package.json");
+  const sourceText = fs.readFileSync(unknownFile, "utf8");
+  const domainDetection = detectDomainFromSource(sourceText, unknownFile);
+  const unknown = buildContextDecision({
+    filePath: unknownFile,
+    cwd: repoRoot,
+    sourceText,
+    domainDetection,
+  });
+  assert.equal(unknown.evidence.domain, "unknown");
+  assert.equal(unknown.decision.kind, "defer");
+  assert.equal(unknown.evidence.freshness, "unknown");
+  assert.equal(unknown.policy.allowed, false);
+});

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -405,6 +405,59 @@ test("CLI inspect-domain emits explicit report-only domain memory receipt only w
   assert.doesNotMatch(JSON.stringify(receipt), forbiddenSupportClaims);
 });
 
+test("CLI inspect-domain emits explicit report-only context decision only with its flag", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+
+  const plainCli = spawnSync(process.execPath, [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(plainCli.status, 0, plainCli.stderr);
+  const plainResult = JSON.parse(plainCli.stdout);
+  assert.equal("contextDecision" in plainResult, false);
+
+  const decisionCli = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json", "--context-decision"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(decisionCli.status, 0, decisionCli.stderr);
+  const result = JSON.parse(decisionCli.stdout);
+  const decision = result.contextDecision;
+  assert.ok(decision);
+  assert.equal(decision.schemaVersion, "context-decision.v1");
+  assert.equal(decision.evidence.domain, "react-web");
+  assert.equal(decision.decision.kind, "compact-context");
+  assert.equal(decision.decision.diagnosticOnly, true);
+  assert.equal(decision.policy.allowed, false);
+  assert.match(decision.policy.allowedMeaning, /report-only/);
+  assert.ok(decision.nonClaims.includes("does not authorize runtime reuse"));
+  assert.ok(decision.nonClaims.includes("does not authorize pre-read reuse"));
+  assert.ok(decision.nonClaims.includes("does not authorize cache reuse"));
+  assert.ok(decision.nonClaims.includes("does not authorize model-facing payload reuse"));
+  assert.doesNotMatch(JSON.stringify(decision), forbiddenSupportClaims);
+});
+
+test("CLI inspect-domain requires --json before emitting a context decision", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const cli = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--context-decision"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.notEqual(cli.status, 0);
+  assert.match(cli.stderr, /--context-decision requires --json/);
+  assert.equal(cli.stdout, "");
+});
+
 test("CLI inspect-domain requires --json before emitting a domain memory receipt", () => {
   const fixture = path.join(fixtureRoot, "webview-boundary-basic.tsx");
   const cli = spawnSync(

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -405,6 +405,166 @@ test("CLI inspect-domain emits explicit report-only domain memory receipt only w
   assert.doesNotMatch(JSON.stringify(receipt), forbiddenSupportClaims);
 });
 
+test("CLI domain-memory verify reports fresh, stale, incompatible, and unsupported receipt states", () => {
+  const receiptFixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const incompatibleFixture = path.join(fixtureRoot, "rn-primitive-basic.tsx");
+  const receiptCli = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", receiptFixture, "--json", "--domain-memory-receipt"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(receiptCli.status, 0, receiptCli.stderr);
+
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-verify-"));
+  try {
+    const receiptPath = path.join(tempDir, "receipt.json");
+    fs.writeFileSync(receiptPath, JSON.stringify(JSON.parse(receiptCli.stdout).domainMemoryReceipt, null, 2));
+
+    const freshCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", receiptPath, "--file", receiptFixture, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(freshCli.status, 0, freshCli.stderr);
+    const fresh = JSON.parse(freshCli.stdout);
+    assert.equal(fresh.schemaVersion, "domain-memory-verify.v1");
+    assert.equal(fresh.status, "fresh");
+    assert.equal(fresh.checks.sourceFingerprint, "match");
+    assert.equal(fresh.checks.domainLane, "match");
+    assert.equal(fresh.checks.claimBoundary, "match");
+    assert.equal(fresh.checks.policyBoundary, "report-only");
+    assert.equal(fresh.checks.runtimeOrCacheReuse, false);
+    assert.equal(fresh.safeNextAction, "reuse-for-report-only");
+    assert.ok(fresh.nonClaims.includes("does not authorize runtime reuse"));
+    assert.ok(fresh.nonClaims.includes("does not authorize pre-read reuse"));
+    assert.ok(fresh.nonClaims.includes("does not authorize cache reuse"));
+    assert.ok(fresh.nonClaims.includes("does not authorize model-facing payload reuse"));
+    assert.doesNotMatch(JSON.stringify(fresh), forbiddenSupportClaims);
+
+    const staleFile = path.join(tempDir, "custom-form-shell.tsx");
+    fs.copyFileSync(receiptFixture, staleFile);
+    fs.appendFileSync(staleFile, "\nexport const changedForDomainMemoryVerify = true;\n");
+    const staleReceipt = JSON.parse(fs.readFileSync(receiptPath, "utf8"));
+    staleReceipt.scope.filePath = path.relative(repoRoot, staleFile);
+    const staleReceiptPath = path.join(tempDir, "stale-receipt.json");
+    fs.writeFileSync(staleReceiptPath, JSON.stringify(staleReceipt, null, 2));
+    const staleCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", staleReceiptPath, "--file", staleFile, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(staleCli.status, 0, staleCli.stderr);
+    const stale = JSON.parse(staleCli.stdout);
+    assert.equal(stale.status, "stale");
+    assert.equal(stale.checks.sourceFingerprint, "mismatch");
+    assert.equal(stale.safeNextAction, "rerun-inspect-domain");
+
+    const incompatibleCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", receiptPath, "--file", incompatibleFixture, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(incompatibleCli.status, 0, incompatibleCli.stderr);
+    const incompatible = JSON.parse(incompatibleCli.stdout);
+    assert.equal(incompatible.status, "incompatible");
+    assert.equal(incompatible.checks.fileScope, "mismatch");
+    assert.equal(incompatible.checks.domainLane, "mismatch");
+    assert.equal(incompatible.safeNextAction, "full-read");
+
+    const unsupportedReceipt = JSON.parse(fs.readFileSync(receiptPath, "utf8"));
+    unsupportedReceipt.policy.allowed = true;
+    unsupportedReceipt.policy.allowedMeaning = "domain-memory receipts are report-only and do not authorize runtime or cache reuse";
+    unsupportedReceipt.receipt.runtimeOrCacheReuse = true;
+    const unsupportedReceiptPath = path.join(tempDir, "unsupported-receipt.json");
+    fs.writeFileSync(unsupportedReceiptPath, JSON.stringify(unsupportedReceipt, null, 2));
+    const unsupportedCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", unsupportedReceiptPath, "--file", receiptFixture, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(unsupportedCli.status, 0, unsupportedCli.stderr);
+    const unsupported = JSON.parse(unsupportedCli.stdout);
+    assert.equal(unsupported.status, "unsupported");
+    assert.equal(unsupported.checks.policyBoundary, "mismatch");
+
+    const malformedPath = path.join(tempDir, "malformed.json");
+    fs.writeFileSync(malformedPath, "{not-json");
+    const malformedCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", malformedPath, "--file", receiptFixture, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(malformedCli.status, 0, malformedCli.stderr);
+    const malformed = JSON.parse(malformedCli.stdout);
+    assert.equal(malformed.status, "unsupported");
+    assert.match(malformed.reasons.join("\n"), /could not be parsed/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI domain-memory verify requires JSON and rejects unknown arguments", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const receiptCli = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", fixture, "--json", "--domain-memory-receipt"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(receiptCli.status, 0, receiptCli.stderr);
+
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-verify-"));
+  try {
+    const receiptPath = path.join(tempDir, "receipt.json");
+    fs.writeFileSync(receiptPath, JSON.stringify(JSON.parse(receiptCli.stdout).domainMemoryReceipt, null, 2));
+
+    const noJson = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", receiptPath, "--file", fixture],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.notEqual(noJson.status, 0);
+    assert.match(noJson.stderr, /domain-memory verify requires --json/);
+    assert.equal(noJson.stdout, "");
+
+    const unknown = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "verify", "--receipt", receiptPath, "--file", fixture, "--json", "--surprise"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    assert.notEqual(unknown.status, 0);
+    assert.match(unknown.stderr, /Unexpected domain-memory verify argument/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI inspect-domain emits explicit report-only context decision only with its flag", () => {
   const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -3963,6 +3963,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect react-web-label-preview <file> \[--json\]/);
   assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\|--dry-run-json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\] \[--domain-memory-receipt\] \[--context-decision\]/);
+  assert.match(help, /fooks domain-memory verify --receipt <receipt\.json> --file <file> --json/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\] \[--handoff-resume-json <file>\]/);
   assert.match(help, /fooks status artifacts/);

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -494,6 +494,7 @@ test("file commands accept --json before or after the file path", () => {
   const inspectBefore = run(["inspect-domain", "--json", "test/fixtures/frontend-domain-expectations/webview-boundary-basic.tsx"]);
   assert.deepEqual(inspectBefore, inspectAfter);
   assert.equal("domainMemoryReceipt" in inspectAfter, false);
+  assert.equal("contextDecision" in inspectAfter, false);
 
   const inspectReceiptAfter = run([
     "inspect-domain",
@@ -511,6 +512,23 @@ test("file commands accept --json before or after the file path", () => {
   assert.equal(inspectReceiptBefore.domainMemoryReceipt.schemaVersion, "domain-memory.v1");
   assert.equal(inspectReceiptAfter.domainMemoryReceipt.policy.allowed, false);
   assert.equal(inspectReceiptBefore.domainMemoryReceipt.policy.allowed, false);
+
+  const inspectDecisionAfter = run([
+    "inspect-domain",
+    "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx",
+    "--json",
+    "--context-decision",
+  ]);
+  const inspectDecisionBefore = run([
+    "inspect-domain",
+    "--context-decision",
+    "--json",
+    "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx",
+  ]);
+  assert.equal(inspectDecisionAfter.contextDecision.schemaVersion, "context-decision.v1");
+  assert.equal(inspectDecisionBefore.contextDecision.schemaVersion, "context-decision.v1");
+  assert.equal(inspectDecisionAfter.contextDecision.policy.allowed, false);
+  assert.equal(inspectDecisionBefore.contextDecision.policy.allowed, false);
 
   const extractAfter = run(["extract", "fixtures/compressed/FormSection.tsx", "--model-payload", "--json"]);
   const extractBefore = run(["extract", "--json", "fixtures/compressed/FormSection.tsx", "--model-payload"]);
@@ -3944,7 +3962,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect ranked-bundle <id> \[--json\]/);
   assert.match(help, /fooks inspect react-web-label-preview <file> \[--json\]/);
   assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\|--dry-run-json\]/);
-  assert.match(help, /fooks inspect-domain <file> \[--json\] \[--domain-memory-receipt\]/);
+  assert.match(help, /fooks inspect-domain <file> \[--json\] \[--domain-memory-receipt\] \[--context-decision\]/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\] \[--handoff-resume-json <file>\]/);
   assert.match(help, /fooks status artifacts/);


### PR DESCRIPTION
## Summary
- add the report-only context-decision foundation for domain memory receipts
- add `fooks domain-memory verify --receipt <receipt.json> --file <file> --json`
- classify receipts as `fresh`, `stale`, `incompatible`, or `unsupported` while keeping `fresh` limited to report-only evidence
- document that runtime/pre-read/cache/model-facing consumers remain deferred

Closes #1051
Follow-up: #1052

## Safety boundary
This PR intentionally does **not** wire verified receipts into runtime hooks, pre-read, cache, or model-facing payload reuse. Any receipt that is malformed, stale, incompatible, unsupported, or tries to claim runtime/cache reuse fails closed.

## Verification
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `node --test test/domain-detector.test.mjs test/domain-memory-contract-docs.test.mjs test/fooks.test.mjs`
- [x] `npm run smoke:domain-detector`

## Not tested
- Full `npm test` in the final pass. Earlier full run had unrelated `operator-activity` tmux/socket expectation failures, so this PR used targeted verifier/domain-memory coverage plus smoke.