### PR TITLE
Make runtime receipt lookup advisory by default

### DIFF
--- a/docs/domain-memory-contract.md
+++ b/docs/domain-memory-contract.md
@@ -175,11 +175,13 @@ The first consumer is deliberately narrow: the Codex runtime hook may consume an
 Again inspect src/Foo.tsx with domain-memory receipt .fooks/domain-memory/foo.json
 ```
 
-This lane does not search cache directories, does not persist receipts, and does not let a receipt authorize compact injection. The normal pre-read/runtime payload gate must already allow injection. When the receipt verifies as `fresh`, the hook may append a bounded `FOOKS DOMAIN MEMORY ADVISORY` block that repeats the receipt status, reasons, safe next action, and non-claims.
+This lane does not persist receipts and does not let a receipt authorize compact injection. The normal pre-read/runtime payload gate must already allow injection. When the receipt verifies as `fresh`, the hook may append a bounded `FOOKS DOMAIN MEMORY ADVISORY` block that repeats the receipt status, reasons, safe next action, and non-claims.
 
 If the explicit receipt is `stale`, `incompatible`, `unsupported`, missing, or unreadable, the runtime hook fails closed to full-read guidance. The stale receipt is not silently ignored, because an explicit receipt hint means the prompt is asking the runtime to rely on that evidence.
 
-This lane still does not add pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims. Automatic cache lookup and pre-read consumers require separate plans.
+When no explicit receipt hint is present and the normal repeated-file payload gate already allows injection, the Codex runtime hook may also run an **automatic project-local lookup** in `.fooks/domain-memory/`. A `fresh` automatic lookup may append the same bounded `FOOKS DOMAIN MEMORY ADVISORY` block with `authorization: none` and `advisoryOnly: true`. Automatic `not-found`, `stale`, `incompatible`, `unsupported`, or `ambiguous` results are debug-only no-ops: they do not force full-read fallback, do not append advisory context, and do not change the normal runtime/pre-read decision. Runtime lookup errors are represented as `unsupported` debug metadata.
+
+This lane still does not add pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims. Pre-read consumers, automatic receipt persistence, and authorized runtime/cache reuse require separate plans.
 
 ## Lookup diagnostic lane
 
@@ -193,4 +195,4 @@ The lookup recursively scans only the project-local `.fooks/domain-memory/` dire
 
 A `fresh` lookup means exactly one receipt is fresh for report/advisory evidence only. The machine result still carries `authorization: "none"` and `advisoryOnly: true`; any `advisoryReceiptPath` is evidence-only, not permission. Multiple fresh receipts are `ambiguous` and must not be auto-selected. Stale, incompatible, unsupported, mixed fresh/non-fresh, missing, unreadable, or ambiguous lookup results do not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/performance claims.
 
-This lane intentionally does not change runtime hook behavior, pre-read decisions, cache storage, or model-facing payloads. Runtime automatic advisory lookup, pre-read appendices, and any payload/cache reuse require separate plans and tests.
+This lane intentionally does not authorize pre-read decisions, cache storage, or model-facing payload reuse. The runtime hook consumes a `fresh` lookup only as advisory context after normal payload eligibility, while pre-read appendices, automatic receipt persistence, and any payload/cache reuse require separate plans and tests.

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -4,6 +4,8 @@ import { decidePreRead } from "./pre-read";
 import { hasFullReadEscapeHatch, resolvePromptFileContext } from "./prompt-context";
 import { discoverProjectFiles } from "../core/discover";
 import { detectDomainFromSource } from "../core/domain-detector";
+import { lookupDomainMemoryReceipts } from "../core/domain-memory-lookup";
+import type { DomainMemoryLookupResult } from "../core/domain-memory-lookup";
 import { unsupportedDomainMemoryVerifyResult, verifyDomainMemoryReceipt } from "../core/domain-memory-verify";
 import { appendProjectKnowledgeBlock, resolveProjectKnowledgeContext } from "../core/project-knowledge";
 import { buildPreReadReuseStatus } from "./codex-runtime-status";
@@ -182,6 +184,7 @@ type RuntimeReactWebContextPackingSummary = NonNullable<NonNullable<CodexRuntime
 type CodexRuntimeDebug = NonNullable<CodexRuntimeHookDecision["debug"]>;
 type PreflightAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["preflightAdvisoryIntent"]>;
 type DomainMemoryAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["domainMemoryAdvisory"]>;
+type DomainMemoryLookupDebugReceipt = NonNullable<CodexRuntimeDebug["domainMemoryLookup"]>;
 
 function unquotePromptPath(value: string): string {
   return value.replace(/^["'`]+|["'`,.;:)]+$/gu, "");
@@ -262,6 +265,49 @@ function renderDomainMemoryAdvisoryContext(result: ReturnType<typeof verifyDomai
   ].join("\n");
 }
 
