### PR TITLE
Clarify clean-idle nudge handoff authority

### DIFF
--- a/docs/dogfood/clean-idle-nudge-handoff-1085.md
+++ b/docs/dogfood/clean-idle-nudge-handoff-1085.md
@@ -1,0 +1,80 @@
+# Issue #1085 clean-idle nudge handoff
+
+This is a narrow read-only dogfood/operator artifact for the clean-idle
+`fooks nudge` handoff. It covers the state where `npm run --silent check --
+--json` returns `idleRequiresActiveArtifact` after clean post-merge `main` and
+there is no open issue, PR, mapped session, live non-`main` branch/worktree, or
+concrete blocker to report as current development.
+
+## Boundary
+
+A clean post-merge `main` CI echo is a receipt, not active work. Stale local
+worktree residue is cleanup-review context, not active work. When both are the
+only visible evidence, the operator must seed or resume an explicit handoff
+artifact before claiming development is active: an open GitHub issue, a
+non-`main` branch or live worktree, a mapped fooks tmux session, or an open PR.
+
+The CLI remains read-only. It must not auto-create issues, open PRs, create
+sessions, mutate worktrees, close or mutate `#960`, change runtime/provider or
+frontend behavior, weaken CI/approval/merge-gate policy, or broaden product or
+release claims. This artifact preserves the existing top-level
+`idleRequiresActiveArtifact` verdict; it only makes the handoff boundary visible
+and testable.
+
+## Report shape
+
+```json
+{
+  "issue": "#1085",
+  "readOnly": true,
+  "operatorCheckField": "activeWorkReceipts.cleanIdleNudgeHandoffBoundary",
+  "classification": "clean-idle-handoff-artifact-required",
+  "preservesOperatorCheckVerdict": "idleRequiresActiveArtifact",
+  "currentEvidence": {
+    "clean": true,
+    "branch": "main",
+    "openIssueCount": 0,
+    "openPullRequestCount": 0,
+    "mappedFooksTmuxSessionCount": 0,
+    "liveNonMainWorktreePresent": false,
+    "postMergeMainCiEchoPresent": true,
+    "staleResidueCount": 1,
+    "staleResidueIsActiveDevelopmentEvidence": false,
+    "ciEchoIsActiveDevelopmentEvidence": false
+  },
+  "requiresExplicitHandoffArtifactBeforeDevelopmentClaim": true,
+  "acceptableHandoffArtifacts": [
+    "open GitHub issue",
+    "non-main branch or live worktree",
+    "mapped fooks tmux session",
+    "open GitHub pull request"
+  ],
+  "mutationBoundary": {
+    "createsIssuesFromCli": false,
+    "mutatesGitHub": false,
+    "mutatesWorktrees": false,
+    "changesRuntimeProviderFrontendOrMergeGatePolicy": false
+  },
+  "rule": "Clean post-merge main with only CI echoes and stale residue remains idleRequiresActiveArtifact; seed or resume an explicit issue, branch/session/worktree, or PR before claiming current development, and must not auto-create an issue from the CLI; do not auto-create an issue from the CLI."
+}
+```
+
+## Operator wording
+
+Use this wording when a clean-idle nudge has no live artifact:
+
+- Current development: **idle / handoff artifact required**.
+- Evidence that is not active work: post-merge CI echoes, release echoes, stale
+  local worktree residue, closed PR residue, and cleanup-review receipts.
+- Required before an active-development report: name the explicit issue,
+  branch/live worktree, mapped session, or PR that the operator seeded or
+  resumed.
+
+## Verification
+
+```bash
+git diff --check HEAD
+npm run build
+npm run typecheck -- --pretty false
+node --test test/operator-activity.test.mjs test/clean-idle-nudge-handoff-1085-doc.test.mjs
+```

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -54,6 +54,7 @@ export const OPERATOR_CHECK_NEXT_CHILD_EVIDENCE_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_EPIC_STALE_CHECKLIST_RECONCILIATION_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_DRAIN_READY_CUTOFF_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_960_CLOSEOUT_RECEIPT_BOUNDARY_SCHEMA_VERSION = 1;
+export const OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SCHEMA_VERSION = 1;
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_SOURCE = "operator/check active-work receipt projection";
 export const OPERATOR_CHECK_SESSION_WHIP_RUN_RECEIPT_SOURCE = "operator/check compact session-whip run receipt projection";
