### PR TITLE
Add advisory-only domain-memory lookup diagnostics

### DIFF
--- a/docs/domain-memory-contract.md
+++ b/docs/domain-memory-contract.md
@@ -180,3 +180,17 @@ This lane does not search cache directories, does not persist receipts, and does
 If the explicit receipt is `stale`, `incompatible`, `unsupported`, missing, or unreadable, the runtime hook fails closed to full-read guidance. The stale receipt is not silently ignored, because an explicit receipt hint means the prompt is asking the runtime to rely on that evidence.
 
 This lane still does not add pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims. Automatic cache lookup and pre-read consumers require separate plans.
+
+## Lookup diagnostic lane
+
+The next consumer-adjacent lane is an advisory-only lookup diagnostic:
+
+```bash
+fooks domain-memory lookup --file src/Foo.tsx --json
+```
+
+The lookup recursively scans only the project-local `.fooks/domain-memory/` directory for JSON receipts, rejects symlinked lookup directories, verifies every candidate with the same freshness verifier, and returns a machine-readable status: `not-found`, `fresh`, `stale`, `incompatible`, `unsupported`, or `ambiguous`.
+
+A `fresh` lookup means exactly one receipt is fresh for report/advisory evidence only. The machine result still carries `authorization: "none"` and `advisoryOnly: true`; any `advisoryReceiptPath` is evidence-only, not permission. Multiple fresh receipts are `ambiguous` and must not be auto-selected. Stale, incompatible, unsupported, mixed fresh/non-fresh, missing, unreadable, or ambiguous lookup results do not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims.
+
+This lane intentionally does not change runtime hook behavior, pre-read decisions, cache storage, or model-facing payloads. Runtime automatic advisory lookup, pre-read appendices, and any payload/cache reuse require separate plans and tests.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import type { ExtractionResult } from "../core/schema";
 import type { ContextDecision } from "../core/context-decision";
 import type { DomainMemoryReceipt } from "../core/domain-memory-receipt";
 import type { DomainMemoryVerifyResult } from "../core/domain-memory-verify";
