### PR TITLE
Preserve React Web form-state roles in runtime context

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -58,6 +58,7 @@ const RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY: RuntimeReactWebContextArrayKey
   "formStateFlow",
   "a11yAnchors",
   "intentTargets",
+  "formStateRoles",
   "stateHints",
   "layoutRegionHints",
   "componentApiHints",
@@ -65,7 +66,6 @@ const RUNTIME_REACT_WEB_CONTEXT_PACKING_PRIORITY: RuntimeReactWebContextArrayKey
   "importRoleHints",
   "renderStates",
   "localDependencies",
-  "formStateRoles",
 ];
 
 function payloadContextMode(payload: ModelFacingPayload): ContextMode {

--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -131,7 +131,6 @@ type ReactWebContextArrayKey = Exclude<{
 }[keyof ReactWebContext], undefined>;
 
 const REACT_WEB_CONTEXT_TRIM_POLICY: ReactWebContextArrayKey[] = [
-  "formStateRoles",
   "importRoleHints",
   "stylingVariantHints",
   "localDependencies",
@@ -139,6 +138,7 @@ const REACT_WEB_CONTEXT_TRIM_POLICY: ReactWebContextArrayKey[] = [
   "stateHints",
   "componentApiHints",
   "layoutRegionHints",
+  "formStateRoles",
   "intentTargets",
   "a11yAnchors",
   "formStateFlow",

--- a/test/pre-read-payload-builder.test.mjs
+++ b/test/pre-read-payload-builder.test.mjs
@@ -11,6 +11,7 @@ import {
   reactWebA11yAnchorSource,
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
+  reactWebFormStateRolesSource,
   reactWebLayoutRegionSource,
   reactWebStylingVariantSource,
   reactWebImportRoleSource,
@@ -230,6 +231,65 @@ test("pre-read payload builder preserves React Web form state-flow when context 
       ),
     );
     assert.equal("concernProfiles" in decision.payload, false);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-read payload builder trims lower-priority metadata before React Web form-state roles under budget pressure", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-form-role-trim-budget-"));
+  try {
+    const target = path.join(tempDir, "InlineFormStateRolesForm.tsx");
+    const pressuredSource = reactWebFormStateRolesSource().replace(
+      /\/\* form state role budget filler [\s\S]*?\*\//,
+      `/* ${"form state role budget filler ".repeat(390)} */`,
+    );
+    fs.writeFileSync(target, pressuredSource);
+
+    const decision = preRead.decidePreRead(target, repoRoot, "codex", {
+      includeEditGuidance: true,
+    });
+
+    assert.equal(decision.decision, "payload");
+    assert.ok(decision.payload.reactWebContext);
+    assert.equal(decision.debug.reactWebContextBudget.included, true);
+    assert.equal(decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(decision.debug.reactWebContextBudget.estimatedPayloadBytes <= decision.debug.reactWebContextBudget.maxPayloadBytes);
+
+    for (const lowerPriorityField of [
+      "importRoleHints",
+      "stylingVariantHints",
+      "localDependencies",
+      "renderStates",
+      "stateHints",
+      "componentApiHints",
+      "layoutRegionHints",
+    ]) {
+      assert.equal(
+        lowerPriorityField in decision.payload.reactWebContext,
+        false,
+        `${lowerPriorityField} should trim before formStateRoles`,
+      );
+    }
+
+    for (const protectedField of ["editTargetRouting", "formStateFlow", "a11yAnchors", "intentTargets", "formStateRoles"]) {
+      assert.ok(Array.isArray(decision.payload.reactWebContext[protectedField]), `${protectedField} should survive pressured trim`);
+      assert.ok(
+        decision.payload.reactWebContext[protectedField].length > 0,
+        `${protectedField} should retain source-backed entries`,
+      );
+    }
+
+    const roles = new Set(decision.payload.reactWebContext.formStateRoles.map((item) => item.role));
+    assert.equal(roles.has("form-root"), true);
+    assert.equal(roles.has("field-registration"), true);
+    assert.equal(roles.has("submit-flow"), true);
+    assert.equal(roles.has("value-control-relation"), true);
+    assert.equal(roles.has("validation-defaults"), true);
+    assert.doesNotMatch(
+      JSON.stringify(decision.payload.reactWebContext.formStateRoles),
+      /authoriz|cross-file|typechecker|LSP-backed|billing|latency|provider-token|auto-apply/i,
+    );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/react-web-inline-sources.mjs
+++ b/test/react-web-inline-sources.mjs
@@ -28,6 +28,39 @@ export function InlineRetentionForm({ onSubmit }: Props) {
 `;
 }
 
+export function reactWebFormStateRolesSource() {
+  return `import { useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+type FormStateRolesDraft = { email: string; role: string };
+type InlineFormStateRolesFormProps = { initialEmail?: string; disabled?: boolean; onSubmit?: (value: FormStateRolesDraft) => void };
+
+export function InlineFormStateRolesForm({ initialEmail = "", disabled = false, onSubmit }: InlineFormStateRolesFormProps) {
+  const [loading, setLoading] = useState(false);
+  const { register, handleSubmit, control, formState: { errors } } = useForm<FormStateRolesDraft>({
+    defaultValues: { email: initialEmail, role: "member" },
+  });
+  const busy = useMemo(() => loading || disabled, [disabled, loading]);
+  const submitForm = handleSubmit((value) => {
+    setLoading(true);
+    onSubmit?.(value);
+  });
+
+  return (
+    <form onSubmit={submitForm} className="grid gap-3" aria-busy={busy}>
+      <label htmlFor="email">Email</label>
+      <input id="email" {...register("email")} disabled={busy} aria-invalid={Boolean(errors.email)} />
+      {errors.email ? <p role="alert">{errors.email.message}</p> : null}
+      <Controller name="role" control={control} render={({ field }) => <input {...field} readOnly />} />
+      <button type="submit" disabled={busy}>Save</button>
+    </form>
+  );
+}
+
+/* ${"form state role budget filler ".repeat(620)} */
+`;
+}
+
 export function reactWebLayoutRegionSource() {
   return `type LayoutItem = { id: string; label: string };
 type LayoutPanelProps = { items: LayoutItem[]; loading?: boolean; error?: string };

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -9,6 +9,7 @@ import {
   reactWebA11yAnchorSource,
   reactWebComponentApiSource,
   reactWebFormStateFlowSource,
+  reactWebFormStateRolesSource,
   reactWebLayoutRegionSource,
   reactWebStylingVariantSource,
   reactWebImportRoleSource,
@@ -97,6 +98,10 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.debug.reactWebContextPacking.included, true);
   assert.equal(secondInject.debug.reactWebContextPacking.reason, "packed");
   assert.equal(secondInject.debug.reactWebContextPacking.priority[0], "editTargetRouting");
+  assert.ok(
+    secondInject.debug.reactWebContextPacking.priority.indexOf("formStateRoles") >
+      secondInject.debug.reactWebContextPacking.priority.indexOf("intentTargets"),
+  );
   assert.equal(secondInject.debug.reactWebContextPacking.fields[0].name, "editTargetRouting");
   assert.equal(
     secondInject.debug.reactWebContextPacking.fields.find((field) => field.name === "editTargetRouting")?.count,
@@ -201,6 +206,22 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
     assert.ok(packedPayload.reactWebContext.editTargetRouting.length > 0);
     assert.equal(packedContext.debug.reactWebContextPacking.fields[0].name, "editTargetRouting");
     assert.ok(Array.isArray(packedPayload.reactWebContext.a11yAnchors));
+    assert.ok(
+      packedContext.debug.reactWebContextPacking.priority.indexOf("formStateRoles") >
+        packedContext.debug.reactWebContextPacking.priority.indexOf("editTargetRouting"),
+    );
+    assert.ok(
+      packedContext.debug.reactWebContextPacking.priority.indexOf("formStateRoles") >
+        packedContext.debug.reactWebContextPacking.priority.indexOf("formStateFlow"),
+    );
+    assert.ok(
+      packedContext.debug.reactWebContextPacking.priority.indexOf("formStateRoles") >
+        packedContext.debug.reactWebContextPacking.priority.indexOf("a11yAnchors"),
+    );
+    assert.ok(
+      packedContext.debug.reactWebContextPacking.priority.indexOf("formStateRoles") >
+        packedContext.debug.reactWebContextPacking.priority.indexOf("intentTargets"),
+    );
     assert.ok(Buffer.byteLength(packedContext.additionalContext, "utf8") <= Buffer.byteLength(largeReactSource, "utf8"));
     assert.equal("sourceRanges" in packedPayload.reactWebContext, false);
   } finally {
@@ -531,6 +552,59 @@ test("runtime bridge preserves React Web form state-flow in repeated-read contex
       payload.reactWebContext.formStateFlow.some(
         (item) => item.kind === "controlled-control" && item.label === "input[name=email]",
       ),
+    );
+    assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime bridge preserves React Web form-state roles in repeated-read context when budget permits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-runtime-form-role-retention-"));
+  try {
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    const source = reactWebFormStateRolesSource();
+    fs.writeFileSync(path.join(tempDir, "src", "InlineFormStateRolesForm.tsx"), source);
+
+    const sessionId = `bridge-contract-form-role-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    const first = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineFormStateRolesForm.tsx",
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: "Inspect src/InlineFormStateRolesForm.tsx again",
+      },
+      tempDir,
+    );
+    const payload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
+
+    assert.equal(first.action, "record");
+    assert.equal(second.action, "inject");
+    assert.equal(second.contextModeReason, "repeated-exact-file-react-web-payload");
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
+    assert.equal(second.debug.decision.debug.reactWebContextBudget.reason, "within-budget");
+    assert.ok(Array.isArray(payload.reactWebContext.formStateRoles));
+    assert.ok(payload.reactWebContext.formStateRoles.length <= 8);
+
+    const roles = new Set(payload.reactWebContext.formStateRoles.map((item) => item.role));
+    assert.equal(roles.has("form-root"), true);
+    assert.equal(roles.has("field-registration"), true);
+    assert.equal(roles.has("submit-flow"), true);
+    assert.equal(roles.has("value-control-relation"), true);
+    assert.equal(roles.has("validation-defaults"), true);
+    assert.ok(payload.reactWebContext.formStateRoles.every((item) => item.labels.length <= 4));
+    assert.ok(payload.reactWebContext.formStateRoles.every((item) => item.evidence.length > 0));
+    assert.doesNotMatch(
+      JSON.stringify({ payload: payload.reactWebContext.formStateRoles, debug: second.debug.reactWebContextPacking }),
+      /authoriz|cross-file|typechecker|LSP-backed|billing|latency|provider-token|auto-apply/i,
     );
     assert.ok(Buffer.byteLength(second.additionalContext, "utf8") <= Buffer.byteLength(source, "utf8"));
   } finally {


### PR DESCRIPTION
## Summary
- preserve advisory React Web `formStateRoles` in runtime packing after higher-actionability context fields
- adjust pre-read trim order so lower-priority metadata trims before form-state roles while protected fields remain higher priority
- add source-backed RHF-style fixture plus runtime and direct pre-read budget-pressure regressions

Closes #1095

## Verification
- [x] npm run build
- [x] npm run typecheck -- --pretty false
- [x] node --test test/runtime-bridge-contract.test.mjs test/pre-read-payload-builder.test.mjs test/react-web-context-metadata.test.mjs test/fooks.test.mjs test/react-web-runtime-evidence-claim-boundary.test.mjs test/payload-policy-profile-gate.test.mjs
- [x] git diff --check HEAD

## Review evidence
- ai-slop-cleaner: passed
- independent code-reviewer: APPROVE
- independent architect: CLEAR
