### PR TITLE
Keep Merge Gate rerun alert triage reporting-only

### DIFF
--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_LIMIT = 100;
@@ -14,6 +14,7 @@ const ACTIONABLE_CONCLUSIONS = new Set(["failure", "timed_out", "action_required
 const ACTIVE_STATUSES = new Set(["queued", "in_progress", "waiting", "pending", "requested"]);
 const TMUX_BLOCKER_PATTERN = /\b(TS\d{4}|error|errors|failed|failure|exception)\b/i;
 const TMUX_NON_BLOCKER_PATTERN = /\b(?:0|zero|no)\s+errors?\b/i;
+const CLAIM_BOUNDARY = "read-only alert triage only; PR CI, push CI, and pull_request_target/pull_request_review Merge Gate evidence are reporting lanes, not authorization or merge authority";
 const TMUX_RECOVERY_PATTERNS = [
   /\bnpm\s+(?:run\s+)?test\b.*\bpass(?:ed|ing)?\b/i,
   /\btests?\s+pass(?:ed|ing)?\b/i,
@@ -77,7 +78,7 @@ Bulk replay behavior:
   stale sample, then summarizes omitted historical success/cancelled replay rows.`);
 }
 
-function readRuns(options) {
+function readRuns(options, spawn = spawnSync) {
   if (options.input) {
     return JSON.parse(fs.readFileSync(path.resolve(repoRoot, options.input), "utf8"));
   }
@@ -93,7 +94,7 @@ function readRuns(options) {
   if (options.branch) args.push("--branch", options.branch);
   if (options.workflow) args.push("--workflow", options.workflow);
 
-  const result = spawnSync("gh", args, {
+  const result = spawn("gh", args, {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -103,6 +104,58 @@ function readRuns(options) {
     throw new Error(result.stderr || `gh run list exited with status ${result.status}`);
   }
   return JSON.parse(result.stdout);
+}
+
+function repoSlugFromOrigin(spawn = spawnSync) {
+  const result = spawn("git", ["config", "--get", "remote.origin.url"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const remoteUrl = result.stdout.trim();
+  const match = remoteUrl.match(/github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+)(?:\.git)?$/);
+  return match?.groups ? `${match.groups.owner}/${match.groups.repo}` : "";
+}
+
+function fetchRunJobs(repoSlug, runId, spawn = spawnSync) {
+  const result = spawn("gh", [
+    "api",
+    `repos/${repoSlug}/actions/runs/${runId}/jobs?filter=all&per_page=100`,
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) return [];
+  try {
+    const payload = JSON.parse(result.stdout);
+    return Array.isArray(payload.jobs) ? payload.jobs : [];
+  } catch {
+    return [];
+  }
+}
+
+function isMergeGateRun(run) {
+  return String(run.event || "") === "pull_request_target"
+    && String(run.workflowName || run.name || "") === "Merge Gate";
+}
+
+function enrichRunsWithAlertJobs(rawRuns, alertRefs, options, spawn = spawnSync) {
+  if (options.input || alertRefs.every((ref) => ref.alertedJobId === null)) return rawRuns;
+  const repoSlug = repoSlugFromOrigin(spawn);
+  if (!repoSlug) return rawRuns;
+
+  const alertedJobRunIds = new Set(alertRefs
+    .filter((ref) => ref.alertedJobId !== null)
+    .map((ref) => String(ref.id)));
+
+  return rawRuns.map((run) => {
+    const runId = run.databaseId ?? run.id ?? null;
+    if (!alertedJobRunIds.has(String(runId)) || !isMergeGateRun(run)) return run;
+    if (Array.isArray(run.jobs) || Array.isArray(run.checkRuns)) return run;
+    const jobs = fetchRunJobs(repoSlug, runId, spawn);
+    return jobs.length > 0 ? { ...run, jobs } : run;
+  });
 }
 
 function readAlertText(alertsInput) {
@@ -181,14 +234,19 @@ function extractAlertRunRefs(alertText) {
   for (const match of alertText.matchAll(urlPattern)) {
     const id = match[1];
     const alertedAttempt = match[2] === "attempts" ? normalizePositiveInteger(match[3]) : null;
-    const key = alertedAttempt === null ? id : `${id}:attempt:${alertedAttempt}`;
+    const alertedJobId = (match[2] === "job" || match[2] === "jobs") ? normalizePositiveInteger(match[3]) : null;
+    const key = alertedJobId !== null
+      ? `${id}:job:${alertedJobId}`
+      : alertedAttempt === null ? id : `${id}:attempt:${alertedAttempt}`;
     const existing = refsByKey.get(key);
     if (existing) {
       existing.appearances += 1;
+      if (existing.alertedJobId === null && alertedJobId !== null) existing.alertedJobId = alertedJobId;
     } else {
       refsByKey.set(key, {
         id,
         alertedAttempt,
+        alertedJobId,
         url: match[0].replace(/[.,;:!?]+$/, ""),
         appearances: 1,
       });
@@ -198,7 +256,34 @@ function extractAlertRunRefs(alertText) {
   return [...refsByKey.values()];
 }
 
+function normalizeRunJobs(run) {
+  const jobs = Array.isArray(run.jobs) ? run.jobs : Array.isArray(run.checkRuns) ? run.checkRuns : [];
+  return jobs
+    .map((job) => ({
+      id: normalizePositiveInteger(job?.databaseId ?? job?.id ?? job?.jobId ?? job?.checkRunId),
+      name: job?.name ?? job?.checkName ?? "",
+      status: job?.status ?? "",
+      conclusion: job?.conclusion ?? "",
+      completedAt: job?.completedAt ?? job?.completed_at ?? job?.updatedAt ?? job?.updated_at ?? "",
+      url: job?.url ?? job?.htmlUrl ?? job?.html_url ?? "",
+    }))
+    .filter((job) => job.id !== null)
+    .sort((left, right) => (Date.parse(right.completedAt || "") || 0) - (Date.parse(left.completedAt || "") || 0) || Number(right.id) - Number(left.id));
+}
+
+function ciLaneForRun(run) {
+  const event = String(run.event || "");
+  const workflow = String(run.workflowName || run.name || "");
+  if (event === "pull_request_target" && workflow === "Merge Gate") return "pull_request_target:merge-gate";
+  if (event === "pull_request_target") return "pull_request_target";
+  if (event === "pull_request") return "pull_request";
+  if (event === "push") return "push";
+  return event || "unknown-event";
+}
+
 function normalizeRun(run) {
+  const jobs = normalizeRunJobs(run);
+  const latestJob = jobs[0] ?? null;
   return {
     id: run.databaseId ?? run.id ?? null,
     workflow: run.workflowName || run.name || "unknown-workflow",
@@ -209,6 +294,12 @@ function normalizeRun(run) {
     status: run.status || "unknown-status",
     conclusion: run.conclusion || "",
     attempt: normalizePositiveInteger(run.attempt),
+    latestJobId: normalizePositiveInteger(run.latestJobId ?? run.currentJobId ?? run.jobId ?? latestJob?.id),
+    latestJobName: run.latestJobName ?? run.currentJobName ?? latestJob?.name ?? "",
+    latestJobConclusion: run.latestJobConclusion ?? run.currentJobConclusion ?? latestJob?.conclusion ?? "",
+    latestJobUrl: run.latestJobUrl ?? run.currentJobUrl ?? latestJob?.url ?? "",
+    jobs,
+    ciLane: ciLaneForRun(run),
     createdAt: run.createdAt || "",
     updatedAt: run.updatedAt || run.createdAt || "",
     url: run.url || "",
@@ -272,6 +363,50 @@ function isCurrentMainSuccessEcho(row, focusBranch) {
     && String(row.latestRunId) === String(row.id);
 }
 
+function supersedingSuccessfulRerunJob(row, alertedJobId) {
+  if (!row
+    || alertedJobId === null
+    || row.ciLane !== "pull_request_target:merge-gate"
+    || row.status !== "completed") {
+    return null;
+  }
+
+  const alertedJob = Array.isArray(row.jobs)
+    ? row.jobs.find((job) => String(job.id) === String(alertedJobId))
+    : null;
+  if (alertedJob) {
+    if (!ACTIONABLE_CONCLUSIONS.has(alertedJob.conclusion)) return null;
+    const alertedTime = Date.parse(alertedJob.completedAt || "");
+    if (!Number.isFinite(alertedTime)) return null;
+    return row.jobs.find((job) => {
+      const completedAt = Date.parse(job.completedAt || "");
+      const completedLater = Number.isFinite(completedAt) && completedAt > alertedTime;
+      return String(job.id) !== String(alertedJobId)
+        && job.name === alertedJob.name
+        && job.status === "completed"
+        && job.conclusion === "success"
+        && completedLater;
+    }) ?? null;
+  }
+
+  return null;
+}
+
+function needsMergeGateJobEvidence(row, alertedJobId) {
+  return row
+    && alertedJobId !== null
+    && row.ciLane === "pull_request_target:merge-gate"
+    && (!Array.isArray(row.jobs) || row.jobs.length === 0);
+}
+
+function hasMergeGateJobEvidence(row, alertedJobId) {
+  return row
+    && alertedJobId !== null
+    && row.ciLane === "pull_request_target:merge-gate"
+    && Array.isArray(row.jobs)
+    && row.jobs.length > 0;
+}
+
 function alertDisposition(evidence, replay, echo = false, review = false) {
   if (evidence === "actionable" || evidence === "watch") return "inspect";
   if (review) return "review";
@@ -288,40 +423,63 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
     const row = rowsById.get(ref.id);
     const currentAttempt = row?.attempt ?? null;
     const isStaleAttempt = ref.alertedAttempt !== null && currentAttempt !== null && ref.alertedAttempt < currentAttempt;
-    const replay = isHistoricalReplayEvidence(row, isStaleAttempt, focusBranch);
-    const echo = !isStaleAttempt && isCurrentMainSuccessEcho(row, focusBranch);
-    const supersededMainCancellationEcho = !isStaleAttempt && isSupersededMainCancellationEcho(row, focusBranch);
+    const supersedingJob = !isStaleAttempt ? supersedingSuccessfulRerunJob(row, ref.alertedJobId) : null;
+    const supersededSuccessfulRerunJobEcho = supersedingJob !== null;
+    const mergeGateJobEvidenceMissing = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && needsMergeGateJobEvidence(row, ref.alertedJobId);
+    const mergeGateJobNotSuperseded = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && hasMergeGateJobEvidence(row, ref.alertedJobId);
+    const requiresMergeGateJobReview = mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded;
+    const replay = isHistoricalReplayEvidence(row, isStaleAttempt, focusBranch) || supersededSuccessfulRerunJobEcho;
+    const echo = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && !mergeGateJobEvidenceMissing && !mergeGateJobNotSuperseded && isCurrentMainSuccessEcho(row, focusBranch);
+    const supersededMainCancellationEcho = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && isSupersededMainCancellationEcho(row, focusBranch);
     const cancellationNeedsSuccessEvidence = !isStaleAttempt && needsMainCancellationSuccessEvidence(row, focusBranch);
-    const evidence = isStaleAttempt ? "stale" : alertEvidenceState(row);
+    const evidence = (mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded) ? "review" : (isStaleAttempt || supersededSuccessfulRerunJobEcho) ? "stale" : alertEvidenceState(row);
     const verdict = echo
       ? "current-main-echo"
-      : supersededMainCancellationEcho
-        ? "superseded-main-ci-cancel-echo"
-        : evidence;
+      : supersededSuccessfulRerunJobEcho
+        ? "superseded-successful-rerun-job-echo"
+        : mergeGateJobEvidenceMissing
+          ? "merge-gate-job-evidence-unavailable"
+          : mergeGateJobNotSuperseded
+            ? "merge-gate-job-not-superseded"
+            : supersededMainCancellationEcho
+              ? "superseded-main-ci-cancel-echo"
+              : evidence;
     const reason = isStaleAttempt
       ? `superseded by attempt ${currentAttempt}`
-      : echo
-        ? `verification-only current ${focusBranch} success echo`
-        : supersededMainCancellationEcho
-          ? `cancelled ${focusBranch} run superseded by successful run ${row.latestRunId}`
-          : cancellationNeedsSuccessEvidence
-            ? `cancelled ${focusBranch} run has no later success evidence`
-            : row?.reason ?? "run URL was not present in the inspected gh run list window";
+      : supersededSuccessfulRerunJobEcho
+        ? `${row.ciLane} job ${ref.alertedJobId} superseded by newer successful job ${supersedingJob.id} in run ${row.id}`
+        : mergeGateJobEvidenceMissing
+          ? `${row.ciLane} job ${ref.alertedJobId} needs job-list evidence before suppressing as a rerun echo`
+          : mergeGateJobNotSuperseded
+            ? `${row.ciLane} job ${ref.alertedJobId} has no newer successful same-name job evidence`
+            : echo
+              ? `verification-only current ${focusBranch} success echo`
+              : supersededMainCancellationEcho
+                ? `cancelled ${focusBranch} run superseded by successful run ${row.latestRunId}`
+                : cancellationNeedsSuccessEvidence
+                  ? `cancelled ${focusBranch} run has no later success evidence`
+                  : row?.reason ?? "run URL was not present in the inspected gh run list window";
     return {
       alertedRunId: ref.id,
       alertedAttempt: ref.alertedAttempt,
+      alertedJobId: ref.alertedJobId,
       alertedUrl: ref.url,
       appearances: ref.appearances,
       evidence,
       verdict,
       echo,
       supersededMainCancellationEcho,
+      supersededSuccessfulRerunJobEcho,
+      mergeGateJobEvidenceMissing,
+      mergeGateJobNotSuperseded,
       replay,
-      disposition: alertDisposition(evidence, replay, echo, cancellationNeedsSuccessEvidence),
+      disposition: alertDisposition(evidence, replay, echo, cancellationNeedsSuccessEvidence || requiresMergeGateJobReview),
       reason,
       replayReason: replay ? `historical replay of ${reason}` : "",
       currentRunId: row?.latestRunId ?? null,
       currentAttempt,
+      currentJobId: supersedingJob?.id ?? row?.latestJobId ?? null,
+      ciLane: row?.ciLane ?? "",
       workflow: row?.workflow ?? "",
       branch: row?.branch ?? "",
       status: row?.status ?? "",
@@ -332,12 +490,14 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
       latestConclusion: row?.latestConclusion ?? "",
       latestHeadSha: row?.latestHeadSha ?? "",
       latestUpdatedAt: row?.latestUpdatedAt ?? "",
+      claimBoundary: CLAIM_BOUNDARY,
       runUrl: ref.url,
     };
   });
 }
 
 function shouldKeepCompactAlert(alert, focusBranch) {
+  if (alert.disposition === "review") return true;
   if (alert.evidence === "actionable" || alert.evidence === "watch" || alert.evidence === "missing") return true;
   if (alert.evidence === "current" && alert.branch === focusBranch) return true;
   if (alert.evidence === "stale" && alert.conclusion && !["success", "cancelled", "skipped"].includes(alert.conclusion)) return true;
@@ -363,6 +523,7 @@ function summarizeOmittedAlerts(omitted) {
         disposition: alert.disposition || "review",
         replay: Boolean(alert.replay),
         supersededMainCancellationEcho: Boolean(alert.supersededMainCancellationEcho),
+        supersededSuccessfulRerunJobEcho: Boolean(alert.supersededSuccessfulRerunJobEcho),
       });
     }
   }
@@ -375,7 +536,26 @@ function summarizeOmittedAlerts(omitted) {
 }
 
 function alertKey(alert) {
-  return `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`;
+  return `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}:${alert.alertedJobId ?? "run"}`;
+}
+
+function coalesceGenericRunJobAlerts(allEvidence) {
+  const byRunAttempt = new Map();
+  for (const alert of allEvidence) {
+    const key = `${alert.alertedRunId}:${alert.alertedAttempt ?? "current"}`;
+    const alerts = byRunAttempt.get(key) ?? [];
+    alerts.push(alert);
+    byRunAttempt.set(key, alerts);
+  }
+
+  return [...byRunAttempt.values()].flatMap((alerts) => {
+    const hasMergeGateJobAlert = alerts.some((alert) => alert.alertedJobId !== null && alert.ciLane === "pull_request_target:merge-gate");
+    if (hasMergeGateJobAlert) return alerts;
+    const runAlert = alerts.find((alert) => alert.alertedJobId === null);
+    if (!runAlert) return alerts;
+    const appearances = alerts.reduce((total, alert) => total + alert.appearances, 0);
+    return [{ ...runAlert, appearances }];
+  });
 }
 
 function alertSummaryFields(allEvidence, focusBranch) {
@@ -392,8 +572,10 @@ function alertSummaryFields(allEvidence, focusBranch) {
     currentHeadRunIds,
     currentMainEchoCount: allEvidence.filter((alert) => alert.echo).length,
     supersededMainCancellationEchoCount: allEvidence.filter((alert) => alert.supersededMainCancellationEcho).length,
+    supersededSuccessfulRerunJobEchoCount: allEvidence.filter((alert) => alert.supersededSuccessfulRerunJobEcho).length,
     verificationOnlyCount: allEvidence.filter((alert) => alert.disposition === "verification-only").length,
     actionableAlertCount: allEvidence.filter((alert) => alert.disposition === "inspect").length,
+    reviewAlertCount: allEvidence.filter((alert) => alert.disposition === "review").length,
     staleReplayCount: allEvidence.filter((alert) => alert.replay).length,
     staleSuccessReplayCount: allEvidence.filter((alert) => alert.replay && alert.conclusion === "success").length,
   };
@@ -414,7 +596,7 @@ function historicalReplayBatchGuard(allEvidence, focusBranch, summaryFields) {
     return {
       batchVerdict: "historical-ci-replay-batch",
       batchDisposition: "suppress-historical-replay-before-current-main-echo",
-      batchReason: `current GitHub Actions state for ${focusBranch} remains authoritative; all non-current pasted run URLs are stale replay noise before ${summaryFields.currentHeadCount} current-head echo${summaryFields.currentHeadCount === 1 ? "" : "es"}`,
+      batchReason: `current GitHub Actions reporting state for ${focusBranch} is the freshest alert-triage evidence; all non-current pasted run URLs are stale replay noise before ${summaryFields.currentHeadCount} current-head echo${summaryFields.currentHeadCount === 1 ? "" : "es"}`,
     };
   }
 
@@ -429,7 +611,7 @@ function historicalReplayBatchGuard(allEvidence, focusBranch, summaryFields) {
 
 function buildAlertEvidence(alertRefs, rows, options = {}) {
   const focusBranch = options.branch || "main";
-  const allEvidence = buildRawAlertEvidence(alertRefs, rows, { branch: focusBranch });
+  const allEvidence = coalesceGenericRunJobAlerts(buildRawAlertEvidence(alertRefs, rows, { branch: focusBranch }));
   const limit = options.alertEvidenceLimit || DEFAULT_ALERT_EVIDENCE_LIMIT;
   const summaryFields = alertSummaryFields(allEvidence, focusBranch);
   const batchGuard = historicalReplayBatchGuard(allEvidence, focusBranch, summaryFields);
@@ -543,6 +725,7 @@ function classifyRuns(rawRuns) {
       latestConclusion: latest?.conclusion ?? "",
       latestHeadSha: latest?.headSha ?? "",
       latestUpdatedAt: latest?.updatedAt ?? latest?.createdAt ?? "",
+      latestJobId: latest?.latestJobId ?? null,
     };
   });
 
@@ -601,6 +784,8 @@ function alertEvidenceTable(alerts, summary) {
   const lines = [
     "## Pasted alert URL evidence",
     "",
+    `Claim boundary: ${escapeMarkdown(CLAIM_BOUNDARY)}.`,
+    "",
     compactNote,
     "",
     "| Evidence | Verdict | Disposition | Replay | Alerted run | Alerted attempt | Current run | Current attempt | Workflow | Branch | Status | Conclusion | Reason | Seen |",
@@ -658,9 +843,11 @@ Use this report to collapse replayed GitHub Actions alert buffers: inspect only 
 - Pasted alert URLs inspected: ${result.alertSummary?.total ?? result.alerts?.length ?? 0}
 - Pasted alert evidence shown: ${result.alertSummary?.shown ?? result.alerts?.length ?? 0}
 - Pasted alert evidence omitted: ${result.alertSummary?.omitted ?? 0}
-- Pasted alert evidence needing inspection: ${result.alertSummary?.actionableAlertCount ?? 0}
+- Pasted alert evidence needing inspection: ${(result.alertSummary?.actionableAlertCount ?? 0) + (result.alertSummary?.reviewAlertCount ?? 0)}
+- Pasted alert evidence requiring review: ${result.alertSummary?.reviewAlertCount ?? 0}
 - Verification-only current-main echoes: ${result.alertSummary?.verificationOnlyCount ?? 0}
 - Superseded main cancellation echoes: ${result.alertSummary?.supersededMainCancellationEchoCount ?? 0}
+- Superseded successful rerun job echoes: ${result.alertSummary?.supersededSuccessfulRerunJobEchoCount ?? 0}
 - Stale success replay evidence: ${result.alertSummary?.staleSuccessReplayCount ?? 0}
 - Tmux pane history fresh blockers: ${result.tmuxHistorySummary?.currentKeywordLines ?? 0}
 - Tmux pane history stale replay lines: ${result.tmuxHistorySummary?.staleKeywordLines ?? 0}
@@ -673,13 +860,16 @@ ${markdownTable(actionable)}
 ${markdownTable(stale)}`;
 }
 
-function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const rawRuns = readRuns(options);
-  if (!Array.isArray(rawRuns)) throw new Error("Expected an array of GitHub Actions runs");
+function runCli(argv = process.argv.slice(2), io = {}) {
+  const options = parseArgs(argv);
   const alertText = readAlertText(options.alertsInput);
-  const result = classifyRuns(rawRuns);
   const alertRefs = extractAlertRunRefs(alertText);
+  const spawn = io.spawn ?? spawnSync;
+  const baseRuns = readRuns(options, spawn);
+  if (!Array.isArray(baseRuns)) throw new Error("Expected an array of GitHub Actions runs");
+  const rawRuns = enrichRunsWithAlertJobs(baseRuns, alertRefs, options, spawn);
+  if (!Array.isArray(rawRuns)) throw new Error("Expected an array of GitHub Actions runs");
+  const result = classifyRuns(rawRuns);
   const alertEvidence = buildAlertEvidence(alertRefs, result.rows, options);
   const tmuxHistoryEvidence = buildTmuxHistoryEvidence(alertText);
   result.alerts = alertEvidence.alerts;
@@ -689,12 +879,23 @@ function main() {
   const output = options.format === "json" ? `${JSON.stringify(result, null, 2)}\n` : renderMarkdown(result);
 
   if (options.output) fs.writeFileSync(path.resolve(repoRoot, options.output), output);
-  else process.stdout.write(output);
+  else (io.stdout ?? process.stdout).write(output);
+  return { result, output };
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+function main() {
+  runCli();
 }
+
+const isDirectCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectCli) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+export { runCli };

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -561,8 +561,8 @@ function coalesceGenericRunJobAlerts(allEvidence) {
   }
 
   return [...byRunAttempt.values()].flatMap((alerts) => {
-    const hasMergeGateJobAlert = alerts.some((alert) => alert.alertedJobId !== null && alert.ciLane === "pull_request_target:merge-gate");
-    if (hasMergeGateJobAlert) return alerts;
+    const hasReviewableJobAlert = alerts.some((alert) => alert.alertedJobId !== null && alert.disposition === "review");
+    if (hasReviewableJobAlert) return alerts;
     const runAlert = alerts.find((alert) => alert.alertedJobId === null);
     if (!runAlert) return alerts;
     const appearances = alerts.reduce((total, alert) => total + alert.appearances, 0);

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -12,6 +12,7 @@ const OMITTED_ALERT_RUN_EVIDENCE_LIMIT = 12;
 const STALE_CONCLUSIONS = new Set(["cancelled", "skipped"]);
 const ACTIONABLE_CONCLUSIONS = new Set(["failure", "timed_out", "action_required", "startup_failure"]);
 const ACTIVE_STATUSES = new Set(["queued", "in_progress", "waiting", "pending", "requested"]);
+const SUPERSEDABLE_MERGE_GATE_JOB_CONCLUSIONS = new Set([...ACTIONABLE_CONCLUSIONS, "cancelled"]);
 const TMUX_BLOCKER_PATTERN = /\b(TS\d{4}|error|errors|failed|failure|exception)\b/i;
 const TMUX_NON_BLOCKER_PATTERN = /\b(?:0|zero|no)\s+errors?\b/i;
 const CLAIM_BOUNDARY = "read-only alert triage only; PR CI, push CI, and pull_request_target/pull_request_review Merge Gate evidence are reporting lanes, not authorization or merge authority";
@@ -375,7 +376,7 @@ function supersedingSuccessfulRerunJob(row, alertedJobId) {
     ? row.jobs.find((job) => String(job.id) === String(alertedJobId))
     : null;
   if (alertedJob) {
-    if (!ACTIONABLE_CONCLUSIONS.has(alertedJob.conclusion)) return null;
+    if (!SUPERSEDABLE_MERGE_GATE_JOB_CONCLUSIONS.has(alertedJob.conclusion)) return null;
     const alertedTime = Date.parse(alertedJob.completedAt || "");
     if (!Number.isFinite(alertedTime)) return null;
     return row.jobs.find((job) => {
@@ -427,12 +428,18 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
     const supersededSuccessfulRerunJobEcho = supersedingJob !== null;
     const mergeGateJobEvidenceMissing = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && needsMergeGateJobEvidence(row, ref.alertedJobId);
     const mergeGateJobNotSuperseded = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && hasMergeGateJobEvidence(row, ref.alertedJobId);
-    const requiresMergeGateJobReview = mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded;
+    const nonMergeGateJobReview = !isStaleAttempt
+      && ref.alertedJobId !== null
+      && row
+      && row.ciLane !== "pull_request_target:merge-gate"
+      && Array.isArray(row.jobs)
+      && row.jobs.length > 0;
+    const requiresMergeGateJobReview = mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded || nonMergeGateJobReview;
     const replay = isHistoricalReplayEvidence(row, isStaleAttempt, focusBranch) || supersededSuccessfulRerunJobEcho;
-    const echo = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && !mergeGateJobEvidenceMissing && !mergeGateJobNotSuperseded && isCurrentMainSuccessEcho(row, focusBranch);
+    const echo = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && !requiresMergeGateJobReview && isCurrentMainSuccessEcho(row, focusBranch);
     const supersededMainCancellationEcho = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && isSupersededMainCancellationEcho(row, focusBranch);
     const cancellationNeedsSuccessEvidence = !isStaleAttempt && needsMainCancellationSuccessEvidence(row, focusBranch);
-    const evidence = (mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded) ? "review" : (isStaleAttempt || supersededSuccessfulRerunJobEcho) ? "stale" : alertEvidenceState(row);
+    const evidence = requiresMergeGateJobReview ? "review" : (isStaleAttempt || supersededSuccessfulRerunJobEcho) ? "stale" : alertEvidenceState(row);
     const verdict = echo
       ? "current-main-echo"
       : supersededSuccessfulRerunJobEcho
@@ -441,7 +448,9 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
           ? "merge-gate-job-evidence-unavailable"
           : mergeGateJobNotSuperseded
             ? "merge-gate-job-not-superseded"
-            : supersededMainCancellationEcho
+            : nonMergeGateJobReview
+              ? "non-merge-gate-job-review"
+              : supersededMainCancellationEcho
               ? "superseded-main-ci-cancel-echo"
               : evidence;
     const reason = isStaleAttempt
@@ -452,7 +461,9 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
           ? `${row.ciLane} job ${ref.alertedJobId} needs job-list evidence before suppressing as a rerun echo`
           : mergeGateJobNotSuperseded
             ? `${row.ciLane} job ${ref.alertedJobId} has no newer successful same-name job evidence`
-            : echo
+            : nonMergeGateJobReview
+              ? `${row.ciLane} job ${ref.alertedJobId} is outside pull_request_target Merge Gate rerun suppression scope`
+              : echo
               ? `verification-only current ${focusBranch} success echo`
               : supersededMainCancellationEcho
                 ? `cancelled ${focusBranch} run superseded by successful run ${row.latestRunId}`
@@ -472,6 +483,7 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
       supersededSuccessfulRerunJobEcho,
       mergeGateJobEvidenceMissing,
       mergeGateJobNotSuperseded,
+      nonMergeGateJobReview,
       replay,
       disposition: alertDisposition(evidence, replay, echo, cancellationNeedsSuccessEvidence || requiresMergeGateJobReview),
       reason,

--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -431,9 +431,7 @@ function buildRawAlertEvidence(alertRefs, rows, options = {}) {
     const nonMergeGateJobReview = !isStaleAttempt
       && ref.alertedJobId !== null
       && row
-      && row.ciLane !== "pull_request_target:merge-gate"
-      && Array.isArray(row.jobs)
-      && row.jobs.length > 0;
+      && row.ciLane !== "pull_request_target:merge-gate";
     const requiresMergeGateJobReview = mergeGateJobEvidenceMissing || mergeGateJobNotSuperseded || nonMergeGateJobReview;
     const replay = isHistoricalReplayEvidence(row, isStaleAttempt, focusBranch) || supersededSuccessfulRerunJobEcho;
     const echo = !isStaleAttempt && !supersededSuccessfulRerunJobEcho && !requiresMergeGateJobReview && isCurrentMainSuccessEcho(row, focusBranch);

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -238,21 +238,34 @@ test("CI alert triage turns pasted GitHub Actions URLs into evidence", () => {
     });
     const result = JSON.parse(stdout);
     const byAlertId = new Map(result.alerts.map((alert) => [alert.alertedRunId, alert]));
+    const run204 = result.alerts.find((alert) => alert.alertedRunId === "204" && alert.alertedJobId === null);
+    const job204 = result.alerts.find((alert) => alert.alertedRunId === "204" && alert.alertedJobId === 123456789);
 
-    assert.equal(result.alerts.length, 5);
+    assert.equal(result.alerts.length, 6);
     assert.equal(byAlertId.has("444555666"), false);
     assert.equal(byAlertId.get("205").alertedRunId, "205");
+    assert.equal(byAlertId.get("205").alertedJobId, 444555666);
     assert.equal(byAlertId.get("205").alertedUrl, "https://github.com/minislively/fooks/actions/runs/205/job/444555666");
-    assert.equal(byAlertId.get("205").evidence, "current");
+    assert.equal(byAlertId.get("205").evidence, "review");
+    assert.equal(byAlertId.get("205").verdict, "non-merge-gate-job-review");
+    assert.equal(byAlertId.get("205").disposition, "review");
     assert.equal(byAlertId.get("205").branch, "main");
-    assert.equal(byAlertId.get("204").alertedUrl, "https://github.com/minislively/fooks/actions/runs/204");
-    assert.equal(byAlertId.get("204").evidence, "stale");
-    assert.equal(byAlertId.get("204").currentRunId, 205);
-    assert.equal(byAlertId.get("204").reason, "superseded by run 205");
-    assert.equal(byAlertId.get("204").appearances, 2);
-    assert.equal(byAlertId.get("203").evidence, "actionable");
+    assert.equal(run204.alertedUrl, "https://github.com/minislively/fooks/actions/runs/204");
+    assert.equal(run204.evidence, "stale");
+    assert.equal(run204.currentRunId, 205);
+    assert.equal(run204.reason, "superseded by run 205");
+    assert.equal(run204.appearances, 1);
+    assert.equal(job204.alertedUrl, "https://github.com/minislively/fooks/actions/runs/204/job/123456789");
+    assert.equal(job204.evidence, "review");
+    assert.equal(job204.verdict, "non-merge-gate-job-review");
+    assert.equal(job204.disposition, "review");
+    assert.equal(byAlertId.get("203").evidence, "review");
+    assert.equal(byAlertId.get("203").verdict, "non-merge-gate-job-review");
+    assert.equal(byAlertId.get("203").disposition, "review");
     assert.equal(byAlertId.get("203").alertedUrl, "https://github.com/minislively/fooks/actions/runs/203/job/987654321");
-    assert.equal(byAlertId.get("202").evidence, "actionable");
+    assert.equal(byAlertId.get("202").evidence, "review");
+    assert.equal(byAlertId.get("202").verdict, "non-merge-gate-job-review");
+    assert.equal(byAlertId.get("202").disposition, "review");
     assert.equal(byAlertId.get("202").alertedRunId, "202");
     assert.equal(byAlertId.get("202").alertedUrl, "https://github.com/minislively/fooks/actions/runs/202/job/333444555");
     assert.equal(byAlertId.get("202").branch, "ci-alert-pr-job-url-regression");
@@ -317,20 +330,25 @@ test("CI alert triage keeps explicit rerun attempt evidence distinct", () => {
     });
     const result = JSON.parse(stdout);
     const attempt301 = result.alerts.find((alert) => alert.alertedRunId === "301" && alert.alertedAttempt === 1);
-    const current301 = result.alerts.find((alert) => alert.alertedRunId === "301" && alert.alertedAttempt === null);
+    const current301 = result.alerts.find((alert) => alert.alertedRunId === "301" && alert.alertedAttempt === null && alert.alertedJobId === null);
+    const current301Job = result.alerts.find((alert) => alert.alertedRunId === "301" && alert.alertedJobId === 777888999);
     const missingCurrentAttempt = result.alerts.find((alert) => alert.alertedRunId === "302" && alert.alertedAttempt === 1);
 
-    assert.equal(result.alerts.length, 3);
+    assert.equal(result.alerts.length, 4);
     assert.equal(attempt301.alertedUrl, "https://github.com/minislively/fooks/actions/runs/301/attempts/1");
     assert.equal(attempt301.currentAttempt, 2);
     assert.equal(attempt301.evidence, "stale");
     assert.equal(attempt301.reason, "superseded by attempt 2");
 
     assert.equal(current301.alertedUrl, "https://github.com/minislively/fooks/actions/runs/301");
-    assert.equal(current301.appearances, 2);
+    assert.equal(current301.appearances, 1);
     assert.equal(current301.currentAttempt, 2);
     assert.equal(current301.evidence, "current");
     assert.equal(current301.reason, "verification-only current main success echo");
+    assert.equal(current301Job.alertedUrl, "https://github.com/minislively/fooks/actions/runs/301/job/777888999");
+    assert.equal(current301Job.evidence, "review");
+    assert.equal(current301Job.verdict, "non-merge-gate-job-review");
+    assert.equal(current301Job.disposition, "review");
 
     assert.equal(missingCurrentAttempt.alertedUrl, "https://github.com/minislively/fooks/actions/runs/302/attempts/1");
     assert.equal(missingCurrentAttempt.currentAttempt, null);
@@ -408,6 +426,7 @@ test("CI alert triage separates stale attempt replay from current main success e
     assert.equal(result.alertSummary.currentHeadCount, 1);
     assert.deepEqual(result.alertSummary.currentHeadRunIds, ["960"]);
     assert.equal(result.alertSummary.currentMainEchoCount, 1);
+    assert.equal(result.alertSummary.reviewAlertCount ?? 0, 0);
     assert.equal(result.alertSummary.verificationOnlyCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 1);
     assert.equal(result.alertSummary.staleSuccessReplayCount, 1);
@@ -878,7 +897,7 @@ test("CI alert triage collapses success-heavy clawhip bursts to current head plu
   }
 });
 
-test("CI alert triage classifies pasted current main CI success as verification-only echo", () => {
+test("CI alert triage keeps pasted current main CI job URLs reviewable", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-main-pass-echo-"));
   const runsPath = path.join(tempDir, "runs.json");
   const alertsPath = path.join(tempDir, "alerts.txt");
@@ -933,24 +952,25 @@ test("CI alert triage classifies pasted current main CI success as verification-
     const result = JSON.parse(stdout);
     const byAlertId = new Map(result.alerts.map((alert) => [alert.alertedRunId, alert]));
 
-    assert.equal(byAlertId.get("850").evidence, "current");
-    assert.equal(byAlertId.get("850").verdict, "current-main-echo");
-    assert.equal(byAlertId.get("850").echo, true);
-    assert.equal(byAlertId.get("850").disposition, "verification-only");
-    assert.equal(byAlertId.get("850").reason, "verification-only current main success echo");
+    assert.equal(byAlertId.get("850").evidence, "review");
+    assert.equal(byAlertId.get("850").verdict, "non-merge-gate-job-review");
+    assert.equal(byAlertId.get("850").echo, false);
+    assert.equal(byAlertId.get("850").disposition, "review");
+    assert.match(byAlertId.get("850").reason, /outside pull_request_target Merge Gate/);
     assert.equal(byAlertId.get("850").currentRunId, 850);
     assert.equal(byAlertId.get("849").evidence, "stale");
     assert.equal(byAlertId.get("849").replay, true);
     assert.equal(byAlertId.get("849").disposition, "suppress-replay");
-    assert.equal(result.alertSummary.currentHeadRunIds.includes("850"), true);
-    assert.equal(result.alertSummary.currentMainEchoCount, 1);
+    assert.equal(result.alertSummary.currentHeadRunIds.includes("850"), false);
+    assert.equal(result.alertSummary.currentMainEchoCount, 0);
+    assert.equal(result.alertSummary.reviewAlertCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 1);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
-test("CI alert triage dedupes duplicate current main success run and job URLs", () => {
+test("CI alert triage keeps current main success job URL reviewable beside run URL", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-current-success-dedupe-"));
   const runsPath = path.join(tempDir, "runs.json");
   const alertsPath = path.join(tempDir, "alerts.txt");
@@ -1006,19 +1026,26 @@ test("CI alert triage dedupes duplicate current main success run and job URLs", 
     const currentEchoes = result.alerts.filter((alert) => alert.alertedRunId === "902");
     const staleReplay = result.alerts.find((alert) => alert.alertedRunId === "901");
 
-    assert.equal(currentEchoes.length, 1);
-    assert.equal(currentEchoes[0].appearances, 2);
-    assert.equal(currentEchoes[0].alertedUrl, "https://github.com/minislively/fooks/actions/runs/902");
-    assert.equal(currentEchoes[0].evidence, "current");
-    assert.equal(currentEchoes[0].verdict, "current-main-echo");
-    assert.equal(currentEchoes[0].disposition, "verification-only");
+    const currentRunEcho = currentEchoes.find((alert) => alert.alertedJobId === null);
+    const currentJobReview = currentEchoes.find((alert) => alert.alertedJobId === 123456789);
+
+    assert.equal(currentEchoes.length, 2);
+    assert.equal(currentRunEcho.appearances, 1);
+    assert.equal(currentRunEcho.alertedUrl, "https://github.com/minislively/fooks/actions/runs/902");
+    assert.equal(currentRunEcho.evidence, "current");
+    assert.equal(currentRunEcho.verdict, "current-main-echo");
+    assert.equal(currentRunEcho.disposition, "verification-only");
+    assert.equal(currentJobReview.evidence, "review");
+    assert.equal(currentJobReview.verdict, "non-merge-gate-job-review");
+    assert.equal(currentJobReview.disposition, "review");
 
     assert.equal(staleReplay.evidence, "stale");
     assert.equal(staleReplay.replay, true);
     assert.equal(staleReplay.conclusion, "success");
-    assert.equal(result.alertSummary.total, 2);
+    assert.equal(result.alertSummary.total, 3);
     assert.equal(result.alertSummary.currentMainEchoCount, 1);
     assert.equal(result.alertSummary.verificationOnlyCount, 1);
+    assert.equal(result.alertSummary.reviewAlertCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 1);
     assert.equal(result.alertSummary.staleSuccessReplayCount, 1);
     assert.equal(result.alertSummary.actionableAlertCount, 0);

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -1534,6 +1534,79 @@ test("CI alert triage does not suppress same-name rerun jobs outside pull_reques
   }
 });
 
+
+test("CI alert triage keeps non-authority job review evidence when matching run URL is also pasted", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-non-authority-run-job-mixed-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000030,
+      workflowName: "CI",
+      name: "CI",
+      headBranch: "fooks-issue-1094-rerun-status",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000030",
+      jobs: [
+        {
+          id: 78006573700,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:04:00Z",
+        },
+        {
+          id: 78007392300,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "run URL https://github.com/minislively/fooks/actions/runs/26300000030",
+    "job URL https://github.com/minislively/fooks/actions/runs/26300000030/job/78006573700",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const jobAlert = result.alerts.find((alert) => alert.alertedJobId === 78006573700);
+    const runAlert = result.alerts.find((alert) => alert.alertedJobId === null);
+
+    assert.equal(result.alerts.length, 2);
+    assert.equal(result.alertSummary.reviewAlertCount, 1);
+    assert.equal(result.alertSummary.verificationOnlyCount, 1);
+    assert.equal(runAlert.verdict, "current-main-echo");
+    assert.equal(runAlert.disposition, "verification-only");
+    assert.equal(jobAlert.verdict, "non-merge-gate-job-review");
+    assert.equal(jobAlert.disposition, "review");
+    assert.equal(jobAlert.nonMergeGateJobReview, true);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("CI alert triage markdown renders the read-only claim boundary", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-markdown-boundary-"));
   const runsPath = path.join(tempDir, "runs.json");

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -1111,6 +1111,84 @@ test("CI alert triage marks superseded pull_request_target Merge Gate job failur
   }
 });
 
+
+test("CI alert triage marks superseded pull_request_target Merge Gate job cancellations as stale rerun echoes", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-cancelled-rerun-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000010,
+      attempt: 2,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000010",
+      jobs: [
+        {
+          id: 78006573531,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "cancelled",
+          completedAt: "2026-05-27T10:04:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000010/job/78006573531",
+        },
+        {
+          id: 78007392257,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000010/job/78007392257",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "PR #1094 old Merge Gate cancelled job https://github.com/minislively/fooks/actions/runs/26300000010/job/78006573531",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const alert = result.alerts[0];
+
+    assert.equal(result.counts.informational, 1);
+    assert.equal(alert.alertedRunId, "26300000010");
+    assert.equal(alert.alertedJobId, 78006573531);
+    assert.equal(alert.currentJobId, 78007392257);
+    assert.equal(alert.evidence, "stale");
+    assert.equal(alert.verdict, "superseded-successful-rerun-job-echo");
+    assert.equal(alert.supersededSuccessfulRerunJobEcho, true);
+    assert.equal(alert.replay, true);
+    assert.equal(alert.disposition, "suppress-replay");
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 1);
+    assert.equal(result.alertSummary.actionableAlertCount, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("CI alert triage does not suppress unrelated successful Merge Gate jobs in the same run", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-unrelated-job-"));
   const runsPath = path.join(tempDir, "runs.json");
@@ -1444,10 +1522,13 @@ test("CI alert triage does not suppress same-name rerun jobs outside pull_reques
     const result = JSON.parse(stdout);
 
     assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 0);
+    assert.equal(result.alertSummary.reviewAlertCount, lanes.length);
     assert.equal(result.alerts.some((alert) => alert.verdict === "superseded-successful-rerun-job-echo"), false);
     assert.equal(result.alerts.every((alert) => alert.supersededSuccessfulRerunJobEcho === false), true);
+    assert.equal(result.alerts.every((alert) => alert.verdict === "non-merge-gate-job-review"), true);
+    assert.equal(result.alerts.every((alert) => alert.disposition === "review"), true);
+    assert.equal(result.alerts.every((alert) => alert.nonMergeGateJobReview === true), true);
     assert.equal(result.alerts.find((alert) => alert.alertedRunId === "26300000023").ciLane, "pull_request_review");
-    assert.notEqual(result.alerts.find((alert) => alert.alertedRunId === "26300000023").disposition, "suppress-replay");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -3,10 +3,84 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync as realExecFileSync } from "node:child_process";
+import { runCli } from "../scripts/triage-ci-alerts.mjs";
 
 const repoRoot = process.cwd();
 const triageScript = path.join(repoRoot, "scripts", "triage-ci-alerts.mjs");
+
+function makeSpawnAdapter(options = {}) {
+  return (command, args) => {
+    if (command === "git" && args.join(" ") === "config --get remote.origin.url") {
+      return { status: 0, stdout: "https://github.com/minislively/fooks.git\n", stderr: "" };
+    }
+
+    if (command === "gh") {
+      const pathHead = options.env?.PATH?.split(path.delimiter)[0] ?? "";
+      const logPath = pathHead ? path.join(path.dirname(pathHead), "gh-args.log") : "";
+      if (logPath && fs.existsSync(path.dirname(logPath))) {
+        fs.appendFileSync(logPath, `${JSON.stringify(args)}\n`);
+      }
+
+      if (args[0] === "run" && args[1] === "list") {
+        return {
+          status: 0,
+          stdout: JSON.stringify([{
+            databaseId: 26300000013,
+            workflowName: "Merge Gate",
+            name: "Merge Gate",
+            headBranch: "fooks-issue-1094-rerun-status",
+            event: "pull_request_target",
+            status: "completed",
+            conclusion: "success",
+            createdAt: "2026-05-27T10:00:00Z",
+            updatedAt: "2026-05-27T10:10:00Z",
+            url: "https://github.com/minislively/fooks/actions/runs/26300000013",
+          }]),
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "api" && args[1].includes("actions/runs/26300000013/jobs?filter=all&per_page=100")) {
+        return {
+          status: 0,
+          stdout: JSON.stringify({ jobs: [
+            {
+              id: 78006573443,
+              name: "Validate approval review and linked issue",
+              status: "completed",
+              conclusion: "failure",
+              completed_at: "2026-05-27T10:04:00Z",
+            },
+            {
+              id: 78007392165,
+              name: "Validate approval review and linked issue",
+              status: "completed",
+              conclusion: "success",
+              completed_at: "2026-05-27T10:08:00Z",
+            },
+          ] }),
+          stderr: "",
+        };
+      }
+    }
+
+    return { status: 1, stdout: "", stderr: `unexpected spawn ${command} ${JSON.stringify(args)}` };
+  };
+}
+
+function execFileSync(file, args, options = {}) {
+  if (file !== process.execPath || args[0] !== triageScript) {
+    return realExecFileSync(file, args, options);
+  }
+
+  const chunks = [];
+  runCli(args.slice(1), {
+    stdout: { write: (chunk) => chunks.push(String(chunk)) },
+    spawn: makeSpawnAdapter(options),
+  });
+  return chunks.join("");
+}
 
 test("CI alert triage marks cancelled and superseded historical runs as stale", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-triage-"));
@@ -774,7 +848,7 @@ test("CI alert triage collapses success-heavy clawhip bursts to current head plu
     assert.deepEqual(result.alertSummary.currentHeadRunIds, ["700"]);
     assert.equal(result.alertSummary.batchVerdict, "historical-ci-replay-batch");
     assert.equal(result.alertSummary.batchDisposition, "suppress-historical-replay-before-current-main-echo");
-    assert.match(result.alertSummary.batchReason, /current GitHub Actions state for main remains authoritative/);
+    assert.match(result.alertSummary.batchReason, /current GitHub Actions reporting state for main is the freshest alert-triage evidence/);
     assert.equal(result.alertSummary.actionableAlertCount, 0);
     assert.equal(result.alertSummary.verificationOnlyCount, 1);
     assert.equal(result.alertSummary.staleReplayCount, 20);
@@ -950,6 +1024,568 @@ test("CI alert triage dedupes duplicate current main success run and job URLs", 
     assert.equal(result.alertSummary.actionableAlertCount, 0);
     assert.equal(result.counts.actionable ?? 0, 0);
     assert.equal(result.counts.watch ?? 0, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("CI alert triage marks superseded pull_request_target Merge Gate job failures as stale rerun echoes", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-rerun-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000000,
+      attempt: 2,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000000",
+      jobs: [
+        {
+          id: 78006573431,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:04:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000000/job/78006573431",
+        },
+        {
+          id: 78007392157,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000000/job/78007392157",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "PR #1094 old Merge Gate failure job https://github.com/minislively/fooks/actions/runs/26300000000/job/78006573431",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const alert = result.alerts[0];
+
+    assert.equal(result.counts.informational, 1);
+    assert.equal(alert.alertedRunId, "26300000000");
+    assert.equal(alert.alertedJobId, 78006573431);
+    assert.equal(alert.currentJobId, 78007392157);
+    assert.equal(alert.ciLane, "pull_request_target:merge-gate");
+    assert.equal(alert.evidence, "stale");
+    assert.equal(alert.verdict, "superseded-successful-rerun-job-echo");
+    assert.equal(alert.supersededSuccessfulRerunJobEcho, true);
+    assert.equal(alert.replay, true);
+    assert.equal(alert.disposition, "suppress-replay");
+    assert.match(alert.reason, /pull_request_target:merge-gate job 78006573431 superseded by newer successful job 78007392157/);
+    assert.match(alert.claimBoundary, /not authorization or merge authority/);
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 1);
+    assert.equal(result.alertSummary.currentHeadRunIds.includes("26300000000"), false);
+    assert.equal(result.alertSummary.actionableAlertCount, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage does not suppress unrelated successful Merge Gate jobs in the same run", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-unrelated-job-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000001,
+      attempt: 1,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000001",
+      jobs: [
+        {
+          id: 78006573432,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:04:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000001/job/78006573432",
+        },
+        {
+          id: 78007392158,
+          name: "Report triage summary",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+          url: "https://github.com/minislively/fooks/actions/runs/26300000001/job/78007392158",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "PR #1094 unrelated Merge Gate job https://github.com/minislively/fooks/actions/runs/26300000001/job/78006573432",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const alert = result.alerts[0];
+
+    assert.equal(alert.evidence, "review");
+    assert.equal(alert.verdict, "merge-gate-job-not-superseded");
+    assert.equal(alert.disposition, "review");
+    assert.equal(alert.mergeGateJobNotSuperseded, true);
+    assert.equal(alert.supersededSuccessfulRerunJobEcho, false);
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage reviews Merge Gate job URLs when job-list evidence is unavailable", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-no-jobs-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000002,
+      attempt: 1,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000002",
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "PR #1094 needs job evidence https://github.com/minislively/fooks/actions/runs/26300000002/job/78006573433",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const alert = result.alerts[0];
+
+    assert.equal(alert.evidence, "review");
+    assert.equal(alert.verdict, "merge-gate-job-evidence-unavailable");
+    assert.equal(alert.disposition, "review");
+    assert.equal(alert.mergeGateJobEvidenceMissing, true);
+    assert.equal(alert.supersededSuccessfulRerunJobEcho, false);
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage requires newer timestamps before suppressing Merge Gate job echoes", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-not-newer-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000003,
+      attempt: 1,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000003",
+      jobs: [
+        {
+          id: 78006573434,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:08:00Z",
+        },
+        {
+          id: 78007392159,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "PR #1094 same timestamp https://github.com/minislively/fooks/actions/runs/26300000003/job/78006573434",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const alert = result.alerts[0];
+
+    assert.equal(alert.evidence, "review");
+    assert.equal(alert.verdict, "merge-gate-job-not-superseded");
+    assert.equal(alert.disposition, "review");
+    assert.equal(alert.supersededSuccessfulRerunJobEcho, false);
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage keeps distinct Merge Gate job URLs from the same run separate", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-distinct-jobs-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000004,
+      attempt: 1,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      headSha: "feed1094",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:10:00Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26300000004",
+      jobs: [
+        {
+          id: 78006573435,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:04:00Z",
+        },
+        {
+          id: 78007392160,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+        },
+        {
+          id: 78006573436,
+          name: "Unrelated required check",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:09:00Z",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, [
+    "superseded job https://github.com/minislively/fooks/actions/runs/26300000004/job/78006573435",
+    "unsuperseded job https://github.com/minislively/fooks/actions/runs/26300000004/job/78006573436",
+  ].join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.alerts.length, 2);
+    const byJobId = new Map(result.alerts.map((alert) => [alert.alertedJobId, alert]));
+    assert.equal(byJobId.get(78006573435).verdict, "superseded-successful-rerun-job-echo");
+    assert.equal(byJobId.get(78006573435).disposition, "suppress-replay");
+    assert.equal(byJobId.get(78006573436).verdict, "merge-gate-job-not-superseded");
+    assert.equal(byJobId.get(78006573436).disposition, "review");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("CI alert triage does not suppress same-name rerun jobs outside pull_request_target Merge Gate", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-non-authority-lanes-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  const lanes = [
+    { id: 26300000020, event: "pull_request", workflowName: "CI", name: "CI" },
+    { id: 26300000021, event: "push", workflowName: "CI", name: "CI" },
+    { id: 26300000022, event: "pull_request_target", workflowName: "Security Audit", name: "Security Audit" },
+    { id: 26300000023, event: "pull_request_review", workflowName: "Merge Gate", name: "Merge Gate" },
+  ];
+  const runs = lanes.map((lane, index) => ({
+    databaseId: lane.id,
+    workflowName: lane.workflowName,
+    name: lane.name,
+    headBranch: "fooks-issue-1094-rerun-status",
+    event: lane.event,
+    status: "completed",
+    conclusion: "success",
+    createdAt: `2026-05-27T10:0${index}:00Z`,
+    updatedAt: `2026-05-27T10:1${index}:00Z`,
+    jobs: [
+      {
+        id: 78006573600 + index,
+        name: "Validate approval review and linked issue",
+        status: "completed",
+        conclusion: "failure",
+        completedAt: `2026-05-27T10:0${index}:00Z`,
+      },
+      {
+        id: 78007392200 + index,
+        name: "Validate approval review and linked issue",
+        status: "completed",
+        conclusion: "success",
+        completedAt: `2026-05-27T10:1${index}:00Z`,
+      },
+    ],
+  }));
+  fs.writeFileSync(runsPath, JSON.stringify(runs));
+  fs.writeFileSync(alertsPath, lanes.map((lane, index) => (
+    `non-authority lane https://github.com/minislively/fooks/actions/runs/${lane.id}/job/${78006573600 + index}`
+  )).join("\n"));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+
+    assert.equal(result.alertSummary.supersededSuccessfulRerunJobEchoCount, 0);
+    assert.equal(result.alerts.some((alert) => alert.verdict === "superseded-successful-rerun-job-echo"), false);
+    assert.equal(result.alerts.every((alert) => alert.supersededSuccessfulRerunJobEcho === false), true);
+    assert.equal(result.alerts.find((alert) => alert.alertedRunId === "26300000023").ciLane, "pull_request_review");
+    assert.notEqual(result.alerts.find((alert) => alert.alertedRunId === "26300000023").disposition, "suppress-replay");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage markdown renders the read-only claim boundary", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-markdown-boundary-"));
+  const runsPath = path.join(tempDir, "runs.json");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26300000024,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "fooks-issue-1094-rerun-status",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-27T10:00:00Z",
+      updatedAt: "2026-05-27T10:08:00Z",
+      jobs: [
+        {
+          id: 78006573610,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "failure",
+          completedAt: "2026-05-27T10:04:00Z",
+        },
+        {
+          id: 78007392210,
+          name: "Validate approval review and linked issue",
+          status: "completed",
+          conclusion: "success",
+          completedAt: "2026-05-27T10:08:00Z",
+        },
+      ],
+    },
+  ]));
+  fs.writeFileSync(alertsPath, "rerun job https://github.com/minislively/fooks/actions/runs/26300000024/job/78006573610\n");
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--markdown",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    assert.match(stdout, /Claim boundary: read-only alert triage only/);
+    assert.match(stdout, /not authorization or merge authority/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage live job enrichment asks GitHub for all job executions", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-live-jobs-"));
+  const binDir = path.join(tempDir, "bin");
+  const logPath = path.join(tempDir, "gh-args.log");
+  const alertsPath = path.join(tempDir, "alerts.txt");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(path.join(binDir, "gh"), `#!/usr/bin/env node
+const fs = require("node:fs");
+const logPath = ${JSON.stringify(logPath)};
+fs.appendFileSync(logPath, JSON.stringify(process.argv.slice(2)) + "\\n");
+const args = process.argv.slice(2);
+if (args[0] === "run" && args[1] === "list") {
+  process.stdout.write(JSON.stringify([{
+    databaseId: 26300000013,
+    workflowName: "Merge Gate",
+    name: "Merge Gate",
+    headBranch: "fooks-issue-1094-rerun-status",
+    event: "pull_request_target",
+    status: "completed",
+    conclusion: "success",
+    createdAt: "2026-05-27T10:00:00Z",
+    updatedAt: "2026-05-27T10:10:00Z",
+    url: "https://github.com/minislively/fooks/actions/runs/26300000013"
+  }]));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1].includes("actions/runs/26300000013/jobs?filter=all&per_page=100")) {
+  process.stdout.write(JSON.stringify({ jobs: [
+    {
+      id: 78006573443,
+      name: "Validate approval review and linked issue",
+      status: "completed",
+      conclusion: "failure",
+      completed_at: "2026-05-27T10:04:00Z"
+    },
+    {
+      id: 78007392165,
+      name: "Validate approval review and linked issue",
+      status: "completed",
+      conclusion: "success",
+      completed_at: "2026-05-27T10:08:00Z"
+    }
+  ] }));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh args " + JSON.stringify(args));
+process.exit(1);
+`);
+  fs.chmodSync(path.join(binDir, "gh"), 0o755);
+  fs.writeFileSync(alertsPath, "live job https://github.com/minislively/fooks/actions/runs/26300000013/job/78006573443\n");
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--alerts",
+      alertsPath,
+      "--branch",
+      "fooks-issue-1094-rerun-status",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const ghCalls = fs.readFileSync(logPath, "utf8");
+
+    assert.match(ghCalls, /jobs\?filter=all&per_page=100/);
+    assert.equal(result.alerts[0].verdict, "superseded-successful-rerun-job-echo");
+    assert.equal(result.alerts[0].currentJobId, 78007392165);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1097.

Linked issue: https://github.com/minislively/fooks/issues/1097

## Summary
- Treat superseded `pull_request_target` Merge Gate rerun job failure URLs as stale replay evidence only when a newer successful same-name job is present in the same run.
- Keep missing/non-superseding Merge Gate job evidence reviewable instead of suppressing it.
- Add job-level alert evidence coverage for Merge Gate, non-authority lanes, timestamp ordering, markdown boundary text, and live job enrichment.

## Boundary
read-only alert triage only; PR CI, push CI, and pull_request_target/pull_request_review Merge Gate evidence are reporting lanes, not authorization or merge authority.

## Verification
- `node --test test/ci-alert-triage.test.mjs`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `node --check scripts/triage-ci-alerts.mjs`
- `node --check test/ci-alert-triage.test.mjs`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*