### PR TITLE
Add explicit domain-memory runtime advisory consumer

### DIFF
--- a/docs/domain-memory-contract.md
+++ b/docs/domain-memory-contract.md
@@ -166,3 +166,17 @@ Verifier statuses are fail-closed:
 - `unsupported` means the receipt is malformed, from an unsupported schema, or attempts to claim runtime/cache reuse.
 
 For this lane, any receipt with `policy.allowed: true` or `receipt.runtimeOrCacheReuse: true` is unsupported. Runtime/cache/pre-read consumers remain deferred until a later plan names the exact consumer, freshness gates, policy boundaries, and verification evidence.
+
+## Runtime advisory consumer lane
+
+The first consumer is deliberately narrow: the Codex runtime hook may consume an explicit prompt-provided receipt path as **advisory-only** context on a repeated-file turn:
+
+```text
+Again inspect src/Foo.tsx with domain-memory receipt .fooks/domain-memory/foo.json
+```
+
+This lane does not search cache directories, does not persist receipts, and does not let a receipt authorize compact injection. The normal pre-read/runtime payload gate must already allow injection. When the receipt verifies as `fresh`, the hook may append a bounded `FOOKS DOMAIN MEMORY ADVISORY` block that repeats the receipt status, reasons, safe next action, and non-claims.
+
+If the explicit receipt is `stale`, `incompatible`, `unsupported`, missing, or unreadable, the runtime hook fails closed to full-read guidance. The stale receipt is not silently ignored, because an explicit receipt hint means the prompt is asking the runtime to rely on that evidence.
+
+This lane still does not add pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims. Automatic cache lookup and pre-read consumers require separate plans.

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { decidePreRead } from "./pre-read";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import { discoverProjectFiles } from "../core/discover";
+import { detectDomainFromSource } from "../core/domain-detector";
+import { unsupportedDomainMemoryVerifyResult, verifyDomainMemoryReceipt } from "../core/domain-memory-verify";
 import { appendProjectKnowledgeBlock, resolveProjectKnowledgeContext } from "../core/project-knowledge";
 import { buildPreReadReuseStatus } from "./codex-runtime-status";
 import { clearCodexActiveFile, ensureFreshCodexContextForTarget, markCodexAttachPrepared, markCodexReady } from "./codex-runtime-trust";
@@ -30,6 +32,7 @@ const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|mo
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const EDIT_GUIDANCE_CONTEXT_MAX_BYTES = 8_192;
 const PREFLIGHT_ADVISORY_CONTEXT_MARKER = "FOOKS PREFLIGHT ADVISORY";
