### PR TITLE
Gate React Web graph injection by source budget

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -178,11 +178,11 @@ function assertSuccessPath(success) {
   if (success.preReadGraphDiagnostics.selectedAnchorCount <= 0) failures.push("pre-read graph selected no anchors");
   if (success.firstNative.emitted) failures.push("first native-hook prompt emitted output instead of record-only empty stdout");
   if (!success.secondNative.hasAdditionalContext) failures.push("second native-hook prompt did not emit additionalContext");
-  if (!success.secondNative.containsReactWebFactGraph) failures.push("second native-hook additionalContext did not include reactWebFactGraph");
+  if (!success.secondNative.hasAdditionalContext) failures.push("second native-hook additionalContext did not emit host-facing context");
   if (!success.evidenceArtifact.exists) failures.push("React Web evidence artifact was not emitted");
   if (!success.evidenceArtifact.filePathMatchesTarget) failures.push("React Web evidence artifact did not match replay target");
   if (success.evidenceArtifact.runtimeGraph?.diagnosticOnly !== true) failures.push("runtimeGraph was not diagnostic-only");
-  if (success.evidenceArtifact.runtimeGraph?.reason !== "fresh-anchors-packed") failures.push("runtimeGraph reason was not fresh-anchors-packed");
+  if (!["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(success.evidenceArtifact.runtimeGraph?.reason)) failures.push("runtimeGraph reason was not an allowed fresh graph admission outcome");
   if (success.evidenceArtifact.runtimeGraph?.freshnessStatus !== "fresh") failures.push("runtimeGraph freshness was not fresh");
   return failures;
 }
@@ -216,7 +216,9 @@ function summarizeLiveHookSuiteRow({ projectRoot, relativeFile, preRead, firstNa
 
 function summarizeLiveHookSuite(rows) {
   const reductionValues = rows.map((row) => row.additionalContextReductionPct);
-  const graphObservedCount = rows.filter((row) => row.secondNative.containsReactWebFactGraph).length;
+  const graphDiagnosticCount = rows.filter((row) => row.preReadGraphDiagnostics.emitted).length;
+  const graphIncludedCount = rows.filter((row) => row.secondNative.containsReactWebFactGraph).length;
+  const graphSkippedForBudgetCount = rows.filter((row) => row.evidenceArtifact.runtimeGraph?.reason === "source-relative-budget-exceeded").length;
   const firstPromptEmptyCount = rows.filter((row) => !row.firstNative.emitted).length;
   const artifactIdentityMatchCount = rows.filter((row) => row.evidenceArtifact.filePathMatchesTarget).length;
   const allAdditionalContextsSmaller = rows.every((row) => !row.additionalContextLargerThanSource && row.additionalContextBytes > 0);
@@ -231,7 +233,10 @@ function summarizeLiveHookSuite(rows) {
     claimable: false,
     measurement: "built-cli-native-hook-fixture-matrix-additional-context-bytes",
     fixtureCount: rows.length,
-    graphObservedCount,
+    graphDiagnosticCount,
+    graphIncludedCount,
+    graphSkippedForBudgetCount,
+    graphObservedCount: graphIncludedCount,
     firstPromptEmptyCount,
     artifactIdentityMatchCount,
     compactRowsCount,
@@ -241,16 +246,18 @@ function summarizeLiveHookSuite(rows) {
     minAdditionalContextReductionPct: Math.min(...reductionValues),
     maxAdditionalContextReductionPct: Math.max(...reductionValues),
     blocker:
-      graphObservedCount === rows.length && artifactIdentityMatchCount === rows.length
+      graphDiagnosticCount === rows.length && graphIncludedCount > 0 && graphSkippedForBudgetCount > 0 && artifactIdentityMatchCount === rows.length
         ? null
-        : "one or more live/native hook fixture rows did not emit graph-assisted additionalContext with matching evidence artifact identity",
+        : "live/native hook fixture rows did not preserve graph diagnostics with at least one included graph and one source-relative budget skip",
   };
 }
 
 function assertLiveHookSuite(suite) {
   const failures = [];
   if (suite.summary.fixtureCount === 0) failures.push("live hook suite had no fixtures");
-  if (suite.summary.graphObservedCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture observed reactWebFactGraph");
+  if (suite.summary.graphDiagnosticCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture preserved graph diagnostics");
+  if (suite.summary.graphIncludedCount <= 0) failures.push("no live hook suite fixture included reactWebFactGraph after admission");
+  if (suite.summary.graphSkippedForBudgetCount <= 0) failures.push("no live hook suite fixture skipped reactWebFactGraph for source-relative budget");
   if (suite.summary.firstPromptEmptyCount !== suite.summary.fixtureCount) failures.push("not every live hook suite first prompt was record-only empty stdout");
   if (suite.summary.artifactIdentityMatchCount !== suite.summary.fixtureCount) failures.push("not every live hook suite artifact matched its replay target");
   if (!suite.summary.allFreshGraphs) failures.push("not every live hook suite fixture had fresh pre-read/runtime graph diagnostics");
@@ -359,7 +366,7 @@ export async function buildReactWebLiveHookDogfoodEvidence({
   const graphAssistedContextPath = {
     diagnosticOnly: true,
     claimable: false,
-    observed: successFailures.length === 0 && suite.summary.graphObservedCount > 0,
+    observed: successFailures.length === 0 && suite.summary.graphDiagnosticCount > 0 && suite.summary.graphIncludedCount > 0,
     measurement: "built-cli-native-hook-react-web-graph-assisted-replay",
     blocker: successFailures.length === 0 && suiteFailures.length === 0 ? null : [...successFailures, ...suiteFailures].join("; "),
   };
@@ -419,7 +426,9 @@ ${evidence.claimBoundary}
 ## Fixture matrix
 
 - Fixture count: ${evidence.suite.summary.fixtureCount}
-- Graph observed: ${evidence.suite.summary.graphObservedCount}/${evidence.suite.summary.fixtureCount}
+- Graph diagnostics observed: ${evidence.suite.summary.graphDiagnosticCount}/${evidence.suite.summary.fixtureCount}
+- Graph included in additionalContext: ${evidence.suite.summary.graphIncludedCount}/${evidence.suite.summary.fixtureCount}
+- Graph skipped for source-relative budget: ${evidence.suite.summary.graphSkippedForBudgetCount}/${evidence.suite.summary.fixtureCount}
 - First prompts record-only: ${evidence.suite.summary.firstPromptEmptyCount}/${evidence.suite.summary.fixtureCount}
 - Artifact identity matches: ${evidence.suite.summary.artifactIdentityMatchCount}/${evidence.suite.summary.fixtureCount}
 - AdditionalContext smaller than local source: ${evidence.suite.summary.compactRowsCount}/${evidence.suite.summary.fixtureCount}

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -470,7 +470,7 @@ export function runtimeReactWebFactGraphPackingSummary(
 
 export function summarizeRuntimeReactWebFactGraphDryRun(
   dryRun: ReactWebFactGraphConsumerDryRun,
-  options: { budgetExceeded?: boolean } = {},
+  options: { budgetExceeded?: boolean; sourceRelativeBudgetExceeded?: boolean } = {},
 ): RuntimeReactWebFactGraphPackingSummary {
   if (!dryRun.inScope) {
     return runtimeReactWebFactGraphPackingSummary("out-of-scope", undefined, dryRun);
@@ -483,6 +483,9 @@ export function summarizeRuntimeReactWebFactGraphDryRun(
   }
   if (options.budgetExceeded) {
     return runtimeReactWebFactGraphPackingSummary("budget-exceeded", undefined, dryRun);
+  }
+  if (options.sourceRelativeBudgetExceeded) {
+    return runtimeReactWebFactGraphPackingSummary("source-relative-budget-exceeded", undefined, dryRun);
   }
   return runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", undefined, dryRun);
 }
@@ -564,10 +567,14 @@ function buildAdditionalContext(
       reactWebFactGraph = compacted.graph;
       reactWebFactGraphPacking = compacted.packing;
     }
-    if (reactWebFactGraph && runtimeReactWebContextBudget !== undefined) {
+    if (reactWebFactGraph) {
       const contextWithGraph = renderOptimizedReactWebAdditionalContext(filePath, payload, contextMode, reactWebContext, reactWebFactGraph);
-      if (estimateTextBytes(contextWithGraph) > runtimeReactWebContextBudget) {
+      const contextWithGraphBytes = estimateTextBytes(contextWithGraph);
+      if (runtimeReactWebContextBudget !== undefined && contextWithGraphBytes > runtimeReactWebContextBudget) {
         reactWebFactGraphPacking = runtimeReactWebFactGraphPackingSummary("budget-exceeded", reactWebFactGraph);
+        reactWebFactGraph = undefined;
+      } else if (shouldSkipReactWebFactGraphForSourceRelativeBudget(maxOptimizedContextBytes, contextWithGraphBytes)) {
+        reactWebFactGraphPacking = runtimeReactWebFactGraphPackingSummary("source-relative-budget-exceeded", reactWebFactGraph);
         reactWebFactGraph = undefined;
       }
     }
@@ -679,6 +686,12 @@ function hasMatchingEditGuidance(payload: ModelFacingPayload): boolean {
 function editGuidanceBudgetLimit(originalEstimatedBytes: number | undefined): number {
   if (originalEstimatedBytes === undefined) return EDIT_GUIDANCE_CONTEXT_MAX_BYTES;
   return Math.min(EDIT_GUIDANCE_CONTEXT_MAX_BYTES, Math.max(originalEstimatedBytes * 2, 4_096));
+}
+
+function shouldSkipReactWebFactGraphForSourceRelativeBudget(originalEstimatedBytes: number | undefined, contextWithGraphBytes: number): boolean {
+  if (originalEstimatedBytes === undefined) return false;
+  if (originalEstimatedBytes >= 4_096) return false;
+  return contextWithGraphBytes > originalEstimatedBytes;
 }
 
 function recordRuntimeDecisionMetric(

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -778,7 +778,8 @@ export type CodexRuntimeHookDecision = {
         | "out-of-scope"
         | "freshness-not-fresh"
         | "no-anchors-selected"
-        | "budget-exceeded";
+        | "budget-exceeded"
+        | "source-relative-budget-exceeded";
       selectedAnchorCount: number;
       deferredAnchorCount: number;
       freshnessStatus: "fresh" | "stale" | "unknown";

--- a/src/reporting/react-web-evidence-artifact.ts
+++ b/src/reporting/react-web-evidence-artifact.ts
@@ -39,6 +39,7 @@ const REACT_WEB_RUNTIME_GRAPH_REASONS = new Set([
   "freshness-not-fresh",
   "no-anchors-selected",
   "budget-exceeded",
+  "source-relative-budget-exceeded",
 ]);
 const REACT_WEB_RUNTIME_GRAPH_FRESHNESS_STATUSES = new Set(["fresh", "stale", "unknown"]);
 

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -65,8 +65,8 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   });
   assert.equal(artifact.domainPayload?.domain, "react-web");
   assert.equal(artifact.runtimeGraph?.diagnosticOnly, true);
-  assert.equal(artifact.runtimeGraph?.included, true);
-  assert.equal(artifact.runtimeGraph?.reason, "fresh-anchors-packed");
+  assert.equal(typeof artifact.runtimeGraph?.included, "boolean");
+  assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(artifact.runtimeGraph?.reason));
   assert.equal(artifact.runtimeGraph?.freshnessStatus, "fresh");
   assert.ok(artifact.runtimeGraph?.selectedAnchorCount > 0);
   assert.ok(artifact.sourceFingerprint);
@@ -84,7 +84,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.match(markdown, /frontend-source-evidence/);
   assert.match(markdown, /summarized=no/);
   assert.match(markdown, /Runtime graph diagnostics/);
-  assert.match(markdown, /reason: fresh-anchors-packed/);
+  assert.match(markdown, /reason: (fresh-anchors-packed|source-relative-budget-exceeded)/);
 
   const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id, "--json"], {
     cwd: tempDir,

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -32,7 +32,7 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.success.secondNative.emitted, true);
   assert.equal(evidence.success.secondNative.hookEventName, "UserPromptSubmit");
   assert.equal(evidence.success.secondNative.hasAdditionalContext, true);
-  assert.equal(evidence.success.secondNative.containsReactWebFactGraph, true);
+  assert.equal(typeof evidence.success.secondNative.containsReactWebFactGraph, "boolean");
   assert.match(evidence.success.secondNative.firstLine, /fooks: reused pre-read \(compressed\)/);
 
   assert.equal(evidence.success.evidenceArtifact.exists, true);
@@ -40,8 +40,8 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.success.evidenceArtifact.filePathMatchesTarget, true);
   assert.equal(evidence.success.evidenceArtifact.decision, "use");
   assert.equal(evidence.success.evidenceArtifact.runtimeGraph.diagnosticOnly, true);
-  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.included, true);
-  assert.equal(evidence.success.evidenceArtifact.runtimeGraph.reason, "fresh-anchors-packed");
+  assert.equal(typeof evidence.success.evidenceArtifact.runtimeGraph.included, "boolean");
+  assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(evidence.success.evidenceArtifact.runtimeGraph.reason));
   assert.equal(evidence.success.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
   assert.ok(evidence.success.evidenceArtifact.runtimeGraph.selectedAnchorCount > 0);
 
@@ -50,7 +50,9 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.suite.summary.measurement, "built-cli-native-hook-fixture-matrix-additional-context-bytes");
   assert.equal(evidence.suite.summary.diagnosticOnly, true);
   assert.equal(evidence.suite.summary.fixtureCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
-  assert.equal(evidence.suite.summary.graphObservedCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(evidence.suite.summary.graphDiagnosticCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.ok(evidence.suite.summary.graphIncludedCount > 0);
+  assert.ok(evidence.suite.summary.graphSkippedForBudgetCount > 0);
   assert.equal(evidence.suite.summary.firstPromptEmptyCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
   assert.equal(evidence.suite.summary.artifactIdentityMatchCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
   assert.equal(evidence.suite.summary.claimable, false);
@@ -64,12 +66,12 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
     assert.equal(row.diagnosticOnly, true);
     assert.equal(row.claimable, false);
     assert.equal(row.firstNative.emitted, false);
-    assert.equal(row.secondNative.containsReactWebFactGraph, true);
+    assert.equal(typeof row.secondNative.containsReactWebFactGraph, "boolean");
     assert.equal(row.preReadGraphDiagnostics.classification, "react-web");
     assert.equal(row.preReadGraphDiagnostics.freshnessStatus, "fresh");
     assert.equal(row.evidenceArtifact.filePathMatchesTarget, true);
     assert.equal(row.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
-    assert.equal(row.evidenceArtifact.runtimeGraph.reason, "fresh-anchors-packed");
+    assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(row.evidenceArtifact.runtimeGraph.reason));
     assert.equal(typeof row.additionalContextReductionPct, "number");
   }
 
@@ -100,10 +102,12 @@ test("React Web live hook dogfood evidence Markdown keeps diagnostic-only bounda
   assert.match(markdown, /Graph-assisted path observed: yes \(diagnostic-only\)/);
   assert.match(markdown, /Prompt shape: repeated same-file edit-intent prompts/);
   assert.match(markdown, /First native hook: emitted=no \(record-only empty stdout expected\)/);
-  assert.match(markdown, /contains reactWebFactGraph=yes/);
+  assert.match(markdown, /contains reactWebFactGraph=(yes|no)/);
   assert.match(markdown, /Artifact identity matches replay target: yes/);
   assert.match(markdown, /Fixture matrix/);
-  assert.match(markdown, /Graph observed: \d+\/\d+/);
+  assert.match(markdown, /Graph diagnostics observed: \d+\/\d+/);
+  assert.match(markdown, /Graph included in additionalContext: \d+\/\d+/);
+  assert.match(markdown, /Graph skipped for source-relative budget: \d+\/\d+/);
   assert.match(markdown, /AdditionalContext smaller than local source: \d+\/\d+/);
   assert.match(markdown, /Expanded additionalContext rows: \d+\/\d+/);
   assert.match(markdown, /Local additionalContext reduction range:/);

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -82,6 +82,10 @@ test("runtime graph packing reasons cover every canonical omission and success s
   assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ selectedAnchors: [] })).reason, "no-anchors-selected");
   assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture({ inScope: false, selectedAnchors: [] })).reason, "out-of-scope");
   assert.equal(summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture(), { budgetExceeded: true }).reason, "budget-exceeded");
+  assert.equal(
+    summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture(), { sourceRelativeBudgetExceeded: true }).reason,
+    "source-relative-budget-exceeded",
+  );
 });
 
 test("runtime bridge contract keeps repeated-read inject and fallback semantics stable", () => {
@@ -122,24 +126,11 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(optimizedEditPayload.editGuidance.freshness.fileHash, optimizedEditPayload.sourceFingerprint.fileHash);
   assert.ok(Array.isArray(optimizedEditPayload.reactWebContext.editTargetRouting));
   assert.ok(optimizedEditPayload.reactWebContext.editTargetRouting.length > 0);
-  assert.equal(optimizedEditPayload.reactWebFactGraph.schemaVersion, "react-web-fact-graph-runtime-context.v1");
-  assert.equal(optimizedEditPayload.reactWebFactGraph.freshnessStatus, "fresh");
-  assert.equal(optimizedEditPayload.reactWebFactGraph.freshnessVerified, true);
-  assert.equal(optimizedEditPayload.reactWebFactGraph.boundary, "advisory-current-source-only");
-  assert.ok(Array.isArray(optimizedEditPayload.reactWebFactGraph.selectedAnchors));
-  assert.ok(optimizedEditPayload.reactWebFactGraph.selectedAnchors.length > 0);
-  assert.equal(optimizedEditPayload.reactWebFactGraph.selectedAnchors[0].label.includes("FormSection"), true);
-  assert.equal(secondInject.debug.reactWebFactGraphPacking.included, true);
-  assert.equal(secondInject.debug.reactWebFactGraphPacking.reason, "fresh-anchors-packed");
+  assert.equal(secondInject.debug.reactWebFactGraphPacking.included, false);
+  assert.equal(secondInject.debug.reactWebFactGraphPacking.reason, "source-relative-budget-exceeded");
   assert.equal(secondInject.debug.reactWebFactGraphPacking.freshnessStatus, "fresh");
-  assert.equal(
-    secondInject.debug.reactWebFactGraphPacking.selectedAnchorCount,
-    optimizedEditPayload.reactWebFactGraph.selectedAnchors.length,
-  );
-  assert.doesNotMatch(
-    JSON.stringify(optimizedEditPayload.reactWebFactGraph),
-    /provider|billing|latency|cost|cache-performance|auto-apply|runtimeAuthorized|preReadAuthorized/i,
-  );
+  assert.ok(secondInject.debug.reactWebFactGraphPacking.selectedAnchorCount > 0);
+  assert.equal("reactWebFactGraph" in optimizedEditPayload, false);
   assert.equal(secondInject.debug.reactWebContextPacking.included, true);
   assert.equal(secondInject.debug.reactWebContextPacking.reason, "packed");
   assert.equal(secondInject.debug.reactWebContextPacking.priority[0], "editTargetRouting");


### PR DESCRIPTION
Closes #1117

## Summary
- Adds source-relative admission for React Web runtime/native-hook fact graph injection.
- Preserves graph diagnostics/freshness while omitting model-facing `reactWebFactGraph` when small-file graph envelope expansion fails the source-relative guard.
- Adds `source-relative-budget-exceeded` as an explicit runtime graph packing reason and artifact/schema-accepted diagnostic reason.
- Updates live hook dogfood evidence to report graph diagnostics separately from graph inclusion/skips.

## Evidence
- Adaptive evidence summary: `graphDiagnosticCount=6`, `graphIncludedCount=2`, `graphSkippedForBudgetCount=4`.
- Small files now skip model-facing graph anchors while retaining diagnostics.
- Larger eligible fixtures can still include graph when admitted.

## Boundaries / non-claims
- No provider token/cost/billing/invoice savings claim.
- No cache performance or latency claim.
- No broad runtime-token savings claim.
- No React Native/WebView/TUI support expansion.

## Verification
- `npm run build`
- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/runtime-bridge-contract.test.mjs test/react-web-evidence-artifact.test.mjs`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm run -s evidence:react-web-live-hook-dogfood -- --run-id=adaptive-local --output=.omx/quality/react-web-adaptive-graph-admission-evidence.json --markdown-output=.omx/quality/react-web-adaptive-graph-admission-evidence.md`
- `npm test` (1043/1043)

## Planning
- Autoresearch: `.omx/specs/autoresearch-react-web-adaptive-graph-budget/report.md`
- Ralplan handoff: `.omx/plans/ralplan-handoff-react-web-adaptive-graph-admission.json`
- Ultragoal ledger: `.omx/ultragoal/goals.json`, `.omx/ultragoal/ledger.jsonl`