+function modelTextValue(value: string | undefined): string {
+  return JSON.stringify(value ?? "");
+}
+
+function renderAutomaticDomainMemoryAdvisoryContext(result: DomainMemoryLookupResult): string {
+  return [
+    DOMAIN_MEMORY_ADVISORY_CONTEXT_MARKER,
+    `- Source: automatic project-local lookup ${modelTextValue(result.advisoryReceiptPath)}; verified against ${modelTextValue(result.filePath)}.`,
+    `- Authorization: ${result.authorization}; advisoryOnly: ${result.advisoryOnly}.`,
+    `- Status: ${result.status}; safe next action: ${result.safeNextAction}.`,
+    `- Reasons: ${result.reasons.join(", ")}.`,
+    `- Non-claims: ${result.nonClaims.join("; ")}.`,
+    "- Boundary: advisory-only report evidence; does not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse, setup readiness, support expansion, or provider token/cost/billing/runtime savings claims.",
+  ].join("\n");
+}
+
+function domainMemoryLookupDebugReceipt(result: DomainMemoryLookupResult): DomainMemoryLookupDebugReceipt {
+  return {
+    source: "automatic project-local lookup",
+    status: result.status,
+    authorization: result.authorization,
+    advisoryOnly: result.advisoryOnly,
+    candidateCount: result.candidateCount,
+    freshCandidateCount: result.freshCandidateCount,
+    ...(result.advisoryReceiptPath ? { advisoryReceiptPath: result.advisoryReceiptPath } : {}),
+    safeNextAction: result.safeNextAction,
+    reasons: result.reasons,
+  };
+}
+
+function unsupportedAutomaticDomainMemoryLookupDebug(reason: string): DomainMemoryLookupDebugReceipt {
+  return {
+    source: "automatic project-local lookup",
+    status: "unsupported",
+    authorization: "none",
+    advisoryOnly: true,
+    candidateCount: 0,
+    freshCandidateCount: 0,
+    safeNextAction: "full-read",
+    reasons: [reason],
+  };
+}
+
 function attachDomainMemoryAdvisoryDebug(
   runtimeDecision: CodexRuntimeHookDecision,
   receipt: DomainMemoryAdvisoryDebugReceipt,
@@ -274,6 +320,22 @@ function attachDomainMemoryAdvisoryDebug(
   runtimeDecision.debug = {
     ...debug,
     domainMemoryAdvisory: receipt,
+  };
+  return runtimeDecision;
+}
+
+function attachDomainMemoryLookupDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  receipt: DomainMemoryLookupDebugReceipt,
+): CodexRuntimeHookDecision {
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    domainMemoryLookup: receipt,
   };
   return runtimeDecision;
 }
@@ -852,9 +914,26 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     const contextMode = payloadContextMode(decision.payload);
     const runtimeContext = buildAdditionalContext(target, decision.payload, contextMode, originalEstimatedBytes);
     const projectKnowledge = resolveProjectKnowledgeContext(prompt, [target], cwd);