+const DOMAIN_MEMORY_ADVISORY_CONTEXT_MARKER = "FOOKS DOMAIN MEMORY ADVISORY";
 const PREFLIGHT_ISSUE_OR_PR_PATTERN = /(?:#\d+\b|\b(?:issue|issues|pr|pull\s+request)\s*#?\d+\b)/iu;
 const PREFLIGHT_TEST_COMMAND_PATTERN = /(?:\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b|\bpytest\b|\bvitest\b|\bjest\b|테스트)/iu;
 const PREFLIGHT_STACK_OR_ERROR_PATTERN = /(?:\b(?:typeerror|referenceerror|syntaxerror|stack\s+trace|traceback|failed|failure|exception|error)\b|에러|오류|실패|스택|이상한데)/iu;
@@ -178,6 +181,102 @@ function compactRuntimeReactWebContext(
 type RuntimeReactWebContextPackingSummary = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebContextPacking"]>;
 type CodexRuntimeDebug = NonNullable<CodexRuntimeHookDecision["debug"]>;
 type PreflightAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["preflightAdvisoryIntent"]>;
+type DomainMemoryAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["domainMemoryAdvisory"]>;
+
+function unquotePromptPath(value: string): string {
+  return value.replace(/^["'`]+|["'`,.;:)]+$/gu, "");
+}
+
+function resolveDomainMemoryReceiptHint(prompt: string, cwd: string): { receiptPath?: string; reasons: string[] } {
+  const match =
+    /(?:--receipt|domain-memory\s+receipt|domain\s+memory\s+receipt)\s+(?<path>["'`]?[^\s"'`]+\.json["'`]?)/iu.exec(prompt);
+  const rawPath = match?.groups?.path;
+  if (!rawPath) return { reasons: [] };
+
+  const receiptPath = path.resolve(cwd, unquotePromptPath(rawPath));
+  const relative = path.relative(cwd, receiptPath) || path.basename(receiptPath);
+  if (!fs.existsSync(receiptPath) || !fs.statSync(receiptPath).isFile()) {
+    return {
+      receiptPath,
+      reasons: [`domain-memory receipt hint not readable: ${relative}`],
+    };
+  }
+  return { receiptPath, reasons: [] };
+}
+
+function verifyDomainMemoryAdvisory(
+  prompt: string,
+  target: string,
+  cwd: string,
+): { requested: boolean; result?: ReturnType<typeof verifyDomainMemoryReceipt>; debug: DomainMemoryAdvisoryDebugReceipt } {
+  const hint = resolveDomainMemoryReceiptHint(prompt, cwd);
+  if (!hint.receiptPath && hint.reasons.length === 0) {
+    return { requested: false, debug: { requested: false, reasons: [] } };
+  }
+
+  const filePath = path.join(cwd, target);
+  const receiptPath = hint.receiptPath ?? path.join(cwd, "__missing-domain-memory-receipt__.json");
+  const sourceText = fs.readFileSync(filePath, "utf8");
+  let receipt: unknown;
+  let result: ReturnType<typeof verifyDomainMemoryReceipt>;
+  try {
+    receipt = JSON.parse(fs.readFileSync(receiptPath, "utf8"));
+    result = verifyDomainMemoryReceipt({
+      receipt,
+      receiptPath,
+      filePath,
+      cwd,
+      sourceText,
+      domainDetection: detectDomainFromSource(sourceText, filePath),
+    });
+  } catch (error) {
+    result = unsupportedDomainMemoryVerifyResult({
+      filePath,
+      receiptPath,
+      cwd,
+      reason: hint.reasons[0] ?? `domain-memory receipt could not be verified: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  return {
+    requested: true,
+    result,
+    debug: {
+      requested: true,
+      receiptPath: result.receiptPath,
+      status: result.status,
+      safeNextAction: result.safeNextAction,
+      reasons: result.reasons,
+    },
+  };
+}
+
+function renderDomainMemoryAdvisoryContext(result: ReturnType<typeof verifyDomainMemoryReceipt>): string {
+  return [
+    DOMAIN_MEMORY_ADVISORY_CONTEXT_MARKER,
+    `- Source: explicit prompt-provided receipt ${result.receiptPath}; verified against ${result.filePath}.`,
+    `- Status: ${result.status}; safe next action: ${result.safeNextAction}.`,
+    `- Reasons: ${result.reasons.join(", ")}.`,
+    `- Non-claims: ${result.nonClaims.join("; ")}.`,
+    "- Boundary: advisory-only report evidence; does not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/billing/runtime savings claims.",
+  ].join("\n");
+}
+
+function attachDomainMemoryAdvisoryDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  receipt: DomainMemoryAdvisoryDebugReceipt,
+): CodexRuntimeHookDecision {
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    domainMemoryAdvisory: receipt,
+  };
+  return runtimeDecision;
+}
 
 function preflightAdvisoryDebugReceipt(decision: PreflightAdvisoryDecision): PreflightAdvisoryDebugReceipt {
   return {
@@ -697,6 +796,35 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
   }
 
   const originalEstimatedBytes = targetEstimatedBytes(cwd, target);
+  const domainMemoryAdvisory = verifyDomainMemoryAdvisory(prompt, target, cwd);
+  if (domainMemoryAdvisory.requested && domainMemoryAdvisory.result?.status !== "fresh") {
+    markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
+    const runtimeDecision = fallbackDecision(
+      hookEventName,
+      target,
+      statePath,
+      [
+        "repeated-file",
+        "domain-memory-receipt-not-fresh",
+        ...(domainMemoryAdvisory.result ? [`domain-memory-receipt:${domainMemoryAdvisory.result.status}`] : []),
+      ],
+      true,
+      true,
+      false,
+      "domain-memory-receipt-not-fresh",
+      policy,
+      decision,
+    );
+    attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
+    attachDomainMemoryAdvisoryDebug(runtimeDecision, domainMemoryAdvisory.debug);
+    recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
+      originalEstimatedBytes,
+      actualEstimatedBytes: originalEstimatedBytes,
+      comparableForSavings: originalEstimatedBytes !== undefined,
+    });
+    return attachReactWebEvidenceArtifact(cwd, runtimeDecision);
+  }
+
   const editGuidanceAllowed =
     decision.decision === "payload" &&
     Boolean(decision.payload?.sourceFingerprint) &&
@@ -724,7 +852,13 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     const contextMode = payloadContextMode(decision.payload);
     const runtimeContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
     const projectKnowledge = resolveProjectKnowledgeContext(prompt, [target], cwd);
-    const additionalContext = appendProjectKnowledgeBlock(runtimeContext.additionalContext, projectKnowledge?.block);
+    const advisoryContext = domainMemoryAdvisory.result?.status === "fresh"
+      ? renderDomainMemoryAdvisoryContext(domainMemoryAdvisory.result)
+      : undefined;
+    const additionalContext = appendProjectKnowledgeBlock(
+      [runtimeContext.additionalContext, advisoryContext].filter(Boolean).join("\n\n"),
+      projectKnowledge?.block,
+    );
     const { reactWebContextPacking } = runtimeContext;
     markCodexAttachPrepared({ filePath: target, source: "prompt-target" }, cwd);
     const editGuidanceIncluded = hasMatchingEditGuidance(decision.payload);
@@ -756,6 +890,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       },
     };
     attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
+    if (domainMemoryAdvisory.requested) {
+      attachDomainMemoryAdvisoryDebug(runtimeDecision, domainMemoryAdvisory.debug);
+    }
 
     if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
       const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
@@ -812,6 +949,9 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     decision,
   );
   attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
