### PR TITLE
Expose React Web runtime graph diagnostics

### DIFF
--- a/scripts/react-web-context-evidence.mjs
+++ b/scripts/react-web-context-evidence.mjs
@@ -49,6 +49,11 @@ async function loadRuntimeHook(repoRoot) {
   return import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 }
 
+function incrementCount(target, key) {
+  const normalizedKey = key ?? "unknown";
+  target[normalizedKey] = (target[normalizedKey] ?? 0) + 1;
+}
+
 export async function measureReactWebFixture({ repoRoot = defaultRepoRoot, relativeFile, runId = Date.now().toString() }) {
   const { handleCodexRuntimeHook } = await loadRuntimeHook(repoRoot);
   const sessionPrefix = `react-web-context-evidence-${runId}-`;
@@ -100,6 +105,67 @@ export async function measureReactWebFixture({ repoRoot = defaultRepoRoot, relat
     domainPayloadLargerThanSource: domainPayloadBytes > sourceBytes,
     claimBoundary: domainPayload?.claimBoundary ?? null,
     claimStatus: domainPayload?.claimStatus ?? null,
+    runtimeGraph: second.debug?.reactWebFactGraphPacking ?? null,
+  };
+}
+
+export async function measureReactWebGraphDiagnosticFixture({ repoRoot = defaultRepoRoot, relativeFile, runId = Date.now().toString() }) {
+  const { handleCodexRuntimeHook } = await loadRuntimeHook(repoRoot);
+  const sessionPrefix = `react-web-context-evidence-graph-${runId}-`;
+  const sessionId = `${sessionPrefix}${relativeFile.replace(/[^a-z0-9]+/gi, "-")}`;
+
+  handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, repoRoot);
+  handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Please update ${relativeFile}`,
+    },
+    repoRoot,
+  );
+  const second = handleCodexRuntimeHook(
+    {
+      hookEventName: "UserPromptSubmit",
+      sessionId,
+      prompt: `Again, update ${relativeFile} and keep graph diagnostics compact if safe`,
+    },
+    repoRoot,
+  );
+
+  return {
+    file: relativeFile,
+    firstPromptKind: "edit-path-diagnostic",
+    secondAction: second.action,
+    runtimeGraph: second.debug?.reactWebFactGraphPacking ?? null,
+    diagnosticOnly: true,
+    claimable: false,
+  };
+}
+
+function summarizeRuntimeGraphDiagnostics(rows) {
+  const reasonCounts = {};
+  const freshnessStatusCounts = {};
+  let emittedCount = 0;
+  let omittedCount = 0;
+
+  for (const row of rows) {
+    const graph = row.runtimeGraph;
+    if (graph?.included) emittedCount += 1;
+    else omittedCount += 1;
+    incrementCount(reasonCounts, graph?.reason);
+    incrementCount(freshnessStatusCounts, graph?.freshnessStatus);
+  }
+
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    measurement: "separate-edit-path-runtime-graph-diagnostic-probe",
+    fixtureCount: rows.length,
+    emittedCount,
+    omittedCount,
+    reasonCounts,
+    freshnessStatusCounts,
+    blocker: emittedCount > 0 ? null : "no edit-path diagnostic fixture emitted fresh graph anchors",
   };
 }
 
@@ -110,10 +176,13 @@ export async function buildReactWebContextEvidence({
 } = {}) {
   cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-${runId}-`);
   const rows = [];
+  const graphDiagnosticRows = [];
   for (const relativeFile of fixtures) {
     rows.push(await measureReactWebFixture({ repoRoot, relativeFile, runId }));
+    graphDiagnosticRows.push(await measureReactWebGraphDiagnosticFixture({ repoRoot, relativeFile, runId }));
   }
   cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-${runId}-`);
+  cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-graph-${runId}-`);
 
   const domainReductionValues = rows.map((row) => row.domainPayloadReductionPct);
   const runtimeReductionValues = rows.map((row) => row.runtimePayloadReductionPct);
@@ -166,6 +235,12 @@ export async function buildReactWebContextEvidence({
         claimable: false,
         blocker: "no provider usage, billing dashboard, invoice, or charged-cost data is measured by this artifact",
       },
+      runtimeGraphDiagnostics: summarizeRuntimeGraphDiagnostics(graphDiagnosticRows),
+    },
+    runtimeGraphDiagnostics: {
+      diagnosticOnly: true,
+      claimable: false,
+      fixtures: graphDiagnosticRows,
     },
   };
 }
