### PR TITLE
Add React Web fact graph consumer dry-run

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -684,6 +684,7 @@ Everyday commands:
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
   ${displayCliName} inspect react-web-fact-graph <file> [--json]
+  ${displayCliName} inspect react-web-fact-graph-consumer <file> [--json] [--max-anchors <n>]
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
   ${displayCliName} domain-memory verify --receipt <receipt.json> --file <file> --json
@@ -807,6 +808,39 @@ function parseCompareArgs(args: string[]): { filePath: string; json: boolean } {
   }
 
   return { filePath: requireFilePath(filePath), json };
+}
+
+
+function parseReactWebFactGraphConsumerArgs(args: string[]): { filePath: string; json: boolean; maxAnchors?: number } {
+  let filePath: string | undefined;
+  let json = false;
+  let maxAnchors: number | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--max-anchors") {
+      const value = args[index + 1];
+      if (!value) throw new Error("inspect react-web-fact-graph-consumer requires a value after --max-anchors");
+      maxAnchors = Number(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--max-anchors=")) {
+      maxAnchors = Number(arg.slice("--max-anchors=".length));
+      continue;
+    }
+    if (!filePath) {
+      filePath = arg;
+      continue;
+    }
+    throw new Error(`Unexpected react-web-fact-graph-consumer argument: ${arg}`);
+  }
+
+  return { filePath: requireFilePath(filePath), json, ...(maxAnchors !== undefined ? { maxAnchors } : {}) };
 }
 
 function parseInspectDomainArgs(args: string[]): { filePath: string; json: boolean; domainMemoryReceipt: boolean; contextDecision: boolean } {
@@ -1776,6 +1810,20 @@ async function run(): Promise<void> {
         }
         return;
       }
