### PR TITLE
Add advisory-only queue after completed child guard (#1050)

### DIFF
--- a/docs/dogfood/advisory-only-queue-after-completed-child-1050.md
+++ b/docs/dogfood/advisory-only-queue-after-completed-child-1050.md
@@ -1,0 +1,71 @@
+# Advisory-only queue after completed child work (#1050)
+
+This is a narrow read-only dogfood docs/test/operator-check/session-whip guard
+for issue #1050. It covers the state after PR #1049 closes the clean
+advisory-inventory child work: the only open issue can again be Epic `#960`,
+with no branch, session, open PR, active worktree, or process.
+
+## Guard rule
+
+A clean post-child-completion `session-whip` or `fooks check` snapshot with:
+
+- completed child evidence from PR `#1049` / issue `#1046` as receipt-only
+  history;
+- only Epic `#960` in the open issue inventory;
+- `open_pr=0`;
+- no non-main branch;
+- no mapped tmux/OMX session;
+- no active worktree or mapped process; and
+- a clean root worktree on `main` with zero divergence
+
+is `advisory-only-queue-after-completed-child-action-required`. It is not a
+terminal idle answer. The operator path must create or adopt a concrete child
+issue/session/branch/PR/worktree/process before claiming current active
+development or ending a dogfood nudge.
+
+Existing active artifact cases still count normally: an open child issue, active
+branch, mapped live session, open PR, active worktree, or active process makes
+the snapshot `concrete-child-session-present` and should be adopted rather than
+ignored.
+
+This guard is intentionally read-only. It does not mutate GitHub issues
+automatically beyond this branch/PR, reopen closed PRs or issues, change merge
+policy, runtime hooks, telemetry, billing/token proof, detector scope, product
+claims, or merge anything.
+
+## Expected read-only report shape
+
+```json
+{
+  "issue": "#1050",
+  "readOnly": true,
+  "sourceEpic": "#960",
+  "completedChildReceipt": {
+    "issue": "#1046",
+    "pullRequest": "#1049",
+    "activeWorkEvidence": false
+  },
+  "openIssueInventory": ["#960"],
+  "operatorDecision": {
+    "classification": "advisory-only-queue-after-completed-child-action-required",
+    "terminalIdleAllowed": false,
+    "activeDevelopmentAllowed": false,
+    "actionRequiredForConcreteChildOrSession": true,
+    "activeDevelopmentRequiresOneOf": [
+      "open-child-issue",
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process"
+    ],
+    "rule": "After completed child work closes and only planning epic #960 remains open, the advisory-only queue is action-required for a concrete child/session; it is not a terminal idle dogfood answer."
+  }
+}
+```
+
+## Focused verification
+
+```sh
+node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
+```

--- a/docs/dogfood/advisory-only-queue-after-completed-child-1050.md
+++ b/docs/dogfood/advisory-only-queue-after-completed-child-1050.md
@@ -67,5 +67,5 @@ claims, or merge anything.
 ## Focused verification
 
 ```sh
-node --test test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
+node --test test/advisory-only-queue-after-completed-child-1050.test.mjs test/epic-only-open-issue-idle-guard.test.mjs test/operator-activity.test.mjs
 ```

--- a/test/advisory-only-queue-after-completed-child-1050.test.mjs
+++ b/test/advisory-only-queue-after-completed-child-1050.test.mjs
@@ -109,7 +109,7 @@ test("issue #1050 helper treats open PR as concrete-child-session-present", () =
   assert.equal(result.actionRequiredForConcreteChildOrSession, false);
 });
 
