### PR TITLE
Preserve source-backed fact graph boundaries

### DIFF
--- a/src/core/fact-graph.ts
+++ b/src/core/fact-graph.ts
@@ -1,0 +1,141 @@
+import type { SourceFingerprint, SourceRange } from "./schema";
+
+export const FACT_GRAPH_REPORT_SCHEMA_VERSION = "fact-graph-report.v1" as const;
+export const FACT_GRAPH_REPORT_PRODUCER = "fooks" as const;
+export const FACT_GRAPH_REPORT_CLAIM_BOUNDARY =
+  "Local source-backed fact graph report only: captures observed nodes and edges with source references for planning and inspection. This report does not authorize runtime reuse, pre-read reuse, cache reuse, setup-readiness reuse, or model-facing payload reuse; does not promote React Web, backend, database, React Native, WebView, or TUI support; and does not claim token, cost, latency, billing, cache-performance, or provider savings.";
+
+export const FACT_GRAPH_REPORT_NON_CLAIMS = [
+  "does not authorize runtime reuse",
+  "does not authorize pre-read reuse",
+  "does not authorize cache reuse",
+  "does not authorize setup-readiness reuse",
+  "does not authorize model-facing payload reuse",
+  "does not claim token, cost, latency, billing, cache-performance, provider-cost, or provider-token savings",
+  "does not promote frontend, backend, database, React Native, WebView, or TUI support by itself",
+] as const;
+
+export type FactGraphDomain = string;
+export type FactGraphConfidence = "known" | "candidate" | "unsupported";
+export type FactGraphFreshnessStatus = "fresh" | "stale" | "unknown";
+
+export type FactGraphExtractorRef = {
+  id: string;
+  version: string;
+};
+
+export type FactGraphSourceRef = {
+  filePath: string;
+  loc?: SourceRange;
+  fingerprint?: SourceFingerprint;
+  extractor: FactGraphExtractorRef;
+};
+
+export type FactGraphPrimitive = string | number | boolean;
+export type FactGraphPropertyValue = FactGraphPrimitive | FactGraphPrimitive[];
+export type FactGraphProperties = Record<string, FactGraphPropertyValue>;
+
+export type FactNode = {
+  id: string;
+  domain: FactGraphDomain;
+  kind: string;
+  label: string;
+  confidence: FactGraphConfidence;
+  sourceRefs: FactGraphSourceRef[];
+  evidence: string[];
+  properties?: FactGraphProperties;
+};
+
+export type FactEdge = {
+  id: string;
+  domain: FactGraphDomain;
+  kind: string;
+  from: string;
+  to: string;
+  confidence: FactGraphConfidence;
+  sourceRefs: FactGraphSourceRef[];
+  evidence: string[];
+  properties?: FactGraphProperties;
+};
+
+export type FactGraphFreshness = {
+  status: FactGraphFreshnessStatus;
+  staleWhen: string[];
+  sourceFingerprints: SourceFingerprint[];
+  extractorVersions: Record<string, string>;
+};
+
+export type FactGraphReportPolicy = {
+  reportOnly: true;
+  runtimeAuthorized: false;
+  candidatesAuthorizeRuntime: false;
+};
+
+export type FactGraphReportMetrics = {
+  nodeCount: number;
+  edgeCount: number;
+  knownCount: number;
+  candidateCount: number;
+  unsupportedCount: number;
+};
+
+export type FactGraphReport = {
+  schemaVersion: typeof FACT_GRAPH_REPORT_SCHEMA_VERSION;
+  generatedAt: string;
+  producer: typeof FACT_GRAPH_REPORT_PRODUCER;
+  scope: {
+    files: string[];
+    domain: FactGraphDomain;
+  };
+  claimBoundary: typeof FACT_GRAPH_REPORT_CLAIM_BOUNDARY | string;
+  policy: FactGraphReportPolicy;
+  freshness: FactGraphFreshness;
+  nodes: FactNode[];
+  edges: FactEdge[];
+  metrics: FactGraphReportMetrics;
+  warnings: string[];
+  nonClaims: string[];
+};
+
+export type BuildFactGraphReportOptions = {
+  generatedAt?: string;
+  scope: FactGraphReport["scope"];
+  freshness: FactGraphFreshness;
+  nodes?: FactNode[];
+  edges?: FactEdge[];
+  warnings?: string[];
+};
+
+export function buildFactGraphMetrics(nodes: FactNode[] = [], edges: FactEdge[] = []): FactGraphReportMetrics {
+  const confidences = [...nodes.map((node) => node.confidence), ...edges.map((edge) => edge.confidence)];
+  return {
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    knownCount: confidences.filter((confidence) => confidence === "known").length,
+    candidateCount: confidences.filter((confidence) => confidence === "candidate").length,
+    unsupportedCount: confidences.filter((confidence) => confidence === "unsupported").length,
+  };
+}
+
+export function buildFactGraphReport(options: BuildFactGraphReportOptions): FactGraphReport {
+  const nodes = options.nodes ?? [];
+  const edges = options.edges ?? [];
+  return {
+    schemaVersion: FACT_GRAPH_REPORT_SCHEMA_VERSION,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    producer: FACT_GRAPH_REPORT_PRODUCER,
+    scope: options.scope,
+    claimBoundary: FACT_GRAPH_REPORT_CLAIM_BOUNDARY,
+    policy: {
+      reportOnly: true,
+      runtimeAuthorized: false,
+      candidatesAuthorizeRuntime: false,
+    },
+    freshness: options.freshness,
+    nodes,
+    edges,
+    metrics: buildFactGraphMetrics(nodes, edges),
+    warnings: options.warnings ?? [],
+    nonClaims: [...FACT_GRAPH_REPORT_NON_CLAIMS],
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,3 +373,29 @@ export type {
   LongRunBudgetWarningAction,
   LongRunBudgetWarningTrigger,
 } from "./ops/long-run-budget-warning";
+
+export {
+  FACT_GRAPH_REPORT_CLAIM_BOUNDARY,
+  FACT_GRAPH_REPORT_NON_CLAIMS,
+  FACT_GRAPH_REPORT_PRODUCER,
+  FACT_GRAPH_REPORT_SCHEMA_VERSION,
+  buildFactGraphMetrics,
+  buildFactGraphReport,
+} from "./core/fact-graph";
+export type {
+  BuildFactGraphReportOptions,
+  FactEdge,
+  FactGraphConfidence,
+  FactGraphDomain,
+  FactGraphExtractorRef,
+  FactGraphFreshness,
+  FactGraphFreshnessStatus,
+  FactGraphPrimitive,
+  FactGraphProperties,
+  FactGraphPropertyValue,
+  FactGraphReport,
+  FactGraphReportMetrics,
+  FactGraphReportPolicy,
+  FactGraphSourceRef,
+  FactNode,
+} from "./core/fact-graph";

--- a/test/fact-graph.test.mjs
+++ b/test/fact-graph.test.mjs
@@ -1,0 +1,147 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  FACT_GRAPH_REPORT_CLAIM_BOUNDARY,
+  FACT_GRAPH_REPORT_NON_CLAIMS,
+  FACT_GRAPH_REPORT_SCHEMA_VERSION,
+  buildFactGraphMetrics,
+  buildFactGraphReport,
+} from "../dist/index.js";
+
+const sourceRef = {
+  filePath: "src/components/UserForm.tsx",
+  loc: { startLine: 10, endLine: 18 },
+  fingerprint: { fileHash: "sha256:abc123", lineCount: 120 },
+  extractor: { id: "test.extractor", version: "1.0.0" },
+};
+
+const freshness = {
+  status: "fresh",
+  staleWhen: ["source fingerprint changes", "extractor version changes"],
+  sourceFingerprints: [{ fileHash: "sha256:abc123", lineCount: 120 }],
+  extractorVersions: { "test.extractor": "1.0.0" },
+};
+
+const nodes = [
+  {
+    id: "component:UserForm",
+    domain: "react-web",
+    kind: "component",
+    label: "UserForm",
+    confidence: "known",
+    sourceRefs: [sourceRef],
+    evidence: ["function UserForm"],
+  },
+  {
+    id: "field:email",
+    domain: "react-web",
+    kind: "field-role",
+    label: "email",
+    confidence: "candidate",
+    sourceRefs: [sourceRef],
+    evidence: ["Controller name=\"email\""],
+    properties: { name: "email", repeated: false, priority: 1, aliases: ["user.email"] },
+  },
+  {
+    id: "field:legacy",
+    domain: "react-web",
+    kind: "field-role",
+    label: "legacy",
+    confidence: "unsupported",
+    sourceRefs: [sourceRef],
+    evidence: ["unclassified custom field wrapper"],
+  },
+];
+
+const edges = [
+  {
+    id: "edge:email-validates-schema",
+    domain: "react-web",
+    kind: "validates",
+    from: "field:email",
+    to: "schema:email",
+    confidence: "known",
+    sourceRefs: [sourceRef],
+    evidence: ["z.object({ email"],
+  },
+];
+
+test("fact graph metrics count nodes, edges, and confidence classes", () => {
+  const metrics = buildFactGraphMetrics(nodes, edges);
+
+  assert.equal(metrics.nodeCount, 3);
+  assert.equal(metrics.edgeCount, 1);
+  assert.equal(metrics.knownCount, 2);
+  assert.equal(metrics.candidateCount, 1);
+  assert.equal(metrics.unsupportedCount, 1);
+});
+
+test("fact graph report preserves report-only policy and explicit non-claims", () => {
+  const report = buildFactGraphReport({
+    generatedAt: "2026-05-28T00:00:00.000Z",
+    scope: { files: ["src/components/UserForm.tsx"], domain: "react-web" },
+    freshness,
+    nodes,
+    edges,
+  });
+
+  assert.equal(report.schemaVersion, FACT_GRAPH_REPORT_SCHEMA_VERSION);
+  assert.equal(report.producer, "fooks");
+  assert.equal(report.claimBoundary, FACT_GRAPH_REPORT_CLAIM_BOUNDARY);
+  assert.equal(report.policy.reportOnly, true);
+  assert.equal(report.policy.runtimeAuthorized, false);
+  assert.equal(report.policy.candidatesAuthorizeRuntime, false);
+  assert.ok(report.nonClaims.includes("does not authorize runtime reuse"));
+  assert.ok(report.nonClaims.includes("does not authorize pre-read reuse"));
+  assert.ok(report.nonClaims.includes("does not authorize model-facing payload reuse"));
+  assert.ok(report.nonClaims.some((claim) => /token, cost, latency/.test(claim)));
+  assert.ok(report.nonClaims.some((claim) => /does not promote frontend, backend, database/.test(claim)));
+  assert.deepEqual(report.nonClaims, [...FACT_GRAPH_REPORT_NON_CLAIMS]);
+});
+
+test("fact graph report does not allow caller overrides to weaken boundary text", () => {
+  const report = buildFactGraphReport({
+    scope: { files: ["src/components/UserForm.tsx"], domain: "react-web" },
+    freshness,
+    // @ts-expect-error Runtime JS may pass stale/custom fields; the builder must ignore them.
+    claimBoundary: "runtime reuse is allowed",
+    nonClaims: ["claims token savings"],
+  });
+
+  assert.equal(report.claimBoundary, FACT_GRAPH_REPORT_CLAIM_BOUNDARY);
+  assert.deepEqual(report.nonClaims, [...FACT_GRAPH_REPORT_NON_CLAIMS]);
+});
+
+test("fact graph core represents React Web role strings without frontend enums or runtime eligibility", () => {
+  const report = buildFactGraphReport({
+    scope: { files: ["src/components/UserForm.tsx"], domain: "react-web" },
+    freshness,
+    nodes,
+    edges,
+  });
+
+  assert.equal(report.nodes[1].domain, "react-web");
+  assert.equal(report.nodes[1].kind, "field-role");
+  assert.equal(report.edges[0].kind, "validates");
+  assert.equal(Object.hasOwn(report.nodes[1], "runtimeEligibility"), false);
+  assert.equal(Object.hasOwn(report.edges[0], "runtimeEligibility"), false);
+});
+
+test("fact graph source refs and freshness use relative files and extractor versions", () => {
+  const report = buildFactGraphReport({
+    scope: { files: ["src/components/UserForm.tsx"], domain: "react-web" },
+    freshness,
+    nodes,
+    edges,
+  });
+
+  assert.equal(report.scope.files[0], "src/components/UserForm.tsx");
+  assert.equal(report.nodes[0].sourceRefs[0].filePath, "src/components/UserForm.tsx");
+  assert.deepEqual(report.nodes[0].sourceRefs[0].loc, { startLine: 10, endLine: 18 });
+  assert.deepEqual(report.nodes[0].sourceRefs[0].fingerprint, { fileHash: "sha256:abc123", lineCount: 120 });
+  assert.deepEqual(report.freshness.sourceFingerprints, [{ fileHash: "sha256:abc123", lineCount: 120 }]);
+  assert.equal(report.freshness.extractorVersions["test.extractor"], "1.0.0");
+});


### PR DESCRIPTION
## Linked issue

Fixes #1100

## Summary

- Add a report-only `fact-graph-report.v1` core contract for source-backed nodes, edges, freshness, metrics, and source references.
- Export the fact graph constants, types, and builders from the package root.
- Add regression coverage that keeps the contract non-authorizing and prevents caller overrides from weakening claim boundaries.

## Verification

- `npm run build`
- `node --test test/fact-graph.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check HEAD`
- `npm test`

## Review gate

- [x] Current head has a GitHub PR review, review comment, or PR/issue comment from `minislively` or `yeachan-heo`. Self-review and self-comment by those accounts are allowed. Official PR reviews must be on the current head commit.