+      if (arg1 === "react-web-fact-graph-consumer") {
+        const { filePath: file, json, maxAnchors } = parseReactWebFactGraphConsumerArgs(rest.slice(1));
+        const {
+          buildReactWebFactGraphConsumerDryRun,
+          renderReactWebFactGraphConsumerDryRunText,
+        } = await import("../core/react-web-fact-graph-consumer.js");
+        const dryRun = buildReactWebFactGraphConsumerDryRun(file, process.cwd(), { maxAnchors });
+        if (json) {
+          print(dryRun);
+        } else {
+          process.stdout.write(renderReactWebFactGraphConsumerDryRunText(dryRun));
+        }
+        return;
+      }
       if (arg1 === "react-web-issues") {
         const { filePath: file, outputMode } = parseReactWebIssuesArgs(rest.slice(1));
         const {
@@ -1796,7 +1844,7 @@ async function run(): Promise<void> {
         }
         return;
       }
-      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', 'react-web-fact-graph', or 'react-web-issues'");
+      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', 'react-web-fact-graph', 'react-web-fact-graph-consumer', or 'react-web-issues'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -26,6 +26,8 @@ export type ReactWebFactGraphAnchorDeferredReason = "budget-deferred" | "stale-o
 
 export type ReactWebFactGraphAnchor = {
   rank: number;
+  reportOnly: true;
+  authorization: ReactWebFactGraphConsumerAuthorization;
   anchorType: ReactWebFactGraphAnchorType;
   anchorId: string;
   nodeId?: string;
@@ -76,7 +78,7 @@ export type ReactWebFactGraphConsumerOptions = {
   maxAnchors?: number;
 };
 
-type Candidate = Omit<ReactWebFactGraphAnchor, "rank" | "deferredReason"> & {
+type Candidate = Omit<ReactWebFactGraphAnchor, "rank" | "reportOnly" | "authorization" | "deferredReason"> & {
   firstLine: number;
 };
 
@@ -193,6 +195,8 @@ function ranked(anchor: Candidate, rank: number, deferredReason?: ReactWebFactGr
   const { firstLine: _firstLine, ...publicAnchor } = anchor;
   return {
     rank,
+    reportOnly: true,
+    authorization: "none",
     ...publicAnchor,
     ...(deferredReason ? { deferredReason } : {}),
   };

--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -1,0 +1,288 @@
+import {
+  FACT_GRAPH_REPORT_NON_CLAIMS,
+  type FactEdge,
+  type FactGraphConfidence,
+  type FactGraphFreshnessStatus,
+  type FactGraphReport,
+  type FactGraphSourceRef,
+  type FactNode,
+} from "./fact-graph";
+import {
+  buildReactWebFactGraphInspection,
+  type ReactWebFactGraphInspection,
+} from "./react-web-fact-graph";
+
+export const REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION = "react-web-fact-graph-consumer-dry-run.v1" as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND = "inspect react-web-fact-graph-consumer" as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_DEFAULT_MAX_ANCHORS = 8 as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_MIN_ANCHORS = 1 as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_MAX_ANCHORS = 20 as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY =
+  "React Web fact graph consumer dry-run is advisory and report-only: it ranks source-backed graph anchors for inspection only and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse." as const;
+
+export type ReactWebFactGraphConsumerAuthorization = "none";
+export type ReactWebFactGraphAnchorType = "node" | "edge";
+export type ReactWebFactGraphAnchorDeferredReason = "budget-deferred" | "stale-or-unknown-freshness";
+
+export type ReactWebFactGraphAnchor = {
+  rank: number;
+  anchorType: ReactWebFactGraphAnchorType;
+  anchorId: string;
+  nodeId?: string;
+  edgeId?: string;
+  fromNodeId?: string;
+  toNodeId?: string;
+  kind: string;
+  label: string;
+  confidence: FactGraphConfidence;
+  priority: number;
+  reason: string;
+  sourceRefs: FactGraphSourceRef[];
+  freshnessStatus: FactGraphFreshnessStatus;
+  deferredReason?: ReactWebFactGraphAnchorDeferredReason;
+};
+
+export type ReactWebFactGraphConsumerDryRun = {
+  schemaVersion: typeof REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION;
+  command: typeof REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND;
+  profile: "react-web";
+  advisoryOnly: true;
+  inScope: boolean;
+  skippedReason?: string;
+  selectionPolicy: {
+    reportOnly: true;
+    authorization: ReactWebFactGraphConsumerAuthorization;
+    maxAnchors: number;
+    staleBehavior: "defer-all";
+  };
+  graphSummary: {
+    schemaVersion: FactGraphReport["schemaVersion"];
+    files: string[];
+    domain: string;
+    freshnessStatus: FactGraphFreshnessStatus;
+    nodeCount: number;
+    edgeCount: number;
+    knownCount: number;
+    candidateCount: number;
+    unsupportedCount: number;
+  };
+  selectedAnchors: ReactWebFactGraphAnchor[];
+  deferredAnchors: ReactWebFactGraphAnchor[];
+  warnings: string[];
+  nonClaims: string[];
+};
+
+export type ReactWebFactGraphConsumerOptions = {
+  maxAnchors?: number;
+};
+
+type Candidate = Omit<ReactWebFactGraphAnchor, "rank" | "deferredReason"> & {
+  firstLine: number;
+};
+
+function boundedMaxAnchors(value: number | undefined): number {
+  if (value === undefined) return REACT_WEB_FACT_GRAPH_CONSUMER_DEFAULT_MAX_ANCHORS;
+  if (!Number.isInteger(value) || value < REACT_WEB_FACT_GRAPH_CONSUMER_MIN_ANCHORS || value > REACT_WEB_FACT_GRAPH_CONSUMER_MAX_ANCHORS) {
+    throw new Error(`--max-anchors must be an integer between ${REACT_WEB_FACT_GRAPH_CONSUMER_MIN_ANCHORS} and ${REACT_WEB_FACT_GRAPH_CONSUMER_MAX_ANCHORS}`);
+  }
+  return value;
+}
+
+export function normalizeReactWebFactGraphConsumerMaxAnchors(value: number | undefined): number {
+  return boundedMaxAnchors(value);
+}
+
+function firstSourceLine(refs: FactGraphSourceRef[]): number {
+  const lines = refs.map((ref) => ref.loc?.startLine).filter((line): line is number => typeof line === "number");
+  return lines.length > 0 ? Math.min(...lines) : Number.MAX_SAFE_INTEGER;
+}
+
+function confidenceScore(confidence: FactGraphConfidence): number {
+  switch (confidence) {
+    case "known":
+      return 3;
+    case "candidate":
+      return 2;
+    case "unsupported":
+      return 1;
+  }
+}
+
+function priorityFor(kind: string, anchorType: ReactWebFactGraphAnchorType): number {
+  if (kind.startsWith("patch-target") || kind === "targets") return 100;
+  if (kind === "component" || kind === "file" || kind === "contains") return 90;
+  if (kind.startsWith("edit-target-route")) return 85;
+  if (kind.startsWith("form-state") || kind.includes("validation")) return 75;
+  if (
+    kind.startsWith("a11y-anchor") ||
+    kind.startsWith("component-api") ||
+    kind.startsWith("layout-region") ||
+    kind.startsWith("import-role") ||
+    kind.startsWith("local-dependency") ||
+    kind === "associated-with" ||
+    kind === "depends-on" ||
+    kind === "flows-to" ||
+    kind === "uses-form-role"
+  ) return 65;
+  if (kind === "concern-profile" || kind === "supports-concern") return 20;
+  return anchorType === "edge" ? 11 : 10;
+}
+
+function nodeReason(node: FactNode): string {
+  return `node:${node.kind}; ${node.evidence.slice(0, 3).join("; ") || "source-backed fact"}`;
+}
+
+function edgeReason(edge: FactEdge): string {
+  return `edge:${edge.kind}; ${edge.evidence.slice(0, 3).join("; ") || "source-backed relation"}`;
+}
+
+function nodeCandidate(node: FactNode, freshnessStatus: FactGraphFreshnessStatus): Candidate | null {
+  if (node.sourceRefs.length === 0) return null;
+  return {
+    anchorType: "node",
+    anchorId: node.id,
+    nodeId: node.id,
+    kind: node.kind,
+    label: node.label,
+    confidence: node.confidence,
+    priority: priorityFor(node.kind, "node"),
+    reason: nodeReason(node),
+    sourceRefs: node.sourceRefs,
+    freshnessStatus,
+    firstLine: firstSourceLine(node.sourceRefs),
+  };
+}
+
+function edgeLabel(edge: FactEdge, nodesById: Map<string, FactNode>): string {
+  const from = nodesById.get(edge.from)?.label ?? edge.from;
+  const to = nodesById.get(edge.to)?.label ?? edge.to;
+  return `${from} ${edge.kind} ${to}`;
+}
+
+function edgeCandidate(edge: FactEdge, nodesById: Map<string, FactNode>, freshnessStatus: FactGraphFreshnessStatus): Candidate | null {
+  if (edge.sourceRefs.length === 0) return null;
+  return {
+    anchorType: "edge",
+    anchorId: edge.id,
+    edgeId: edge.id,
+    fromNodeId: edge.from,
+    toNodeId: edge.to,
+    kind: edge.kind,
+    label: edgeLabel(edge, nodesById),
+    confidence: edge.confidence,
+    priority: priorityFor(edge.kind, "edge"),
+    reason: edgeReason(edge),
+    sourceRefs: edge.sourceRefs,
+    freshnessStatus,
+    firstLine: firstSourceLine(edge.sourceRefs),
+  };
+}
+
+function compareCandidates(left: Candidate, right: Candidate): number {
+  if (left.priority !== right.priority) return right.priority - left.priority;
+  const confidenceDelta = confidenceScore(right.confidence) - confidenceScore(left.confidence);
+  if (confidenceDelta !== 0) return confidenceDelta;
+  if (left.firstLine !== right.firstLine) return left.firstLine - right.firstLine;
+  if (left.anchorType !== right.anchorType) return left.anchorType === "edge" ? -1 : 1;
+  const labelCompare = left.label.localeCompare(right.label);
+  if (labelCompare !== 0) return labelCompare;
+  return left.anchorId.localeCompare(right.anchorId);
+}
+
+function ranked(anchor: Candidate, rank: number, deferredReason?: ReactWebFactGraphAnchorDeferredReason): ReactWebFactGraphAnchor {
+  const { firstLine: _firstLine, ...publicAnchor } = anchor;
+  return {
+    rank,
+    ...publicAnchor,
+    ...(deferredReason ? { deferredReason } : {}),
+  };
+}
+
+function buildCandidates(graph: FactGraphReport): Candidate[] {
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+  return [
+    ...graph.nodes.map((node) => nodeCandidate(node, graph.freshness.status)),
+    ...graph.edges.map((edge) => edgeCandidate(edge, nodesById, graph.freshness.status)),
+  ].filter((candidate): candidate is Candidate => candidate !== null).sort(compareCandidates);
+}
+
+export function selectReactWebFactGraphAnchors(
+  inspection: ReactWebFactGraphInspection,
+  options: ReactWebFactGraphConsumerOptions = {},
+): ReactWebFactGraphConsumerDryRun {
+  const maxAnchors = boundedMaxAnchors(options.maxAnchors);
+  const graph = inspection.graph;
+  const candidates = inspection.inScope ? buildCandidates(graph) : [];
+  const warnings = [
+    REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY,
+    ...graph.warnings,
+  ];
+  if (inspection.inScope && candidates.length === 0) {
+    warnings.push("React Web fact graph consumer found no source-backed anchors to select.");
+  }
+
+  const staleOrUnknown = graph.freshness.status !== "fresh";
+  const selectedAnchors = staleOrUnknown ? [] : candidates.slice(0, maxAnchors).map((candidate, index) => ranked(candidate, index + 1));
+  const deferredCandidates = staleOrUnknown ? candidates : candidates.slice(maxAnchors);
+  const deferredReason: ReactWebFactGraphAnchorDeferredReason = staleOrUnknown ? "stale-or-unknown-freshness" : "budget-deferred";
+  const deferredAnchors = deferredCandidates.map((candidate, index) => ranked(candidate, selectedAnchors.length + index + 1, deferredReason));
+
+  if (staleOrUnknown && candidates.length > 0) {
+    warnings.push("React Web fact graph freshness is stale or unknown; all source-backed anchors were deferred.");
+  }
+
+  return {
+    schemaVersion: REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION,
+    command: REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND,
+    profile: "react-web",
+    advisoryOnly: true,
+    inScope: inspection.inScope,
+    ...(inspection.skippedReason ? { skippedReason: inspection.skippedReason } : {}),
+    selectionPolicy: {
+      reportOnly: true,
+      authorization: "none",
+      maxAnchors,
+      staleBehavior: "defer-all",
+    },
+    graphSummary: {
+      schemaVersion: graph.schemaVersion,
+      files: graph.scope.files,
+      domain: graph.scope.domain,
+      freshnessStatus: graph.freshness.status,
+      nodeCount: graph.metrics.nodeCount,
+      edgeCount: graph.metrics.edgeCount,
+      knownCount: graph.metrics.knownCount,
+      candidateCount: graph.metrics.candidateCount,
+      unsupportedCount: graph.metrics.unsupportedCount,
+    },
+    selectedAnchors,
+    deferredAnchors,
+    warnings,
+    nonClaims: [...FACT_GRAPH_REPORT_NON_CLAIMS],
+  };
+}
+
+export function buildReactWebFactGraphConsumerDryRun(
+  filePath: string,
+  cwd = process.cwd(),
+  options: ReactWebFactGraphConsumerOptions = {},
+): ReactWebFactGraphConsumerDryRun {
+  return selectReactWebFactGraphAnchors(buildReactWebFactGraphInspection(filePath, cwd), options);
+}
+
+export function renderReactWebFactGraphConsumerDryRunText(dryRun: ReactWebFactGraphConsumerDryRun): string {
+  const lines = [
+    `React Web fact graph consumer dry-run (${dryRun.schemaVersion})`,
+    `Command: ${dryRun.command}`,
+    `In scope: ${dryRun.inScope}${dryRun.skippedReason ? ` (${dryRun.skippedReason})` : ""}`,
+    `Policy: reportOnly=${dryRun.selectionPolicy.reportOnly}, authorization=${dryRun.selectionPolicy.authorization}, maxAnchors=${dryRun.selectionPolicy.maxAnchors}`,
+    `Graph: ${dryRun.graphSummary.nodeCount} node(s), ${dryRun.graphSummary.edgeCount} edge(s), freshness=${dryRun.graphSummary.freshnessStatus}`,
+    `Selected anchors: ${dryRun.selectedAnchors.length}`,
+    ...dryRun.selectedAnchors.map((anchor) => `- #${anchor.rank} ${anchor.anchorType}:${anchor.kind} ${anchor.label} (${anchor.confidence}, priority=${anchor.priority})`),
+    `Deferred anchors: ${dryRun.deferredAnchors.length}`,
+  ];
+  if (dryRun.warnings.length > 0) {
+    lines.push("Warnings:", ...dryRun.warnings.map((warning) => `- ${warning}`));
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -18,7 +18,7 @@ export const REACT_WEB_FACT_GRAPH_CONSUMER_DEFAULT_MAX_ANCHORS = 8 as const;
 export const REACT_WEB_FACT_GRAPH_CONSUMER_MIN_ANCHORS = 1 as const;
 export const REACT_WEB_FACT_GRAPH_CONSUMER_MAX_ANCHORS = 20 as const;
 export const REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY =
-  "React Web fact graph consumer dry-run is advisory and report-only: it ranks source-backed graph anchors for inspection only and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse." as const;
+  "React Web fact graph consumer dry-run is advisory and report-only: it ranks source-backed graph anchors for inspection only and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse; it does not claim token, cost, latency, billing, cache-performance, provider-cost, or provider-token savings." as const;
 
 export type ReactWebFactGraphConsumerAuthorization = "none";
 export type ReactWebFactGraphAnchorType = "node" | "edge";
@@ -283,6 +283,9 @@ export function renderReactWebFactGraphConsumerDryRunText(dryRun: ReactWebFactGr
   ];
   if (dryRun.warnings.length > 0) {
     lines.push("Warnings:", ...dryRun.warnings.map((warning) => `- ${warning}`));
+  }
+  if (dryRun.nonClaims.length > 0) {
+    lines.push("Non-claims:", ...dryRun.nonClaims.map((claim) => `- ${claim}`));
   }
   return `${lines.join("\n")}\n`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,3 +410,24 @@ export {
   renderReactWebFactGraphInspectionText,
 } from "./core/react-web-fact-graph";
 export type { ReactWebFactGraphInspection } from "./core/react-web-fact-graph";
+
+export {
+  REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY,
+  REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND,
+  REACT_WEB_FACT_GRAPH_CONSUMER_DEFAULT_MAX_ANCHORS,
+  REACT_WEB_FACT_GRAPH_CONSUMER_MAX_ANCHORS,
+  REACT_WEB_FACT_GRAPH_CONSUMER_MIN_ANCHORS,
+  REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION,
+  buildReactWebFactGraphConsumerDryRun,
+  normalizeReactWebFactGraphConsumerMaxAnchors,
+  renderReactWebFactGraphConsumerDryRunText,
+  selectReactWebFactGraphAnchors,
+} from "./core/react-web-fact-graph-consumer";
+export type {
+  ReactWebFactGraphAnchor,
+  ReactWebFactGraphAnchorDeferredReason,
+  ReactWebFactGraphAnchorType,
+  ReactWebFactGraphConsumerAuthorization,
+  ReactWebFactGraphConsumerDryRun,
+  ReactWebFactGraphConsumerOptions,
+} from "./core/react-web-fact-graph-consumer";

--- a/test/react-web-fact-graph-consumer.test.mjs
+++ b/test/react-web-fact-graph-consumer.test.mjs
@@ -194,14 +194,18 @@ test("unknown freshness defers all source-backed candidates instead of selecting
   assert.match(dryRun.warnings.join("\n"), /stale or unknown/i);
 });
 
-test("consumer JSON preserves non-authorization boundary", () => {
+test("consumer JSON and text preserve non-authorization boundary", () => {
   const dryRun = buildReactWebFactGraphConsumerDryRun(supportedFixture(), repoRoot);
   const serialized = JSON.stringify(dryRun);
+  const text = runCli(["inspect", "react-web-fact-graph-consumer", "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx"]).stdout;
 
   assert.doesNotMatch(serialized, /runtimeAuthorized\s*[:=]\s*true|preReadAuthorized|cacheAuthorized|compact-safe|modelFacingReuse/i);
   assert.doesNotMatch(serialized, /(?:proves?|guarantees?|establishes?|unlocks?)\s+[^.]{0,80}(?:token|cost|latency|provider|support-promotion|support promotion)/i);
   assert.ok(dryRun.nonClaims.some((claim) => /does not authorize runtime reuse/i.test(claim)));
   assert.ok(dryRun.nonClaims.some((claim) => /does not claim token/i.test(claim)));
+  assert.match(dryRun.warnings.join("\n"), /does not claim token, cost, latency/i);
+  assert.match(text, /Non-claims:/);
+  assert.match(text, /does not claim token/i);
 });
 
 test("CLI inspect react-web-fact-graph-consumer parses JSON and max-anchors flags", () => {

--- a/test/react-web-fact-graph-consumer.test.mjs
+++ b/test/react-web-fact-graph-consumer.test.mjs
@@ -51,6 +51,8 @@ test("React Web fact graph consumer dry-run selects fresh source-backed anchors"
   for (const anchor of dryRun.selectedAnchors) {
     assert.equal(anchor.freshnessStatus, "fresh");
     assert.ok(anchor.rank > 0);
+    assert.equal(anchor.reportOnly, true);
+    assert.equal(anchor.authorization, "none");
     assert.ok(anchor.anchorId.length > 0);
     assert.ok(anchor.kind.length > 0);
     assert.ok(anchor.reason.length > 0);
@@ -149,6 +151,7 @@ test("budget overflow is deferred with explicit reason", () => {
   assert.equal(dryRun.selectedAnchors.length, 1);
   assert.ok(dryRun.deferredAnchors.length > 0);
   assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.deferredReason === "budget-deferred"));
+  assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.reportOnly === true && anchor.authorization === "none"));
 });
 
 test("mixed and unsupported files fail closed without selected anchors", () => {
@@ -191,6 +194,7 @@ test("unknown freshness defers all source-backed candidates instead of selecting
   assert.equal(dryRun.selectedAnchors.length, 0);
   assert.ok(dryRun.deferredAnchors.length > 0);
   assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.deferredReason === "stale-or-unknown-freshness"));
+  assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.reportOnly === true && anchor.authorization === "none"));
   assert.match(dryRun.warnings.join("\n"), /stale or unknown/i);
 });
 
@@ -201,6 +205,7 @@ test("consumer JSON and text preserve non-authorization boundary", () => {
 
   assert.doesNotMatch(serialized, /runtimeAuthorized\s*[:=]\s*true|preReadAuthorized|cacheAuthorized|compact-safe|modelFacingReuse/i);
   assert.doesNotMatch(serialized, /(?:proves?|guarantees?|establishes?|unlocks?)\s+[^.]{0,80}(?:token|cost|latency|provider|support-promotion|support promotion)/i);
+  assert.ok([...dryRun.selectedAnchors, ...dryRun.deferredAnchors].every((anchor) => anchor.reportOnly === true && anchor.authorization === "none"));
   assert.ok(dryRun.nonClaims.some((claim) => /does not authorize runtime reuse/i.test(claim)));
   assert.ok(dryRun.nonClaims.some((claim) => /does not claim token/i.test(claim)));
   assert.match(dryRun.warnings.join("\n"), /does not claim token, cost, latency/i);

--- a/test/react-web-fact-graph-consumer.test.mjs
+++ b/test/react-web-fact-graph-consumer.test.mjs
@@ -1,0 +1,219 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION,
+  buildFactGraphReport,
+  buildReactWebFactGraphConsumerDryRun,
+  buildReactWebFactGraphInspection,
+  selectReactWebFactGraphAnchors,
+} from "../dist/index.js";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+
+function fixture(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function runCli(args, expectedStatus = 0) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], { cwd: repoRoot, encoding: "utf8" });
+  assert.equal(result.status, expectedStatus, result.stderr || result.stdout);
+  return result;
+}
+
+function supportedFixture() {
+  return fixture("test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx");
+}
+
+function ids(anchors) {
+  return anchors.map((anchor) => `${anchor.rank}:${anchor.anchorType}:${anchor.anchorId}`);
+}
+
+test("React Web fact graph consumer dry-run selects fresh source-backed anchors", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(supportedFixture(), repoRoot);
+
+  assert.equal(dryRun.schemaVersion, REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION);
+  assert.equal(dryRun.command, "inspect react-web-fact-graph-consumer");
+  assert.equal(dryRun.profile, "react-web");
+  assert.equal(dryRun.advisoryOnly, true);
+  assert.equal(dryRun.inScope, true);
+  assert.equal(dryRun.selectionPolicy.reportOnly, true);
+  assert.equal(dryRun.selectionPolicy.authorization, "none");
+  assert.equal(dryRun.selectionPolicy.maxAnchors, 8);
+  assert.equal(dryRun.graphSummary.freshnessStatus, "fresh");
+  assert.ok(dryRun.selectedAnchors.length > 0);
+
+  for (const anchor of dryRun.selectedAnchors) {
+    assert.equal(anchor.freshnessStatus, "fresh");
+    assert.ok(anchor.rank > 0);
+    assert.ok(anchor.anchorId.length > 0);
+    assert.ok(anchor.kind.length > 0);
+    assert.ok(anchor.reason.length > 0);
+    assert.ok(anchor.sourceRefs.length > 0);
+  }
+});
+
+test("pure selector preserves edge-backed anchors and deterministic ordering", () => {
+  const inspection = buildReactWebFactGraphInspection(supportedFixture(), repoRoot);
+  const first = selectReactWebFactGraphAnchors(inspection, { maxAnchors: 8 });
+  const second = selectReactWebFactGraphAnchors(inspection, { maxAnchors: 8 });
+
+  assert.deepEqual(ids(first.selectedAnchors), ids(second.selectedAnchors));
+  const edgeAnchor = first.selectedAnchors.find((anchor) => anchor.anchorType === "edge") ?? first.deferredAnchors.find((anchor) => anchor.anchorType === "edge");
+  assert.ok(edgeAnchor, "expected at least one edge-backed graph anchor");
+  assert.ok(edgeAnchor.edgeId);
+  assert.ok(edgeAnchor.fromNodeId);
+  assert.ok(edgeAnchor.toNodeId);
+});
+
+test("selector comparator ties by source line, edge before node, label, and id", () => {
+  const sourceRef = (line, id) => ({
+    filePath: "fixtures/Tie.tsx",
+    loc: { startLine: line, startColumn: 1, endLine: line, endColumn: 10 },
+    fingerprint: { fileHash: `hash-${id}`, lineCount: 30 },
+    extractor: { id: "test", version: "v1" },
+  });
+  const graph = buildFactGraphReport({
+    scope: { files: ["fixtures/Tie.tsx"], domain: "react-web" },
+    freshness: {
+      status: "fresh",
+      staleWhen: ["test changes"],
+      sourceFingerprints: [{ fileHash: "hash-root", lineCount: 30 }],
+      extractorVersions: { test: "v1" },
+    },
+    nodes: [
+      {
+        id: "node-z",
+        domain: "react-web",
+        kind: "patch-target:component",
+        label: "Z node",
+        confidence: "known",
+        sourceRefs: [sourceRef(10, "node-z")],
+        evidence: ["test node z"],
+      },
+      {
+        id: "node-a",
+        domain: "react-web",
+        kind: "patch-target:component",
+        label: "A node",
+        confidence: "known",
+        sourceRefs: [sourceRef(10, "node-a")],
+        evidence: ["test node a"],
+      },
+      {
+        id: "node-early",
+        domain: "react-web",
+        kind: "patch-target:component",
+        label: "Early node",
+        confidence: "known",
+        sourceRefs: [sourceRef(5, "node-early")],
+        evidence: ["test node early"],
+      },
+    ],
+    edges: [
+      {
+        id: "edge-same-line",
+        domain: "react-web",
+        kind: "targets",
+        from: "node-z",
+        to: "node-a",
+        confidence: "known",
+        sourceRefs: [sourceRef(10, "edge-same-line")],
+        evidence: ["test edge"],
+      },
+    ],
+  });
+  const dryRun = selectReactWebFactGraphAnchors({
+    schemaVersion: "react-web-fact-graph-inspection.v1",
+    command: "inspect react-web-fact-graph",
+    profile: "react-web",
+    inScope: true,
+    advisoryOnly: true,
+    graph,
+  }, { maxAnchors: 4 });
+
+  assert.equal(dryRun.selectedAnchors[0].anchorId, "node-early", "lower source line wins before edge tie");
+  assert.equal(dryRun.selectedAnchors[1].anchorType, "edge", "edge wins over node when priority/confidence/line tie");
+  assert.equal(dryRun.selectedAnchors[2].anchorId, "node-a", "label tiebreak sorts A before Z");
+  assert.equal(dryRun.selectedAnchors[3].anchorId, "node-z");
+});
+
+test("budget overflow is deferred with explicit reason", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(supportedFixture(), repoRoot, { maxAnchors: 1 });
+
+  assert.equal(dryRun.selectedAnchors.length, 1);
+  assert.ok(dryRun.deferredAnchors.length > 0);
+  assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.deferredReason === "budget-deferred"));
+});
+
+test("mixed and unsupported files fail closed without selected anchors", () => {
+  const mixed = buildReactWebFactGraphConsumerDryRun(
+    fixture("test/fixtures/frontend-domain-expectations/tui-ink-web-dom-mixed.tsx"),
+    repoRoot,
+  );
+  const unsupported = buildReactWebFactGraphConsumerDryRun(
+    fixture("test/fixtures/frontend-domain-expectations/rn-primitive-basic.tsx"),
+    repoRoot,
+  );
+
+  assert.equal(mixed.inScope, false);
+  assert.equal(mixed.skippedReason, "mixed-domain-fail-closed");
+  assert.equal(mixed.selectedAnchors.length, 0);
+  assert.equal(unsupported.inScope, false);
+  assert.equal(unsupported.skippedReason, "unsupported-domain:react-native");
+  assert.equal(unsupported.selectedAnchors.length, 0);
+});
+
+test("supported empty React Web files are distinct from unsupported files", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(
+    fixture("test/fixtures/react-web-label-preview/related-context-form.tsx"),
+    repoRoot,
+  );
+
+  assert.equal(dryRun.inScope, true);
+  assert.equal("skippedReason" in dryRun, false);
+  assert.equal(dryRun.selectedAnchors.length, 0);
+  assert.match(dryRun.warnings.join("\n"), /no graphable source-backed facts|no source-backed anchors/i);
+});
+
+test("unknown freshness defers all source-backed candidates instead of selecting", () => {
+  const inspection = structuredClone(buildReactWebFactGraphInspection(supportedFixture(), repoRoot));
+  inspection.graph.freshness.status = "unknown";
+  inspection.graph.freshness.sourceFingerprints = [];
+
+  const dryRun = selectReactWebFactGraphAnchors(inspection, { maxAnchors: 8 });
+
+  assert.equal(dryRun.selectedAnchors.length, 0);
+  assert.ok(dryRun.deferredAnchors.length > 0);
+  assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.deferredReason === "stale-or-unknown-freshness"));
+  assert.match(dryRun.warnings.join("\n"), /stale or unknown/i);
+});
+
+test("consumer JSON preserves non-authorization boundary", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(supportedFixture(), repoRoot);
+  const serialized = JSON.stringify(dryRun);
+
+  assert.doesNotMatch(serialized, /runtimeAuthorized\s*[:=]\s*true|preReadAuthorized|cacheAuthorized|compact-safe|modelFacingReuse/i);
+  assert.doesNotMatch(serialized, /(?:proves?|guarantees?|establishes?|unlocks?)\s+[^.]{0,80}(?:token|cost|latency|provider|support-promotion|support promotion)/i);
+  assert.ok(dryRun.nonClaims.some((claim) => /does not authorize runtime reuse/i.test(claim)));
+  assert.ok(dryRun.nonClaims.some((claim) => /does not claim token/i.test(claim)));
+});
+
+test("CLI inspect react-web-fact-graph-consumer parses JSON and max-anchors flags", () => {
+  const file = "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx";
+  const after = JSON.parse(runCli(["inspect", "react-web-fact-graph-consumer", file, "--json"]).stdout);
+  const before = JSON.parse(runCli(["inspect", "react-web-fact-graph-consumer", "--json", "--max-anchors", "1", file]).stdout);
+
+  assert.equal(after.schemaVersion, REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION);
+  assert.equal(before.schemaVersion, REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION);
+  assert.equal(before.selectionPolicy.maxAnchors, 1);
+  assert.equal(before.selectedAnchors.length, 1);
+
+  const invalid = runCli(["inspect", "react-web-fact-graph-consumer", "--max-anchors", "0", file, "--json"], 1);
+  assert.match(invalid.stderr || invalid.stdout, /max-anchors must be an integer between 1 and 20/i);
+});