+    let domainMemoryLookupDebug: DomainMemoryLookupDebugReceipt | undefined;
+    let automaticAdvisoryContext: string | undefined;
+    let automaticDomainMemoryReason: string | undefined;
+    if (!domainMemoryAdvisory.requested) {
+      try {
+        const lookupResult = lookupDomainMemoryReceipts(path.join(cwd, target), cwd);
+        domainMemoryLookupDebug = domainMemoryLookupDebugReceipt(lookupResult);
+        if (lookupResult.status === "fresh") {
+          automaticAdvisoryContext = renderAutomaticDomainMemoryAdvisoryContext(lookupResult);
+          automaticDomainMemoryReason = "domain-memory-automatic-advisory:fresh";
+        }
+      } catch (error) {
+        domainMemoryLookupDebug = unsupportedAutomaticDomainMemoryLookupDebug(
+          `domain-memory automatic lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     const advisoryContext = domainMemoryAdvisory.result?.status === "fresh"
       ? renderDomainMemoryAdvisoryContext(domainMemoryAdvisory.result)
-      : undefined;
+      : automaticAdvisoryContext;
     const additionalContext = appendProjectKnowledgeBlock(
       [runtimeContext.additionalContext, advisoryContext].filter(Boolean).join("\n\n"),
       projectKnowledge?.block,
@@ -872,6 +951,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
         ...(policy.promptSpecificity === "file-hinted" ? ["glob-match-runtime-target"] : []),
         ...(freshness.refreshed ? ["refreshed-before-attach"] : []),
         ...(editGuidanceIncluded ? ["edit-guidance-opt-in"] : []),
+        ...(automaticDomainMemoryReason ? [automaticDomainMemoryReason] : []),
       ],
       statePath,
       additionalContext,
@@ -892,6 +972,8 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     if (domainMemoryAdvisory.requested) {
       attachDomainMemoryAdvisoryDebug(runtimeDecision, domainMemoryAdvisory.debug);
+    } else if (domainMemoryLookupDebug) {
+      attachDomainMemoryLookupDebug(runtimeDecision, domainMemoryLookupDebug);
     }
 
     if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,6 @@
 import type { DesignReviewMetadataV0 } from "./design-review-metadata";
 import type { DomainDetectionResult } from "./domain-detector";
+import type { DomainMemoryLookupResult } from "./domain-memory-lookup";
 import type { DomainMemoryVerifyResult } from "./domain-memory-verify";
 import type { ProjectKnowledgeMetadata } from "./project-knowledge";
 import type { DomainPayload } from "./payload/domain-payload";
@@ -756,6 +757,17 @@ export type CodexRuntimeHookDecision = {
       receiptPath?: string;
       status?: DomainMemoryVerifyResult["status"];
       safeNextAction?: DomainMemoryVerifyResult["safeNextAction"];
+      reasons: string[];
+    };
+    domainMemoryLookup?: {
+      source: "automatic project-local lookup";
+      status: DomainMemoryLookupResult["status"];
+      authorization: "none";
+      advisoryOnly: true;
+      candidateCount: number;
+      freshCandidateCount: number;
+      advisoryReceiptPath?: string;
+      safeNextAction: DomainMemoryLookupResult["safeNextAction"];
       reasons: string[];
     };
   };

--- a/test/domain-memory-contract-docs.test.mjs
+++ b/test/domain-memory-contract-docs.test.mjs
@@ -72,7 +72,7 @@ test("domain-memory contract forbids support and runtime expansion", () => {
   ]);
 });
 
-test("domain-memory contract scopes runtime advisory consumer to explicit fresh receipts", () => {
+test("domain-memory contract scopes runtime advisory consumer to explicit and automatic fresh advisory receipts", () => {
   assertContains("domain memory", domainMemory, [
     "Runtime advisory consumer lane",
     "explicit prompt-provided receipt path",
@@ -80,8 +80,14 @@ test("domain-memory contract scopes runtime advisory consumer to explicit fresh 
     "FOOKS DOMAIN MEMORY ADVISORY",
     "normal pre-read/runtime payload gate must already allow injection",
     "fails closed to full-read guidance",
+    "automatic project-local lookup",
+    "authorization: none",
+    "advisoryOnly: true",
+    "debug-only no-ops",
+    "do not force full-read fallback",
+    "Runtime lookup errors are represented as `unsupported` debug metadata",
     "does not add pre-read reuse, cache reuse, model-facing payload reuse",
-    "Automatic cache lookup and pre-read consumers require separate plans",
+    "Pre-read consumers, automatic receipt persistence, and authorized runtime/cache reuse require separate plans",
   ]);
 });
 
@@ -98,7 +104,8 @@ test("domain-memory contract scopes lookup diagnostics to advisory-only evidence
     "Multiple fresh receipts are `ambiguous`",
     "mixed fresh/non-fresh",
     "do not authorize runtime reuse, pre-read reuse, cache reuse, model-facing payload reuse",
-    "does not change runtime hook behavior, pre-read decisions, cache storage, or model-facing payloads",
+    "does not authorize pre-read decisions, cache storage, or model-facing payload reuse",
+    "runtime hook consumes a `fresh` lookup only as advisory context after normal payload eligibility",
   ]);
 });
 

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2274,6 +2274,161 @@ test("codex runtime hook appends fresh explicit domain-memory receipt as advisor
   assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
 });
 
+test("codex runtime hook appends fresh automatic domain-memory lookup as advisory-only context", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-auto-fresh-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  writeDomainMemoryReceipt(tempDir, target);
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.ok(second.additionalContext.includes("FOOKS DOMAIN MEMORY ADVISORY"));
+  assert.ok(second.additionalContext.includes("Source: automatic project-local lookup"));
+  assert.match(second.additionalContext, /automatic project-local lookup ".+domain-memory-receipt\.json"; verified against "src\/components\/FormSection\.tsx"/);
+  assert.ok(second.additionalContext.includes("Authorization: none; advisoryOnly: true."));
+  assert.ok(second.additionalContext.includes("does not authorize runtime reuse"));
+  assert.equal(second.debug.domainMemoryAdvisory, undefined);
+  assert.equal(second.debug.domainMemoryLookup.source, "automatic project-local lookup");
+  assert.equal(second.debug.domainMemoryLookup.status, "fresh");
+  assert.equal(second.debug.domainMemoryLookup.authorization, "none");
+  assert.equal(second.debug.domainMemoryLookup.advisoryOnly, true);
+  assert.equal(second.debug.domainMemoryLookup.candidateCount, 1);
+  assert.equal(second.debug.domainMemoryLookup.freshCandidateCount, 1);
+  assert.equal(second.reasons.includes("domain-memory-automatic-advisory:fresh"), true);
+  assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
+});
+
+test("codex runtime hook treats stale automatic domain-memory lookup as debug-only no-op", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-auto-stale-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  writeDomainMemoryReceipt(tempDir, target);
+  fs.appendFileSync(path.join(tempDir, target), "\nexport const changedAfterAutomaticReceipt = true;\n");
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.equal(second.additionalContext.includes("FOOKS DOMAIN MEMORY ADVISORY"), false);
+  assert.equal(second.debug.domainMemoryAdvisory, undefined);
+  assert.equal(second.debug.domainMemoryLookup.status, "stale");
+  assert.equal(second.debug.domainMemoryLookup.authorization, "none");
+  assert.equal(second.debug.domainMemoryLookup.advisoryOnly, true);
+  assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+  assert.equal(second.reasons.includes("domain-memory-automatic-advisory:fresh"), false);
+  assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
+  assert.equal(second.fallback, undefined);
+});
+
+test("codex runtime hook treats ambiguous automatic domain-memory lookup as debug-only no-op", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-auto-ambiguous-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  writeDomainMemoryReceipt(tempDir, target, "one.json");
+  writeDomainMemoryReceipt(tempDir, target, "two.json");
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.equal(second.additionalContext.includes("FOOKS DOMAIN MEMORY ADVISORY"), false);
+  assert.equal(second.debug.domainMemoryLookup.status, "ambiguous");
+  assert.equal(second.debug.domainMemoryLookup.candidateCount, 2);
+  assert.equal(second.debug.domainMemoryLookup.freshCandidateCount, 2);
+  assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
+  assert.equal(second.fallback, undefined);
+});
+
+test("codex runtime hook treats unsupported automatic domain-memory lookup as debug-only no-op", () => {
+  const tempDir = makeTempProject();
+  const sessionId = `hook-domain-memory-auto-unsupported-${Date.now()}`;
+  const target = path.join("src", "components", "FormSection.tsx");
+  const receiptDir = path.join(tempDir, ".fooks", "domain-memory");
+  fs.mkdirSync(path.dirname(receiptDir), { recursive: true });
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-domain-memory-outside-"));
+  fs.symlinkSync(outsideDir, receiptDir);
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+  const first = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please inspect ${target}`,
+    },
+    tempDir,
+  );
+  assert.equal(first.action, "record");
+
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, inspect ${target}`,
+    },
+    tempDir,
+  );
+
+  assert.equal(second.action, "inject");
+  assert.equal(second.additionalContext.includes("FOOKS DOMAIN MEMORY ADVISORY"), false);
+  assert.equal(second.debug.domainMemoryLookup.status, "unsupported");
+  assert.ok(second.debug.domainMemoryLookup.reasons.some((reason) => reason.includes("lookup directory must not be a symlink")));
+  assert.equal(second.reasons.includes("domain-memory-receipt-not-fresh"), false);
+  assert.equal(second.fallback, undefined);
+});
+
 test("codex runtime hook fails closed when explicit domain-memory receipt is stale", () => {
   const tempDir = makeTempProject();
   const sessionId = `hook-domain-memory-stale-${Date.now()}`;


### PR DESCRIPTION
## Summary

- connect automatic domain-memory lookup to the Codex runtime repeated-file inject path
- append `FOOKS DOMAIN MEMORY ADVISORY` only for exactly fresh automatic lookup results
- keep automatic non-fresh/error lookup states as debug-only no-ops
- preserve explicit receipt behavior, including explicit stale full-read fallback
- document and test that receipts remain `authorization: none` / `advisoryOnly: true`

## Verification

- `git diff --check`
- `npm run typecheck`
- `npm run build && node --test test/fooks.test.mjs test/domain-detector.test.mjs test/domain-memory-contract-docs.test.mjs`
- `npm run smoke:domain-detector`
- ai-slop-cleaner report: no masking fallback slop
- code-review: APPROVE
- architect re-review: CLEAR

## Boundaries

- no pre-read metadata or payload change
- no receipt writer/persistence
- no runtime/pre-read/cache/model-facing reuse authorization
- no provider token/cost/billing/latency/runtime-token savings claims

Fixes #1059
