### PR TITLE
Add React Web fact graph inspector

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -683,6 +683,7 @@ Everyday commands:
   ${displayCliName} inspect activation-mode <id> [--json]
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
+  ${displayCliName} inspect react-web-fact-graph <file> [--json]
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
   ${displayCliName} domain-memory verify --receipt <receipt.json> --file <file> --json
@@ -1764,6 +1765,17 @@ async function run(): Promise<void> {
         }
         return;
       }
+      if (arg1 === "react-web-fact-graph") {
+        const { filePath: file, json } = parseCompareArgs(rest.slice(1));
+        const { buildReactWebFactGraphInspection, renderReactWebFactGraphInspectionText } = await import("../core/react-web-fact-graph.js");
+        const inspection = buildReactWebFactGraphInspection(file, process.cwd());
+        if (json) {
+          print(inspection);
+        } else {
+          process.stdout.write(renderReactWebFactGraphInspectionText(inspection));
+        }
+        return;
+      }
       if (arg1 === "react-web-issues") {
         const { filePath: file, outputMode } = parseReactWebIssuesArgs(rest.slice(1));
         const {
@@ -1784,7 +1796,7 @@ async function run(): Promise<void> {
         }
         return;
       }
-      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', or 'react-web-issues'");
+      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', 'react-web-fact-graph', or 'react-web-issues'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-fact-graph.ts
+++ b/src/core/react-web-fact-graph.ts
@@ -1,0 +1,364 @@
+import { extractFile } from "./extract";
+import {
+  type FactEdge,
+  type FactGraphConfidence,
+  type FactGraphFreshness,
+  type FactGraphSourceRef,
+  type FactNode,
+  buildFactGraphReport,
+} from "./fact-graph";
+import { REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION, type ModelFacingPayload, type SourceFingerprint, type SourceRange } from "./schema";
+import { toModelFacingPayload } from "./payload/model-facing";
+
+export const REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION = "react-web-fact-graph-inspection.v1" as const;
+export const REACT_WEB_FACT_GRAPH_COMMAND = "inspect react-web-fact-graph" as const;
+export const REACT_WEB_FACT_GRAPH_EXTRACTOR_ID = "react-web.fact-graph" as const;
+export const REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION = REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION;
+export const REACT_WEB_FACT_GRAPH_ADVISORY_BOUNDARY =
+  "React Web fact graph inspection is advisory and report-only; it does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse." as const;
+
+export type ReactWebFactGraphInspection = {
+  schemaVersion: typeof REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION;
+  command: typeof REACT_WEB_FACT_GRAPH_COMMAND;
+  profile: "react-web";
+  inScope: boolean;
+  skippedReason?: string;
+  advisoryOnly: true;
+  graph: ReturnType<typeof buildFactGraphReport>;
+};
+
+type MutableGraph = {
+  nodes: FactNode[];
+  edges: FactEdge[];
+};
+
+function stableId(...parts: Array<string | number | undefined>): string {
+  return parts
+    .filter((part) => part !== undefined && String(part).trim().length > 0)
+    .map((part) =>
+      String(part)
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "fact",
+    )
+    .join(":");
+}
+
+function sourceRef(filePath: string, loc: SourceRange | undefined, fingerprint: SourceFingerprint | undefined): FactGraphSourceRef | undefined {
+  if (!loc && !fingerprint) return undefined;
+  return {
+    filePath,
+    ...(loc ? { loc } : {}),
+    ...(fingerprint ? { fingerprint } : {}),
+    extractor: {
+      id: REACT_WEB_FACT_GRAPH_EXTRACTOR_ID,
+      version: REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+    },
+  };
+}
+
+function refs(filePath: string, loc: SourceRange | undefined, fingerprint: SourceFingerprint | undefined): FactGraphSourceRef[] {
+  const ref = sourceRef(filePath, loc, fingerprint);
+  return ref ? [ref] : [];
+}
+
+function addNode(graph: MutableGraph, node: FactNode): void {
+  if (graph.nodes.some((current) => current.id === node.id)) return;
+  graph.nodes.push(node);
+}
+
+function addEdge(graph: MutableGraph, edge: FactEdge): void {
+  if (edge.from === edge.to || graph.edges.some((current) => current.id === edge.id)) return;
+  graph.edges.push(edge);
+}
+
+function payloadFingerprint(payload: ModelFacingPayload): SourceFingerprint | undefined {
+  return payload.sourceFingerprint ?? payload.reactWebContext?.freshness;
+}
+
+function freshnessFor(payload: ModelFacingPayload, warnings: string[]): FactGraphFreshness {
+  const fingerprint = payloadFingerprint(payload);
+  if (!fingerprint) warnings.push("No source fingerprint was available; rerun extraction or inspect source before relying on ranges.");
+
+  return {
+    status: fingerprint ? "fresh" : "unknown",
+    staleWhen: [
+      "source fingerprint changes",
+      "React Web context schema version changes",
+      "React Web fact graph producer version changes",
+    ],
+    sourceFingerprints: fingerprint ? [fingerprint] : [],
+    extractorVersions: {
+      [REACT_WEB_FACT_GRAPH_EXTRACTOR_ID]: REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+      reactWebContext: REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION,
+    },
+  };
+}
+
+function buildEmptyInspection(payload: ModelFacingPayload, inScope: boolean, skippedReason: string | undefined, warnings: string[]): ReactWebFactGraphInspection {
+  return {
+    schemaVersion: REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION,
+    command: REACT_WEB_FACT_GRAPH_COMMAND,
+    profile: "react-web",
+    inScope,
+    ...(skippedReason ? { skippedReason } : {}),
+    advisoryOnly: true,
+    graph: buildFactGraphReport({
+      scope: { files: [payload.filePath], domain: "react-web" },
+      freshness: freshnessFor(payload, warnings),
+      warnings,
+    }),
+  };
+}
+
+function addComponentNodes(graph: MutableGraph, payload: ModelFacingPayload): string | undefined {
+  const fingerprint = payloadFingerprint(payload);
+  const fileNodeId = stableId("file", payload.filePath);
+  addNode(graph, {
+    id: fileNodeId,
+    domain: "react-web",
+    kind: "file",
+    label: payload.filePath,
+    confidence: fingerprint ? "known" : "candidate",
+    sourceRefs: refs(payload.filePath, undefined, fingerprint),
+    evidence: ["modelFacingPayload.filePath"],
+  });
+
+  if (!payload.componentName && !payload.componentLoc) return fileNodeId;
+
+  const componentNodeId = stableId("component", payload.componentName ?? payload.filePath, payload.componentLoc?.startLine);
+  addNode(graph, {
+    id: componentNodeId,
+    domain: "react-web",
+    kind: "component",
+    label: payload.componentName ?? "component",
+    confidence: payload.componentLoc ? "known" : "candidate",
+    sourceRefs: refs(payload.filePath, payload.componentLoc, fingerprint),
+    evidence: [payload.componentLoc ? "componentLoc" : "componentName"],
+  });
+  addEdge(graph, {
+    id: stableId("edge", fileNodeId, "contains", componentNodeId),
+    domain: "react-web",
+    kind: "contains",
+    from: fileNodeId,
+    to: componentNodeId,
+    confidence: payload.componentLoc ? "known" : "candidate",
+    sourceRefs: refs(payload.filePath, payload.componentLoc, fingerprint),
+    evidence: ["file contains component declaration"],
+  });
+  return componentNodeId;
+}
+
+function addPatchTargetNodes(graph: MutableGraph, payload: ModelFacingPayload, parentId: string): void {
+  const fingerprint = payloadFingerprint(payload);
+  for (const target of payload.editGuidance?.patchTargets ?? []) {
+    const nodeId = stableId("patch-target", target.kind, target.label, target.loc.startLine);
+    addNode(graph, {
+      id: nodeId,
+      domain: "react-web",
+      kind: `patch-target:${target.kind}`,
+      label: target.label,
+      confidence: "known",
+      sourceRefs: refs(payload.filePath, target.loc, fingerprint),
+      evidence: ["editGuidance.patchTargets", target.reason],
+      properties: { targetKind: target.kind },
+    });
+    addEdge(graph, {
+      id: stableId("edge", parentId, "targets", nodeId),
+      domain: "react-web",
+      kind: "targets",
+      from: parentId,
+      to: nodeId,
+      confidence: "known",
+      sourceRefs: refs(payload.filePath, target.loc, fingerprint),
+      evidence: ["patch target belongs to current React Web inspection scope"],
+    });
+  }
+}
+
+function addContextArray<T extends { kind?: string; label?: string; evidence?: string[]; loc?: SourceRange }>(
+  graph: MutableGraph,
+  payload: ModelFacingPayload,
+  parentId: string,
+  field: keyof NonNullable<ModelFacingPayload["reactWebContext"]>,
+  kindPrefix: string,
+  edgeKind: string,
+  confidence: FactGraphConfidence = "candidate",
+): void {
+  const values = payload.reactWebContext?.[field] as T[] | undefined;
+  if (!Array.isArray(values)) return;
+  const fingerprint = payloadFingerprint(payload);
+  values.forEach((value: T, index) => {
+    const label = value.label ?? value.kind ?? `${String(field)} ${index + 1}`;
+    const nodeId = stableId(kindPrefix, value.kind, label, value.loc?.startLine, index);
+    addNode(graph, {
+      id: nodeId,
+      domain: "react-web",
+      kind: value.kind ? `${kindPrefix}:${value.kind}` : kindPrefix,
+      label,
+      confidence: value.loc ? confidence : "candidate",
+      sourceRefs: refs(payload.filePath, value.loc, fingerprint),
+      evidence: [`reactWebContext.${String(field)}`, ...(value.evidence ?? [])],
+    });
+    addEdge(graph, {
+      id: stableId("edge", parentId, edgeKind, nodeId),
+      domain: "react-web",
+      kind: edgeKind,
+      from: parentId,
+      to: nodeId,
+      confidence: value.loc ? confidence : "candidate",
+      sourceRefs: refs(payload.filePath, value.loc, fingerprint),
+      evidence: [`reactWebContext.${String(field)} is source-backed advisory context`],
+    });
+  });
+}
+
+function addFormStateRoleNodes(graph: MutableGraph, payload: ModelFacingPayload, parentId: string): void {
+  for (const role of payload.reactWebContext?.formStateRoles ?? []) {
+    const nodeId = stableId("form-state-role", role.role, role.labels.join("-"));
+    addNode(graph, {
+      id: nodeId,
+      domain: "react-web",
+      kind: `form-state-role:${role.role}`,
+      label: role.labels.join(", ") || role.role,
+      confidence: "candidate",
+      sourceRefs: refs(payload.filePath, undefined, payloadFingerprint(payload)),
+      evidence: [`reactWebContext.formStateRoles.${role.role}`, ...role.evidence],
+      properties: { role: role.role, source: role.source, labels: role.labels },
+    });
+    addEdge(graph, {
+      id: stableId("edge", parentId, "uses-form-role", nodeId),
+      domain: "react-web",
+      kind: "uses-form-role",
+      from: parentId,
+      to: nodeId,
+      confidence: "candidate",
+      sourceRefs: refs(payload.filePath, undefined, payloadFingerprint(payload)),
+      evidence: ["form-state role is advisory source-backed context, not runtime authorization"],
+    });
+  }
+}
+
+function addConcernProfileNodes(graph: MutableGraph, payload: ModelFacingPayload, parentId: string): void {
+  for (const concern of payload.concernProfiles ?? []) {
+    const nodeId = stableId("concern-profile", concern.id);
+    addNode(graph, {
+      id: nodeId,
+      domain: "react-web",
+      kind: "concern-profile",
+      label: concern.id,
+      confidence: "candidate",
+      sourceRefs: refs(payload.filePath, undefined, payloadFingerprint(payload)),
+      evidence: [concern.claim, concern.nonAuthorizationBoundary, ...concern.signals.map((signal) => `concern:${signal}`)],
+      properties: { advisoryOnly: true, concernId: concern.id },
+    });
+    addEdge(graph, {
+      id: stableId("edge", parentId, "supports-concern", nodeId),
+      domain: "react-web",
+      kind: "supports-concern",
+      from: parentId,
+      to: nodeId,
+      confidence: "candidate",
+      sourceRefs: refs(payload.filePath, undefined, payloadFingerprint(payload)),
+      evidence: ["concern profile is advisory-only and never compact payload authorization"],
+    });
+  }
+}
+
+function hasGraphableFacts(payload: ModelFacingPayload): boolean {
+  return Boolean(
+    payload.componentName ||
+      payload.componentLoc ||
+      payload.editGuidance?.patchTargets?.length ||
+      payload.concernProfiles?.length ||
+      payload.reactWebContext?.editTargetRouting?.length ||
+      payload.reactWebContext?.formStateFlow?.length ||
+      payload.reactWebContext?.a11yAnchors?.length ||
+      payload.reactWebContext?.componentApiHints?.length ||
+      payload.reactWebContext?.layoutRegionHints?.length ||
+      payload.reactWebContext?.importRoleHints?.length ||
+      payload.reactWebContext?.localDependencies?.length ||
+      payload.reactWebContext?.formStateRoles?.length,
+  );
+}
+
+function buildGraph(payload: ModelFacingPayload, warnings: string[]): ReturnType<typeof buildFactGraphReport> {
+  if (!hasGraphableFacts(payload)) {
+    warnings.push("React Web source is in scope, but no graphable source-backed facts were detected for P0.");
+    return buildFactGraphReport({
+      scope: { files: [payload.filePath], domain: "react-web" },
+      freshness: freshnessFor(payload, warnings),
+      warnings,
+    });
+  }
+
+  const graph: MutableGraph = { nodes: [], edges: [] };
+  const parentId = addComponentNodes(graph, payload) ?? stableId("file", payload.filePath);
+  addPatchTargetNodes(graph, payload, parentId);
+  addContextArray(graph, payload, parentId, "editTargetRouting", "edit-target-route", "targets", "known");
+  addContextArray(graph, payload, parentId, "formStateFlow", "form-state-flow", "flows-to", "candidate");
+  addContextArray(graph, payload, parentId, "a11yAnchors", "a11y-anchor", "associated-with", "candidate");
+  addContextArray(graph, payload, parentId, "componentApiHints", "component-api", "contains", "candidate");
+  addContextArray(graph, payload, parentId, "layoutRegionHints", "layout-region", "contains", "candidate");
+  addContextArray(graph, payload, parentId, "importRoleHints", "import-role", "depends-on", "candidate");
+  addContextArray(graph, payload, parentId, "localDependencies", "local-dependency", "depends-on", "candidate");
+  addFormStateRoleNodes(graph, payload, parentId);
+  addConcernProfileNodes(graph, payload, parentId);
+
+  if (payload.domainPayload?.domain === "react-web") {
+    warnings.push("React Web domain payload was used only as advisory evidence; payload planning metadata is not a graph authorization signal.");
+  }
+
+  return buildFactGraphReport({
+    scope: { files: [payload.filePath], domain: "react-web" },
+    freshness: freshnessFor(payload, warnings),
+    nodes: graph.nodes,
+    edges: graph.edges,
+    warnings,
+  });
+}
+
+export function buildReactWebFactGraphInspection(filePath: string, cwd = process.cwd()): ReactWebFactGraphInspection {
+  const result = extractFile(filePath);
+  const payload = toModelFacingPayload(result, cwd, {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+    includeDomainPayload: true,
+  });
+  const warnings: string[] = [REACT_WEB_FACT_GRAPH_ADVISORY_BOUNDARY];
+  const classification = result.domainDetection?.classification ?? "unknown";
+
+  if (classification !== "react-web") {
+    const skippedReason = classification === "mixed"
+      ? "mixed-domain-fail-closed"
+      : `unsupported-domain:${classification}`;
+    warnings.push(`React Web fact graph inspection skipped: ${skippedReason}.`);
+    return buildEmptyInspection(payload, false, skippedReason, warnings);
+  }
+
+  return {
+    schemaVersion: REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION,
+    command: REACT_WEB_FACT_GRAPH_COMMAND,
+    profile: "react-web",
+    inScope: true,
+    advisoryOnly: true,
+    graph: buildGraph(payload, warnings),
+  };
+}
+
+export function renderReactWebFactGraphInspectionText(inspection: ReactWebFactGraphInspection): string {
+  const graph = inspection.graph;
+  const lines = [
+    `React Web fact graph inspection (${inspection.schemaVersion})`,
+    `Command: ${inspection.command}`,
+    `In scope: ${inspection.inScope}${inspection.skippedReason ? ` (${inspection.skippedReason})` : ""}`,
+    `Advisory only: ${inspection.advisoryOnly}`,
+    `Graph: ${graph.metrics.nodeCount} node(s), ${graph.metrics.edgeCount} edge(s), freshness=${graph.freshness.status}`,
+    `Policy: reportOnly=${graph.policy.reportOnly}, runtimeAuthorized=${graph.policy.runtimeAuthorized}, candidatesAuthorizeRuntime=${graph.policy.candidatesAuthorizeRuntime}`,
+  ];
+  if (graph.warnings.length > 0) {
+    lines.push("Warnings:", ...graph.warnings.map((warning) => `- ${warning}`));
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,3 +399,14 @@ export type {
   FactGraphSourceRef,
   FactNode,
 } from "./core/fact-graph";
+
+export {
+  REACT_WEB_FACT_GRAPH_ADVISORY_BOUNDARY,
+  REACT_WEB_FACT_GRAPH_COMMAND,
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_ID,
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+  REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION,
+  buildReactWebFactGraphInspection,
+  renderReactWebFactGraphInspectionText,
+} from "./core/react-web-fact-graph";
+export type { ReactWebFactGraphInspection } from "./core/react-web-fact-graph";

--- a/test/react-web-fact-graph.test.mjs
+++ b/test/react-web-fact-graph.test.mjs
@@ -1,0 +1,112 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_ID,
+  REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION,
+  buildReactWebFactGraphInspection,
+} from "../dist/index.js";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function fixture(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function runCli(args) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], { cwd: repoRoot, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("React Web fact graph inspection emits report-only graph with source provenance", () => {
+  const report = buildReactWebFactGraphInspection(
+    fixture("test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx"),
+    repoRoot,
+  );
+
+  assert.equal(report.schemaVersion, REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION);
+  assert.equal(report.command, "inspect react-web-fact-graph");
+  assert.equal(report.profile, "react-web");
+  assert.equal(report.inScope, true);
+  assert.equal(report.advisoryOnly, true);
+  assert.equal(report.graph.schemaVersion, "fact-graph-report.v1");
+  assert.equal(report.graph.scope.domain, "react-web");
+  assert.equal(report.graph.policy.reportOnly, true);
+  assert.equal(report.graph.policy.runtimeAuthorized, false);
+  assert.equal(report.graph.policy.candidatesAuthorizeRuntime, false);
+  assert.ok(report.graph.metrics.nodeCount > 0);
+  assert.ok(report.graph.metrics.edgeCount > 0);
+  assert.equal(report.graph.freshness.status, "fresh");
+  assert.equal(report.graph.freshness.extractorVersions[REACT_WEB_FACT_GRAPH_EXTRACTOR_ID], REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION);
+  assert.equal(report.graph.freshness.extractorVersions.reactWebContext, "react-web-context.v0");
+
+  const sourceBackedNode = report.graph.nodes.find((node) => node.sourceRefs.length > 0);
+  assert.ok(sourceBackedNode, "expected at least one source-backed node");
+  assert.equal(sourceBackedNode.sourceRefs[0].extractor.id, REACT_WEB_FACT_GRAPH_EXTRACTOR_ID);
+  assert.equal(sourceBackedNode.sourceRefs[0].extractor.version, REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION);
+  assert.ok(!path.isAbsolute(sourceBackedNode.sourceRefs[0].filePath));
+  assert.equal(Object.hasOwn(sourceBackedNode, "runtimeEligibility"), false);
+});
+
+test("React Web fact graph keeps domain payload and concerns advisory-only", () => {
+  const report = buildReactWebFactGraphInspection(
+    fixture("test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx"),
+    repoRoot,
+  );
+  const serialized = JSON.stringify(report);
+
+  assert.doesNotMatch(serialized, /compact-safe|claimStatus|plannerDecision|runtimeEligibility|preReadAuthorized|cacheAuthorized/i);
+  assert.ok(report.graph.nodes.filter((node) => node.kind === "concern-profile").every((node) => node.confidence === "candidate"));
+  assert.ok(report.graph.nodes.filter((node) => node.kind === "concern-profile").every((node) => node.properties?.advisoryOnly === true));
+});
+
+test("React Web fact graph fails closed for mixed-domain files", () => {
+  const report = buildReactWebFactGraphInspection(
+    fixture("test/fixtures/frontend-domain-expectations/tui-ink-web-dom-mixed.tsx"),
+    repoRoot,
+  );
+
+  assert.equal(report.inScope, false);
+  assert.equal(report.skippedReason, "mixed-domain-fail-closed");
+  assert.equal(report.graph.metrics.nodeCount, 0);
+  assert.equal(report.graph.metrics.edgeCount, 0);
+  assert.match(report.graph.warnings.join("\n"), /mixed-domain-fail-closed/);
+});
+
+test("React Web fact graph distinguishes unsupported from supported empty", () => {
+  const unsupported = buildReactWebFactGraphInspection(
+    fixture("test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx"),
+    repoRoot,
+  );
+  const supportedEmpty = buildReactWebFactGraphInspection(
+    fixture("test/fixtures/react-web-label-preview/related-context-form.tsx"),
+    repoRoot,
+  );
+
+  assert.equal(unsupported.inScope, false);
+  assert.equal(unsupported.skippedReason, "unsupported-domain:react-native");
+  assert.equal(unsupported.graph.metrics.nodeCount, 0);
+  assert.equal(supportedEmpty.inScope, true);
+  assert.equal("skippedReason" in supportedEmpty, false);
+  assert.equal(supportedEmpty.graph.metrics.nodeCount, 0);
+  assert.match(supportedEmpty.graph.warnings.join("\n"), /no graphable source-backed facts/i);
+});
+
+test("CLI inspect react-web-fact-graph emits JSON with flags before or after file", () => {
+  const file = "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx";
+  const after = runCli(["inspect", "react-web-fact-graph", file, "--json"]);
+  const before = runCli(["inspect", "react-web-fact-graph", "--json", file]);
+
+  assert.equal(after.schemaVersion, REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION);
+  assert.equal(before.schemaVersion, REACT_WEB_FACT_GRAPH_INSPECTION_SCHEMA_VERSION);
+  assert.equal(after.inScope, true);
+  assert.equal(before.inScope, true);
+  assert.equal(after.graph.scope.files[0], file);
+  assert.equal(before.graph.scope.files[0], file);
+});


### PR DESCRIPTION
## Summary
- Add a report-only React Web fact graph inspection builder backed by existing extraction/model-facing payloads.
- Wire `fooks inspect react-web-fact-graph <file> [--json]` and public exports.
- Cover source provenance, freshness, advisory-only boundaries, mixed/unsupported fail-closed behavior, supported-empty behavior, and CLI flag ordering.

## Safety boundary
- This PR does **not** authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse.
- Domain payload and concern profiles remain advisory evidence only.
- Mixed-domain and unsupported-domain files produce empty fail-closed reports.

## Verification
- [x] `npm run build`
- [x] `node --test test/fact-graph.test.mjs test/react-web-fact-graph.test.mjs`
- [x] `npm run typecheck -- --pretty false`
- [x] `git diff --check HEAD`
- [x] `node dist/cli/index.js --help | rg 'inspect react-web-fact-graph'`
- [x] `node --test test/stale-worktree-audit.test.mjs`

## Notes
- Full `npm test` reached 1020/1021 passing; one unrelated `status stale-worktrees` test hit a 30s `spawnSync` timeout. The isolated stale-worktree audit test rerun passed 5/5.

Closes #1102