### PR TITLE
Prove React Web live hook graph dogfood evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "evidence:react-native-readiness": "npm run build && node scripts/react-native-readiness-evidence.mjs",
     "evidence:react-web-pr-advisory": "npm run build && node scripts/react-web-pr-advisory-surface.mjs",
     "evidence:react-web-pr-gate": "npm run build && node scripts/react-web-pr-gate-surface.mjs",
-    "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs"
+    "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs",
+    "evidence:react-web-live-hook-dogfood": "npm run build && node scripts/react-web-live-hook-dogfood-evidence.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -8,9 +8,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRepoRoot = path.resolve(__dirname, "..");
 
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v1";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v2";
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
+export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES = [
+  "fixtures/compressed/FormSection.tsx",
+  "fixtures/compressed/HookEffectPanel.tsx",
+  "fixtures/hybrid/DashboardPanel.tsx",
+  "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+  "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+  "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+];
 
 const NON_CLAIMS = [
   "provider-token-savings",
@@ -23,6 +31,15 @@ const NON_CLAIMS = [
   "react-native-webview-or-tui-support-expansion",
   "stale-graph-reuse",
 ];
+
+function byteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function percentReduction(beforeBytes, afterBytes) {
+  if (!Number.isFinite(beforeBytes) || beforeBytes <= 0) return 0;
+  return Number.parseFloat(((1 - afterBytes / beforeBytes) * 100).toFixed(3));
+}
 
 function copyFile(src, dest) {
   fs.mkdirSync(path.dirname(dest), { recursive: true });
@@ -42,6 +59,10 @@ export function createLiveHookReplayProject({ repoRoot = defaultRepoRoot } = {})
     path.join(projectRoot, "package.json"),
     `${JSON.stringify({ name: "fooks-live-hook-dogfood-project", repository: { url: "https://github.com/minislively/fooks-live-hook-dogfood-project.git" } }, null, 2)}\n`,
   );
+
+  for (const fixture of DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES) {
+    copyFile(path.join(repoRoot, fixture), path.join(projectRoot, fixture));
+  }
 
   return { projectRoot, codexHome };
 }
@@ -172,6 +193,70 @@ function assertBoundaryPath(boundary) {
   return failures;
 }
 
+function summarizeLiveHookSuiteRow({ projectRoot, relativeFile, preRead, firstNative, secondNative, artifactRef }) {
+  const source = fs.readFileSync(path.join(projectRoot, relativeFile), "utf8");
+  const sourceBytes = byteLength(source);
+  const additionalContextBytes = secondNative.additionalContextBytes;
+  const artifact = summarizeArtifact(artifactRef, relativeFile);
+
+  return {
+    file: relativeFile,
+    sourceBytes,
+    additionalContextBytes,
+    additionalContextReductionPct: percentReduction(sourceBytes, additionalContextBytes),
+    additionalContextLargerThanSource: additionalContextBytes > sourceBytes,
+    preReadGraphDiagnostics: summarizePreReadGraph(preRead),
+    firstNative,
+    secondNative,
+    evidenceArtifact: artifact,
+    diagnosticOnly: true,
+    claimable: false,
+  };
+}
+
+function summarizeLiveHookSuite(rows) {
+  const reductionValues = rows.map((row) => row.additionalContextReductionPct);
+  const graphObservedCount = rows.filter((row) => row.secondNative.containsReactWebFactGraph).length;
+  const firstPromptEmptyCount = rows.filter((row) => !row.firstNative.emitted).length;
+  const artifactIdentityMatchCount = rows.filter((row) => row.evidenceArtifact.filePathMatchesTarget).length;
+  const allAdditionalContextsSmaller = rows.every((row) => !row.additionalContextLargerThanSource && row.additionalContextBytes > 0);
+  const compactRowsCount = rows.filter((row) => !row.additionalContextLargerThanSource && row.additionalContextBytes > 0).length;
+  const expandedRowsCount = rows.length - compactRowsCount;
+  const allFreshGraphs = rows.every(
+    (row) => row.preReadGraphDiagnostics.freshnessStatus === "fresh" && row.evidenceArtifact.runtimeGraph?.freshnessStatus === "fresh",
+  );
+
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    measurement: "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+    fixtureCount: rows.length,
+    graphObservedCount,
+    firstPromptEmptyCount,
+    artifactIdentityMatchCount,
+    compactRowsCount,
+    expandedRowsCount,
+    allAdditionalContextsSmaller,
+    allFreshGraphs,
+    minAdditionalContextReductionPct: Math.min(...reductionValues),
+    maxAdditionalContextReductionPct: Math.max(...reductionValues),
+    blocker:
+      graphObservedCount === rows.length && artifactIdentityMatchCount === rows.length
+        ? null
+        : "one or more live/native hook fixture rows did not emit graph-assisted additionalContext with matching evidence artifact identity",
+  };
+}
+
+function assertLiveHookSuite(suite) {
+  const failures = [];
+  if (suite.summary.fixtureCount === 0) failures.push("live hook suite had no fixtures");
+  if (suite.summary.graphObservedCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture observed reactWebFactGraph");
+  if (suite.summary.firstPromptEmptyCount !== suite.summary.fixtureCount) failures.push("not every live hook suite first prompt was record-only empty stdout");
+  if (suite.summary.artifactIdentityMatchCount !== suite.summary.fixtureCount) failures.push("not every live hook suite artifact matched its replay target");
+  if (!suite.summary.allFreshGraphs) failures.push("not every live hook suite fixture had fresh pre-read/runtime graph diagnostics");
+  return failures;
+}
+
 export async function buildReactWebLiveHookDogfoodEvidence({
   repoRoot = defaultRepoRoot,
   runId = new Date().toISOString().replace(/[:.]/g, "-"),
@@ -224,6 +309,42 @@ export async function buildReactWebLiveHookDogfoodEvidence({
     secondNative: summarizeNativeResult(secondNative),
     evidenceArtifact: summarizeArtifact(artifactRef, DEFAULT_LIVE_HOOK_REACT_WEB_TARGET),
   };
+
+  const suiteRows = [];
+  for (const relativeFile of DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES) {
+    const suiteSessionId = `react-web-live-hook-suite-${runId}-${relativeFile.replace(/[^a-z0-9]+/gi, "-")}`;
+    const suiteFirstPrompt = `Please update ${relativeFile}`;
+    const suiteSecondPrompt = `Again, update ${relativeFile} and keep graph diagnostics compact if safe`;
+    recordCommand(`suite-codex-pre-read:${relativeFile}`, ["codex-pre-read", relativeFile, "--json"]);
+    const suitePreRead = runCliJson({ repoRoot, projectRoot, args: ["codex-pre-read", relativeFile, "--json"], env }, `suite codex-pre-read ${relativeFile}`);
+    recordCommand(`suite-native-hook-first:${relativeFile}`, ["codex-runtime-hook", "--native-hook"]);
+    const suiteFirstNative = runCliJson(
+      { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: suiteSessionId, prompt: suiteFirstPrompt }), env },
+      `suite native hook first ${relativeFile}`,
+    );
+    recordCommand(`suite-native-hook-second:${relativeFile}`, ["codex-runtime-hook", "--native-hook"]);
+    const suiteSecondNative = runCliJson(
+      { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: suiteSessionId, prompt: suiteSecondPrompt }), env },
+      `suite native hook second ${relativeFile}`,
+    );
+    suiteRows.push(
+      summarizeLiveHookSuiteRow({
+        projectRoot,
+        relativeFile,
+        preRead: suitePreRead,
+        firstNative: summarizeNativeResult(suiteFirstNative),
+        secondNative: summarizeNativeResult(suiteSecondNative),
+        artifactRef: latestReactWebArtifact(projectRoot),
+      }),
+    );
+  }
+  const suite = {
+    diagnosticOnly: true,
+    claimBoundary:
+      "Live/native hook fixture-matrix evidence only: local source bytes are compared with host-facing additionalContext bytes after built CLI replay. This is not provider tokenizer output, not provider billing/cost proof, and not a broad runtime-token claim.",
+    fixtures: suiteRows,
+    summary: summarizeLiveHookSuite(suiteRows),
+  };
   const boundary = {
     targetFile: DEFAULT_LIVE_HOOK_BOUNDARY_TARGET,
     prompts: { first: boundaryFirstPrompt, second: boundarySecondPrompt, editIntent: true },
@@ -234,12 +355,13 @@ export async function buildReactWebLiveHookDogfoodEvidence({
   };
   const successFailures = assertSuccessPath(success);
   const boundaryFailures = assertBoundaryPath(boundary);
+  const suiteFailures = assertLiveHookSuite(suite);
   const graphAssistedContextPath = {
     diagnosticOnly: true,
     claimable: false,
-    observed: successFailures.length === 0,
+    observed: successFailures.length === 0 && suite.summary.graphObservedCount > 0,
     measurement: "built-cli-native-hook-react-web-graph-assisted-replay",
-    blocker: successFailures.length === 0 ? null : successFailures.join("; "),
+    blocker: successFailures.length === 0 && suiteFailures.length === 0 ? null : [...successFailures, ...suiteFailures].join("; "),
   };
 
   return {
@@ -259,11 +381,13 @@ export async function buildReactWebLiveHookDogfoodEvidence({
     },
     commands,
     success,
+    suite,
     boundary,
     graphAssistedContextPath,
     validation: {
-      passed: successFailures.length === 0 && boundaryFailures.length === 0,
+      passed: successFailures.length === 0 && boundaryFailures.length === 0 && suiteFailures.length === 0,
       successFailures,
+      suiteFailures,
       boundaryFailures,
     },
     nonClaims: Object.fromEntries(NON_CLAIMS.map((claim) => [claim, false])),
@@ -291,6 +415,18 @@ ${evidence.claimBoundary}
 - Second native hook: additionalContext=${evidence.success.secondNative.hasAdditionalContext ? "yes" : "no"}, contains reactWebFactGraph=${evidence.success.secondNative.containsReactWebFactGraph ? "yes" : "no"}
 - Runtime graph artifact: reason=${evidence.success.evidenceArtifact.runtimeGraph?.reason ?? "none"}, freshness=${evidence.success.evidenceArtifact.runtimeGraph?.freshnessStatus ?? "none"}, selected=${evidence.success.evidenceArtifact.runtimeGraph?.selectedAnchorCount ?? 0}, diagnostic-only=${evidence.success.evidenceArtifact.runtimeGraph?.diagnosticOnly ? "yes" : "no"}
 - Artifact identity matches replay target: ${evidence.success.evidenceArtifact.filePathMatchesTarget ? "yes" : "no"}
+
+## Fixture matrix
+
+- Fixture count: ${evidence.suite.summary.fixtureCount}
+- Graph observed: ${evidence.suite.summary.graphObservedCount}/${evidence.suite.summary.fixtureCount}
+- First prompts record-only: ${evidence.suite.summary.firstPromptEmptyCount}/${evidence.suite.summary.fixtureCount}
+- Artifact identity matches: ${evidence.suite.summary.artifactIdentityMatchCount}/${evidence.suite.summary.fixtureCount}
+- AdditionalContext smaller than local source: ${evidence.suite.summary.compactRowsCount}/${evidence.suite.summary.fixtureCount}
+- Expanded additionalContext rows: ${evidence.suite.summary.expandedRowsCount}/${evidence.suite.summary.fixtureCount}
+- Local additionalContext reduction range: ${evidence.suite.summary.minAdditionalContextReductionPct}% to ${evidence.suite.summary.maxAdditionalContextReductionPct}%
+- Claimable as broad token/cost savings: no
+- Claim boundary: ${evidence.suite.claimBoundary}
 
 ## Boundary replay
 

--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -1,0 +1,329 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v1";
+export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
+export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
+
+const NON_CLAIMS = [
+  "provider-token-savings",
+  "provider-cost-savings",
+  "provider-billing-or-invoice-savings",
+  "cache-performance-improvement",
+  "latency-improvement",
+  "broad-runtime-token-savings",
+  "broad-react-web-support",
+  "react-native-webview-or-tui-support-expansion",
+  "stale-graph-reuse",
+];
+
+function copyFile(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+export function createLiveHookReplayProject({ repoRoot = defaultRepoRoot } = {}) {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-live-hook-dogfood-"));
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-live-hook-codex-home-"));
+
+  copyFile(path.join(repoRoot, "fixtures", "raw", "SimpleButton.tsx"), path.join(projectRoot, DEFAULT_LIVE_HOOK_BOUNDARY_TARGET));
+  copyFile(path.join(repoRoot, "fixtures", "raw", "Button.types.ts"), path.join(projectRoot, "src", "components", "Button.types.ts"));
+  copyFile(path.join(repoRoot, "fixtures", "compressed", "FormSection.tsx"), path.join(projectRoot, DEFAULT_LIVE_HOOK_REACT_WEB_TARGET));
+  copyFile(path.join(repoRoot, "fixtures", "compressed", "Button.types.ts"), path.join(projectRoot, "src", "components", "Button.types.ts"));
+  copyFile(path.join(repoRoot, "fixtures", "compressed", "FormSection.utils.ts"), path.join(projectRoot, "src", "components", "FormSection.utils.ts"));
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    `${JSON.stringify({ name: "fooks-live-hook-dogfood-project", repository: { url: "https://github.com/minislively/fooks-live-hook-dogfood-project.git" } }, null, 2)}\n`,
+  );
+
+  return { projectRoot, codexHome };
+}
+
+function cliPath(repoRoot) {
+  return path.join(repoRoot, "dist", "cli", "index.js");
+}
+
+function runCli({ repoRoot, projectRoot, args, input, env = {} }) {
+  const stdout = execFileSync(process.execPath, [cliPath(repoRoot), ...args], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    input,
+    env: { ...process.env, ...env },
+  });
+  return stdout;
+}
+
+function parseOptionalJson(stdout, label) {
+  if (!stdout.trim()) return null;
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} emitted non-JSON stdout: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function runCliJson(options, label) {
+  return parseOptionalJson(runCli(options), label);
+}
+
+function nativePayload({ projectRoot, sessionId, prompt }) {
+  return JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    cwd: projectRoot,
+    session_id: sessionId,
+    prompt,
+  });
+}
+
+function latestReactWebArtifact(projectRoot) {
+  const latestPath = path.join(projectRoot, ".fooks", "artifacts", "react-web-evidence", "latest.json");
+  if (!fs.existsSync(latestPath)) return null;
+  const latest = JSON.parse(fs.readFileSync(latestPath, "utf8"));
+  const artifactPath = latest.latest?.path;
+  if (!artifactPath || !fs.existsSync(artifactPath)) return null;
+  return {
+    latestPath,
+    artifactPath,
+    latest: latest.latest,
+    artifact: JSON.parse(fs.readFileSync(artifactPath, "utf8")),
+  };
+}
+
+function summarizePreReadGraph(preRead) {
+  const graph = preRead?.debug?.reactWebFactGraphConsumer ?? null;
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    decision: preRead?.decision ?? null,
+    filePath: preRead?.filePath ?? null,
+    classification: preRead?.debug?.domainDetection?.classification ?? null,
+    freshnessStatus: graph?.freshnessStatus ?? "unknown",
+    selectedAnchorCount: graph?.selectedAnchorCount ?? 0,
+    deferredAnchorCount: graph?.deferredAnchorCount ?? 0,
+    advisoryOnly: graph?.advisoryOnly === true,
+    authorization: graph?.authorization ?? "none",
+    emitted: (graph?.selectedAnchorCount ?? 0) > 0,
+  };
+}
+
+function summarizeNativeResult(result) {
+  const additionalContext = result?.hookSpecificOutput?.additionalContext;
+  return {
+    emitted: result !== null,
+    hookEventName: result?.hookSpecificOutput?.hookEventName ?? null,
+    hasAdditionalContext: typeof additionalContext === "string" && additionalContext.length > 0,
+    additionalContextBytes: typeof additionalContext === "string" ? Buffer.byteLength(additionalContext, "utf8") : 0,
+    containsReactWebFactGraph: typeof additionalContext === "string" && additionalContext.includes("reactWebFactGraph"),
+    firstLine: typeof additionalContext === "string" ? additionalContext.split("\n")[0] : null,
+  };
+}
+
+function summarizeArtifact(artifactRef, expectedFile) {
+  const artifact = artifactRef?.artifact ?? null;
+  const runtimeGraph = artifact?.runtimeGraph ?? null;
+  return {
+    diagnosticOnly: true,
+    claimable: false,
+    exists: Boolean(artifact),
+    artifactPath: artifactRef?.artifactPath ?? null,
+    filePath: artifact?.filePath ?? null,
+    expectedFilePath: expectedFile,
+    filePathMatchesTarget: artifact?.filePath === expectedFile,
+    decision: artifact?.decision ?? null,
+    evidenceStrength: artifact?.evidenceStrength ?? null,
+    runtimeGraph: runtimeGraph
+      ? {
+          diagnosticOnly: runtimeGraph.diagnosticOnly === true,
+          included: runtimeGraph.included === true,
+          reason: runtimeGraph.reason,
+          selectedAnchorCount: runtimeGraph.selectedAnchorCount ?? 0,
+          deferredAnchorCount: runtimeGraph.deferredAnchorCount ?? 0,
+          freshnessStatus: runtimeGraph.freshnessStatus ?? "unknown",
+        }
+      : null,
+  };
+}
+
+function assertSuccessPath(success) {
+  const failures = [];
+  if (success.preReadGraphDiagnostics.freshnessStatus !== "fresh") failures.push("pre-read graph was not fresh");
+  if (success.preReadGraphDiagnostics.selectedAnchorCount <= 0) failures.push("pre-read graph selected no anchors");
+  if (success.firstNative.emitted) failures.push("first native-hook prompt emitted output instead of record-only empty stdout");
+  if (!success.secondNative.hasAdditionalContext) failures.push("second native-hook prompt did not emit additionalContext");
+  if (!success.secondNative.containsReactWebFactGraph) failures.push("second native-hook additionalContext did not include reactWebFactGraph");
+  if (!success.evidenceArtifact.exists) failures.push("React Web evidence artifact was not emitted");
+  if (!success.evidenceArtifact.filePathMatchesTarget) failures.push("React Web evidence artifact did not match replay target");
+  if (success.evidenceArtifact.runtimeGraph?.diagnosticOnly !== true) failures.push("runtimeGraph was not diagnostic-only");
+  if (success.evidenceArtifact.runtimeGraph?.reason !== "fresh-anchors-packed") failures.push("runtimeGraph reason was not fresh-anchors-packed");
+  if (success.evidenceArtifact.runtimeGraph?.freshnessStatus !== "fresh") failures.push("runtimeGraph freshness was not fresh");
+  return failures;
+}
+
+function assertBoundaryPath(boundary) {
+  const failures = [];
+  if (boundary.secondNative.containsReactWebFactGraph) failures.push("boundary native-hook additionalContext leaked reactWebFactGraph");
+  return failures;
+}
+
+export async function buildReactWebLiveHookDogfoodEvidence({
+  repoRoot = defaultRepoRoot,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const { projectRoot, codexHome } = createLiveHookReplayProject({ repoRoot });
+  const env = { FOOKS_CODEX_HOME: codexHome };
+  const commands = [];
+  const recordCommand = (name, args) => commands.push({ name, command: [process.execPath, cliPath(repoRoot), ...args].join(" ") });
+
+  recordCommand("attach-codex", ["attach", "codex", "--json"]);
+  const attach = runCliJson({ repoRoot, projectRoot, args: ["attach", "codex", "--json"], env }, "attach codex");
+
+  recordCommand("codex-pre-read", ["codex-pre-read", DEFAULT_LIVE_HOOK_REACT_WEB_TARGET, "--json"]);
+  const preRead = runCliJson({ repoRoot, projectRoot, args: ["codex-pre-read", DEFAULT_LIVE_HOOK_REACT_WEB_TARGET, "--json"], env }, "codex-pre-read");
+
+  const successSessionId = `react-web-live-hook-${runId}`;
+  const successFirstPrompt = `Please update ${DEFAULT_LIVE_HOOK_REACT_WEB_TARGET}`;
+  const successSecondPrompt = `Again, update ${DEFAULT_LIVE_HOOK_REACT_WEB_TARGET} and keep graph diagnostics compact if safe`;
+  recordCommand("native-hook-success-first", ["codex-runtime-hook", "--native-hook"]);
+  const firstNative = runCliJson(
+    { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: successSessionId, prompt: successFirstPrompt }), env },
+    "native hook success first",
+  );
+  recordCommand("native-hook-success-second", ["codex-runtime-hook", "--native-hook"]);
+  const secondNative = runCliJson(
+    { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: successSessionId, prompt: successSecondPrompt }), env },
+    "native hook success second",
+  );
+  const artifactRef = latestReactWebArtifact(projectRoot);
+
+  const boundarySessionId = `react-web-live-hook-boundary-${runId}`;
+  const boundaryFirstPrompt = `Please update ${DEFAULT_LIVE_HOOK_BOUNDARY_TARGET}`;
+  const boundarySecondPrompt = `Again, update ${DEFAULT_LIVE_HOOK_BOUNDARY_TARGET}`;
+  recordCommand("native-hook-boundary-first", ["codex-runtime-hook", "--native-hook"]);
+  const boundaryFirst = runCliJson(
+    { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: boundarySessionId, prompt: boundaryFirstPrompt }), env },
+    "native hook boundary first",
+  );
+  recordCommand("native-hook-boundary-second", ["codex-runtime-hook", "--native-hook"]);
+  const boundarySecond = runCliJson(
+    { repoRoot, projectRoot, args: ["codex-runtime-hook", "--native-hook"], input: nativePayload({ projectRoot, sessionId: boundarySessionId, prompt: boundarySecondPrompt }), env },
+    "native hook boundary second",
+  );
+
+  const success = {
+    targetFile: DEFAULT_LIVE_HOOK_REACT_WEB_TARGET,
+    prompts: { first: successFirstPrompt, second: successSecondPrompt, editIntent: true },
+    preReadGraphDiagnostics: summarizePreReadGraph(preRead),
+    firstNative: summarizeNativeResult(firstNative),
+    secondNative: summarizeNativeResult(secondNative),
+    evidenceArtifact: summarizeArtifact(artifactRef, DEFAULT_LIVE_HOOK_REACT_WEB_TARGET),
+  };
+  const boundary = {
+    targetFile: DEFAULT_LIVE_HOOK_BOUNDARY_TARGET,
+    prompts: { first: boundaryFirstPrompt, second: boundarySecondPrompt, editIntent: true },
+    firstNative: summarizeNativeResult(boundaryFirst),
+    secondNative: summarizeNativeResult(boundarySecond),
+    diagnosticOnly: true,
+    claimable: false,
+  };
+  const successFailures = assertSuccessPath(success);
+  const boundaryFailures = assertBoundaryPath(boundary);
+  const graphAssistedContextPath = {
+    diagnosticOnly: true,
+    claimable: false,
+    observed: successFailures.length === 0,
+    measurement: "built-cli-native-hook-react-web-graph-assisted-replay",
+    blocker: successFailures.length === 0 ? null : successFailures.join("; "),
+  };
+
+  return {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "built-cli-native-hook-dogfood-replay",
+    claimBoundary:
+      "Local built-CLI/native-hook dogfood evidence only: proves bounded React Web graph-assisted context is observable through an isolated attached replay path. It is not provider tokenizer output, not runtime-token savings, not cache performance, not latency, not provider cost, billing, invoice, or charged-cost proof, and not broad React Web/RN/WebView/TUI support.",
+    isolatedReplay: {
+      projectRoot,
+      codexHome,
+      attached: attach?.runtimeProof?.status === "passed" && fs.existsSync(path.join(projectRoot, ".fooks", "adapters", "codex", "adapter.json")),
+      globalSettingsMutated: false,
+      attachRuntimeProofStatus: attach?.runtimeProof?.status ?? null,
+      trustLifecycleState: attach?.trustStatus?.lifecycleState ?? null,
+    },
+    commands,
+    success,
+    boundary,
+    graphAssistedContextPath,
+    validation: {
+      passed: successFailures.length === 0 && boundaryFailures.length === 0,
+      successFailures,
+      boundaryFailures,
+    },
+    nonClaims: Object.fromEntries(NON_CLAIMS.map((claim) => [claim, false])),
+  };
+}
+
+export function renderReactWebLiveHookDogfoodEvidenceMarkdown(evidence) {
+  return `# React Web live/native hook dogfood evidence
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Measurement: ${evidence.measurement}
+- Isolated attached replay: ${evidence.isolatedReplay.attached ? "yes" : "no"}
+- Graph-assisted path observed: ${evidence.graphAssistedContextPath.observed ? "yes" : "no"} (diagnostic-only)
+- Validation passed: ${evidence.validation.passed ? "yes" : "no"}
+
+## Success replay
+
+- Target: \`${evidence.success.targetFile}\`
+- Prompt shape: repeated same-file edit-intent prompts
+- Pre-read graph: freshness=${evidence.success.preReadGraphDiagnostics.freshnessStatus}, selected=${evidence.success.preReadGraphDiagnostics.selectedAnchorCount}, deferred=${evidence.success.preReadGraphDiagnostics.deferredAnchorCount}, diagnostic-only=yes
+- First native hook: emitted=${evidence.success.firstNative.emitted ? "yes" : "no"} (record-only empty stdout expected)
+- Second native hook: additionalContext=${evidence.success.secondNative.hasAdditionalContext ? "yes" : "no"}, contains reactWebFactGraph=${evidence.success.secondNative.containsReactWebFactGraph ? "yes" : "no"}
+- Runtime graph artifact: reason=${evidence.success.evidenceArtifact.runtimeGraph?.reason ?? "none"}, freshness=${evidence.success.evidenceArtifact.runtimeGraph?.freshnessStatus ?? "none"}, selected=${evidence.success.evidenceArtifact.runtimeGraph?.selectedAnchorCount ?? 0}, diagnostic-only=${evidence.success.evidenceArtifact.runtimeGraph?.diagnosticOnly ? "yes" : "no"}
+- Artifact identity matches replay target: ${evidence.success.evidenceArtifact.filePathMatchesTarget ? "yes" : "no"}
+
+## Boundary replay
+
+- Target: \`${evidence.boundary.targetFile}\`
+- Graph context leaked: ${evidence.boundary.secondNative.containsReactWebFactGraph ? "yes" : "no"}
+- Diagnostic-only: yes
+
+## Non-claims
+
+- Provider token/cost/billing/invoice savings: no
+- Cache performance or latency improvement: no
+- Broad runtime-token savings: no
+- Broad React Web/RN/WebView/TUI support: no
+- Stale graph reuse: no
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebLiveHookDogfoodEvidence({ repoRoot: defaultRepoRoot, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebLiveHookDogfoodEvidenceMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
+  DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES,
   buildReactWebLiveHookDogfoodEvidence,
   renderReactWebLiveHookDogfoodEvidenceMarkdown,
 } from "../scripts/react-web-live-hook-dogfood-evidence.mjs";
@@ -44,6 +45,34 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.success.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
   assert.ok(evidence.success.evidenceArtifact.runtimeGraph.selectedAnchorCount > 0);
 
+  assert.equal(evidence.suite.diagnosticOnly, true);
+  assert.match(evidence.suite.claimBoundary, /not provider tokenizer output/);
+  assert.equal(evidence.suite.summary.measurement, "built-cli-native-hook-fixture-matrix-additional-context-bytes");
+  assert.equal(evidence.suite.summary.diagnosticOnly, true);
+  assert.equal(evidence.suite.summary.fixtureCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(evidence.suite.summary.graphObservedCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(evidence.suite.summary.firstPromptEmptyCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(evidence.suite.summary.artifactIdentityMatchCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(evidence.suite.summary.claimable, false);
+  assert.equal(evidence.suite.summary.allFreshGraphs, true);
+  assert.ok(evidence.suite.summary.compactRowsCount > 0);
+  assert.ok(evidence.suite.summary.expandedRowsCount > 0);
+  assert.ok(evidence.suite.summary.minAdditionalContextReductionPct < 0);
+  assert.ok(evidence.suite.summary.maxAdditionalContextReductionPct > 0);
+  assert.deepEqual(evidence.suite.fixtures.map((row) => row.file), DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES);
+  for (const row of evidence.suite.fixtures) {
+    assert.equal(row.diagnosticOnly, true);
+    assert.equal(row.claimable, false);
+    assert.equal(row.firstNative.emitted, false);
+    assert.equal(row.secondNative.containsReactWebFactGraph, true);
+    assert.equal(row.preReadGraphDiagnostics.classification, "react-web");
+    assert.equal(row.preReadGraphDiagnostics.freshnessStatus, "fresh");
+    assert.equal(row.evidenceArtifact.filePathMatchesTarget, true);
+    assert.equal(row.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
+    assert.equal(row.evidenceArtifact.runtimeGraph.reason, "fresh-anchors-packed");
+    assert.equal(typeof row.additionalContextReductionPct, "number");
+  }
+
   assert.equal(evidence.boundary.diagnosticOnly, true);
   assert.equal(evidence.boundary.claimable, false);
   assert.equal(evidence.boundary.secondNative.containsReactWebFactGraph, false);
@@ -52,6 +81,7 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.graphAssistedContextPath.observed, true);
   assert.equal(evidence.validation.passed, true);
   assert.deepEqual(evidence.validation.successFailures, []);
+  assert.deepEqual(evidence.validation.suiteFailures, []);
   assert.deepEqual(evidence.validation.boundaryFailures, []);
 
   assert.equal(evidence.nonClaims["provider-token-savings"], false);
@@ -72,6 +102,12 @@ test("React Web live hook dogfood evidence Markdown keeps diagnostic-only bounda
   assert.match(markdown, /First native hook: emitted=no \(record-only empty stdout expected\)/);
   assert.match(markdown, /contains reactWebFactGraph=yes/);
   assert.match(markdown, /Artifact identity matches replay target: yes/);
+  assert.match(markdown, /Fixture matrix/);
+  assert.match(markdown, /Graph observed: \d+\/\d+/);
+  assert.match(markdown, /AdditionalContext smaller than local source: \d+\/\d+/);
+  assert.match(markdown, /Expanded additionalContext rows: \d+\/\d+/);
+  assert.match(markdown, /Local additionalContext reduction range:/);
+  assert.match(markdown, /Claimable as broad token\/cost savings: no/);
   assert.match(markdown, /Graph context leaked: no/);
   assert.match(markdown, /Provider token\/cost\/billing\/invoice savings: no/);
   assert.match(markdown, /Cache performance or latency improvement: no/);

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
+  buildReactWebLiveHookDogfoodEvidence,
+  renderReactWebLiveHookDogfoodEvidenceMarkdown,
+} from "../scripts/react-web-live-hook-dogfood-evidence.mjs";
+
+test("React Web live hook dogfood evidence replays built CLI native hook graph path", async () => {
+  const evidence = await buildReactWebLiveHookDogfoodEvidence({ runId: `test-${Date.now()}-${Math.random()}` });
+
+  assert.equal(evidence.schemaVersion, REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION);
+  assert.equal(evidence.measurement, "built-cli-native-hook-dogfood-replay");
+  assert.equal(evidence.isolatedReplay.attached, true);
+  assert.equal(evidence.isolatedReplay.globalSettingsMutated, false);
+  assert.equal(evidence.isolatedReplay.attachRuntimeProofStatus, "passed");
+  assert.ok(evidence.commands.some((command) => command.name === "codex-pre-read"));
+  assert.ok(evidence.commands.some((command) => command.name === "native-hook-success-second"));
+
+  assert.equal(evidence.success.prompts.editIntent, true);
+  assert.match(evidence.success.prompts.first, /update/);
+  assert.match(evidence.success.prompts.second, /Again, update/);
+  assert.equal(evidence.success.preReadGraphDiagnostics.diagnosticOnly, true);
+  assert.equal(evidence.success.preReadGraphDiagnostics.claimable, false);
+  assert.equal(evidence.success.preReadGraphDiagnostics.classification, "react-web");
+  assert.equal(evidence.success.preReadGraphDiagnostics.freshnessStatus, "fresh");
+  assert.ok(evidence.success.preReadGraphDiagnostics.selectedAnchorCount > 0);
+
+  assert.equal(evidence.success.firstNative.emitted, false);
+  assert.equal(evidence.success.firstNative.hasAdditionalContext, false);
+  assert.equal(evidence.success.secondNative.emitted, true);
+  assert.equal(evidence.success.secondNative.hookEventName, "UserPromptSubmit");
+  assert.equal(evidence.success.secondNative.hasAdditionalContext, true);
+  assert.equal(evidence.success.secondNative.containsReactWebFactGraph, true);
+  assert.match(evidence.success.secondNative.firstLine, /fooks: reused pre-read \(compressed\)/);
+
+  assert.equal(evidence.success.evidenceArtifact.exists, true);
+  assert.equal(evidence.success.evidenceArtifact.filePath, evidence.success.targetFile);
+  assert.equal(evidence.success.evidenceArtifact.filePathMatchesTarget, true);
+  assert.equal(evidence.success.evidenceArtifact.decision, "use");
+  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.diagnosticOnly, true);
+  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.included, true);
+  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.reason, "fresh-anchors-packed");
+  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
+  assert.ok(evidence.success.evidenceArtifact.runtimeGraph.selectedAnchorCount > 0);
+
+  assert.equal(evidence.boundary.diagnosticOnly, true);
+  assert.equal(evidence.boundary.claimable, false);
+  assert.equal(evidence.boundary.secondNative.containsReactWebFactGraph, false);
+  assert.equal(evidence.graphAssistedContextPath.diagnosticOnly, true);
+  assert.equal(evidence.graphAssistedContextPath.claimable, false);
+  assert.equal(evidence.graphAssistedContextPath.observed, true);
+  assert.equal(evidence.validation.passed, true);
+  assert.deepEqual(evidence.validation.successFailures, []);
+  assert.deepEqual(evidence.validation.boundaryFailures, []);
+
+  assert.equal(evidence.nonClaims["provider-token-savings"], false);
+  assert.equal(evidence.nonClaims["provider-cost-savings"], false);
+  assert.equal(evidence.nonClaims["cache-performance-improvement"], false);
+  assert.equal(evidence.nonClaims["broad-runtime-token-savings"], false);
+  assert.equal(evidence.nonClaims["react-native-webview-or-tui-support-expansion"], false);
+});
+
+test("React Web live hook dogfood evidence Markdown keeps diagnostic-only boundaries explicit", async () => {
+  const evidence = await buildReactWebLiveHookDogfoodEvidence({ runId: `markdown-${Date.now()}-${Math.random()}` });
+  const markdown = renderReactWebLiveHookDogfoodEvidenceMarkdown(evidence);
+
+  assert.match(markdown, /built-CLI\/native-hook dogfood evidence/i);
+  assert.match(markdown, /Isolated attached replay: yes/);
+  assert.match(markdown, /Graph-assisted path observed: yes \(diagnostic-only\)/);
+  assert.match(markdown, /Prompt shape: repeated same-file edit-intent prompts/);
+  assert.match(markdown, /First native hook: emitted=no \(record-only empty stdout expected\)/);
+  assert.match(markdown, /contains reactWebFactGraph=yes/);
+  assert.match(markdown, /Artifact identity matches replay target: yes/);
+  assert.match(markdown, /Graph context leaked: no/);
+  assert.match(markdown, /Provider token\/cost\/billing\/invoice savings: no/);
+  assert.match(markdown, /Cache performance or latency improvement: no/);
+  assert.match(markdown, /Broad runtime-token savings: no/);
+  assert.match(markdown, /Broad React Web\/RN\/WebView\/TUI support: no/);
+  assert.match(markdown, /Stale graph reuse: no/);
+  assert.doesNotMatch(markdown, /Provider token\/cost\/billing\/invoice savings: yes/i);
+});


### PR DESCRIPTION
Closes #1115

## Summary
- Adds `scripts/react-web-live-hook-dogfood-evidence.mjs` as a diagnostic dogfood replay for the built CLI/native-hook path.
- Adds `evidence:react-web-live-hook-dogfood` npm script for reproducible JSON/Markdown evidence generation.
- Adds focused tests that assert isolated attach, pre-read fresh graph selection, first native empty stdout, second native `reactWebFactGraph` context, artifact identity, and boundary no-leak behavior.

## Boundaries / non-claims
- Evidence-only; no runtime/pre-read authority change.
- No global hook/settings mutation; replay uses isolated temp project and temp `FOOKS_CODEX_HOME`.
- Does not claim provider token/cost/billing/invoice savings, cache performance, latency, broad runtime-token savings, or broad React Web/RN/WebView/TUI support.

## Verification
- `npm run build`
- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm run -s evidence:react-web-live-hook-dogfood -- --run-id=local --output=.omx/quality/react-web-live-hook-dogfood-evidence.json --markdown-output=.omx/quality/react-web-live-hook-dogfood-evidence.md`
- `npm test` (1043/1043)

## Planning / gate evidence
- `$autoresearch` validated: `.omx/specs/autoresearch-live-hook-dogfood-evidence/result.json`
- `$ralplan` consensus: `.omx/plans/ralplan-handoff-react-web-live-hook-dogfood-evidence.json`
- `$ultragoal` ledger: `.omx/ultragoal/goals.json`, `.omx/ultragoal/ledger.jsonl`
- Final quality gate: `.omx/quality/final-gate-react-web-live-hook-dogfood-evidence.json`
