### PR TITLE
Surface advisory React Web form-state roles in context consumers

### DIFF
--- a/src/core/react-web-context-summary.ts
+++ b/src/core/react-web-context-summary.ts
@@ -12,6 +12,10 @@ export type ReactWebContextSummary = {
   };
   fieldCounts: Record<string, number>;
   fieldOrder: string[];
+  formStateRoles?: {
+    roles: string[];
+    counts: Record<string, number>;
+  };
   totalAnchors: number;
   claimBoundary: typeof REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY;
 };
@@ -28,7 +32,23 @@ const REACT_WEB_CONTEXT_SUMMARY_FIELDS = [
   "importRoleHints",
   "renderStates",
   "localDependencies",
+  "formStateRoles",
 ] as const;
+
+function summarizeFormStateRoles(payload: ModelFacingPayload): ReactWebContextSummary["formStateRoles"] | undefined {
+  const roles = payload.reactWebContext?.formStateRoles;
+  if (!Array.isArray(roles) || roles.length === 0) return undefined;
+
+  const counts: Record<string, number> = {};
+  for (const role of roles) {
+    counts[role.role] = (counts[role.role] ?? 0) + 1;
+  }
+
+  return {
+    roles: Object.keys(counts).sort(),
+    counts,
+  };
+}
 
 export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOriginal: boolean): ReactWebContextSummary | undefined {
   if (useOriginal || !payload.reactWebContext) return undefined;
@@ -44,6 +64,7 @@ export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOrigin
   const fieldOrder = REACT_WEB_CONTEXT_SUMMARY_FIELDS.filter((field) => fieldCounts[field] > 0).sort(
     (left, right) => fieldCounts[right] - fieldCounts[left],
   );
+  const formStateRoles = summarizeFormStateRoles(payload);
 
   return {
     present: true,
@@ -55,6 +76,7 @@ export function reactWebContextSummaryFor(payload: ModelFacingPayload, useOrigin
     },
     fieldCounts,
     fieldOrder,
+    ...(formStateRoles ? { formStateRoles } : {}),
     totalAnchors: Object.values(fieldCounts).reduce((total, count) => total + count, 0),
     claimBoundary: REACT_WEB_CONTEXT_SUMMARY_CLAIM_BOUNDARY,
   };
@@ -66,5 +88,8 @@ export function formatReactWebContextSummary(summary: ReactWebContextSummary): s
     .map((field) => `${field}=${summary.fieldCounts[field]}`)
     .join(", ");
   const fieldDetails = topFields ? `; top fields: ${topFields}` : "";
-  return `React Web context: ${summary.totalAnchors} source-backed anchors across ${summary.fieldOrder.length} summary fields${fieldDetails} (source-only counts; see --json).`;
+  const roleDetails = summary.formStateRoles?.roles.length
+    ? `; form-state roles: ${summary.formStateRoles.roles.slice(0, 6).join(", ")}`
+    : "";
+  return `React Web context: ${summary.totalAnchors} source-backed anchors across ${summary.fieldOrder.length} summary fields${fieldDetails}${roleDetails} (source-only counts; see --json).`;
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -502,6 +502,29 @@ test("extract can return model-facing payload without engine metadata", () => {
   assert.equal("domainPayload" in result, false);
 });
 
+test("extract summary surfaces advisory React Web form-state roles", () => {
+  const result = run(["extract", "fixtures/compressed/FormControls.tsx", "--model-payload"]);
+  const summary = result.reactWebContextSummary;
+
+  assert.equal(summary.present, true);
+  assert.equal(summary.schemaVersion, "react-web-context.v0");
+  assert.equal(summary.scope.filePath, path.join("fixtures", "compressed", "FormControls.tsx"));
+  assert.ok(summary.fieldCounts.formStateRoles > 0);
+  assert.ok(summary.fieldOrder.includes("formStateRoles"));
+  assert.deepEqual(summary.formStateRoles.roles, [
+    "field-registration",
+    "form-root",
+    "submit-flow",
+    "validation-defaults",
+    "value-control-relation",
+  ]);
+  assert.equal(summary.formStateRoles.counts["field-registration"], 1);
+  assert.equal(summary.formStateRoles.counts["validation-defaults"], 1);
+  assert.equal(summary.claimBoundary, "source-backed-react-web-context-counts-only");
+  assert.doesNotMatch(JSON.stringify(summary), /cross-file|typechecker|lsp|visual proof|billing|latency|authoriz/i);
+  assert.equal("reactWebContext" in result, false);
+});
+
 test("file commands accept --json before or after the file path", () => {
   const compareAfter = run(["compare", "fixtures/compressed/FormSection.tsx", "--json"]);
   const compareBefore = run(["compare", "--json", "fixtures/compressed/FormSection.tsx"]);
@@ -713,6 +736,15 @@ test("compare reports local estimated model-facing payload reduction", () => {
   assert.ok(result.excludes.includes("provider-tokenizer-behavior"));
   assert.ok(result.excludes.includes("runtime-hook-envelope-overhead"));
   assert.ok(result.excludes.includes("optional-edit-guidance-overhead"));
+});
+
+test("compare text names advisory React Web form-state roles when present", () => {
+  const output = runText(["compare", "fixtures/compressed/FormControls.tsx"]);
+
+  assert.match(output, /React Web context:/);
+  assert.match(output, /formStateRoles=/);
+  assert.match(output, /form-state roles: field-registration, form-root, submit-flow/);
+  assert.doesNotMatch(output, /authoriz|LSP-backed|runtime-token savings/i);
 });
 
 test("compare keeps tiny raw fallback from reporting false positive savings", () => {


### PR DESCRIPTION
## Summary
- Include `formStateRoles` in `reactWebContextSummary` field counts/order.
- Add a bounded role-name/count breakdown for source-backed form-state roles.
- Mention form-state role names in compare text while preserving source-only claim boundaries.

Closes #1093

## Validation
- [x] `npm run build`
- [x] `npm run typecheck -- --pretty false`
- [x] `node --test test/fooks.test.mjs test/react-web-context-metadata.test.mjs test/runtime-bridge-contract.test.mjs` — 225/225 pass
- [x] `git diff --check HEAD`