### PR DESCRIPTION
## Summary
- Add a report-only React Web fact graph consumer dry-run over existing fact graph inspection output.
- Preserve node/edge anchor identity and deterministic ranking for source-backed anchors.
- Add `fooks inspect react-web-fact-graph-consumer <file> [--json] [--max-anchors <n>]` plus root exports.
- Add regression tests for supported, mixed/unsupported, empty, stale/unknown, budget deferral, forbidden claims, and CLI parsing.

Closes #1103

## Boundary
This PR is inspect-only/advisory-only. It does **not** authorize runtime, pre-read, cache, setup-readiness, provider, token/cost, or model-facing reuse.

## Verification
- `npm run build`
- `node --test test/react-web-fact-graph.test.mjs test/react-web-fact-graph-consumer.test.mjs` — 14/14 pass
- `npm run typecheck -- --pretty false`
- `git diff --check HEAD`
- `node dist/cli/index.js --help | rg 'inspect react-web-fact-graph-consumer'`
- `git diff --name-only HEAD | rg 'src/adapters/pre-read.ts|runtime-hook|cache|payload-policy' || true`
- `npm test` — 1030/1030 pass

## Final quality gate
- ai-slop-cleaner: passed on changed files only; removed duplicate `warnings` key.
- code-reviewer: APPROVE.
- architect: CLEAR.