@@ -86,6 +87,7 @@ export const OPERATOR_CHECK_NEXT_CHILD_EVIDENCE_BOUNDARY_ISSUE = "#1065";
 export const OPERATOR_CHECK_EPIC_STALE_CHECKLIST_RECONCILIATION_ISSUE = "#1070";
 export const OPERATOR_CHECK_DRAIN_READY_CUTOFF_ISSUE = "#1077";
 export const OPERATOR_CHECK_960_CLOSEOUT_RECEIPT_BOUNDARY_ISSUE = "#1079";
+export const OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE = "#1085";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_ISSUE_URL = "https://github.com/minislively/fooks/issues/736";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_ISSUE_URL = "https://github.com/minislively/fooks/issues/739";
 export const OPERATOR_CHECK_LEGACY_LOCAL_RESIDUE_CLEANUP_REVIEW_ISSUE_URL = "https://github.com/minislively/fooks/issues/778";
@@ -99,6 +101,7 @@ export const OPERATOR_CHECK_NEXT_CHILD_EVIDENCE_BOUNDARY_ISSUE_URL = "https://gi
 export const OPERATOR_CHECK_EPIC_STALE_CHECKLIST_RECONCILIATION_ISSUE_URL = "https://github.com/minislively/fooks/issues/1070";
 export const OPERATOR_CHECK_DRAIN_READY_CUTOFF_ISSUE_URL = "https://github.com/minislively/fooks/issues/1077";
 export const OPERATOR_CHECK_960_CLOSEOUT_RECEIPT_BOUNDARY_ISSUE_URL = "https://github.com/minislively/fooks/issues/1079";
+export const OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE_URL = "https://github.com/minislively/fooks/issues/1085";
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_ISSUE_URL = "https://github.com/minislively/fooks/issues/895";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_SOURCE = "operator/check stale worktree residue ledger projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_SOURCE = "operator/check stale worktree residue cleanup-review manifest projection";
@@ -120,6 +123,8 @@ export const OPERATOR_CHECK_DRAIN_READY_CUTOFF_SOURCE =
 export const OPERATOR_CHECK_960_CLOSEOUT_RECEIPT_STATUS_CUE_SOURCE =
   "operator/status activity issue #1079 bounded #960 closeout receipt cue projection";
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_SOURCE = "operator/check issue #895 legacy review residue cleanup-review guard projection";
+export const OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SOURCE =
+  "operator/check issue #1085 clean-idle nudge handoff boundary projection";
 export const OPERATOR_CHECK_STALE_RESIDUE_LEDGER_CLAIM_BOUNDARY =
   "Read-only issue #736 operator receipt for stale sibling worktree residue; groups existing triage classes by count and next review action only, without paths, cleanup commands, fetch, delete, push, or mutation authority.";
 export const OPERATOR_CHECK_STALE_RESIDUE_CLEANUP_REVIEW_MANIFEST_CLAIM_BOUNDARY =
@@ -148,6 +153,8 @@ export const OPERATOR_CHECK_DRAIN_READY_CUTOFF_CLAIM_BOUNDARY =
   "Read-only issue #1077 dogfood drain-ready cutoff artifact; after landed child evidence, clean main with only epic #960 open may be reported as no-new-child/drain-ready instead of active development or an auto-sliced child, while concrete child issue, PR, session, branch, worktree/process, or blocker evidence continues to use the next-child evidence path.";
 export const OPERATOR_CHECK_960_CLOSEOUT_RECEIPT_BOUNDARY_CLAIM_BOUNDARY =
   "Read-only issue #1079 dogfood #960 closeout receipt boundary; clean main with only epic #960 open is no active development and the bounded next action is an operator closeout receipt for #960, without auto-closing #960, mutating GitHub, creating children from stale checklist text, or weakening approval, CI, merge, provider, runtime, frontend, or product boundaries.";
