### PR TITLE
Correlate React Web graph diagnostics in dogfood evidence

### DIFF
--- a/scripts/react-web-context-evidence.mjs
+++ b/scripts/react-web-context-evidence.mjs
@@ -49,6 +49,10 @@ async function loadRuntimeHook(repoRoot) {
   return import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 }
 
+async function loadPreRead(repoRoot) {
+  return import(path.join(repoRoot, "dist", "adapters", "pre-read.js"));
+}
+
 function incrementCount(target, key) {
   const normalizedKey = key ?? "unknown";
   target[normalizedKey] = (target[normalizedKey] ?? 0) + 1;
@@ -109,6 +113,24 @@ export async function measureReactWebFixture({ repoRoot = defaultRepoRoot, relat
   };
 }
 
+export async function measureReactWebPreReadGraphDiagnosticFixture({ repoRoot = defaultRepoRoot, relativeFile }) {
+  const { decidePreRead } = await loadPreRead(repoRoot);
+  const decision = decidePreRead(path.join(repoRoot, relativeFile), repoRoot, "codex", {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+  const graph = decision.debug?.reactWebFactGraphConsumer ?? null;
+  return {
+    file: relativeFile,
+    decision: decision.decision,
+    classification: decision.debug?.domainDetection?.classification ?? null,
+    preReadGraph: graph,
+    diagnosticOnly: true,
+    claimable: false,
+    payloadContainsGraph: Boolean(decision.payload?.reactWebFactGraph),
+  };
+}
+
 export async function measureReactWebGraphDiagnosticFixture({ repoRoot = defaultRepoRoot, relativeFile, runId = Date.now().toString() }) {
   const { handleCodexRuntimeHook } = await loadRuntimeHook(repoRoot);
   const sessionPrefix = `react-web-context-evidence-graph-${runId}-`;
@@ -139,6 +161,65 @@ export async function measureReactWebGraphDiagnosticFixture({ repoRoot = default
     runtimeGraph: second.debug?.reactWebFactGraphPacking ?? null,
     diagnosticOnly: true,
     claimable: false,
+  };
+}
+
+function summarizePreReadGraphDiagnostics(rows) {
+  const freshnessStatusCounts = {};
+  let emittedCount = 0;
+  let omittedCount = 0;
+  let selectedAnchorTotal = 0;
+  let deferredAnchorTotal = 0;
+  let payloadGraphLeakCount = 0;
+
+  for (const row of rows) {
+    const graph = row.preReadGraph;
+    if (graph?.selectedAnchorCount > 0) emittedCount += 1;
+    else omittedCount += 1;
+    if (row.payloadContainsGraph) payloadGraphLeakCount += 1;
+    selectedAnchorTotal += graph?.selectedAnchorCount ?? 0;
+    deferredAnchorTotal += graph?.deferredAnchorCount ?? 0;
+    incrementCount(freshnessStatusCounts, graph?.freshnessStatus);
+  }
+
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    measurement: "pre-read-react-web-graph-consumer-debug",
+    fixtureCount: rows.length,
+    emittedCount,
+    omittedCount,
+    selectedAnchorTotal,
+    deferredAnchorTotal,
+    freshnessStatusCounts,
+    payloadGraphLeakCount,
+    blocker: emittedCount > 0 && payloadGraphLeakCount === 0 ? null : "pre-read graph diagnostics were missing or leaked into model-facing payload",
+  };
+}
+
+function summarizeGraphAssistedContextPath(preReadRows, runtimeRows) {
+  const runtimeByFile = new Map(runtimeRows.map((row) => [row.file, row]));
+  const joined = preReadRows.map((row) => {
+    const runtime = runtimeByFile.get(row.file);
+    return {
+      file: row.file,
+      preReadFreshSelected: row.preReadGraph?.freshnessStatus === "fresh" && (row.preReadGraph?.selectedAnchorCount ?? 0) > 0,
+      runtimeFreshPacked: runtime?.runtimeGraph?.reason === "fresh-anchors-packed" && runtime?.runtimeGraph?.freshnessStatus === "fresh",
+    };
+  });
+  const preReadFreshSelectedCount = joined.filter((row) => row.preReadFreshSelected).length;
+  const runtimeFreshPackedCount = joined.filter((row) => row.runtimeFreshPacked).length;
+  const correlatedFreshPathCount = joined.filter((row) => row.preReadFreshSelected && row.runtimeFreshPacked).length;
+
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    measurement: "pre-read-to-runtime-graph-dogfood-correlation",
+    fixtureCount: joined.length,
+    preReadFreshSelectedCount,
+    runtimeFreshPackedCount,
+    correlatedFreshPathCount,
+    blocker: correlatedFreshPathCount > 0 ? null : "no fixture showed both pre-read fresh selected graph diagnostics and runtime fresh graph packing",
   };
 }
 
@@ -176,9 +257,11 @@ export async function buildReactWebContextEvidence({
 } = {}) {
   cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-${runId}-`);
   const rows = [];
+  const preReadGraphDiagnosticRows = [];
   const graphDiagnosticRows = [];
   for (const relativeFile of fixtures) {
     rows.push(await measureReactWebFixture({ repoRoot, relativeFile, runId }));
+    preReadGraphDiagnosticRows.push(await measureReactWebPreReadGraphDiagnosticFixture({ repoRoot, relativeFile }));
     graphDiagnosticRows.push(await measureReactWebGraphDiagnosticFixture({ repoRoot, relativeFile, runId }));
   }
   cleanupRuntimeSessions(repoRoot, `react-web-context-evidence-${runId}-`);
@@ -235,7 +318,14 @@ export async function buildReactWebContextEvidence({
         claimable: false,
         blocker: "no provider usage, billing dashboard, invoice, or charged-cost data is measured by this artifact",
       },
+      preReadGraphDiagnostics: summarizePreReadGraphDiagnostics(preReadGraphDiagnosticRows),
       runtimeGraphDiagnostics: summarizeRuntimeGraphDiagnostics(graphDiagnosticRows),
+      graphAssistedContextPath: summarizeGraphAssistedContextPath(preReadGraphDiagnosticRows, graphDiagnosticRows),
+    },
+    preReadGraphDiagnostics: {
+      diagnosticOnly: true,
+      claimable: false,
+      fixtures: preReadGraphDiagnosticRows,
     },
     runtimeGraphDiagnostics: {
       diagnosticOnly: true,
@@ -263,8 +353,10 @@ ${evidence.claimBoundary}
 - Actual injected context reduction claimable: ${evidence.summary.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.summary.actualInjectedContextReduction.minPct}% to ${evidence.summary.actualInjectedContextReduction.maxPct}% local byte reduction)
 - Domain payload reduction diagnostic-only: ${evidence.summary.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.summary.domainPayloadReduction.minPct}% to ${evidence.summary.domainPayloadReduction.maxPct}% local byte reduction)
 - Internal runtime payload reduction diagnostic-only: ${evidence.summary.fullRuntimePayloadReduction.claimable ? "yes" : "no"}
+- Pre-read graph diagnostics emitted: ${evidence.summary.preReadGraphDiagnostics.emittedCount}/${evidence.summary.preReadGraphDiagnostics.fixtureCount} (diagnostic-only)
 - Runtime graph diagnostics emitted: ${evidence.summary.runtimeGraphDiagnostics.emittedCount}/${evidence.summary.runtimeGraphDiagnostics.fixtureCount} (diagnostic-only)
 - Runtime graph omission reasons: ${JSON.stringify(evidence.summary.runtimeGraphDiagnostics.reasonCounts)}
+- Graph-assisted context path observed: ${evidence.summary.graphAssistedContextPath.correlatedFreshPathCount}/${evidence.summary.graphAssistedContextPath.fixtureCount} fixtures (diagnostic-only)
 - Cache performance improvement claimable: no
 - Provider billing savings claimable: no
 
@@ -282,7 +374,7 @@ ${rows}
 
 ## Claim boundary
 
-This artifact supports bounded statements only when actual host-facing additionalContext is smaller than source for the measured React Web current-lane fixtures. The source-derived domainPayload metric is diagnostic-only. It does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims.
+This artifact supports bounded statements only when actual host-facing additionalContext is smaller than source for the measured React Web current-lane fixtures. The source-derived domainPayload metric and graph-assisted context path are diagnostic-only. It does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims.
 `;
 }
 

--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -85,8 +85,18 @@ export async function buildReleaseBenchmarkEvidence({
         maxPct: finite(contextEvidence.summary.fullRuntimePayloadReduction.maxPct),
         blocker: contextEvidence.summary.fullRuntimePayloadReduction.blocker,
       },
+      preReadGraphDiagnostics: {
+        ...contextEvidence.summary.preReadGraphDiagnostics,
+        diagnosticOnly: true,
+        claimable: false,
+      },
       runtimeGraphDiagnostics: {
         ...contextEvidence.summary.runtimeGraphDiagnostics,
+        diagnosticOnly: true,
+        claimable: false,
+      },
+      graphAssistedContextPath: {
+        ...contextEvidence.summary.graphAssistedContextPath,
         diagnosticOnly: true,
         claimable: false,
       },
@@ -131,7 +141,9 @@ export function buildReleaseBenchmarkSmokeSummary(evidence) {
     npmUpdateClaimable: evidence.releaseClaims.npmUpdateClaimable,
     headline: evidence.releaseClaims.headline,
     actualInjectedContextReduction: evidence.context.actualInjectedContextReduction,
+    preReadGraphDiagnostics: evidence.context.preReadGraphDiagnostics,
     runtimeGraphDiagnostics: evidence.context.runtimeGraphDiagnostics,
+    graphAssistedContextPath: evidence.context.graphAssistedContextPath,
     reuseCorrectnessClaimable: evidence.reuse.reuseCorrectnessClaimable,
     nonClaims: {
       cachePerformanceImprovement: evidence.nonClaims.cachePerformanceImprovement.claimable,
@@ -189,7 +201,9 @@ ${evidence.releaseClaims.headline}
 - npm update wording claimable: ${evidence.releaseClaims.npmUpdateClaimable ? "yes" : "no"}
 - React Web actual injected context reduction: ${evidence.context.actualInjectedContextReduction.claimable ? "yes" : "no"} (${evidence.context.actualInjectedContextReduction.minPct}% to ${evidence.context.actualInjectedContextReduction.maxPct}% smaller actual additionalContext)
 - React Web domainPayload reduction diagnostic-only: ${evidence.context.domainPayloadReduction.claimable ? "yes" : "no"} (${evidence.context.domainPayloadReduction.minPct}% to ${evidence.context.domainPayloadReduction.maxPct}% smaller source-derived domainPayloads)
+- React Web pre-read graph diagnostics: ${evidence.context.preReadGraphDiagnostics.emittedCount}/${evidence.context.preReadGraphDiagnostics.fixtureCount} emitted, diagnostic-only=yes
 - React Web runtime graph diagnostics: ${evidence.context.runtimeGraphDiagnostics.emittedCount}/${evidence.context.runtimeGraphDiagnostics.fixtureCount} emitted, diagnostic-only=yes
+- React Web graph-assisted context path: ${evidence.context.graphAssistedContextPath.correlatedFreshPathCount}/${evidence.context.graphAssistedContextPath.fixtureCount} correlated, diagnostic-only=yes
 - React Web reuse correctness: ${evidence.reuse.reuseCorrectnessClaimable ? "yes" : "no"}
 
 ## Fixture context-size measurements

--- a/test/react-web-context-evidence.test.mjs
+++ b/test/react-web-context-evidence.test.mjs
@@ -75,6 +75,15 @@ test("React Web context evidence measures actual injected additionalContext with
   assert.match(evidence.summary.cachePerformanceImprovement.blocker, /no wall-clock, cache-hit-rate, or end-to-end runtime benchmark/);
   assert.equal(evidence.summary.providerBillingSavings.claimable, false);
   assert.match(evidence.summary.providerBillingSavings.blocker, /no provider usage, billing dashboard, invoice, or charged-cost data/);
+  assert.equal(evidence.summary.preReadGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.summary.preReadGraphDiagnostics.claimable, false);
+  assert.equal(evidence.summary.preReadGraphDiagnostics.fixtureCount, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
+  assert.ok(evidence.summary.preReadGraphDiagnostics.emittedCount > 0);
+  assert.ok(evidence.summary.preReadGraphDiagnostics.selectedAnchorTotal > 0);
+  assert.equal(evidence.summary.preReadGraphDiagnostics.payloadGraphLeakCount, 0);
+  assert.equal(evidence.preReadGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.preReadGraphDiagnostics.claimable, false);
+  assert.equal(evidence.preReadGraphDiagnostics.fixtures.length, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
   assert.equal(evidence.summary.runtimeGraphDiagnostics.diagnosticOnly, true);
   assert.equal(evidence.summary.runtimeGraphDiagnostics.claimable, false);
   assert.equal(evidence.summary.runtimeGraphDiagnostics.fixtureCount, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
@@ -83,6 +92,19 @@ test("React Web context evidence measures actual injected additionalContext with
   assert.equal(evidence.runtimeGraphDiagnostics.diagnosticOnly, true);
   assert.equal(evidence.runtimeGraphDiagnostics.claimable, false);
   assert.equal(evidence.runtimeGraphDiagnostics.fixtures.length, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
+  assert.equal(evidence.summary.graphAssistedContextPath.diagnosticOnly, true);
+  assert.equal(evidence.summary.graphAssistedContextPath.claimable, false);
+  assert.equal(evidence.summary.graphAssistedContextPath.fixtureCount, EXPECTED_DEFAULT_REACT_WEB_EVIDENCE_FIXTURES.length);
+  assert.ok(evidence.summary.graphAssistedContextPath.preReadFreshSelectedCount > 0);
+  assert.ok(evidence.summary.graphAssistedContextPath.runtimeFreshPackedCount > 0);
+  assert.ok(evidence.summary.graphAssistedContextPath.correlatedFreshPathCount > 0);
+
+  for (const row of evidence.preReadGraphDiagnostics.fixtures) {
+    assert.equal(row.diagnosticOnly, true);
+    assert.equal(row.claimable, false);
+    assert.equal(row.payloadContainsGraph, false);
+    assert.equal(row.classification, "react-web");
+  }
 
   for (const row of evidence.fixtures) {
     assert.equal(row.firstAction, "record");
@@ -116,14 +138,16 @@ test("React Web context evidence Markdown keeps the public claim boundary explic
   assert.match(markdown, /Actual injected context reduction claimable: yes/);
   assert.match(markdown, /Domain payload reduction diagnostic-only: yes/);
   assert.match(markdown, /Internal runtime payload reduction diagnostic-only: no/);
+  assert.match(markdown, /Pre-read graph diagnostics emitted:/);
   assert.match(markdown, /Runtime graph diagnostics emitted:/);
   assert.match(markdown, /Runtime graph omission reasons:/);
+  assert.match(markdown, /Graph-assisted context path observed:/);
   assert.match(markdown, /Cache performance improvement claimable: no/);
   assert.match(markdown, /Provider billing savings claimable: no/);
   assert.match(markdown, /Metric provenance/);
   assert.match(markdown, /sourceBytes - additionalContextBytes/);
   assert.match(markdown, /Not comparable to: wallClockSpeedup, cacheHitRate, runtimeTokenSavings, providerBillingSavings/);
-  assert.match(markdown, /domainPayload metric is diagnostic-only/);
+  assert.match(markdown, /domainPayload metric and graph-assisted context path are diagnostic-only/);
   assert.match(markdown, /does not support broad runtime-token, latency, cache-performance, provider-cost, billing, invoice, or charged-cost claims/);
   assert.doesNotMatch(markdown, /provider billing savings claimable: yes/i);
   assert.doesNotMatch(markdown, /cache performance improvement claimable: yes/i);

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -36,10 +36,16 @@ test("release benchmark evidence gates npm wording on actual injected context an
   assert.ok(evidence.context.domainPayloadReduction.maxPct > 70);
   assert.equal(evidence.context.fullRuntimePayloadReduction.claimable, false);
   assert.match(evidence.context.fullRuntimePayloadReduction.blocker, /not smaller than source for every fixture/);
+  assert.equal(evidence.context.preReadGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.context.preReadGraphDiagnostics.claimable, false);
+  assert.ok(evidence.context.preReadGraphDiagnostics.emittedCount > 0);
   assert.equal(evidence.context.runtimeGraphDiagnostics.diagnosticOnly, true);
   assert.equal(evidence.context.runtimeGraphDiagnostics.claimable, false);
   assert.ok(evidence.context.runtimeGraphDiagnostics.emittedCount > 0);
   assert.equal(evidence.context.runtimeGraphDiagnostics.reasonCounts["fresh-anchors-packed"] > 0, true);
+  assert.equal(evidence.context.graphAssistedContextPath.diagnosticOnly, true);
+  assert.equal(evidence.context.graphAssistedContextPath.claimable, false);
+  assert.ok(evidence.context.graphAssistedContextPath.correlatedFreshPathCount > 0);
 
   assert.equal(evidence.reuse.reuseCorrectnessClaimable, true);
   assert.equal(evidence.reuse.sameFileReactWebReuse.firstAction, "record");
@@ -71,9 +77,14 @@ test("release benchmark smoke summary exposes only release-safe compact evidence
   assert.ok(summary.actualInjectedContextReduction.minPct > 0);
   assert.ok(summary.actualInjectedContextReduction.maxPct > 70);
   assert.equal(summary.reuseCorrectnessClaimable, true);
+  assert.equal(summary.preReadGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(summary.preReadGraphDiagnostics.claimable, false);
   assert.equal(summary.runtimeGraphDiagnostics.diagnosticOnly, true);
   assert.equal(summary.runtimeGraphDiagnostics.claimable, false);
   assert.ok(summary.runtimeGraphDiagnostics.emittedCount > 0);
+  assert.equal(summary.graphAssistedContextPath.diagnosticOnly, true);
+  assert.equal(summary.graphAssistedContextPath.claimable, false);
+  assert.ok(summary.graphAssistedContextPath.correlatedFreshPathCount > 0);
   assert.deepEqual(summary.nonClaims, {
     cachePerformanceImprovement: false,
     runtimeTokenSavings: false,
@@ -115,7 +126,9 @@ test("release benchmark evidence Markdown gives safe public wording and explicit
   assert.match(markdown, /npm update wording claimable: yes/);
   assert.match(markdown, /React Web actual injected context reduction: yes/);
   assert.match(markdown, /React Web domainPayload reduction diagnostic-only: yes/);
+  assert.match(markdown, /React Web pre-read graph diagnostics:/);
   assert.match(markdown, /React Web runtime graph diagnostics:/);
+  assert.match(markdown, /React Web graph-assisted context path:/);
   assert.match(markdown, /React Web reuse correctness: yes/);
   assert.match(markdown, /Cache performance improvement: no/);
   assert.match(markdown, /Runtime-token savings: no/);


### PR DESCRIPTION
Closes #1113

## Summary

- Adds React Web pre-read graph diagnostic rows to context evidence.
- Adds a diagnostic-only graph-assisted context path correlation between pre-read fresh selected anchors and runtime fresh graph packing.
- Carries pre-read graph diagnostics and graph-assisted path summaries into release benchmark evidence and smoke summaries.
- Keeps graph diagnostics non-claimable and separate from actual injected additionalContext byte evidence.

## Boundaries

- No runtime authority expansion.
- No pre-read model-facing graph payload leak: `payloadGraphLeakCount` remains asserted as `0`.
- No cache reuse, provider token, billing, invoice, charged cost, latency, or runtime-token savings claims.
- Graph-assisted path is diagnostic-only until external/live dogfood evidence supports broader claims.

## Verification

- `npm run build`
- `npm run typecheck -- --pretty false`
- `node --test test/react-web-context-evidence.test.mjs test/release-benchmark-evidence.test.mjs` — 6/6 passed
- `git diff --check`
- `npm test` — 1041/1041 passed

## Planning evidence

- `.omx/specs/autoresearch-react-web-graph-dogfood-evidence/result.json`
- `.omx/plans/ralplan-handoff-react-web-graph-dogfood-evidence.json`

## Approval checklist

- [x] Linked issue included with closing keyword.
- [x] Evidence and claim boundaries are explicit.
- [x] minislively-authored PR/issue flow.