@@ -188,6 +263,8 @@ ${evidence.claimBoundary}
 - Actual injected context reduction claimable: ${evidence.summary.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.summary.actualInjectedContextReduction.minPct}% to ${evidence.summary.actualInjectedContextReduction.maxPct}% local byte reduction)
 - Domain payload reduction diagnostic-only: ${evidence.summary.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.summary.domainPayloadReduction.minPct}% to ${evidence.summary.domainPayloadReduction.maxPct}% local byte reduction)
 - Internal runtime payload reduction diagnostic-only: ${evidence.summary.fullRuntimePayloadReduction.claimable ? "yes" : "no"}
+- Runtime graph diagnostics emitted: ${evidence.summary.runtimeGraphDiagnostics.emittedCount}/${evidence.summary.runtimeGraphDiagnostics.fixtureCount} (diagnostic-only)
+- Runtime graph omission reasons: ${JSON.stringify(evidence.summary.runtimeGraphDiagnostics.reasonCounts)}
 - Cache performance improvement claimable: no
 - Provider billing savings claimable: no
 

--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -85,6 +85,11 @@ export async function buildReleaseBenchmarkEvidence({
         maxPct: finite(contextEvidence.summary.fullRuntimePayloadReduction.maxPct),
         blocker: contextEvidence.summary.fullRuntimePayloadReduction.blocker,
       },
+      runtimeGraphDiagnostics: {
+        ...contextEvidence.summary.runtimeGraphDiagnostics,
+        diagnosticOnly: true,
+        claimable: false,
+      },
       fixtures: contextEvidence.fixtures.map((row) => ({
         file: row.file,
         sourceBytes: row.sourceBytes,
@@ -126,6 +131,7 @@ export function buildReleaseBenchmarkSmokeSummary(evidence) {
     npmUpdateClaimable: evidence.releaseClaims.npmUpdateClaimable,
     headline: evidence.releaseClaims.headline,
     actualInjectedContextReduction: evidence.context.actualInjectedContextReduction,
+    runtimeGraphDiagnostics: evidence.context.runtimeGraphDiagnostics,
     reuseCorrectnessClaimable: evidence.reuse.reuseCorrectnessClaimable,
     nonClaims: {
       cachePerformanceImprovement: evidence.nonClaims.cachePerformanceImprovement.claimable,
@@ -183,6 +189,7 @@ ${evidence.releaseClaims.headline}
 - npm update wording claimable: ${evidence.releaseClaims.npmUpdateClaimable ? "yes" : "no"}
 - React Web actual injected context reduction: ${evidence.context.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.context.actualInjectedContextReduction.minPct}% to ${evidence.context.actualInjectedContextReduction.maxPct}% smaller actual additionalContext)
 - React Web domainPayload reduction diagnostic-only: ${evidence.context.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.context.domainPayloadReduction.minPct}% to ${evidence.context.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads)
+- React Web runtime graph diagnostics: ${evidence.context.runtimeGraphDiagnostics.emittedCount}/${evidence.context.runtimeGraphDiagnostics.fixtureCount} emitted, diagnostic-only=yes
 - React Web reuse correctness: ${evidence.reuse.reuseCorrectnessClaimable ? "yes" : "no"}
 
 ## Fixture context-size measurements

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -210,6 +210,7 @@ function compactRuntimeReactWebContext(
 
 type RuntimeReactWebContextPackingSummary = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebContextPacking"]>;
 type RuntimeReactWebFactGraphPackingSummary = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebFactGraphPacking"]>;
+type RuntimeReactWebFactGraphPackingReason = RuntimeReactWebFactGraphPackingSummary["reason"];
 type CodexRuntimeDebug = NonNullable<CodexRuntimeHookDecision["debug"]>;
 type PreflightAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["preflightAdvisoryIntent"]>;
 type DomainMemoryAdvisoryDebugReceipt = NonNullable<CodexRuntimeDebug["domainMemoryAdvisory"]>;
@@ -453,15 +454,52 @@ function summarizeRuntimeReactWebContextPacking(
   };
 }
 
-function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): PackedRuntimeReactWebFactGraph | undefined {
+export function runtimeReactWebFactGraphPackingSummary(
+  reason: RuntimeReactWebFactGraphPackingReason,
+  reactWebFactGraph?: PackedRuntimeReactWebFactGraph,
+  dryRun?: ReactWebFactGraphConsumerDryRun,
+): RuntimeReactWebFactGraphPackingSummary {
+  return {
+    included: reason === "fresh-anchors-packed",
+    reason,
+    selectedAnchorCount: reactWebFactGraph?.selectedAnchors.length ?? dryRun?.selectedAnchors.length ?? 0,
+    deferredAnchorCount: reactWebFactGraph?.deferredAnchorCount ?? dryRun?.deferredAnchors.length ?? 0,
+    freshnessStatus: reactWebFactGraph?.freshnessStatus ?? dryRun?.graphSummary.freshnessStatus ?? "unknown",
+  };
+}
+
+export function summarizeRuntimeReactWebFactGraphDryRun(
+  dryRun: ReactWebFactGraphConsumerDryRun,
+  options: { budgetExceeded?: boolean } = {},
+): RuntimeReactWebFactGraphPackingSummary {
+  if (!dryRun.inScope) {
+    return runtimeReactWebFactGraphPackingSummary("out-of-scope", undefined, dryRun);
+  }
+  if (dryRun.graphSummary.freshnessStatus !== "fresh") {
+    return runtimeReactWebFactGraphPackingSummary("freshness-not-fresh", undefined, dryRun);
+  }
+  if (dryRun.selectedAnchors.length === 0) {
+    return runtimeReactWebFactGraphPackingSummary("no-anchors-selected", undefined, dryRun);
+  }
+  if (options.budgetExceeded) {
+    return runtimeReactWebFactGraphPackingSummary("budget-exceeded", undefined, dryRun);
+  }
+  return runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", undefined, dryRun);
+}
+
+function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): {
+  graph?: PackedRuntimeReactWebFactGraph;
+  packing: RuntimeReactWebFactGraphPackingSummary;
+} {
   const dryRun = buildReactWebFactGraphConsumerDryRun(path.join(cwd, filePath), cwd, {
     verifyFreshness: true,
     maxAnchors: 3,
   });
-  if (!dryRun.inScope || dryRun.graphSummary.freshnessStatus !== "fresh" || dryRun.selectedAnchors.length === 0) {
-    return undefined;
+  const basePacking = summarizeRuntimeReactWebFactGraphDryRun(dryRun);
+  if (basePacking.reason !== "fresh-anchors-packed") {
+    return { packing: basePacking };
   }
-  return {
+  const graph: PackedRuntimeReactWebFactGraph = {
     schemaVersion: "react-web-fact-graph-runtime-context.v1",
     freshnessStatus: dryRun.graphSummary.freshnessStatus,
     freshnessVerified: true,
@@ -478,18 +516,28 @@ function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): PackedR
     deferredAnchorCount: dryRun.deferredAnchors.length,
     boundary: "advisory-current-source-only",
   };
+  return { graph, packing: runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", graph, dryRun) };
 }
 
-function summarizeRuntimeReactWebFactGraphPacking(
-  reactWebFactGraph: PackedRuntimeReactWebFactGraph | undefined,
-): RuntimeReactWebFactGraphPackingSummary {
-  return {
-    included: Boolean(reactWebFactGraph),
-    reason: reactWebFactGraph ? "fresh-anchors-packed" : "not-emitted",
-    selectedAnchorCount: reactWebFactGraph?.selectedAnchors.length ?? 0,
-    deferredAnchorCount: reactWebFactGraph?.deferredAnchorCount ?? 0,
-    freshnessStatus: reactWebFactGraph?.freshnessStatus ?? "unknown",
+function runtimeReactWebFactGraphOutOfScopePacking(): RuntimeReactWebFactGraphPackingSummary {
+  return runtimeReactWebFactGraphPackingSummary("out-of-scope");
+}
+
+function attachReactWebFactGraphPackingDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  packing: RuntimeReactWebFactGraphPackingSummary | undefined,
+): CodexRuntimeHookDecision {
+  if (!packing) return runtimeDecision;
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
   };
+  runtimeDecision.debug = {
+    ...debug,
+    reactWebFactGraphPacking: packing,
+  };
+  return runtimeDecision;
 }
 
 function buildAdditionalContext(
@@ -505,17 +553,28 @@ function buildAdditionalContext(
       ? editGuidanceBudgetLimit(maxOptimizedContextBytes)
       : maxOptimizedContextBytes;
     const reactWebContext = compactRuntimeReactWebContext(filePath, payload, contextMode, runtimeReactWebContextBudget);
-    let reactWebFactGraph = includeReactWebFactGraph && payload.editGuidance ? compactRuntimeReactWebFactGraph(filePath, cwd) : undefined;
+    let reactWebFactGraph: PackedRuntimeReactWebFactGraph | undefined;
+    let reactWebFactGraphPacking: RuntimeReactWebFactGraphPackingSummary;
+    if (!payload.editGuidance) {
+      reactWebFactGraphPacking = runtimeReactWebFactGraphPackingSummary("no-edit-guidance");
+    } else if (!includeReactWebFactGraph) {
+      reactWebFactGraphPacking = runtimeReactWebFactGraphOutOfScopePacking();
+    } else {
+      const compacted = compactRuntimeReactWebFactGraph(filePath, cwd);
+      reactWebFactGraph = compacted.graph;
+      reactWebFactGraphPacking = compacted.packing;
+    }
     if (reactWebFactGraph && runtimeReactWebContextBudget !== undefined) {
       const contextWithGraph = renderOptimizedReactWebAdditionalContext(filePath, payload, contextMode, reactWebContext, reactWebFactGraph);
       if (estimateTextBytes(contextWithGraph) > runtimeReactWebContextBudget) {
+        reactWebFactGraphPacking = runtimeReactWebFactGraphPackingSummary("budget-exceeded", reactWebFactGraph);
         reactWebFactGraph = undefined;
       }
     }
     return {
       additionalContext: renderOptimizedReactWebAdditionalContext(filePath, payload, contextMode, reactWebContext, reactWebFactGraph),
       reactWebContextPacking: summarizeRuntimeReactWebContextPacking(reactWebContext),
-      reactWebFactGraphPacking: summarizeRuntimeReactWebFactGraphPacking(reactWebFactGraph),
+      reactWebFactGraphPacking,
     };
   }
 
@@ -861,6 +920,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       "escape-hatch-full-read",
       policy,
     );
+    attachReactWebFactGraphPackingDebug(runtimeDecision, runtimeReactWebFactGraphOutOfScopePacking());
     attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {
       originalEstimatedBytes,
@@ -1073,7 +1133,10 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
           decision,
         );
         const activationFallback = attachReactWebActivationDebug(
-          attachPreflightAdvisoryDebug(activationFallbackBase, preflightAdvisoryIntent),
+          attachReactWebFactGraphPackingDebug(
+            attachPreflightAdvisoryDebug(activationFallbackBase, preflightAdvisoryIntent),
+            runtimeReactWebFactGraphOutOfScopePacking(),
+          ),
           { promoted: false },
           cwd,
         );
@@ -1109,6 +1172,7 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     policy,
     decision,
   );
+  attachReactWebFactGraphPackingDebug(runtimeDecision, runtimeReactWebFactGraphOutOfScopePacking());
   attachPreflightAdvisoryDebug(runtimeDecision, preflightAdvisoryIntent);
   if (domainMemoryAdvisory.requested) {
     attachDomainMemoryAdvisoryDebug(runtimeDecision, domainMemoryAdvisory.debug);

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -758,7 +758,13 @@ export type CodexRuntimeHookDecision = {
     };
     reactWebFactGraphPacking?: {
       included: boolean;
-      reason: "fresh-anchors-packed" | "not-emitted";
+      reason:
+        | "fresh-anchors-packed"
+        | "no-edit-guidance"
+        | "out-of-scope"
+        | "freshness-not-fresh"
+        | "no-anchors-selected"
+        | "budget-exceeded";
       selectedAnchorCount: number;
       deferredAnchorCount: number;
       freshnessStatus: "fresh" | "stale" | "unknown";

--- a/src/reporting/react-web-evidence-artifact.ts
+++ b/src/reporting/react-web-evidence-artifact.ts
@@ -28,6 +28,19 @@ export type ReactWebEvidenceArtifactFile = {
 };
 
 export type ReactWebEvidenceArtifactInterop = typeof REACT_WEB_EVIDENCE_ARTIFACT_INTEROP;
+export type ReactWebEvidenceArtifactRuntimeGraph = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebFactGraphPacking"]> & {
+  diagnosticOnly: true;
+};
+
+const REACT_WEB_RUNTIME_GRAPH_REASONS = new Set([
+  "fresh-anchors-packed",
+  "no-edit-guidance",
+  "out-of-scope",
+  "freshness-not-fresh",
+  "no-anchors-selected",
+  "budget-exceeded",
+]);
+const REACT_WEB_RUNTIME_GRAPH_FRESHNESS_STATUSES = new Set(["fresh", "stale", "unknown"]);
 
 export type ReactWebEvidenceArtifact = {
   schemaVersion: typeof REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION;
@@ -54,6 +67,7 @@ export type ReactWebEvidenceArtifact = {
     staleWhen: string[];
   };
   files: ReactWebEvidenceArtifactFile[];
+  runtimeGraph?: ReactWebEvidenceArtifactRuntimeGraph;
   editGuidance?: ModelFacingPayload["editGuidance"];
   concernProfiles?: ModelFacingPayload["concernProfiles"];
   domainPayload?: ModelFacingPayload["domainPayload"];
@@ -185,6 +199,17 @@ function defaultReactWebEvidenceArtifactInterop(): ReactWebEvidenceArtifactInter
   return { ...REACT_WEB_EVIDENCE_ARTIFACT_INTEROP };
 }
 
+function runtimeGraphEvidence(
+  runtimeDecision: CodexRuntimeHookDecision,
+): ReactWebEvidenceArtifactRuntimeGraph | undefined {
+  const packing = runtimeDecision.debug?.reactWebFactGraphPacking;
+  if (!packing) return undefined;
+  return {
+    ...packing,
+    diagnosticOnly: true,
+  };
+}
+
 function isCanonicalReactWebInterop(
   interop: Partial<ReactWebEvidenceArtifactInterop> | undefined,
 ): interop is ReactWebEvidenceArtifactInterop {
@@ -233,6 +258,25 @@ function assertValidArtifact(artifact: unknown): asserts artifact is ReactWebEvi
   if (candidate.interop !== undefined && !isCanonicalReactWebInterop(candidate.interop)) {
     throw new Error("React Web evidence artifact interop contract changed");
   }
+  if (candidate.runtimeGraph !== undefined) {
+    const graph = candidate.runtimeGraph as Partial<ReactWebEvidenceArtifactRuntimeGraph>;
+    if (
+      typeof graph.included !== "boolean" ||
+      typeof graph.reason !== "string" ||
+      !REACT_WEB_RUNTIME_GRAPH_REASONS.has(graph.reason) ||
+      typeof graph.selectedAnchorCount !== "number" ||
+      !Number.isFinite(graph.selectedAnchorCount) ||
+      graph.selectedAnchorCount < 0 ||
+      typeof graph.deferredAnchorCount !== "number" ||
+      !Number.isFinite(graph.deferredAnchorCount) ||
+      graph.deferredAnchorCount < 0 ||
+      typeof graph.freshnessStatus !== "string" ||
+      !REACT_WEB_RUNTIME_GRAPH_FRESHNESS_STATUSES.has(graph.freshnessStatus) ||
+      graph.diagnosticOnly !== true
+    ) {
+      throw new Error("React Web evidence artifact runtimeGraph contract changed");
+    }
+  }
 }
 
 export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookDecision): ReactWebEvidenceArtifact | null {
@@ -249,6 +293,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
 
   const decision = artifactDecision(runtimeDecision, classification);
   const whySelected = buildWhySelected(runtimeDecision, payload);
+  const graphEvidence = runtimeGraphEvidence(runtimeDecision);
   const generatedAt = new Date().toISOString();
   const id = evidenceArtifactId({
     filePath,
@@ -283,6 +328,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
       staleWhen: staleWhen(payload),
     },
     files: [buildFileEntry(filePath, payload, whySelected)],
+    ...(graphEvidence ? { runtimeGraph: graphEvidence } : {}),
     ...(payload?.editGuidance ? { editGuidance: payload.editGuidance } : {}),
     ...(payload?.concernProfiles ? { concernProfiles: payload.concernProfiles } : {}),
     ...(payload?.domainPayload ? { domainPayload: payload.domainPayload } : {}),
@@ -358,6 +404,16 @@ export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenc
     ? artifact.concernProfiles.map((profile) => `- ${profile.id}`).join("\n")
     : "- none";
   const whyDenied = artifact.whyDenied.length > 0 ? artifact.whyDenied.map((reason) => `- ${reason}`).join("\n") : "- none";
+  const runtimeGraph = artifact.runtimeGraph
+    ? [
+        `- included: ${artifact.runtimeGraph.included ? "yes" : "no"}`,
+        `- reason: ${artifact.runtimeGraph.reason}`,
+        `- selected anchors: ${artifact.runtimeGraph.selectedAnchorCount}`,
+        `- deferred anchors: ${artifact.runtimeGraph.deferredAnchorCount}`,
+        `- freshness: ${artifact.runtimeGraph.freshnessStatus}`,
+        `- diagnostic only: ${artifact.runtimeGraph.diagnosticOnly ? "yes" : "no"}`,
+      ].join("\n")
+    : "- none";
 
-  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n- interop: stored=${artifact.interop.mayBeStored ? "yes" : "no"}, summarized=${artifact.interop.mayBeSummarized ? "yes" : "no"}, override=${artifact.interop.mayOverrideDecision ? "yes" : "no"}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
+  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n- interop: stored=${artifact.interop.mayBeStored ? "yes" : "no"}, summarized=${artifact.interop.mayBeSummarized ? "yes" : "no"}, override=${artifact.interop.mayOverrideDecision ? "yes" : "no"}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Runtime graph diagnostics\n\n${runtimeGraph}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
 }

--- a/test/react-web-context-evidence.test.mjs
+++ b/test/react-web-context-evidence.test.mjs
@@ -75,6 +75,14 @@ test("React Web context evidence measures actual injected additionalContext with
   assert.match(evidence.summary.cachePerformanceImprovement.blocker, /no wall-clock, cache-hit-rate, or end-to-end runtime benchmark/);
   assert.equal(evidence.summary.providerBillingSavings.claimable, false);
   assert.match(evidence.summary.providerBillingSavings.blocker, /no provider usage, billing dashboard, invoice, or charged-cost data/);
+  assert.equal(evidence.summary.runtimeGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.summary.runtimeGraphDiagnostics.claimable, false);
+  assert.equal(evidence.summary.runtimeGraphDiagnostics.fixtureCount, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
+  assert.ok(evidence.summary.runtimeGraphDiagnostics.emittedCount > 0);
+  assert.equal(evidence.summary.runtimeGraphDiagnostics.reasonCounts["fresh-anchors-packed"] > 0, true);
+  assert.equal(evidence.runtimeGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.runtimeGraphDiagnostics.claimable, false);
+  assert.equal(evidence.runtimeGraphDiagnostics.fixtures.length, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
 
   for (const row of evidence.fixtures) {
     assert.equal(row.firstAction, "record");
@@ -108,6 +116,8 @@ test("React Web context evidence Markdown keeps the public claim boundary explic
   assert.match(markdown, /Actual injected context reduction claimable: yes/);
   assert.match(markdown, /Domain payload reduction diagnostic-only: yes/);
   assert.match(markdown, /Internal runtime payload reduction diagnostic-only: no/);
+  assert.match(markdown, /Runtime graph diagnostics emitted:/);
+  assert.match(markdown, /Runtime graph omission reasons:/);
   assert.match(markdown, /Cache performance improvement claimable: no/);
   assert.match(markdown, /Provider billing savings claimable: no/);
   assert.match(markdown, /Metric provenance/);

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -64,6 +64,11 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
     mayOverrideDecision: false,
   });
   assert.equal(artifact.domainPayload?.domain, "react-web");
+  assert.equal(artifact.runtimeGraph?.diagnosticOnly, true);
+  assert.equal(artifact.runtimeGraph?.included, true);
+  assert.equal(artifact.runtimeGraph?.reason, "fresh-anchors-packed");
+  assert.equal(artifact.runtimeGraph?.freshnessStatus, "fresh");
+  assert.ok(artifact.runtimeGraph?.selectedAnchorCount > 0);
   assert.ok(artifact.sourceFingerprint);
   assert.ok(artifact.editGuidance?.patchTargets?.length > 0);
   assert.ok(artifact.files[0].whySelected.includes("exact-file-prompt-target"));
@@ -78,6 +83,8 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.match(markdown, /do-not-summarize/);
   assert.match(markdown, /frontend-source-evidence/);
   assert.match(markdown, /summarized=no/);
+  assert.match(markdown, /Runtime graph diagnostics/);
+  assert.match(markdown, /reason: fresh-anchors-packed/);
 
   const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id, "--json"], {
     cwd: tempDir,
@@ -96,6 +103,19 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.equal(cliText.status, 0, cliText.stderr);
   assert.match(cliText.stdout, /React Web evidence artifact/);
   assert.match(cliText.stdout, new RegExp(artifact.id));
+
+  const malformed = {
+    ...artifact,
+    runtimeGraph: {
+      ...artifact.runtimeGraph,
+      reason: "not-emitted",
+    },
+  };
+  fs.writeFileSync(ref.path, `${JSON.stringify(malformed, null, 2)}\n`);
+  assert.throws(
+    () => readReactWebEvidenceArtifact(tempDir, ref.id),
+    /React Web evidence artifact runtimeGraph contract changed/,
+  );
 });
 
 test("repeated unsupported boundary emits a denied evidence artifact instead of widening support", () => {
@@ -115,6 +135,9 @@ test("repeated unsupported boundary emits a denied evidence artifact instead of 
   const artifact = readReactWebEvidenceArtifact(tempDir, ref.id);
   assert.equal(artifact.decision, "deny");
   assert.equal(artifact.evidenceStrength, "denied");
+  assert.equal(artifact.runtimeGraph?.diagnosticOnly, true);
+  assert.equal(artifact.runtimeGraph?.included, false);
+  assert.equal(artifact.runtimeGraph?.reason, "out-of-scope");
   assert.deepEqual(artifact.interop, {
     mayBeStored: true,
     mayBeSummarized: false,

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -36,6 +36,10 @@ test("release benchmark evidence gates npm wording on actual injected context an
   assert.ok(evidence.context.domainPayloadReduction.maxPct > 70);
   assert.equal(evidence.context.fullRuntimePayloadReduction.claimable, false);
   assert.match(evidence.context.fullRuntimePayloadReduction.blocker, /not smaller than source for every fixture/);
+  assert.equal(evidence.context.runtimeGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.context.runtimeGraphDiagnostics.claimable, false);
+  assert.ok(evidence.context.runtimeGraphDiagnostics.emittedCount > 0);
+  assert.equal(evidence.context.runtimeGraphDiagnostics.reasonCounts["fresh-anchors-packed"] > 0, true);
 
   assert.equal(evidence.reuse.reuseCorrectnessClaimable, true);
   assert.equal(evidence.reuse.sameFileReactWebReuse.firstAction, "record");
@@ -67,6 +71,9 @@ test("release benchmark smoke summary exposes only release-safe compact evidence
   assert.ok(summary.actualInjectedContextReduction.minPct > 0);
   assert.ok(summary.actualInjectedContextReduction.maxPct > 70);
   assert.equal(summary.reuseCorrectnessClaimable, true);
+  assert.equal(summary.runtimeGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(summary.runtimeGraphDiagnostics.claimable, false);
+  assert.ok(summary.runtimeGraphDiagnostics.emittedCount > 0);
   assert.deepEqual(summary.nonClaims, {
     cachePerformanceImprovement: false,
     runtimeTokenSavings: false,
@@ -108,6 +115,7 @@ test("release benchmark evidence Markdown gives safe public wording and explicit
   assert.match(markdown, /npm update wording claimable: yes/);
   assert.match(markdown, /React Web actual injected context reduction: yes/);
   assert.match(markdown, /React Web domainPayload reduction diagnostic-only: yes/);
+  assert.match(markdown, /React Web runtime graph diagnostics:/);
   assert.match(markdown, /React Web reuse correctness: yes/);
   assert.match(markdown, /Cache performance improvement: no/);
   assert.match(markdown, /Runtime-token savings: no/);

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -18,7 +18,7 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const { handleCodexRuntimeHook } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const { handleCodexRuntimeHook, summarizeRuntimeReactWebFactGraphDryRun } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
@@ -55,6 +55,33 @@ test.after(async () => {
   await cleanupMetricSessions(repoRoot, ["bridge-contract-"]);
   cleanupRuntimeSessions(repoRoot, "codex-runtime", ["bridge-contract-"]);
   cleanupRuntimeSessions(repoRoot, "claude-runtime", ["bridge-contract-claude-"]);
+});
+
+function graphDryRunFixture(overrides = {}) {
+  return {
+    inScope: true,
+    graphSummary: {
+      freshnessStatus: "fresh",
+    },
+    selectedAnchors: [{ rank: 1 }],
+    deferredAnchors: [],
+    ...overrides,
+  };
+}
+
+test("runtime graph packing reasons cover every canonical omission and success state", () => {
+  assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture()).reason, "fresh-anchors-packed");
+  assert.equal(
+    summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ graphSummary: { freshnessStatus: "stale" }, selectedAnchors: [], deferredAnchors: [{ rank: 1 }] })).reason,
+    "freshness-not-fresh",
+  );
+  assert.equal(
+    summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ graphSummary: { freshnessStatus: "unknown" }, selectedAnchors: [], deferredAnchors: [{ rank: 1 }] })).reason,
+    "freshness-not-fresh",
+  );
+  assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ selectedAnchors: [] })).reason, "no-anchors-selected");
+  assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ inScope: false, selectedAnchors: [] })).reason, "out-of-scope");
+  assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture(), { budgetExceeded: true }).reason, "budget-exceeded");
 });
 
 test("runtime bridge contract keeps repeated-read inject and fallback semantics stable", () => {
@@ -295,6 +322,9 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondReadOnly.action, "inject");
   assert.equal(secondReadOnly.additionalContext.includes("\"editGuidance\""), false);
   assert.equal("editGuidance" in secondReadOnly.debug.decision.payload, false);
+  assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.included, false);
+  assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.reason, "no-edit-guidance");
+  assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.freshnessStatus, "unknown");
 
   const smallRawSession = `bridge-contract-small-raw-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: smallRawSession }, repoRoot);
@@ -335,6 +365,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
 
   assert.equal(override.action, "fallback");
   assert.equal(override.fallback.reason, "escape-hatch-full-read");
+  assert.equal(override.debug.reactWebFactGraphPacking.included, false);
+  assert.equal(override.debug.reactWebFactGraphPacking.reason, "out-of-scope");
 
   const legacyOverride = handleCodexRuntimeHook(
     {


### PR DESCRIPTION
## Summary
Closes #1109.

Adds diagnostic-only React Web runtime graph observability before any broader graph/runtime expansion:
- replaces collapsed graph omission with canonical reasons (`fresh-anchors-packed`, `no-edit-guidance`, `out-of-scope`, `freshness-not-fresh`, `no-anchors-selected`, `budget-exceeded`)
- projects `runtimeGraph` into React Web evidence artifacts, including omission states, with reader validation
- adds a separate edit-path graph diagnostic probe to React Web context evidence while preserving `actualInjectedContextReduction`
- carries graph diagnostics through release benchmark evidence as diagnostic-only without changing npm claim gates

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `git diff --check HEAD`
- `node --test test/runtime-bridge-contract.test.mjs test/react-web-evidence-artifact.test.mjs test/react-web-context-evidence.test.mjs test/release-benchmark-evidence.test.mjs` (24/24)
- `npm test` (1039/1039)

## Review / quality gate
- ai-slop-cleaner: `.omx/quality/ai-slop-cleaner-react-web-runtime-graph-evidence.md`
- independent code-reviewer: APPROVE
- independent architect: CLEAR

## Boundaries
Diagnostic-only; no provider token/cost/billing/cache/latency claims, no runtime authority widening, and no release claim gate widening.

<!-- merge-gate-refresh: minislively issue comment approval recorded 2026-05-29 -->