+export const OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_CLAIM_BOUNDARY =
+  "Read-only issue #1085 dogfood clean-idle nudge handoff boundary; a clean post-merge main snapshot with no open issue, PR, live branch/worktree, or mapped session remains idleRequiresActiveArtifact, treats CI echoes and stale residue as non-active receipts, and requires the next nudge to seed or resume an explicit issue, branch, session, or PR before claiming current development without creating issues from the CLI.";
 export const OPERATOR_CHECK_LEGACY_REVIEW_RESIDUE_CLEANUP_REVIEW_GUARD_CLAIM_BOUNDARY =
   "Read-only issue #895 operator guard for legacy review/refresh worktree residue after clean merges; preserves local residue as actionable cleanup-review evidence while keeping current active anchors limited to live issue, PR, branch, tmux, or proc evidence.";
 export const OPERATOR_CHECK_ACTIVE_WORK_RECEIPT_ISSUE = "#720";
@@ -741,6 +748,46 @@ export type OperatorCheck960CloseoutReceiptStatusCue = {
   oneLine: string;
 };
 
+export type OperatorCheckCleanIdleNudgeHandoffBoundary = {
+  schemaVersion: typeof OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SCHEMA_VERSION;
+  issue: typeof OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE;
+  issueUrl: typeof OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE_URL;
+  source: typeof OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SOURCE;
+  claimBoundary: typeof OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_CLAIM_BOUNDARY;
+  readOnly: true;
+  classification:
+    | "clean-idle-handoff-artifact-required"
+    | "explicit-handoff-artifact-present"
+    | "blocked-or-not-clean-idle";
+  preservesOperatorCheckVerdict: "idleRequiresActiveArtifact";
+  currentEvidence: {
+    clean: boolean | null;
+    branch?: string;
+    openIssueCount?: number;
+    openPullRequestCount?: number;
+    mappedFooksTmuxSessionCount: number;
+    liveNonMainWorktreePresent: boolean;
+    postMergeMainCiEchoPresent: boolean;
+    staleResidueCount: number;
+    staleResidueIsActiveDevelopmentEvidence: false;
+    ciEchoIsActiveDevelopmentEvidence: false;
+  };
+  requiresExplicitHandoffArtifactBeforeDevelopmentClaim: boolean;
+  acceptableHandoffArtifacts: [
+    "open GitHub issue",
+    "non-main branch or live worktree",
+    "mapped fooks tmux session",
+    "open GitHub pull request",
+  ];
+  mutationBoundary: {
+    createsIssuesFromCli: false;
+    mutatesGitHub: false;
+    mutatesWorktrees: false;
+    changesRuntimeProviderFrontendOrMergeGatePolicy: false;
+  };
+  nudgeRule: string;
+};
+
 export type OperatorCheckActiveWorkReceipt = {
   kind: OperatorCheckActiveWorkReceiptKind;
   classification: OperatorCheckActiveWorkReceiptClassification;
@@ -775,6 +822,7 @@ export type OperatorCheckActiveWorkReceipts = {
   nextChildEvidenceBoundary: OperatorCheckNextChildEvidenceBoundary;
   epicStaleChecklistReconciliation: OperatorCheckEpicStaleChecklistReconciliation;
   drainReadyCutoff: OperatorCheckDrainReadyCutoff;
+  cleanIdleNudgeHandoffBoundary: OperatorCheckCleanIdleNudgeHandoffBoundary;
   currentRunReceipt: OperatorActivitySnapshot["currentRunEvidence"]["receipt"];
   sessionWhipRunReceipt: OperatorCheckSessionWhipRunReceipt;
   blockers: string[];
@@ -2165,6 +2213,72 @@ function buildDrainReadyCutoff(
   };
 }
 
+function buildCleanIdleNudgeHandoffBoundary(
+  activity: OperatorActivitySnapshot,
+  staleResidueCount: number,
+  receipts: OperatorCheckActiveWorkReceipt[],
+): OperatorCheckCleanIdleNudgeHandoffBoundary {
+  const openIssueCount = activity.currentRunEvidence.evidence.openIssues;
+  const openPullRequestCount = activity.currentRunEvidence.evidence.openPullRequests;
+  const mappedFooksTmuxSessionCount = activity.currentRunEvidence.evidence.fooksSessionCount;
+  const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main")
+    || receipts.some((receipt) => receipt.kind === "worktree" && receipt.classification === "active");
+  const explicitHandoffArtifactPresent = Boolean(
+    (typeof openIssueCount === "number" && openIssueCount > 0)
+    || (typeof openPullRequestCount === "number" && openPullRequestCount > 0)
+    || mappedFooksTmuxSessionCount > 0
+    || liveNonMainWorktreePresent,
+  );
+  const cleanIdleMainEcho = activity.currentRunEvidence.mainEchoEvidence && !explicitHandoffArtifactPresent;
+  const classification: OperatorCheckCleanIdleNudgeHandoffBoundary["classification"] = cleanIdleMainEcho
+    ? "clean-idle-handoff-artifact-required"
+    : explicitHandoffArtifactPresent
+      ? "explicit-handoff-artifact-present"
+      : "blocked-or-not-clean-idle";
+  const requiresExplicitHandoffArtifactBeforeDevelopmentClaim = classification === "clean-idle-handoff-artifact-required";
+
+  return {
+    schemaVersion: OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SCHEMA_VERSION,
+    issue: OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE,
+    issueUrl: OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_ISSUE_URL,
+    source: OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_SOURCE,
+    claimBoundary: OPERATOR_CHECK_CLEAN_IDLE_NUDGE_HANDOFF_BOUNDARY_CLAIM_BOUNDARY,
+    readOnly: true,
+    classification,
+    preservesOperatorCheckVerdict: "idleRequiresActiveArtifact",
+    currentEvidence: {
+      clean: activity.worktree.clean,
+      branch: activity.worktree.branch,
+      openIssueCount,
+      openPullRequestCount,
+      mappedFooksTmuxSessionCount,
+      liveNonMainWorktreePresent,
+      postMergeMainCiEchoPresent: activity.postMergeMainCiEvidence.summary.allExactHeadConclusionsSuccessful,
+      staleResidueCount,
+      staleResidueIsActiveDevelopmentEvidence: false,
+      ciEchoIsActiveDevelopmentEvidence: false,
+    },
+    requiresExplicitHandoffArtifactBeforeDevelopmentClaim,
+    acceptableHandoffArtifacts: [
+      "open GitHub issue",
+      "non-main branch or live worktree",
+      "mapped fooks tmux session",
+      "open GitHub pull request",
+    ],
+    mutationBoundary: {
+      createsIssuesFromCli: false,
+      mutatesGitHub: false,
+      mutatesWorktrees: false,
+      changesRuntimeProviderFrontendOrMergeGatePolicy: false,
+    },
+    nudgeRule: requiresExplicitHandoffArtifactBeforeDevelopmentClaim
+      ? "A clean post-merge main nudge with no open issue, PR, mapped session, or live non-main branch/worktree remains idleRequiresActiveArtifact; CI echoes and stale residue are receipts only, so seed or resume an explicit issue, branch, session, or PR before claiming current development. The CLI must not auto-create the issue."
+      : explicitHandoffArtifactPresent
+        ? "Use the explicit issue, branch/worktree, mapped session, or PR evidence already present before reporting current development; CI echoes and stale residue remain non-authorizing receipts."
+        : "This boundary is only a clean-idle nudge handoff artifact; blocked or non-clean snapshots still use the ordinary operator-check verdict and active-artifact contract.",
+  };
+}
+
 function buildHandoffArtifactEvidence(
   activity: OperatorActivitySnapshot,
   receipts: OperatorCheckActiveWorkReceipt[],
@@ -2457,6 +2571,11 @@ function buildActiveWorkReceipts(
     nextChildEvidenceBoundary: buildNextChildEvidenceBoundary(activity),
     epicStaleChecklistReconciliation: buildEpicStaleChecklistReconciliation(activity),
     drainReadyCutoff: buildDrainReadyCutoff(activity),
+    cleanIdleNudgeHandoffBoundary: buildCleanIdleNudgeHandoffBoundary(
+      activity,
+      siblingReceipts.staleResidueLedger.totalCount + legacyLocalResidueCleanupReview.rowCount,
+      receipts,
+    ),
     currentRunReceipt: activity.currentRunEvidence.receipt,
     sessionWhipRunReceipt: buildSessionWhipRunReceipt({
       classification,

--- a/test/clean-idle-nudge-handoff-1085-doc.test.mjs
+++ b/test/clean-idle-nudge-handoff-1085-doc.test.mjs
@@ -1,0 +1,69 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const doc = fs.readFileSync(path.join(repoRoot, "docs", "dogfood", "clean-idle-nudge-handoff-1085.md"), "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+function assertDocsInclude(text) {
+  assert.ok(compactDoc.includes(text), `missing issue #1085 doc text: ${text}`);
+}
+
+test("issue #1085 dogfood doc preserves clean-idle handoff shape", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#1085");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.operatorCheckField, "activeWorkReceipts.cleanIdleNudgeHandoffBoundary");
+  assert.equal(report.classification, "clean-idle-handoff-artifact-required");
+  assert.equal(report.preservesOperatorCheckVerdict, "idleRequiresActiveArtifact");
+  assert.equal(report.currentEvidence.postMergeMainCiEchoPresent, true);
+  assert.equal(report.currentEvidence.staleResidueIsActiveDevelopmentEvidence, false);
+  assert.equal(report.currentEvidence.ciEchoIsActiveDevelopmentEvidence, false);
+  assert.equal(report.requiresExplicitHandoffArtifactBeforeDevelopmentClaim, true);
+  assert.deepEqual(report.acceptableHandoffArtifacts, [
+    "open GitHub issue",
+    "non-main branch or live worktree",
+    "mapped fooks tmux session",
+    "open GitHub pull request",
+  ]);
+  assert.equal(report.mutationBoundary.createsIssuesFromCli, false);
+  assert.equal(report.mutationBoundary.changesRuntimeProviderFrontendOrMergeGatePolicy, false);
+  assert.match(report.rule, /idleRequiresActiveArtifact/);
+  assert.match(report.rule, /do not auto-create an issue from the CLI/);
+});
+
+test("issue #1085 docs state CI echoes and stale residue are non-authorizing", () => {
+  for (const required of [
+    "Issue #1085 clean-idle nudge handoff",
+    "clean-idle `fooks nudge` handoff",
+    "`npm run --silent check -- --json` returns `idleRequiresActiveArtifact`",
+    "A clean post-merge `main` CI echo is a receipt, not active work",
+    "Stale local worktree residue is cleanup-review context, not active work",
+    "seed or resume an explicit handoff artifact",
+    "open GitHub issue",
+    "non-`main` branch/worktree",
+    "mapped fooks tmux session",
+    "open PR",
+    "must not auto-create issues",
+    "must not auto-create an issue from the CLI",
+    "close or mutate `#960`",
+    "preserves the existing top-level `idleRequiresActiveArtifact` verdict",
+    "activeWorkReceipts.cleanIdleNudgeHandoffBoundary",
+    "Current development: **idle / handoff artifact required**",
+    "Evidence that is not active work: post-merge CI echoes",
+  ]) {
+    assertDocsInclude(required);
+  }
+});

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -3945,6 +3945,107 @@ test("operator check exposes issue #885 handoff artifact evidence rule", () => {
   assert.equal(/worktree remove|branch -d|deleteCommand|manualCleanupCommands|cleanupOrder|kill-session/.test(receiptJson), false);
 });
 
+test("operator check exposes issue #1085 clean-idle nudge handoff boundary without changing idle verdict", () => {
+  const tempDir = makeTempProject();
+  const staleSibling = path.join(path.dirname(tempDir), "issue-1085-closed-residue");
+  fs.mkdirSync(staleSibling, { recursive: true });
+  const mainHead = "issue-1085-main-head";
+  const workflowRuns = [
+    {
+      databaseId: 108501,
+      status: "completed",
+      conclusion: "success",
+      headBranch: "main",
+      headSha: mainHead,
+      workflowName: "CI",
+      updatedAt: "2026-05-26T06:00:00.000Z",
+    },
+    {
+      databaseId: 108502,
+      status: "completed",
+      conclusion: "success",
+      headBranch: "main",
+      headSha: mainHead,
+      workflowName: "React Web Release Report",
+      updatedAt: "2026-05-26T06:01:00.000Z",
+    },
+  ];
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-05-26T06:30:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return `${mainHead}\n`;
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args, cwd) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") {
+        return JSON.stringify([{ number: 1080, headRefName: "dogfood/issue-1085-closed-residue", state: "MERGED" }]);
+      }
+      if (command === "gh" && args[0] === "run") return JSON.stringify(workflowRuns);
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "https://github.com/minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [
+          `worktree ${tempDir}`,
+          `HEAD ${mainHead}`,
+          "branch refs/heads/main",
+          "",
+          `worktree ${staleSibling}`,
+          "HEAD issue-1085-stale-head",
+          "branch refs/heads/dogfood/issue-1085-closed-residue",
+          "",
+        ].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return `${mainHead}\n`;
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\ndogfood/issue-1085-closed-residue\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\norigin/dogfood/issue-1085-closed-residue\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\ndogfood/issue-1085-closed-residue\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined} cwd=${cwd}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir || targetPath === staleSibling,
+  });
+
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.equal(snapshot.activeArtifacts.length, 0);
+  const boundary = snapshot.activeWorkReceipts.cleanIdleNudgeHandoffBoundary;
+  assert.equal(boundary.issue, "#1085");
+  assert.equal(boundary.readOnly, true);
+  assert.equal(boundary.classification, "clean-idle-handoff-artifact-required");
+  assert.equal(boundary.preservesOperatorCheckVerdict, "idleRequiresActiveArtifact");
+  assert.equal(boundary.currentEvidence.openIssueCount, 0);
+  assert.equal(boundary.currentEvidence.openPullRequestCount, 0);
+  assert.equal(boundary.currentEvidence.mappedFooksTmuxSessionCount, 0);
+  assert.equal(boundary.currentEvidence.liveNonMainWorktreePresent, false);
+  assert.equal(boundary.currentEvidence.postMergeMainCiEchoPresent, true);
+  assert.equal(boundary.currentEvidence.staleResidueCount, 1);
+  assert.equal(boundary.currentEvidence.staleResidueIsActiveDevelopmentEvidence, false);
+  assert.equal(boundary.currentEvidence.ciEchoIsActiveDevelopmentEvidence, false);
+  assert.equal(boundary.requiresExplicitHandoffArtifactBeforeDevelopmentClaim, true);
+  assert.deepEqual(boundary.acceptableHandoffArtifacts, [
+    "open GitHub issue",
+    "non-main branch or live worktree",
+    "mapped fooks tmux session",
+    "open GitHub pull request",
+  ]);
+  assert.equal(boundary.mutationBoundary.createsIssuesFromCli, false);
+  assert.equal(boundary.mutationBoundary.mutatesGitHub, false);
+  assert.equal(boundary.mutationBoundary.changesRuntimeProviderFrontendOrMergeGatePolicy, false);
+  assert.match(boundary.nudgeRule, /remains idleRequiresActiveArtifact/);
+  assert.match(boundary.nudgeRule, /CI echoes and stale residue are receipts only/);
+  assert.match(boundary.nudgeRule, /CLI must not auto-create the issue/);
+});
+
 test("operator activity keeps legacy worktree inference conservative when tmux is unavailable", () => {
   const tempDir = makeTempProject();
   fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });


### PR DESCRIPTION
## Summary
- Clarify the clean-idle `fooks nudge` handoff boundary: clean CI/release echoes and stale residue are non-authorizing without an explicit issue/branch/session/PR artifact.
- Preserve the existing `idleRequiresActiveArtifact` behavior; this is read-only operator/check coverage and documentation.
- Add focused regression coverage for Issue #1085 so future nudges must seed or resume a concrete artifact before claiming active development.

Closes #1085

## Verification
- `git diff --check HEAD`
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/operator-activity.test.mjs test/clean-idle-nudge-handoff-1085-doc.test.mjs`

## Notes
- No runtime/provider/frontend/React Web/merge-gate policy changes.
- No auto-close or mutation of #960 or any epic.
- `.fooks-session-task.txt` is local session residue and intentionally not included.