+  if (domainMemoryAdvisory.requested) {
+    attachDomainMemoryAdvisoryDebug(runtimeDecision, domainMemoryAdvisory.debug);
+  }
   recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
     originalEstimatedBytes,
     actualEstimatedBytes: originalEstimatedBytes,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,6 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
 import type { DomainDetectionResult } from "./domain-detector";
+import type { DomainMemoryVerifyResult } from "./domain-memory-verify";
 import type { ProjectKnowledgeMetadata } from "./project-knowledge";
 import type { DomainPayload } from "./payload/domain-payload";
 import type { FrontendConcernProfile } from "./concern-profiles/types";
@@ -749,6 +750,13 @@ export type CodexRuntimeHookDecision = {
       score: number;
       reasons: string[];
       skipReasons: string[];
+    };
+    domainMemoryAdvisory?: {
+      requested: boolean;
+      receiptPath?: string;
+      status?: DomainMemoryVerifyResult["status"];
+      safeNextAction?: DomainMemoryVerifyResult["safeNextAction"];
+      reasons: string[];
     };
   };
   fallback?: {

--- a/test/domain-memory-contract-docs.test.mjs
+++ b/test/domain-memory-contract-docs.test.mjs
@@ -72,6 +72,19 @@ test("domain-memory contract forbids support and runtime expansion", () => {
   ]);
 });
 
