### PR TITLE
Expose React Web pre-read graph diagnostics

### DIFF
--- a/src/adapters/pre-read-stack.ts
+++ b/src/adapters/pre-read-stack.ts
@@ -3,6 +3,7 @@ import { extractFile } from "../core/extract";
 import { toModelFacingPayload } from "../core/payload/model-facing";
 import { assessPayloadReadiness } from "../core/payload/readiness";
 import { assessFrontendProfilePayloadReuse } from "../core/payload-policy/profile-gate";
+import { buildReactWebFactGraphConsumerDryRun, type ReactWebFactGraphConsumerDryRun } from "../core/react-web-fact-graph-consumer";
 import { toFrontendPayloadBuildOptions } from "../core/payload-policy/registry";
 import type { FrontendPayloadPolicyDecision } from "../core/payload-policy/types";
 import type { PreReadDecision } from "../core/schema";
@@ -191,6 +192,42 @@ function trimReactWebContextToBudget(
   return { payload: trimmedPayload, estimatedPayloadBytes };
 }
 
+function summarizePreReadReactWebFactGraphConsumer(
+  dryRun: ReactWebFactGraphConsumerDryRun,
+): NonNullable<PreReadDecision["debug"]>["reactWebFactGraphConsumer"] {
+  return {
+    schemaVersion: dryRun.schemaVersion,
+    advisoryOnly: true,
+    authorization: dryRun.selectionPolicy.authorization,
+    inScope: dryRun.inScope,
+    ...(dryRun.skippedReason ? { skippedReason: dryRun.skippedReason } : {}),
+    freshnessStatus: dryRun.graphSummary.freshnessStatus,
+    selectedAnchorCount: dryRun.selectedAnchors.length,
+    deferredAnchorCount: dryRun.deferredAnchors.length,
+    maxAnchors: dryRun.selectionPolicy.maxAnchors,
+    staleBehavior: dryRun.selectionPolicy.staleBehavior,
+    warningsCount: dryRun.warnings.length,
+    nonClaimsCount: dryRun.nonClaims.length,
+  };
+}
+
+function buildReactWebFactGraphConsumerDebug(
+  resolvedPath: string,
+  cwd: string,
+  payload: NonNullable<PreReadDecision["payload"]>,
+): NonNullable<PreReadDecision["debug"]>["reactWebFactGraphConsumer"] | undefined {
+  if (payload.domainPayload?.domain !== "react-web") return undefined;
+  try {
+    return summarizePreReadReactWebFactGraphConsumer(
+      buildReactWebFactGraphConsumerDryRun(resolvedPath, cwd, {
+        verifyFreshness: true,
+      }),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreReadPayloadPlan {
   const { frontendPayloadPolicy } = input;
   const result = extractFile(input.resolvedPath);
@@ -247,6 +284,10 @@ export function buildPreReadPayloadPlan(input: PreReadPayloadPlanInput): PreRead
   });
   if (reactWebContextBudget) {
     debug.reactWebContextBudget = reactWebContextBudget;
+  }
+  const reactWebFactGraphConsumer = buildReactWebFactGraphConsumerDebug(input.resolvedPath, input.cwd, payload);
+  if (reactWebFactGraphConsumer) {
+    debug.reactWebFactGraphConsumer = reactWebFactGraphConsumer;
   }
 
   return { payload, readiness, debug };

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -681,6 +681,20 @@ export type PreReadDecision = {
       maxPayloadBytes: number;
       reason?: "within-budget" | "budget-exceeded" | "not-requested" | "not-emitted";
     };
+    reactWebFactGraphConsumer?: {
+      schemaVersion: "react-web-fact-graph-consumer-dry-run.v1";
+      advisoryOnly: true;
+      authorization: "none";
+      inScope: boolean;
+      skippedReason?: string;
+      freshnessStatus: "fresh" | "stale" | "unknown";
+      selectedAnchorCount: number;
+      deferredAnchorCount: number;
+      maxAnchors: number;
+      staleBehavior: "defer-all";
+      warningsCount: number;
+      nonClaimsCount: number;
+    };
     domainMemoryLookup?: {
       source: "codex-pre-read opt-in domain-memory lookup";
       status: DomainMemoryLookupResult["status"];

--- a/test/payload-policy-profile-gate.test.mjs
+++ b/test/payload-policy-profile-gate.test.mjs
@@ -374,3 +374,41 @@ test("pre-read payload-plan seam surfaces frontend profile reuse denial", () => 
   assert.equal(preReadDecision.debug.domainDetection.classification, "react-web");
   assert.equal(preReadDecision.debug.frontendPayloadPolicy.allowed, true);
 });
+
+test("pre-read attaches diagnostic-only React Web graph consumer summary", () => {
+  const filePath = path.join(repoRoot, "test", "fixtures", "react-web-context-expansion", "modal-dialog-preferences-form.tsx");
+  const { decidePreRead } = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+  const decision = decidePreRead(filePath, repoRoot, "codex", {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  assert.equal(decision.decision, "payload");
+  assert.equal(decision.debug.domainDetection.classification, "react-web");
+  assert.equal(decision.debug.reactWebFactGraphConsumer.advisoryOnly, true);
+  assert.equal(decision.debug.reactWebFactGraphConsumer.authorization, "none");
+  assert.equal(decision.debug.reactWebFactGraphConsumer.inScope, true);
+  assert.equal(decision.debug.reactWebFactGraphConsumer.freshnessStatus, "fresh");
+  assert.ok(decision.debug.reactWebFactGraphConsumer.selectedAnchorCount > 0);
+  assert.equal(decision.debug.reactWebFactGraphConsumer.staleBehavior, "defer-all");
+  assert.equal("reactWebFactGraph" in decision.payload, false);
+});
+
+test("pre-read graph diagnostics stay absent for unsupported fallback lanes", () => {
+  const tempDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-pre-read-graph-fallback-"));
+  try {
+    const filePath = path.join(tempDir, "Cli.tsx");
+    fs.writeFileSync(filePath, `import { Box } from "ink"; export function Cli() { return <Box />; }`);
+    const { decidePreRead } = require(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+    const decision = decidePreRead(filePath, tempDir, "codex", {
+      includeEditGuidance: true,
+      includeReactWebContextMetadata: true,
+    });
+
+    assert.equal(decision.decision, "fallback");
+    assert.equal(decision.debug.domainDetection.classification, "tui-ink");
+    assert.equal("reactWebFactGraphConsumer" in decision.debug, false);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/pre-read-phase-order-regression.test.mjs
+++ b/test/pre-read-phase-order-regression.test.mjs
@@ -28,6 +28,7 @@ const PAYLOAD_DEBUG_KEYS = [
   "language",
   "mode",
   "reactWebContextBudget",
+  "reactWebFactGraphConsumer",
 ];
 
 function assertNoPayloadPlanningArtifacts(decision) {
@@ -81,6 +82,8 @@ test("pre-read adapter phase ordering preserves boundary short-circuit and paylo
   assert.equal(payloadDecision.debug.language, "tsx");
   assert.equal(payloadDecision.debug.domainDetection.classification, "react-web");
   assert.equal(payloadDecision.debug.frontendPayloadPolicy.allowed, true);
+  assert.equal(payloadDecision.debug.reactWebFactGraphConsumer.advisoryOnly, true);
+  assert.equal(payloadDecision.debug.reactWebFactGraphConsumer.authorization, "none");
 });
 
 test("pre-read payload-plan seam keeps live fallback reasons ahead of stale cached domain payloads", () => {


### PR DESCRIPTION
## Summary
Closes #1111.

Adds diagnostic-only React Web graph consumer visibility to pre-read decisions:
- reuses the existing freshness-verified fact graph consumer dry-run
- exposes compact `debug.reactWebFactGraphConsumer` counts/status/policy metadata
- keeps graph anchors out of the model-facing payload
- preserves unsupported fallback short-circuit behavior

## Verification
- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/pre-read-phase-order-regression.test.mjs test/payload-policy-profile-gate.test.mjs` (15/15)
- `git diff --check`
- `npm test` (1041/1041)

## Boundaries
Diagnostic-only pre-read debug metadata. No runtime authority widening, no pre-read/cache/model-facing reuse authorization changes, and no provider token/cost/billing claims.

## Planning artifacts
- autoresearch: `.omx/specs/autoresearch-react-web-pre-read-graph-diagnostics/result.json`
- ralplan: `.omx/plans/ralplan-handoff-react-web-pre-read-graph-diagnostics.json`

<!-- merge-gate-refresh: minislively issue comment approval recorded 2026-05-29T04:36Z -->