-test("issue #1050 helper requires completed child receipt before action-required", () => {
+test("issue #1050 helper keeps missing receipt from claiming active development", () => {
   const result = classifyAdvisoryOnlyQueueAfterCompletedChild({
     clean: true,
     branch: "main",
@@ -128,8 +128,11 @@ test("issue #1050 helper requires completed child receipt before action-required
   assert.equal(result.completedChildReceipt, false);
   assert.equal(
     result.classification,
-    "concrete-child-session-present",
+    "completed-child-receipt-missing",
   );
+  assert.equal(result.activeDevelopmentAllowed, false);
+  assert.equal(result.actionRequiredForConcreteChildOrSession, false);
+  assert.deepEqual(result.activeEvidenceKinds, []);
 });
 
 test("issue #1050 doc preserves the advisory-only queue guard contract", () => {

--- a/test/advisory-only-queue-after-completed-child-1050.test.mjs
+++ b/test/advisory-only-queue-after-completed-child-1050.test.mjs
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyAdvisoryOnlyQueueAfterCompletedChild } from "./helpers/stale-epic-checklist-boundary.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docPath = path.join(
+  repoRoot,
+  "docs",
+  "dogfood",
+  "advisory-only-queue-after-completed-child-1050.md",
+);
+const doc = fs.readFileSync(docPath, "utf8");
+
+const completedChildReceipt = {
+  issue: { number: 1046, state: "closed" },
+  pullRequest: { number: 1049, state: "closed", merged: true },
+};
+
+test("issue #1050 helper flags advisory-only epic-only queue as action-required", () => {
+  const result = classifyAdvisoryOnlyQueueAfterCompletedChild({
+    clean: true,
+    branch: "main",
+    ahead: 0,
+    behind: 0,
+    openIssueCount: 1,
+    openPullRequestCount: 0,
+    epic: "#960",
+    completedChildReceipt,
+    evidence: {
+      issues: [{ number: 960, state: "open" }],
+      pullRequests: [],
+    },
+  });
+
+  assert.equal(result.issue, "#1050");
+  assert.equal(result.epic, "#960");
+  assert.equal(
+    result.classification,
+    "advisory-only-queue-after-completed-child-action-required",
+  );
+  assert.equal(result.cleanPostChildCompletionEcho, true);
+  assert.equal(result.completedChildReceipt, true);
+  assert.equal(result.advisoryOnlyQueue, true);
+  assert.equal(result.terminalIdleAllowed, false);
+  assert.equal(result.actionRequiredForConcreteChildOrSession, true);
+  assert.equal(result.activeDevelopmentAllowed, false);
+  assert.deepEqual(result.requiredConcreteChildArtifacts, [
+    "open-child-issue",
+    "active-session",
+    "active-branch",
+    "open-pull-request",
+    "active-worktree",
+    "active-process",
+  ]);
+  assert.deepEqual(result.activeEvidenceKinds, []);
+  assert.match(result.rule, /advisory-only queue is action-required/);
+});
+
+test("issue #1050 helper treats present open child issue as concrete-child-session-present", () => {
+  const result = classifyAdvisoryOnlyQueueAfterCompletedChild({
+    clean: true,
+    branch: "main",
+    ahead: 0,
+    behind: 0,
+    openIssueCount: 2,
+    openPullRequestCount: 0,
+    epic: "#960",
+    completedChildReceipt,
+    evidence: {
+      issues: [
+        { number: 960, state: "open" },
+        { number: 1077, state: "open" },
+      ],
+      pullRequests: [],
+    },
+  });
+
+  assert.equal(
+    result.classification,
+    "concrete-child-session-present",
+  );
+  assert.equal(result.actionRequiredForConcreteChildOrSession, false);
+  assert.equal(result.activeDevelopmentAllowed, true);
+});
+
+test("issue #1050 helper treats open PR as concrete-child-session-present", () => {
+  const result = classifyAdvisoryOnlyQueueAfterCompletedChild({
+    clean: true,
+    branch: "main",
+    ahead: 0,
+    behind: 0,
+    openIssueCount: 1,
+    openPullRequestCount: 1,
+    epic: "#960",
+    completedChildReceipt,
+    evidence: {
+      issues: [{ number: 960, state: "open" }],
+      pullRequests: [{ number: 1080, state: "open" }],
+    },
+  });
+
+  assert.equal(
+    result.classification,
+    "concrete-child-session-present",
+  );
+  assert.equal(result.actionRequiredForConcreteChildOrSession, false);
+});
+
+test("issue #1050 helper requires completed child receipt before action-required", () => {
+  const result = classifyAdvisoryOnlyQueueAfterCompletedChild({
+    clean: true,
+    branch: "main",
+    ahead: 0,
+    behind: 0,
+    openIssueCount: 1,
+    openPullRequestCount: 0,
+    epic: "#960",
+    completedChildReceipt: {},
+    evidence: {
+      issues: [{ number: 960, state: "open" }],
+      pullRequests: [],
+    },
+  });
+
+  assert.equal(result.completedChildReceipt, false);
+  assert.equal(
+    result.classification,
+    "concrete-child-session-present",
+  );
+});
+
+test("issue #1050 doc preserves the advisory-only queue guard contract", () => {
+  const compact = doc.replace(/\s+/gu, " ");
+  for (const required of [
+    "Advisory-only queue after completed child work (#1050)",
+    "PR #1049",
+    "Epic `#960`",
+    "open_pr=0",
+    "advisory-only-queue-after-completed-child-action-required",
+    "not a\nterminal idle answer",
+    "concrete-child-session-present",
+    "intentionally read-only",
+  ]) {
+    const needle = required.replace(/\s+/gu, " ");
+    assert.ok(
+      compact.includes(needle),
+      `missing #1050 doc text: ${required}`,
+    );
+  }
+});

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -209,6 +209,56 @@ export function classifyCleanEpicAdvisoryInventorySessionWhip(input) {
   };
 }
 
+export function classifyAdvisoryOnlyQueueAfterCompletedChild(input) {
+  const epicNumber = issueNumber(input?.epic) ?? 960;
+  const evidence = input?.evidence ?? {};
+  const issues = openIssueNumbers(evidence.issues ?? evidence.childIssues);
+  const openIssueCount = typeof input?.openIssueCount === "number" ? input.openIssueCount : issues.length;
+  const openPullRequestCount = typeof input?.openPullRequestCount === "number"
+    ? input.openPullRequestCount
+    : (evidence.pullRequests ?? []).filter((pr) => isOpenState(pr?.state)).length;
+  const activeKinds = epicOnlyActiveEvidenceKinds(evidence, epicNumber);
+  const cleanPostChildCompletionEcho = Boolean(input?.clean === true && input?.branch === "main" && input?.ahead === 0 && input?.behind === 0);
+  const completedChildReceipt = Boolean(input?.completedChildReceipt?.issue || input?.completedChildReceipt?.pullRequest);
+  const advisoryOnlyQueue = openIssueCount === 1 && issues.length === 1 && issues[0] === epicNumber && openPullRequestCount === 0;
+  const actionRequired = cleanPostChildCompletionEcho && completedChildReceipt && advisoryOnlyQueue && activeKinds.length === 0;
+
+  return {
+    issue: "#1050",
+    epic: `#${epicNumber}`,
+    classification: actionRequired
+      ? "advisory-only-queue-after-completed-child-action-required"
+      : "concrete-child-session-present",
+    cleanPostChildCompletionEcho,
+    completedChildReceipt,
+    advisoryOnlyQueue,
+    terminalIdleAllowed: false,
+    actionRequiredForConcreteChildOrSession: actionRequired,
+    activeDevelopmentAllowed: !actionRequired,
+    requiredConcreteChildArtifacts: [
+      "open-child-issue",
+      "active-session",
+      "active-branch",
+      "open-pull-request",
+      "active-worktree",
+      "active-process",
+    ],
+    activeEvidenceKinds: activeKinds,
+    mutationBoundary: {
+      mutatesGitHubIssues: false,
+      changesMergePolicy: false,
+      changesRuntimeHooks: false,
+      changesTelemetry: false,
+      changesBillingTokenProof: false,
+      changesDetectorScope: false,
+      changesProductClaims: false,
+      reopensClosedArtifacts: false,
+      mergesPullRequests: false,
+    },
+    rule: "After completed child work closes and only planning epic #960 remains open, the advisory-only queue is action-required for a concrete child/session; it is not a terminal idle dogfood answer.",
+  };
+}
+
 export function classifyStaleEpicChecklistCandidate(input) {
   const activeKinds = activeEvidenceKinds(input?.evidence ?? {});
   const hasUncheckedEpicChecklistText = Boolean(input?.uncheckedEpicChecklistText);

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -222,19 +222,23 @@ export function classifyAdvisoryOnlyQueueAfterCompletedChild(input) {
   const completedChildReceipt = Boolean(input?.completedChildReceipt?.issue || input?.completedChildReceipt?.pullRequest);
   const advisoryOnlyQueue = openIssueCount === 1 && issues.length === 1 && issues[0] === epicNumber && openPullRequestCount === 0;
   const actionRequired = cleanPostChildCompletionEcho && completedChildReceipt && advisoryOnlyQueue && activeKinds.length === 0;
+  const missingCompletedChildReceipt = cleanPostChildCompletionEcho && !completedChildReceipt && advisoryOnlyQueue && activeKinds.length === 0;
+  const concreteChildPresent = !actionRequired && !missingCompletedChildReceipt;
 
   return {
     issue: "#1050",
     epic: `#${epicNumber}`,
     classification: actionRequired
       ? "advisory-only-queue-after-completed-child-action-required"
-      : "concrete-child-session-present",
+      : missingCompletedChildReceipt
+        ? "completed-child-receipt-missing"
+        : "concrete-child-session-present",
     cleanPostChildCompletionEcho,
     completedChildReceipt,
     advisoryOnlyQueue,
     terminalIdleAllowed: false,
     actionRequiredForConcreteChildOrSession: actionRequired,
-    activeDevelopmentAllowed: !actionRequired,
+    activeDevelopmentAllowed: concreteChildPresent,
     requiredConcreteChildArtifacts: [
       "open-child-issue",
       "active-session",


### PR DESCRIPTION
Closes #1050. Refs #960.

## Summary
Adds `classifyAdvisoryOnlyQueueAfterCompletedChild` helper + dogfood docs guard for the post-PR-#1049 state where the open issue inventory collapses back to Epic #960 with no concrete child artifacts.

## Why
After advisory-inventory child work merges, the dogfood nudge can land on `open_pr=0`, single open issue = Epic #960. The skill says this is **action-required**, not terminal idle — the operator path must adopt or create a concrete child/session.

## Shape
- `classifyAdvisoryOnlyQueueAfterCompletedChild` returns `advisory-only-queue-after-completed-child-action-required` only when clean main + completed child receipt + epic-only queue + zero active artifacts.
- Any open child issue, open PR, active branch/worktree/session/process collapses the classification to `concrete-child-session-present`.
- Missing completed child receipt also blocks action-required.

## Boundary
Read-only. Does not mutate GitHub issues automatically, change merge policy, runtime hooks, telemetry, billing/token proof, detector scope, or product claims. No PR merges. No reopening closed artifacts.

## Tests
`node --test test/advisory-only-queue-after-completed-child-1050.test.mjs` — 5/5 pass (action-required, child-present, pr-present, missing-receipt, doc-contract).