### PR TITLE
Add React Web fact graph freshness guard

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -684,6 +684,7 @@ Everyday commands:
   ${displayCliName} inspect ranked-bundle <id> [--json]
   ${displayCliName} inspect react-web-label-preview <file> [--json]
   ${displayCliName} inspect react-web-fact-graph <file> [--json]
+  ${displayCliName} inspect react-web-fact-graph-freshness <file> [--json]
   ${displayCliName} inspect react-web-fact-graph-consumer <file> [--json] [--max-anchors <n>]
   ${displayCliName} inspect react-web-issues <file> [--json|--summary-json|--dry-run-json]
   ${displayCliName} inspect-domain <file> [--json] [--domain-memory-receipt] [--context-decision]
@@ -1810,6 +1811,20 @@ async function run(): Promise<void> {
         }
         return;
       }
+      if (arg1 === "react-web-fact-graph-freshness") {
+        const { filePath: file, json } = parseCompareArgs(rest.slice(1));
+        const {
+          buildReactWebFactGraphFreshnessVerification,
+          renderReactWebFactGraphFreshnessVerificationText,
+        } = await import("../core/react-web-fact-graph-freshness.js");
+        const verification = buildReactWebFactGraphFreshnessVerification(file, process.cwd());
+        if (json) {
+          print(verification);
+        } else {
+          process.stdout.write(renderReactWebFactGraphFreshnessVerificationText(verification));
+        }
+        return;
+      }
       if (arg1 === "react-web-fact-graph-consumer") {
         const { filePath: file, json, maxAnchors } = parseReactWebFactGraphConsumerArgs(rest.slice(1));
         const {
@@ -1844,7 +1859,7 @@ async function run(): Promise<void> {
         }
         return;
       }
-      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', 'react-web-fact-graph', 'react-web-fact-graph-consumer', or 'react-web-issues'");
+      throw new Error("inspect expects 'evidence', 'activation-mode', 'ranked-bundle', 'react-web-label-preview', 'react-web-fact-graph', 'react-web-fact-graph-freshness', 'react-web-fact-graph-consumer', or 'react-web-issues'");
     }
     case "attach": {
       const runtime = arg1;

--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -11,6 +11,13 @@ import {
   buildReactWebFactGraphInspection,
   type ReactWebFactGraphInspection,
 } from "./react-web-fact-graph";
+import {
+  buildReactWebFactGraphFreshnessExpected,
+  summarizeReactWebFactGraphFreshnessVerification,
+  verifyReactWebFactGraphFreshness,
+  type ReactWebFactGraphFreshnessSummary,
+  type ReactWebFactGraphFreshnessVerification,
+} from "./react-web-fact-graph-freshness";
 
 export const REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION = "react-web-fact-graph-consumer-dry-run.v1" as const;
 export const REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND = "inspect react-web-fact-graph-consumer" as const;
@@ -57,6 +64,7 @@ export type ReactWebFactGraphConsumerDryRun = {
     maxAnchors: number;
     staleBehavior: "defer-all";
   };
+  freshnessVerification?: ReactWebFactGraphFreshnessSummary;
   graphSummary: {
     schemaVersion: FactGraphReport["schemaVersion"];
     files: string[];
@@ -76,6 +84,8 @@ export type ReactWebFactGraphConsumerDryRun = {
 
 export type ReactWebFactGraphConsumerOptions = {
   maxAnchors?: number;
+  freshnessVerification?: ReactWebFactGraphFreshnessVerification;
+  verifyFreshness?: boolean;
 };
 
 type Candidate = Omit<ReactWebFactGraphAnchor, "rank" | "reportOnly" | "authorization" | "deferredReason"> & {
@@ -202,11 +212,11 @@ function ranked(anchor: Candidate, rank: number, deferredReason?: ReactWebFactGr
   };
 }
 
-function buildCandidates(graph: FactGraphReport): Candidate[] {
+function buildCandidates(graph: FactGraphReport, freshnessStatus: FactGraphFreshnessStatus = graph.freshness.status): Candidate[] {
   const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
   return [
-    ...graph.nodes.map((node) => nodeCandidate(node, graph.freshness.status)),
-    ...graph.edges.map((edge) => edgeCandidate(edge, nodesById, graph.freshness.status)),
+    ...graph.nodes.map((node) => nodeCandidate(node, freshnessStatus)),
+    ...graph.edges.map((edge) => edgeCandidate(edge, nodesById, freshnessStatus)),
   ].filter((candidate): candidate is Candidate => candidate !== null).sort(compareCandidates);
 }
 
@@ -216,7 +226,9 @@ export function selectReactWebFactGraphAnchors(
 ): ReactWebFactGraphConsumerDryRun {
   const maxAnchors = boundedMaxAnchors(options.maxAnchors);
   const graph = inspection.graph;
-  const candidates = inspection.inScope ? buildCandidates(graph) : [];
+  const verification = options.freshnessVerification;
+  const effectiveFreshnessStatus = verification?.status ?? graph.freshness.status;
+  const candidates = inspection.inScope ? buildCandidates(graph, effectiveFreshnessStatus) : [];
   const warnings = [
     REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY,
     ...graph.warnings,
@@ -225,7 +237,7 @@ export function selectReactWebFactGraphAnchors(
     warnings.push("React Web fact graph consumer found no source-backed anchors to select.");
   }
 
-  const staleOrUnknown = graph.freshness.status !== "fresh";
+  const staleOrUnknown = effectiveFreshnessStatus !== "fresh";
   const selectedAnchors = staleOrUnknown ? [] : candidates.slice(0, maxAnchors).map((candidate, index) => ranked(candidate, index + 1));
   const deferredCandidates = staleOrUnknown ? candidates : candidates.slice(maxAnchors);
   const deferredReason: ReactWebFactGraphAnchorDeferredReason = staleOrUnknown ? "stale-or-unknown-freshness" : "budget-deferred";
@@ -233,6 +245,9 @@ export function selectReactWebFactGraphAnchors(
 
   if (staleOrUnknown && candidates.length > 0) {
     warnings.push("React Web fact graph freshness is stale or unknown; all source-backed anchors were deferred.");
+  }
+  if (verification && verification.status !== "fresh") {
+    warnings.push(`React Web fact graph freshness verification is ${verification.status}; all source-backed anchors were deferred.`);
   }
 
   return {
@@ -248,11 +263,12 @@ export function selectReactWebFactGraphAnchors(
       maxAnchors,
       staleBehavior: "defer-all",
     },
+    ...(verification ? { freshnessVerification: summarizeReactWebFactGraphFreshnessVerification(verification) } : {}),
     graphSummary: {
       schemaVersion: graph.schemaVersion,
       files: graph.scope.files,
       domain: graph.scope.domain,
-      freshnessStatus: graph.freshness.status,
+      freshnessStatus: effectiveFreshnessStatus,
       nodeCount: graph.metrics.nodeCount,
       edgeCount: graph.metrics.edgeCount,
       knownCount: graph.metrics.knownCount,
@@ -271,7 +287,11 @@ export function buildReactWebFactGraphConsumerDryRun(
   cwd = process.cwd(),
   options: ReactWebFactGraphConsumerOptions = {},
 ): ReactWebFactGraphConsumerDryRun {
-  return selectReactWebFactGraphAnchors(buildReactWebFactGraphInspection(filePath, cwd), options);
+  const inspection = buildReactWebFactGraphInspection(filePath, cwd);
+  const freshnessVerification = options.freshnessVerification ?? (options.verifyFreshness
+    ? verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection))
+    : undefined);
+  return selectReactWebFactGraphAnchors(inspection, { ...options, freshnessVerification });
 }
 
 export function renderReactWebFactGraphConsumerDryRunText(dryRun: ReactWebFactGraphConsumerDryRun): string {
@@ -285,6 +305,12 @@ export function renderReactWebFactGraphConsumerDryRunText(dryRun: ReactWebFactGr
     ...dryRun.selectedAnchors.map((anchor) => `- #${anchor.rank} ${anchor.anchorType}:${anchor.kind} ${anchor.label} (${anchor.confidence}, priority=${anchor.priority})`),
     `Deferred anchors: ${dryRun.deferredAnchors.length}`,
   ];
+  if (dryRun.freshnessVerification) {
+    lines.push(`Freshness verification: ${dryRun.freshnessVerification.status}`);
+    for (const [check, status] of Object.entries(dryRun.freshnessVerification.checks)) {
+      lines.push(`- ${check}: ${status}`);
+    }
+  }
   if (dryRun.warnings.length > 0) {
     lines.push("Warnings:", ...dryRun.warnings.map((warning) => `- ${warning}`));
   }

--- a/src/core/react-web-fact-graph-freshness.ts
+++ b/src/core/react-web-fact-graph-freshness.ts
@@ -1,0 +1,202 @@
+import { FACT_GRAPH_REPORT_NON_CLAIMS, FACT_GRAPH_REPORT_SCHEMA_VERSION, type FactGraphFreshnessStatus, type FactGraphReport } from "./fact-graph";
+import {
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_ID,
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+  buildReactWebFactGraphInspection,
+  type ReactWebFactGraphInspection,
+} from "./react-web-fact-graph";
+import { REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION, type SourceFingerprint } from "./schema";
+
+export const REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION = "react-web-fact-graph-freshness.v1" as const;
+export const REACT_WEB_FACT_GRAPH_FRESHNESS_COMMAND = "inspect react-web-fact-graph-freshness" as const;
+export const REACT_WEB_FACT_GRAPH_FRESHNESS_CLAIM_BOUNDARY =
+  "React Web fact graph freshness verification is advisory and report-only: it compares current expected source/schema/extractor metadata with graph metadata for inspection only and does not authorize runtime, pre-read, cache, setup-readiness, or model-facing reuse; it does not claim token, cost, latency, billing, cache-performance, provider-cost, or provider-token savings." as const;
+
+export type ReactWebFactGraphFreshnessCheck =
+  | "sourceFingerprint"
+  | "extractorVersion"
+  | "reactWebContextSchemaVersion"
+  | "factGraphSchemaVersion";
+
+export type ReactWebFactGraphFreshnessCheckStatus = "match" | "mismatch" | "missing";
+
+export type ReactWebFactGraphFreshnessExpected = {
+  sourceFingerprint?: SourceFingerprint;
+  extractorVersion?: string;
+  reactWebContextSchemaVersion?: string;
+  factGraphSchemaVersion?: string;
+};
+
+export type ReactWebFactGraphFreshnessActual = {
+  sourceFingerprint?: SourceFingerprint;
+  extractorVersion?: string;
+  reactWebContextSchemaVersion?: string;
+  factGraphSchemaVersion?: string;
+};
+
+export type ReactWebFactGraphFreshnessVerification = {
+  schemaVersion: typeof REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION;
+  command: typeof REACT_WEB_FACT_GRAPH_FRESHNESS_COMMAND;
+  profile: "react-web";
+  advisoryOnly: true;
+  inScope: boolean;
+  skippedReason?: string;
+  status: FactGraphFreshnessStatus;
+  checks: Record<ReactWebFactGraphFreshnessCheck, ReactWebFactGraphFreshnessCheckStatus>;
+  expected: ReactWebFactGraphFreshnessExpected;
+  actual: ReactWebFactGraphFreshnessActual;
+  staleReasons: string[];
+  warnings: string[];
+  nonClaims: string[];
+  policy: {
+    reportOnly: true;
+    authorizesRuntime: false;
+    authorizesPreRead: false;
+    authorizesCache: false;
+    authorizesModelFacingReuse: false;
+  };
+};
+
+export type ReactWebFactGraphFreshnessSummary = Pick<
+  ReactWebFactGraphFreshnessVerification,
+  "schemaVersion" | "status" | "checks" | "staleReasons" | "warnings"
+>;
+
+function firstGraphFingerprint(graph: FactGraphReport): SourceFingerprint | undefined {
+  return graph.freshness.sourceFingerprints[0] ?? graph.nodes.flatMap((node) => node.sourceRefs).find((ref) => ref.fingerprint)?.fingerprint ?? graph.edges.flatMap((edge) => edge.sourceRefs).find((ref) => ref.fingerprint)?.fingerprint;
+}
+
+export function buildReactWebFactGraphFreshnessExpected(
+  inspection: ReactWebFactGraphInspection,
+  overrides: ReactWebFactGraphFreshnessExpected = {},
+): ReactWebFactGraphFreshnessExpected {
+  return {
+    sourceFingerprint: firstGraphFingerprint(inspection.graph),
+    extractorVersion: REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+    reactWebContextSchemaVersion: REACT_WEB_CONTEXT_METADATA_SCHEMA_VERSION,
+    factGraphSchemaVersion: FACT_GRAPH_REPORT_SCHEMA_VERSION,
+    ...overrides,
+  };
+}
+
+function actualFor(inspection: ReactWebFactGraphInspection): ReactWebFactGraphFreshnessActual {
+  return {
+    sourceFingerprint: firstGraphFingerprint(inspection.graph),
+    extractorVersion: inspection.graph.freshness.extractorVersions[REACT_WEB_FACT_GRAPH_EXTRACTOR_ID],
+    reactWebContextSchemaVersion: inspection.graph.freshness.extractorVersions.reactWebContext,
+    factGraphSchemaVersion: inspection.graph.schemaVersion,
+  };
+}
+
+function sameFingerprint(left: SourceFingerprint, right: SourceFingerprint): boolean {
+  return left.fileHash === right.fileHash && left.lineCount === right.lineCount;
+}
+
+function checkVersion(expected: string | undefined, actual: string | undefined): ReactWebFactGraphFreshnessCheckStatus {
+  if (!expected || !actual) return "missing";
+  return expected === actual ? "match" : "mismatch";
+}
+
+function checkFingerprint(expected: SourceFingerprint | undefined, actual: SourceFingerprint | undefined): ReactWebFactGraphFreshnessCheckStatus {
+  if (!expected || !actual) return "missing";
+  return sameFingerprint(expected, actual) ? "match" : "mismatch";
+}
+
+function statusFor(checks: Record<ReactWebFactGraphFreshnessCheck, ReactWebFactGraphFreshnessCheckStatus>): FactGraphFreshnessStatus {
+  if (Object.values(checks).some((status) => status === "mismatch")) return "stale";
+  if (Object.values(checks).some((status) => status === "missing")) return "unknown";
+  return "fresh";
+}
+
+function staleReasonsFor(checks: Record<ReactWebFactGraphFreshnessCheck, ReactWebFactGraphFreshnessCheckStatus>): string[] {
+  return Object.entries(checks).flatMap(([check, status]) => {
+    if (status === "match") return [];
+    return [`${check}:${status}`];
+  });
+}
+
+export function summarizeReactWebFactGraphFreshnessVerification(
+  verification: ReactWebFactGraphFreshnessVerification,
+): ReactWebFactGraphFreshnessSummary {
+  return {
+    schemaVersion: verification.schemaVersion,
+    status: verification.status,
+    checks: verification.checks,
+    staleReasons: verification.staleReasons,
+    warnings: verification.warnings,
+  };
+}
+
+export function verifyReactWebFactGraphFreshness(
+  inspection: ReactWebFactGraphInspection,
+  expected: ReactWebFactGraphFreshnessExpected = buildReactWebFactGraphFreshnessExpected(inspection),
+): ReactWebFactGraphFreshnessVerification {
+  const actual = actualFor(inspection);
+  const checks = {
+    sourceFingerprint: checkFingerprint(expected.sourceFingerprint, actual.sourceFingerprint),
+    extractorVersion: checkVersion(expected.extractorVersion, actual.extractorVersion),
+    reactWebContextSchemaVersion: checkVersion(expected.reactWebContextSchemaVersion, actual.reactWebContextSchemaVersion),
+    factGraphSchemaVersion: checkVersion(expected.factGraphSchemaVersion, actual.factGraphSchemaVersion),
+  } satisfies Record<ReactWebFactGraphFreshnessCheck, ReactWebFactGraphFreshnessCheckStatus>;
+  const status = statusFor(checks);
+  const staleReasons = staleReasonsFor(checks);
+  const warnings: string[] = [REACT_WEB_FACT_GRAPH_FRESHNESS_CLAIM_BOUNDARY];
+  if (status === "stale") warnings.push("React Web fact graph metadata is stale; fallback to current source inspection before using graph anchors.");
+  if (status === "unknown") warnings.push("React Web fact graph freshness is unknown; fallback to current source inspection before using graph anchors.");
+
+  return {
+    schemaVersion: REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION,
+    command: REACT_WEB_FACT_GRAPH_FRESHNESS_COMMAND,
+    profile: "react-web",
+    advisoryOnly: true,
+    inScope: inspection.inScope,
+    ...(inspection.skippedReason ? { skippedReason: inspection.skippedReason } : {}),
+    status,
+    checks,
+    expected,
+    actual,
+    staleReasons,
+    warnings,
+    nonClaims: [...FACT_GRAPH_REPORT_NON_CLAIMS],
+    policy: {
+      reportOnly: true,
+      authorizesRuntime: false,
+      authorizesPreRead: false,
+      authorizesCache: false,
+      authorizesModelFacingReuse: false,
+    },
+  };
+}
+
+export function buildReactWebFactGraphFreshnessVerification(
+  filePath: string,
+  cwd = process.cwd(),
+  expectedOverrides: ReactWebFactGraphFreshnessExpected = {},
+): ReactWebFactGraphFreshnessVerification {
+  const inspection = buildReactWebFactGraphInspection(filePath, cwd);
+  return verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection, expectedOverrides));
+}
+
+export function renderReactWebFactGraphFreshnessVerificationText(verification: ReactWebFactGraphFreshnessVerification): string {
+  const lines = [
+    `React Web fact graph freshness (${verification.schemaVersion})`,
+    `Command: ${verification.command}`,
+    `In scope: ${verification.inScope}${verification.skippedReason ? ` (${verification.skippedReason})` : ""}`,
+    `Status: ${verification.status}`,
+    "Checks:",
+    ...Object.entries(verification.checks).map(([check, status]) => `- ${check}: ${status}`),
+  ];
+  if (verification.staleReasons.length > 0) {
+    lines.push("Stale/unknown reasons:", ...verification.staleReasons.map((reason) => `- ${reason}`));
+  }
+  if (verification.status !== "fresh") {
+    lines.push("Fallback: inspect the current source before relying on graph anchors.");
+  }
+  if (verification.warnings.length > 0) {
+    lines.push("Warnings:", ...verification.warnings.map((warning) => `- ${warning}`));
+  }
+  if (verification.nonClaims.length > 0) {
+    lines.push("Non-claims:", ...verification.nonClaims.map((claim) => `- ${claim}`));
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,26 @@ export {
   renderReactWebFactGraphConsumerDryRunText,
   selectReactWebFactGraphAnchors,
 } from "./core/react-web-fact-graph-consumer";
+
+export {
+  REACT_WEB_FACT_GRAPH_FRESHNESS_CLAIM_BOUNDARY,
+  REACT_WEB_FACT_GRAPH_FRESHNESS_COMMAND,
+  REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION,
+  buildReactWebFactGraphFreshnessExpected,
+  buildReactWebFactGraphFreshnessVerification,
+  renderReactWebFactGraphFreshnessVerificationText,
+  summarizeReactWebFactGraphFreshnessVerification,
+  verifyReactWebFactGraphFreshness,
+} from "./core/react-web-fact-graph-freshness";
+export type {
+  ReactWebFactGraphFreshnessActual,
+  ReactWebFactGraphFreshnessCheck,
+  ReactWebFactGraphFreshnessCheckStatus,
+  ReactWebFactGraphFreshnessExpected,
+  ReactWebFactGraphFreshnessSummary,
+  ReactWebFactGraphFreshnessVerification,
+} from "./core/react-web-fact-graph-freshness";
+
 export type {
   ReactWebFactGraphAnchor,
   ReactWebFactGraphAnchorDeferredReason,

--- a/test/react-web-fact-graph-freshness.test.mjs
+++ b/test/react-web-fact-graph-freshness.test.mjs
@@ -1,0 +1,147 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION,
+  REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION,
+  buildReactWebFactGraphFreshnessExpected,
+  buildReactWebFactGraphFreshnessVerification,
+  buildReactWebFactGraphInspection,
+  selectReactWebFactGraphAnchors,
+  verifyReactWebFactGraphFreshness,
+} from "../dist/index.js";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const cliPath = path.join(repoRoot, "dist", "cli", "index.js");
+const fixturePath = path.join(repoRoot, "test/fixtures/frontend-domain-expectations/react-web/custom-form-shell.tsx");
+
+function runCli(args, expectedStatus = 0) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], { cwd: repoRoot, encoding: "utf8" });
+  assert.equal(result.status, expectedStatus, result.stderr || result.stdout);
+  return result;
+}
+
+function freshInspection() {
+  return buildReactWebFactGraphInspection(fixturePath, repoRoot);
+}
+
+function withoutGraphFingerprints(inspection) {
+  const clone = structuredClone(inspection);
+  clone.graph.freshness.sourceFingerprints = [];
+  for (const node of clone.graph.nodes) {
+    for (const ref of node.sourceRefs) delete ref.fingerprint;
+  }
+  for (const edge of clone.graph.edges) {
+    for (const ref of edge.sourceRefs) delete ref.fingerprint;
+  }
+  return clone;
+}
+
+test("React Web fact graph freshness verifies current source and versions", () => {
+  const verification = buildReactWebFactGraphFreshnessVerification(fixturePath, repoRoot);
+
+  assert.equal(verification.schemaVersion, REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION);
+  assert.equal(verification.status, "fresh");
+  assert.equal(verification.advisoryOnly, true);
+  assert.equal(verification.policy.reportOnly, true);
+  assert.equal(verification.policy.authorizesRuntime, false);
+  assert.equal(verification.policy.authorizesPreRead, false);
+  assert.equal(verification.expected.extractorVersion, REACT_WEB_FACT_GRAPH_EXTRACTOR_VERSION);
+  assert.equal(verification.expected.reactWebContextSchemaVersion, "react-web-context.v0");
+  assert.deepEqual(verification.checks, {
+    sourceFingerprint: "match",
+    extractorVersion: "match",
+    reactWebContextSchemaVersion: "match",
+    factGraphSchemaVersion: "match",
+  });
+});
+
+test("source fingerprint mismatch marks graph stale and consumer defers anchors", () => {
+  const inspection = freshInspection();
+  const expected = buildReactWebFactGraphFreshnessExpected(inspection, {
+    sourceFingerprint: { fileHash: "sha256:changed", lineCount: 999 },
+  });
+  const verification = verifyReactWebFactGraphFreshness(inspection, expected);
+  const dryRun = selectReactWebFactGraphAnchors(inspection, { freshnessVerification: verification });
+
+  assert.equal(verification.status, "stale");
+  assert.equal(verification.checks.sourceFingerprint, "mismatch");
+  assert.equal(dryRun.freshnessVerification.status, "stale");
+  assert.equal(dryRun.selectedAnchors.length, 0);
+  assert.ok(dryRun.deferredAnchors.length > 0);
+  assert.ok(dryRun.deferredAnchors.every((anchor) => anchor.deferredReason === "stale-or-unknown-freshness"));
+});
+
+test("missing graph fingerprint marks freshness unknown", () => {
+  const inspection = withoutGraphFingerprints(freshInspection());
+  const verification = verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection));
+
+  assert.equal(verification.status, "unknown");
+  assert.equal(verification.checks.sourceFingerprint, "missing");
+});
+
+test("extractor and React Web context schema mismatches are stale", () => {
+  const inspection = freshInspection();
+  const extractorMismatch = structuredClone(inspection);
+  extractorMismatch.graph.freshness.extractorVersions["react-web.fact-graph"] = "react-web.fact-graph.old";
+
+  const extractorVerification = verifyReactWebFactGraphFreshness(extractorMismatch, buildReactWebFactGraphFreshnessExpected(inspection));
+  const contextVerification = verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection, {
+    reactWebContextSchemaVersion: "react-web-context.future",
+  }));
+
+  assert.equal(extractorVerification.status, "stale");
+  assert.equal(extractorVerification.checks.extractorVersion, "mismatch");
+  assert.equal(contextVerification.status, "stale");
+  assert.equal(contextVerification.checks.reactWebContextSchemaVersion, "mismatch");
+});
+
+test("fact graph schema mismatch is stale", () => {
+  const inspection = freshInspection();
+  const verification = verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection, {
+    factGraphSchemaVersion: "fact-graph-report.future",
+  }));
+
+  assert.equal(verification.status, "stale");
+  assert.equal(verification.checks.factGraphSchemaVersion, "mismatch");
+});
+
+test("freshness verification is additive and does not mutate graph freshness", () => {
+  const inspection = freshInspection();
+  const before = structuredClone(inspection.graph.freshness);
+  const verification = verifyReactWebFactGraphFreshness(inspection, buildReactWebFactGraphFreshnessExpected(inspection, {
+    sourceFingerprint: { fileHash: "sha256:changed", lineCount: 999 },
+  }));
+
+  assert.equal(verification.status, "stale");
+  assert.deepEqual(inspection.graph.freshness, before);
+  assert.equal(inspection.graph.freshness.status, "fresh");
+});
+
+test("freshness JSON preserves non-authorization boundary", () => {
+  const verification = buildReactWebFactGraphFreshnessVerification(fixturePath, repoRoot);
+  const serialized = JSON.stringify(verification);
+
+  assert.doesNotMatch(serialized, /runtimeAuthorized\s*[:=]\s*true|preReadAuthorized\s*[:=]\s*true|cacheAuthorized\s*[:=]\s*true|compact-safe|modelFacingReuse\s*[:=]\s*true/i);
+  assert.doesNotMatch(serialized, /(?:proves?|guarantees?|establishes?|unlocks?)\s+[^.]{0,80}(?:token|cost|latency|provider|support-promotion|support promotion|runtime|pre-read|cache)/i);
+  assert.ok(verification.nonClaims.some((claim) => /does not authorize runtime reuse/i.test(claim)));
+});
+
+test("CLI inspect react-web-fact-graph-freshness emits JSON and rejects extra args", () => {
+  const json = JSON.parse(runCli(["inspect", "react-web-fact-graph-freshness", fixturePath, "--json"]).stdout);
+
+  assert.equal(json.schemaVersion, REACT_WEB_FACT_GRAPH_FRESHNESS_SCHEMA_VERSION);
+  assert.equal(json.status, "fresh");
+  assert.equal(json.checks.sourceFingerprint, "match");
+
+  const text = runCli(["inspect", "react-web-fact-graph-freshness", fixturePath]).stdout;
+  assert.match(text, /React Web fact graph freshness/);
+  assert.match(text, /sourceFingerprint: match/);
+
+  const invalid = runCli(["inspect", "react-web-fact-graph-freshness", fixturePath, "--json", "extra"], 1);
+  assert.match(invalid.stderr || invalid.stdout, /Unexpected compare argument: extra/i);
+});


### PR DESCRIPTION
## Summary
- Add a pure report-only React Web fact graph freshness verifier.
- Add `fooks inspect react-web-fact-graph-freshness <file> [--json]`.
- Let the fact graph consumer dry-run accept explicit freshness verification and defer anchors when stale/unknown.

Closes #1105

## Boundary
- Inspect/report-only only.
- No runtime/pre-read/cache/payload-policy behavior changes.
- No model-facing reuse authorization.
- No token/cost/latency/billing claims.

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `git diff --check HEAD`
- `node dist/cli/index.js --help | rg 'inspect react-web-fact-graph-freshness'`
- `git diff --name-only HEAD | rg 'src/adapters/pre-read.ts|runtime-hook|cache|payload-policy' || true`
- `node --test test/react-web-fact-graph.test.mjs test/react-web-fact-graph-consumer.test.mjs test/react-web-fact-graph-freshness.test.mjs` (22/22)
- `npm test` (1038/1038)

## Review gate
- ai-slop-cleaner: passed
- independent code-reviewer: APPROVE
- independent architect: CLEAR