+test("domain-memory contract scopes runtime advisory consumer to explicit fresh receipts", () => {
+  assertContains("domain memory", domainMemory, [
+    "Runtime advisory consumer lane",
+    "explicit prompt-provided receipt path",
+    "advisory-only",
+    "FOOKS DOMAIN MEMORY ADVISORY",
+    "normal pre-read/runtime payload gate must already allow injection",
+    "fails closed to full-read guidance",
+    "does not add pre-read reuse, cache reuse, model-facing payload reuse",
+    "Automatic cache lookup and pre-read consumers require separate plans",
+  ]);
+});
+
 test("state and domain-payload architecture docs link the domain-memory contract without widening behavior", () => {
   assertContains("state contract", stateContract, [
     "domain-memory.v1",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -42,6 +42,7 @@ const { RAW_ORIGINAL_SIZE_THRESHOLD_BYTES } = require(path.join(repoRoot, "dist"
 const { toModelFacingPayload } = require(path.join(repoRoot, "dist", "core", "payload", "model-facing.js"));
 const { assessPayloadReadiness } = require(path.join(repoRoot, "dist", "core", "payload", "readiness.js"));
 const { detectDomain, detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { buildDomainMemoryReceipt } = require(path.join(repoRoot, "dist", "core", "domain-memory-receipt.js"));
 const codexPreReadModule = require(path.join(repoRoot, "dist", "adapters", "codex-pre-read.js"));
 const { decideCodexPreRead } = codexPreReadModule;
 const preReadModule = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
@@ -280,6 +281,22 @@ function writeProjectKnowledgeFixture(tempDir, overrides = {}) {
     fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
     fs.writeFileSync(path.join(tempDir, ".fooks", "project-knowledge.json"), JSON.stringify(overrides.ignoredRuleFile, null, 2));
   }
+}
+
+function writeDomainMemoryReceipt(tempDir, target, name = "domain-memory-receipt.json") {
+  const filePath = path.join(tempDir, target);
+  const sourceText = fs.readFileSync(filePath, "utf8");
+  const receipt = buildDomainMemoryReceipt({
+    filePath,
+    cwd: tempDir,
+    sourceText,
+    domainDetection: detectDomainFromSource(sourceText, filePath),
+  });
+  const receiptDir = path.join(tempDir, ".fooks", "domain-memory");
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, name);
+  fs.writeFileSync(receiptPath, JSON.stringify(receipt, null, 2));
+  return path.relative(tempDir, receiptPath);
 }
 
 function makeTempTsJsBetaProject(repositoryUrl = "https://github.com/minislively/temp-ts-js-project.git") {
@@ -2216,6 +2233,84 @@ test("codex runtime hook records first matching exact-file prompt without projec
   assert.equal(lastEvent.authority, "tracked");
   assert.equal(lastEvent.rulesPath, DEFAULT_PROJECT_KNOWLEDGE_RULES_PATH);
   assert.equal(lastEvent.mode, "advisory");
+});
+
+test("codex runtime hook appends fresh explicit domain-memory receipt as advisory-only context", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-fresh-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  const receiptPath = writeDomainMemoryReceipt(tempDir, target);
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target} with domain-memory receipt ${receiptPath}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.ok(second.additionalContext.includes("FOOKS DOMAIN MEMORY ADVISORY"));
+  assert.ok(second.additionalContext.includes("- Status: fresh; safe next action: reuse-for-report-only."));
+  assert.ok(second.additionalContext.includes("advisory-only report evidence"));
+  assert.ok(second.additionalContext.includes("does not authorize runtime reuse"));
+  assert.ok(second.additionalContext.includes("does not authorize pre-read reuse"));
+  assert.ok(second.additionalContext.includes("does not authorize cache reuse"));
+  assert.equal(second.debug.domainMemoryAdvisory.requested, true);
+  assert.equal(second.debug.domainMemoryAdvisory.status, "fresh");
+  assert.equal(second.debug.domainMemoryAdvisory.safeNextAction, "reuse-for-report-only");
+  assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
+});
+
+test("codex runtime hook fails closed when explicit domain-memory receipt is stale", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-stale-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  const receiptPath = writeDomainMemoryReceipt(tempDir, target);
+  fs.appendFileSync(path.join(tempDir, target), "\nexport const changedAfterReceipt = true;\n");
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target} with domain-memory receipt ${receiptPath}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "fallback");
+  assert.equal(second.contextMode, "full");
+  assert.equal(second.contextModeReason, "domain-memory-receipt-not-fresh");
+  assert.equal(second.fallback.action, "full-read");
+  assert.equal(second.fallback.reason, "domain-memory-receipt-not-fresh");
+  assert.ok(second.reasons.includes("domain-memory-receipt-not-fresh"));
+  assert.ok(second.reasons.includes("domain-memory-receipt:stale"));
+  assert.equal(second.debug.domainMemoryAdvisory.requested, true);
+  assert.equal(second.debug.domainMemoryAdvisory.status, "stale");
+  assert.equal(second.debug.domainMemoryAdvisory.safeNextAction, "rerun-inspect-domain");
 });
 
 test("runtime hook falls back when repeated-file payload build throws", () => {


### PR DESCRIPTION
## Summary
- consume explicit prompt-provided domain-memory receipt paths in the Codex runtime hook
- append a bounded `FOOKS DOMAIN MEMORY ADVISORY` block only when the existing repeated-file payload gate already injects and the receipt verifies `fresh`
- fail closed to full-read guidance for stale/incompatible/unsupported/missing/unreadable explicit receipts
- document and test the runtime advisory consumer lane without adding cache/pre-read/model-facing reuse

Closes #1052

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm run build && node --test test/fooks.test.mjs test/domain-detector.test.mjs test/domain-memory-contract-docs.test.mjs`
- `npm run smoke:domain-detector`
- `npm test`

## Boundaries
- No automatic cache lookup or receipt persistence.
- No pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims.
- Fresh receipts are advisory/report evidence only and do not authorize compact injection by themselves.