+import type { DomainMemoryLookupResult } from "../core/domain-memory-lookup";
 import type { InspectDomainReactNativeSourceAnchorBeta } from "../core/react-native-proof-surface";
 
 function print(value: unknown): void {
@@ -685,6 +686,7 @@ Everyday commands:
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
   ${displayCliName} domain-memory verify --receipt <receipt.json> --file <file> --json
+  ${displayCliName} domain-memory lookup --file <file> --json
   ${displayCliName} install codex-hooks
   ${displayCliName} install claude-hooks
   ${displayCliName} install opencode-tool
@@ -839,13 +841,12 @@ function parseInspectDomainArgs(args: string[]): { filePath: string; json: boole
   return { filePath: requireFilePath(filePath), json, domainMemoryReceipt, contextDecision };
 }
 
-function parseDomainMemoryArgs(args: string[]): {
-  receiptPath: string;
-  filePath: string;
-} {
+function parseDomainMemoryArgs(args: string[]):
+  | { action: "verify"; receiptPath: string; filePath: string }
+  | { action: "lookup"; filePath: string } {
   const [action, ...rest] = args;
-  if (action !== "verify") {
-    throw new Error("domain-memory expects 'verify'");
+  if (action !== "verify" && action !== "lookup") {
+    throw new Error("domain-memory expects 'verify' or 'lookup'");
   }
 
   let receiptPath: string | undefined;
@@ -858,7 +859,7 @@ function parseDomainMemoryArgs(args: string[]): {
       json = true;
       continue;
     }
-    if (arg === "--receipt") {
+    if (action === "verify" && arg === "--receipt") {
       receiptPath = rest[index + 1];
       index += 1;
       continue;
@@ -868,14 +869,19 @@ function parseDomainMemoryArgs(args: string[]): {
       index += 1;
       continue;
     }
-    throw new Error(`Unexpected domain-memory verify argument: ${arg}`);
+    throw new Error(`Unexpected domain-memory ${action} argument: ${arg}`);
   }
 
   if (!json) {
-    throw new Error("domain-memory verify requires --json");
+    throw new Error(`domain-memory ${action} requires --json`);
+  }
+
+  if (action === "lookup") {
+    return { action, filePath: requireFilePath(filePath) };
   }
 
   return {
+    action,
     receiptPath: requireFilePath(receiptPath),
     filePath: requireFilePath(filePath),
   };
@@ -1626,6 +1632,13 @@ async function run(): Promise<void> {
       } catch (error) {
         console.error(`fooks domain-memory: ${error instanceof Error ? error.message : String(error)}`);
         process.exitCode = 1;
+        return;
+      }
+
+      if (options.action === "lookup") {
+        const { lookupDomainMemoryReceipts } = await import("../core/domain-memory-lookup.js");
+        const result: DomainMemoryLookupResult = lookupDomainMemoryReceipts(options.filePath, process.cwd());
+        print(result);
         return;
       }
 

--- a/src/core/domain-memory-lookup.ts
+++ b/src/core/domain-memory-lookup.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import path from "node:path";
+import { detectDomainFromSource } from "./domain-detector";
+import {
+  type DomainMemoryVerifyResult,
+  type DomainMemoryVerifySafeNextAction,
+  unsupportedDomainMemoryVerifyResult,
+  verifyDomainMemoryReceipt,
+} from "./domain-memory-verify";
+
+export const DOMAIN_MEMORY_LOOKUP_SCHEMA_VERSION = "domain-memory-lookup.v1" as const;
+export const DOMAIN_MEMORY_LOOKUP_DIR = path.join(".fooks", "domain-memory");
+
+export type DomainMemoryLookupStatus =
+  | "not-found"
+  | "fresh"
+  | "stale"
+  | "incompatible"
+  | "unsupported"
+  | "ambiguous";
+
+export type DomainMemoryLookupCandidate = {
+  receiptPath: string;
+  status: DomainMemoryVerifyResult["status"];
+  safeNextAction: DomainMemoryVerifyResult["safeNextAction"];
+  reasons: string[];
+  verifyResult: DomainMemoryVerifyResult;
+};
+
+export type DomainMemoryLookupResult = {
+  schemaVersion: typeof DOMAIN_MEMORY_LOOKUP_SCHEMA_VERSION;
+  command: "domain-memory lookup";
+  filePath: string;
+  lookupDir: string;
+  status: DomainMemoryLookupStatus;
+  authorization: "none";
+  advisoryOnly: true;
+  advisoryReceiptPath?: string;
+  candidateCount: number;
+  freshCandidateCount: number;
+  candidates: DomainMemoryLookupCandidate[];
+  reasons: string[];
+  nonClaims: string[];
+  safeNextAction: DomainMemoryVerifySafeNextAction;
+};
+
+const NON_CLAIMS = [
+  "does not authorize runtime reuse",
+  "does not authorize pre-read reuse",
+  "does not authorize cache reuse",
+  "does not authorize model-facing payload reuse",
+  "does not expand React Native, WebView, or TUI support",
+  "does not use concern or domain evidence as authorization",
+  "does not claim provider-token, billing, cost, latency, or runtime-token savings",
+] as const;
+
+function relativeFilePath(filePath: string, cwd: string): string {
+  return path.relative(cwd, filePath) || path.basename(filePath);
+}
+
+function lookupDirPath(cwd: string): string {
+  return path.join(cwd, DOMAIN_MEMORY_LOOKUP_DIR);
+}
+
+function isPathInside(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function listReceiptJsonFiles(dir: string, cwd: string): { files: string[]; error?: string } {
+  const files: string[] = [];
+  const visit = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const resolved = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(resolved);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".json")) files.push(resolved);
+    }
+  };
+  try {
+    if (!fs.existsSync(dir)) return { files };
+    const dirStat = fs.lstatSync(dir);
+    if (dirStat.isSymbolicLink()) return { files: [], error: "lookup directory must not be a symlink" };
+    if (!dirStat.isDirectory()) return { files };
+    const realCwd = fs.realpathSync(cwd);
+    const realDir = fs.realpathSync(dir);
+    if (!isPathInside(realDir, realCwd)) {
+      return { files: [], error: "lookup directory must stay inside the project root" };
+    }
+    visit(dir);
+    return { files: files.sort((left, right) => left.localeCompare(right)) };
+  } catch (error) {
+    return { files: [], error: `lookup directory could not be read: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function safeNextActionFor(status: DomainMemoryLookupStatus): DomainMemoryVerifySafeNextAction {
+  if (status === "fresh") return "reuse-for-report-only";
+  if (status === "stale" || status === "not-found") return "rerun-inspect-domain";
+  return "full-read";
+}
+
+function aggregateStatus(candidates: DomainMemoryLookupCandidate[]): DomainMemoryLookupStatus {
+  if (candidates.length === 0) return "not-found";
+  if (candidates.some((candidate) => candidate.status === "unsupported")) return "unsupported";
+  if (candidates.some((candidate) => candidate.status === "incompatible")) return "incompatible";
+  if (candidates.some((candidate) => candidate.status === "stale")) return "stale";
+  const fresh = candidates.filter((candidate) => candidate.status === "fresh");
+  if (fresh.length > 1) return "ambiguous";
+  if (fresh.length === 1 && candidates.length === 1) return "fresh";
+  return "not-found";
+}
+
+function reasonsFor(
+  status: DomainMemoryLookupStatus,
+  candidates: DomainMemoryLookupCandidate[],
+  lookupDir: string,
+  lookupError?: string,
+): string[] {
+  if (lookupError) return [lookupError];
+  if (status === "not-found") return [`no domain-memory receipt JSON files found in ${lookupDir}`];
+  if (status === "fresh") return ["exactly one fresh domain-memory receipt found for report-only evidence"];
+  if (status === "ambiguous") return ["multiple fresh domain-memory receipts found; refusing to select one automatically"];
+  const matching = candidates.filter((candidate) => candidate.status === status);
+  return matching.length > 0
+    ? matching.flatMap((candidate) => candidate.reasons.map((reason) => `${candidate.receiptPath}: ${reason}`))
+    : [`domain-memory lookup resolved ${status}`];
+}
+
+export function lookupDomainMemoryReceipts(filePath: string, cwd = process.cwd()): DomainMemoryLookupResult {
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedFile = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(resolvedCwd, filePath);
+  const sourceText = fs.readFileSync(resolvedFile, "utf8");
+  const domainDetection = detectDomainFromSource(sourceText, resolvedFile);
+  const dir = lookupDirPath(resolvedCwd);
+  const { files: receiptPaths, error: lookupError } = listReceiptJsonFiles(dir, resolvedCwd);
+  const candidates = receiptPaths.map((receiptPath): DomainMemoryLookupCandidate => {
+    let verifyResult: DomainMemoryVerifyResult;
+    try {
+      verifyResult = verifyDomainMemoryReceipt({
+        receipt: JSON.parse(fs.readFileSync(receiptPath, "utf8")),
+        receiptPath,
+        filePath: resolvedFile,
+        cwd: resolvedCwd,
+        sourceText,
+        domainDetection,
+      });
+    } catch (error) {
+      verifyResult = unsupportedDomainMemoryVerifyResult({
+        filePath: resolvedFile,
+        receiptPath,
+        cwd: resolvedCwd,
+        reason: `receipt JSON could not be parsed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+    return {
+      receiptPath: verifyResult.receiptPath,
+      status: verifyResult.status,
+      safeNextAction: verifyResult.safeNextAction,
+      reasons: verifyResult.reasons,
+      verifyResult,
+    };
+  });
+  const status = lookupError ? "unsupported" : aggregateStatus(candidates);
+  const freshCandidates = candidates.filter((candidate) => candidate.status === "fresh");
+  const advisoryReceiptPath = status === "fresh" ? freshCandidates[0]?.receiptPath : undefined;
+  const relativeLookupDir = relativeFilePath(dir, resolvedCwd);
+
+  return {
+    schemaVersion: DOMAIN_MEMORY_LOOKUP_SCHEMA_VERSION,
+    command: "domain-memory lookup",
+    filePath: relativeFilePath(resolvedFile, resolvedCwd),
+    lookupDir: relativeLookupDir,
+    status,
+    authorization: "none",
+    advisoryOnly: true,
+    ...(advisoryReceiptPath ? { advisoryReceiptPath } : {}),
+    candidateCount: candidates.length,
+    freshCandidateCount: freshCandidates.length,
+    candidates,
+    reasons: reasonsFor(status, candidates, relativeLookupDir, lookupError),
+    nonClaims: [...NON_CLAIMS],
+    safeNextAction: safeNextActionFor(status),
+  };
+}

--- a/test/domain-detector.test.mjs
+++ b/test/domain-detector.test.mjs
@@ -11,6 +11,7 @@ import { spawnSync } from "node:child_process";
 const repoRoot = process.cwd();
 const require = createRequire(import.meta.url);
 const { detectDomain, detectDomainFromSource } = require(path.join(repoRoot, "dist", "core", "domain-detector.js"));
+const { lookupDomainMemoryReceipts } = require(path.join(repoRoot, "dist", "core", "domain-memory-lookup.js"));
 
 const fixtureRoot = path.join(repoRoot, "test", "fixtures", "frontend-domain-expectations");
 const manifestPath = path.join(fixtureRoot, "manifest.json");
@@ -563,6 +564,231 @@ test("CLI domain-memory verify requires JSON and rejects unknown arguments", () 
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+
+test("CLI domain-memory lookup reports advisory-only receipt diagnostics", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-lookup-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.copyFileSync(fixture, path.join(tempDir, "src", "custom-form-shell.tsx"));
+    const target = path.join("src", "custom-form-shell.tsx");
+    const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+    const notFoundCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(notFoundCli.status, 0, notFoundCli.stderr);
+    const notFound = JSON.parse(notFoundCli.stdout);
+    assert.equal(notFound.schemaVersion, "domain-memory-lookup.v1");
+    assert.equal(notFound.status, "not-found");
+    assert.equal(notFound.candidateCount, 0);
+    assert.equal(notFound.safeNextAction, "rerun-inspect-domain");
+    assert.ok(notFound.nonClaims.includes("does not authorize runtime reuse"));
+    assert.ok(notFound.nonClaims.includes("does not authorize pre-read reuse"));
+    assert.ok(notFound.nonClaims.includes("does not authorize cache reuse"));
+    assert.ok(notFound.nonClaims.includes("does not authorize model-facing payload reuse"));
+
+    const receiptCli = spawnSync(
+      process.execPath,
+      [cliPath, "inspect-domain", target, "--json", "--domain-memory-receipt"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(receiptCli.status, 0, receiptCli.stderr);
+    const receipt = JSON.parse(receiptCli.stdout).domainMemoryReceipt;
+    fs.writeFileSync(path.join(tempDir, "outside-receipt.json"), JSON.stringify(receipt, null, 2));
+    const outsideIgnoredCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(outsideIgnoredCli.status, 0, outsideIgnoredCli.stderr);
+    assert.equal(JSON.parse(outsideIgnoredCli.stdout).status, "not-found");
+
+    const receiptDir = path.join(tempDir, ".fooks", "domain-memory");
+    fs.mkdirSync(receiptDir, { recursive: true });
+    const receiptPath = path.join(receiptDir, "receipt.json");
+    fs.writeFileSync(receiptPath, JSON.stringify(receipt, null, 2));
+
+    const freshCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(freshCli.status, 0, freshCli.stderr);
+    const fresh = JSON.parse(freshCli.stdout);
+    assert.equal(fresh.status, "fresh");
+    assert.equal(fresh.authorization, "none");
+    assert.equal(fresh.advisoryOnly, true);
+    assert.equal(fresh.advisoryReceiptPath, path.join(".fooks", "domain-memory", "receipt.json"));
+    assert.equal(fresh.candidateCount, 1);
+    assert.equal(fresh.freshCandidateCount, 1);
+    assert.equal(fresh.safeNextAction, "reuse-for-report-only");
+    assert.equal(fresh.candidates[0].verifyResult.status, "fresh");
+    assert.doesNotMatch(JSON.stringify(fresh), forbiddenSupportClaims);
+
+    fs.copyFileSync(receiptPath, path.join(receiptDir, "receipt-copy.json"));
+    const ambiguousCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(ambiguousCli.status, 0, ambiguousCli.stderr);
+    const ambiguous = JSON.parse(ambiguousCli.stdout);
+    assert.equal(ambiguous.status, "ambiguous");
+    assert.equal(ambiguous.advisoryReceiptPath, undefined);
+    assert.equal(ambiguous.freshCandidateCount, 2);
+    assert.equal(ambiguous.safeNextAction, "full-read");
+
+    fs.rmSync(path.join(receiptDir, "receipt-copy.json"));
+    const incompatibleReceipt = JSON.parse(JSON.stringify(receipt));
+    incompatibleReceipt.domain.lane = "react-native";
+    fs.writeFileSync(path.join(receiptDir, "incompatible.json"), JSON.stringify(incompatibleReceipt, null, 2));
+    const mixedIncompatibleCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(mixedIncompatibleCli.status, 0, mixedIncompatibleCli.stderr);
+    const mixedIncompatible = JSON.parse(mixedIncompatibleCli.stdout);
+    assert.equal(mixedIncompatible.status, "incompatible");
+    assert.equal(mixedIncompatible.advisoryReceiptPath, undefined);
+
+    fs.rmSync(path.join(receiptDir, "receipt.json"));
+    fs.renameSync(path.join(receiptDir, "incompatible.json"), receiptPath);
+    const incompatibleCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(incompatibleCli.status, 0, incompatibleCli.stderr);
+    const incompatible = JSON.parse(incompatibleCli.stdout);
+    assert.equal(incompatible.status, "incompatible");
+    assert.equal(incompatible.safeNextAction, "full-read");
+
+    fs.writeFileSync(receiptPath, JSON.stringify(receipt, null, 2));
+    fs.writeFileSync(path.join(receiptDir, "malformed.json"), "{not-json");
+    const mixedMalformedCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(mixedMalformedCli.status, 0, mixedMalformedCli.stderr);
+    const mixedMalformed = JSON.parse(mixedMalformedCli.stdout);
+    assert.equal(mixedMalformed.status, "unsupported");
+    assert.equal(mixedMalformed.advisoryReceiptPath, undefined);
+    fs.rmSync(path.join(receiptDir, "malformed.json"));
+
+    fs.appendFileSync(path.join(tempDir, target), "\nexport const changedForDomainMemoryLookup = true;\n");
+    const staleCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(staleCli.status, 0, staleCli.stderr);
+    const stale = JSON.parse(staleCli.stdout);
+    assert.equal(stale.status, "stale");
+    assert.equal(stale.safeNextAction, "rerun-inspect-domain");
+
+    fs.writeFileSync(path.join(receiptDir, "malformed.json"), "{not-json");
+    const unsupportedCli = spawnSync(
+      process.execPath,
+      [cliPath, "domain-memory", "lookup", "--file", target, "--json"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(unsupportedCli.status, 0, unsupportedCli.stderr);
+    const unsupported = JSON.parse(unsupportedCli.stdout);
+    assert.equal(unsupported.status, "unsupported");
+    assert.equal(unsupported.safeNextAction, "full-read");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("domain-memory lookup returns unsupported JSON when lookup directory cannot be read", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-lookup-error-"));
+  const originalReaddirSync = fs.readdirSync;
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.copyFileSync(fixture, path.join(tempDir, "src", "custom-form-shell.tsx"));
+    fs.mkdirSync(path.join(tempDir, ".fooks", "domain-memory"), { recursive: true });
+    fs.readdirSync = ((target, options) => {
+      if (String(target).endsWith(path.join(".fooks", "domain-memory"))) {
+        throw new Error("simulated unreadable lookup directory");
+      }
+      return originalReaddirSync(target, options);
+    });
+    const lookup = lookupDomainMemoryReceipts(path.join("src", "custom-form-shell.tsx"), tempDir);
+    assert.equal(lookup.status, "unsupported");
+    assert.equal(lookup.safeNextAction, "full-read");
+    assert.equal(lookup.authorization, "none");
+    assert.equal(lookup.advisoryOnly, true);
+    assert.match(lookup.reasons.join("\n"), /lookup directory could not be read/);
+  } finally {
+    fs.readdirSync = originalReaddirSync;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("domain-memory lookup rejects symlinked lookup directories", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-lookup-symlink-"));
+  const outsideDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-domain-memory-outside-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.copyFileSync(fixture, path.join(tempDir, "src", "custom-form-shell.tsx"));
+
+    const target = path.join("src", "custom-form-shell.tsx");
+    const receiptCli = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "dist", "cli", "index.js"), "inspect-domain", target, "--json", "--domain-memory-receipt"],
+      { cwd: tempDir, encoding: "utf8" },
+    );
+    assert.equal(receiptCli.status, 0, receiptCli.stderr);
+    fs.writeFileSync(
+      path.join(outsideDir, "outside-receipt.json"),
+      JSON.stringify(JSON.parse(receiptCli.stdout).domainMemoryReceipt, null, 2),
+    );
+
+    fs.mkdirSync(path.join(tempDir, ".fooks"), { recursive: true });
+    fs.symlinkSync(outsideDir, path.join(tempDir, ".fooks", "domain-memory"), "dir");
+
+    const lookup = lookupDomainMemoryReceipts(target, tempDir);
+    assert.equal(lookup.status, "unsupported");
+    assert.equal(lookup.candidateCount, 0);
+    assert.equal(lookup.safeNextAction, "full-read");
+    assert.equal(lookup.authorization, "none");
+    assert.equal(lookup.advisoryOnly, true);
+    assert.match(lookup.reasons.join("\n"), /lookup directory must not be a symlink/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI domain-memory lookup requires JSON and rejects unknown arguments", () => {
+  const fixture = path.join(fixtureRoot, "react-web", "custom-form-shell.tsx");
+  const noJson = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "lookup", "--file", fixture],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  assert.notEqual(noJson.status, 0);
+  assert.match(noJson.stderr, /domain-memory lookup requires --json/);
+  assert.equal(noJson.stdout, "");
+
+  const unknown = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "dist", "cli", "index.js"), "domain-memory", "lookup", "--file", fixture, "--json", "--surprise"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  assert.notEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /Unexpected domain-memory lookup argument/);
 });
 
 test("CLI inspect-domain emits explicit report-only context decision only with its flag", () => {

--- a/test/domain-memory-contract-docs.test.mjs
+++ b/test/domain-memory-contract-docs.test.mjs
@@ -85,6 +85,23 @@ test("domain-memory contract scopes runtime advisory consumer to explicit fresh 
   ]);
 });
 
+test("domain-memory contract scopes lookup diagnostics to advisory-only evidence", () => {
+  assertContains("domain memory", domainMemory, [
+    "Lookup diagnostic lane",
+    "fooks domain-memory lookup --file src/Foo.tsx --json",
+    "recursively scans only the project-local `.fooks/domain-memory/` directory",
+    "rejects symlinked lookup directories",
+    "not-found`, `fresh`, `stale`, `incompatible`, `unsupported`, or `ambiguous`",
+    "fresh for report/advisory evidence only",
+    "authorization: \"none\"",
+    "advisoryReceiptPath` is evidence-only",
+    "Multiple fresh receipts are `ambiguous`",
+    "mixed fresh/non-fresh",
+    "do not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse",
+    "does not change runtime hook behavior, pre-read decisions, cache storage, or model-facing payloads",
+  ]);
+});
+
 test("state and domain-payload architecture docs link the domain-memory contract without widening behavior", () => {
   assertContains("state contract", stateContract, [
     "domain-memory.v1",

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -4059,6 +4059,7 @@ test("cli help advertises setup and package install has no auto hook side effect
   assert.match(help, /fooks inspect react-web-issues <file> \[--json\|--summary-json\|--dry-run-json\]/);
   assert.match(help, /fooks inspect-domain <file> \[--json\] \[--domain-memory-receipt\] \[--context-decision\]/);
   assert.match(help, /fooks domain-memory verify --receipt <receipt\.json> --file <file> --json/);
+  assert.match(help, /fooks domain-memory lookup --file <file> --json/);
   assert.match(help, /fooks status claude/);
   assert.match(help, /fooks status react-web \[--json\] \[--handoff-resume-json <file>\]/);
   assert.match(help, /fooks status artifacts/);


### PR DESCRIPTION
## Summary

Closes #1055.

- add `fooks domain-memory lookup --file <file> --json` as a CLI-only advisory diagnostic
- scan only project-local `.fooks/domain-memory/` receipts, reject symlinked lookup dirs, and verify candidates with the existing freshness verifier
- return fail-closed lookup statuses with `authorization: "none"` and `advisoryOnly: true`
- document and test that this does not authorize runtime/pre-read/cache/model-facing reuse

## Verification

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build && node --test test/domain-detector.test.mjs test/domain-memory-contract-docs.test.mjs test/fooks.test.mjs` (214 pass)
- [x] `npm run smoke:domain-detector`
- [x] final code-review gate: APPROVE / architect CLEAR

Document-refresh: not-needed | CLI behavior is documented in `docs/domain-memory-contract.md`, help smoke is updated in `test/fooks.test.mjs`, and README/getting-started do not list this internal diagnostic command surface.
