### PR TITLE
Gate inefficient React Web edit additionalContext candidates

### DIFF
--- a/.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.json
+++ b/.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.json
@@ -1,0 +1,664 @@
+{
+  "schemaVersion": "react-web-live-hook-dogfood-evidence.v3",
+  "generatedAt": "2026-05-29T08:41:56.887Z",
+  "runId": "admission-final",
+  "measurement": "built-cli-native-hook-dogfood-replay",
+  "claimBoundary": "Local built-CLI/native-hook dogfood evidence only: proves bounded React Web graph-assisted context is observable through an isolated attached replay path. It is not provider tokenizer output, not runtime-token savings, not cache performance, not latency, not provider cost, billing, invoice, or charged-cost proof, and not broad React Web/RN/WebView/TUI support.",
+  "isolatedReplay": {
+    "projectRoot": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7",
+    "codexHome": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-codex-home-M8dK0m",
+    "attached": true,
+    "globalSettingsMutated": false,
+    "attachRuntimeProofStatus": "passed",
+    "trustLifecycleState": "ready"
+  },
+  "commands": [
+    {
+      "name": "attach-codex",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js attach codex --json"
+    },
+    {
+      "name": "codex-pre-read",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read src/components/FormSection.tsx --json"
+    },
+    {
+      "name": "native-hook-success-first",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "native-hook-success-second",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "native-hook-boundary-first",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "native-hook-boundary-second",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:fixtures/compressed/FormSection.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read fixtures/compressed/FormSection.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:fixtures/compressed/FormSection.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:fixtures/compressed/FormSection.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:fixtures/compressed/HookEffectPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read fixtures/compressed/HookEffectPanel.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:fixtures/compressed/HookEffectPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:fixtures/compressed/HookEffectPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:fixtures/hybrid/DashboardPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read fixtures/hybrid/DashboardPanel.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:fixtures/hybrid/DashboardPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:fixtures/hybrid/DashboardPanel.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-codex-pre-read:test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-pre-read test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx --json"
+    },
+    {
+      "name": "suite-native-hook-first:test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    },
+    {
+      "name": "suite-native-hook-second:test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+      "command": "/Users/veluga/.nvm/versions/node/v24.14.0/bin/node /Users/veluga/Documents/Workspace_Minseol/fooks/dist/cli/index.js codex-runtime-hook --native-hook"
+    }
+  ],
+  "success": {
+    "targetFile": "src/components/FormSection.tsx",
+    "prompts": {
+      "first": "Please update src/components/FormSection.tsx",
+      "second": "Again, update src/components/FormSection.tsx and keep graph diagnostics compact if safe",
+      "editIntent": true
+    },
+    "preReadGraphDiagnostics": {
+      "diagnosticOnly": true,
+      "claimable": false,
+      "decision": "payload",
+      "filePath": "src/components/FormSection.tsx",
+      "classification": "react-web",
+      "freshnessStatus": "fresh",
+      "selectedAnchorCount": 8,
+      "deferredAnchorCount": 27,
+      "advisoryOnly": true,
+      "authorization": "none",
+      "emitted": true
+    },
+    "firstNative": {
+      "emitted": false,
+      "hookEventName": null,
+      "hasAdditionalContext": false,
+      "additionalContextBytes": 0,
+      "containsReactWebFactGraph": false,
+      "firstLine": null
+    },
+    "secondNative": {
+      "emitted": true,
+      "hookEventName": "UserPromptSubmit",
+      "hasAdditionalContext": true,
+      "additionalContextBytes": 144,
+      "containsReactWebFactGraph": false,
+      "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: src/components/FormSection.tsx · Read the full source file for this turn."
+    },
+    "evidenceArtifact": {
+      "diagnosticOnly": true,
+      "claimable": false,
+      "exists": true,
+      "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-b7ab6a4bf6ea49bd.json",
+      "filePath": "src/components/FormSection.tsx",
+      "expectedFilePath": "src/components/FormSection.tsx",
+      "filePathMatchesTarget": true,
+      "decision": "fallback",
+      "evidenceStrength": "adjacent",
+      "runtimeGraph": {
+        "diagnosticOnly": true,
+        "included": false,
+        "reason": "source-relative-budget-exceeded",
+        "selectedAnchorCount": 3,
+        "deferredAnchorCount": 32,
+        "freshnessStatus": "fresh"
+      },
+      "additionalContextAdmission": {
+        "diagnosticOnly": true,
+        "admitted": false,
+        "reason": "candidate-not-smaller-than-source",
+        "sourceBytes": 1541,
+        "candidateBytes": 3048,
+        "reductionPct": -97.794,
+        "minSourceBytes": 1024,
+        "minReductionPct": 25
+      }
+    }
+  },
+  "suite": {
+    "diagnosticOnly": true,
+    "claimBoundary": "Live/native hook fixture-matrix evidence only: local source bytes are compared with host-facing additionalContext bytes after built CLI replay. This is not provider tokenizer output, not provider billing/cost proof, and not a broad runtime-token claim.",
+    "fixtures": [
+      {
+        "file": "fixtures/compressed/FormSection.tsx",
+        "sourceBytes": 1541,
+        "additionalContextBytes": 149,
+        "additionalContextReductionPct": 90.331,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "fixtures/compressed/FormSection.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 27,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 149,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: fixtures/compressed/FormSection.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-1672cacd32bcf527.json",
+          "filePath": "fixtures/compressed/FormSection.tsx",
+          "expectedFilePath": "fixtures/compressed/FormSection.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": false,
+            "reason": "source-relative-budget-exceeded",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 32,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "candidate-not-smaller-than-source",
+            "sourceBytes": 1541,
+            "candidateBytes": 3063,
+            "reductionPct": -98.767,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      },
+      {
+        "file": "fixtures/compressed/HookEffectPanel.tsx",
+        "sourceBytes": 1321,
+        "additionalContextBytes": 153,
+        "additionalContextReductionPct": 88.418,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "fixtures/compressed/HookEffectPanel.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 43,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 153,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: fixtures/compressed/HookEffectPanel.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-0c06c3587feb45eb.json",
+          "filePath": "fixtures/compressed/HookEffectPanel.tsx",
+          "expectedFilePath": "fixtures/compressed/HookEffectPanel.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": false,
+            "reason": "source-relative-budget-exceeded",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 48,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "candidate-not-smaller-than-source",
+            "sourceBytes": 1321,
+            "candidateBytes": 3099,
+            "reductionPct": -134.595,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      },
+      {
+        "file": "fixtures/hybrid/DashboardPanel.tsx",
+        "sourceBytes": 4392,
+        "additionalContextBytes": 148,
+        "additionalContextReductionPct": 96.63,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "fixtures/hybrid/DashboardPanel.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 73,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 148,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: fixtures/hybrid/DashboardPanel.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-3ad9104baf3345d9.json",
+          "filePath": "fixtures/hybrid/DashboardPanel.tsx",
+          "expectedFilePath": "fixtures/hybrid/DashboardPanel.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": true,
+            "reason": "fresh-anchors-packed",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 78,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "reduction-below-threshold",
+            "sourceBytes": 4392,
+            "candidateBytes": 4203,
+            "reductionPct": 4.303,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      },
+      {
+        "file": "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+        "sourceBytes": 4247,
+        "additionalContextBytes": 189,
+        "additionalContextReductionPct": 95.55,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 105,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 189,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-f36f734e590c7f02.json",
+          "filePath": "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+          "expectedFilePath": "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": true,
+            "reason": "fresh-anchors-packed",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 110,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "candidate-not-smaller-than-source",
+            "sourceBytes": 4247,
+            "candidateBytes": 4370,
+            "reductionPct": -2.896,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      },
+      {
+        "file": "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+        "sourceBytes": 2491,
+        "additionalContextBytes": 184,
+        "additionalContextReductionPct": 92.613,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 57,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 184,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-38170a89d3cf227a.json",
+          "filePath": "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+          "expectedFilePath": "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": false,
+            "reason": "source-relative-budget-exceeded",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 62,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "candidate-not-smaller-than-source",
+            "sourceBytes": 2491,
+            "candidateBytes": 2780,
+            "reductionPct": -11.602,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      },
+      {
+        "file": "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+        "sourceBytes": 2811,
+        "additionalContextBytes": 190,
+        "additionalContextReductionPct": 93.241,
+        "additionalContextLargerThanSource": false,
+        "preReadGraphDiagnostics": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "decision": "payload",
+          "filePath": "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+          "classification": "react-web",
+          "freshnessStatus": "fresh",
+          "selectedAnchorCount": 8,
+          "deferredAnchorCount": 63,
+          "advisoryOnly": true,
+          "authorization": "none",
+          "emitted": true
+        },
+        "firstNative": {
+          "emitted": false,
+          "hookEventName": null,
+          "hasAdditionalContext": false,
+          "additionalContextBytes": 0,
+          "containsReactWebFactGraph": false,
+          "firstLine": null
+        },
+        "secondNative": {
+          "emitted": true,
+          "hookEventName": "UserPromptSubmit",
+          "hasAdditionalContext": true,
+          "additionalContextBytes": 190,
+          "containsReactWebFactGraph": false,
+          "firstLine": "fooks: fallback (additional-context-compression-inefficient) · file: test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx · Read the full source file for this turn."
+        },
+        "evidenceArtifact": {
+          "diagnosticOnly": true,
+          "claimable": false,
+          "exists": true,
+          "artifactPath": "/var/folders/mz/z4mzg9s550q6jc8t3b9qyjvw0000gn/T/fooks-live-hook-dogfood-IBkce7/.fooks/artifacts/react-web-evidence/react-web-evidence-7a176746b1014e89.json",
+          "filePath": "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+          "expectedFilePath": "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+          "filePathMatchesTarget": true,
+          "decision": "fallback",
+          "evidenceStrength": "adjacent",
+          "runtimeGraph": {
+            "diagnosticOnly": true,
+            "included": false,
+            "reason": "source-relative-budget-exceeded",
+            "selectedAnchorCount": 3,
+            "deferredAnchorCount": 68,
+            "freshnessStatus": "fresh"
+          },
+          "additionalContextAdmission": {
+            "diagnosticOnly": true,
+            "admitted": false,
+            "reason": "candidate-not-smaller-than-source",
+            "sourceBytes": 2811,
+            "candidateBytes": 3323,
+            "reductionPct": -18.214,
+            "minSourceBytes": 1024,
+            "minReductionPct": 25
+          }
+        },
+        "diagnosticOnly": true,
+        "claimable": false
+      }
+    ],
+    "summary": {
+      "diagnosticOnly": true,
+      "claimable": false,
+      "measurement": "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+      "fixtureCount": 6,
+      "graphDiagnosticCount": 6,
+      "graphIncludedCount": 0,
+      "runtimeGraphIncludedArtifactCount": 2,
+      "graphSkippedForBudgetCount": 4,
+      "graphObservedCount": 0,
+      "firstPromptEmptyCount": 6,
+      "artifactIdentityMatchCount": 6,
+      "compactRowsCount": 6,
+      "expandedRowsCount": 0,
+      "admissionObservedCount": 6,
+      "admittedAdditionalContextCount": 0,
+      "discardedAdditionalContextCount": 6,
+      "discardedReasonCounts": {
+        "candidate-not-smaller-than-source": 5,
+        "reduction-below-threshold": 1
+      },
+      "allAdditionalContextsSmaller": true,
+      "allFreshGraphs": true,
+      "minAdditionalContextReductionPct": 88.418,
+      "maxAdditionalContextReductionPct": 96.63,
+      "blocker": null
+    }
+  },
+  "boundary": {
+    "targetFile": "src/components/SimpleButton.tsx",
+    "prompts": {
+      "first": "Please update src/components/SimpleButton.tsx",
+      "second": "Again, update src/components/SimpleButton.tsx",
+      "editIntent": true
+    },
+    "firstNative": {
+      "emitted": false,
+      "hookEventName": null,
+      "hasAdditionalContext": false,
+      "additionalContextBytes": 0,
+      "containsReactWebFactGraph": false,
+      "firstLine": null
+    },
+    "secondNative": {
+      "emitted": true,
+      "hookEventName": "UserPromptSubmit",
+      "hasAdditionalContext": true,
+      "additionalContextBytes": 1674,
+      "containsReactWebFactGraph": false,
+      "firstLine": "fooks: reused pre-read (raw) · file: src/components/SimpleButton.tsx · context-mode: light-minimal"
+    },
+    "diagnosticOnly": true,
+    "claimable": false
+  },
+  "graphAssistedContextPath": {
+    "diagnosticOnly": true,
+    "claimable": false,
+    "observed": true,
+    "measurement": "built-cli-native-hook-react-web-graph-assisted-replay",
+    "blocker": null
+  },
+  "validation": {
+    "passed": true,
+    "successFailures": [],
+    "suiteFailures": [],
+    "boundaryFailures": []
+  },
+  "nonClaims": {
+    "provider-token-savings": false,
+    "provider-cost-savings": false,
+    "provider-billing-or-invoice-savings": false,
+    "cache-performance-improvement": false,
+    "latency-improvement": false,
+    "broad-runtime-token-savings": false,
+    "broad-react-web-support": false,
+    "react-native-webview-or-tui-support-expansion": false,
+    "stale-graph-reuse": false
+  }
+}

--- a/.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.md
+++ b/.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.md
@@ -1,0 +1,53 @@
+# React Web live/native hook dogfood evidence
+
+Local built-CLI/native-hook dogfood evidence only: proves bounded React Web graph-assisted context is observable through an isolated attached replay path. It is not provider tokenizer output, not runtime-token savings, not cache performance, not latency, not provider cost, billing, invoice, or charged-cost proof, and not broad React Web/RN/WebView/TUI support.
+
+## Summary
+
+- Measurement: built-cli-native-hook-dogfood-replay
+- Isolated attached replay: yes
+- Graph-assisted path observed: yes (diagnostic-only)
+- Validation passed: yes
+
+## Success replay
+
+- Target: `src/components/FormSection.tsx`
+- Prompt shape: repeated same-file edit-intent prompts
+- Pre-read graph: freshness=fresh, selected=8, deferred=27, diagnostic-only=yes
+- First native hook: emitted=no (record-only empty stdout expected)
+- Second native hook: additionalContext=yes, contains reactWebFactGraph=no
+- Runtime graph artifact: reason=source-relative-budget-exceeded, freshness=fresh, selected=3, diagnostic-only=yes
+- Artifact identity matches replay target: yes
+
+## Fixture matrix
+
+- Fixture count: 6
+- Graph diagnostics observed: 6/6
+- Graph included in final additionalContext: 0/6
+- Runtime graph included in artifact diagnostics: 2/6
+- Graph skipped for source-relative budget: 4/6
+- First prompts record-only: 6/6
+- Artifact identity matches: 6/6
+- AdditionalContext smaller than local source: 6/6
+- Expanded additionalContext rows: 0/6
+- AdditionalContext admission diagnostics: 6/6
+- AdditionalContext admitted rows: 0/6
+- AdditionalContext discarded rows: 6/6
+- AdditionalContext discard reasons: {"candidate-not-smaller-than-source":5,"reduction-below-threshold":1}
+- Local additionalContext reduction range: 88.418% to 96.63%
+- Claimable as broad token/cost savings: no
+- Claim boundary: Live/native hook fixture-matrix evidence only: local source bytes are compared with host-facing additionalContext bytes after built CLI replay. This is not provider tokenizer output, not provider billing/cost proof, and not a broad runtime-token claim.
+
+## Boundary replay
+
+- Target: `src/components/SimpleButton.tsx`
+- Graph context leaked: no
+- Diagnostic-only: yes
+
+## Non-claims
+
+- Provider token/cost/billing/invoice savings: no
+- Cache performance or latency improvement: no
+- Broad runtime-token savings: no
+- Broad React Web/RN/WebView/TUI support: no
+- Stale graph reuse: no

--- a/.omx/specs/autoresearch-full-additional-context-admission/mission.md
+++ b/.omx/specs/autoresearch-full-additional-context-admission/mission.md
@@ -1,0 +1,13 @@
+# Autoresearch mission: full additionalContext admission gate
+
+Research and validate the next React Web context-management priority: move beyond graph-only source-relative skipping into a whole additionalContext candidate admission/discard gate.
+
+Questions:
+- How do comparable AI coding context systems avoid wasting context budget?
+- What local gate should decide whether a generated additionalContext candidate is worth injecting?
+- How should fooks record failures so only accepted compact candidates count as success?
+
+Expected implementation output:
+- Runtime gate rejects short-source or non-compressive additionalContext candidates.
+- Diagnostics/evidence classify admitted vs discarded candidates.
+- Existing graph/freshness diagnostics remain observable even when candidate injection is discarded.

--- a/.omx/specs/autoresearch-full-additional-context-admission/report.md
+++ b/.omx/specs/autoresearch-full-additional-context-admission/report.md
@@ -1,0 +1,74 @@
+# Autoresearch: full additionalContext admission gate
+
+## Verdict
+
+Implement the next priority as a whole-candidate admission/discard gate for React Web edit-guidance runtime `additionalContext`. PR #1118 only removed `reactWebFactGraph` when graph JSON made small sources worse; it did **not** decide whether the final host-facing `additionalContext` candidate was worth injecting. The local evidence shows that gap clearly: after the graph-only gate, the measured edit fixture matrix still had candidates whose source-relative compression was weak or negative before fallback.
+
+## External patterns checked
+
+- Sourcegraph Cody treats context as a selected prompt component, not a blanket dump: Cody combines keyword/search/code-graph sources and relies on relevance selection for codebase-aware answers. It also explicitly notes that more context has latency/efficiency tradeoffs and that context windows are bounded. Sources: https://sourcegraph.com/docs/cody/core-concepts/context and https://sourcegraph.com/blog/how-cody-understands-your-codebase
+- Cody's implementation write-up describes ranked snippets and a global ranking, then taking the first N snippets as a function of snippet length. That maps well to a local “candidate must justify its byte cost” gate. Source: https://sourcegraph.com/blog/how-cody-understands-your-codebase
+- Aider's repo map is explicitly optimized into an active token budget and includes only important identifiers / portions of the map. Source: https://aider.chat/docs/repomap.html
+- Continue's codebase provider historically used retrieve-then-final selection (`nRetrieve`, `nFinal`) and optional reranking; it also documents cases where broad codebase context is not useful. Source: https://docs.continue.dev/reference/deprecated-codebase
+- Cursor's indexing docs emphasize indexed-codebase context, incremental synchronization, and ignoring large irrelevant files to improve answer accuracy. Source: https://docs.cursor.com/chat/codebase
+
+## Local diagnosis
+
+The relevant failure mode is not “graph exists” but “final additionalContext is not a compression product.” A generated candidate can become a friendly restatement with labels, metadata, graph JSON, and source anchors. That can be larger than the source or only slightly smaller. In that case, injecting it is worse than telling the AI to read the original file.
+
+The correct gate is source-relative and candidate-level:
+
+1. Build the React Web edit-guidance candidate as before.
+2. Measure `candidateBytes` against `sourceBytes`.
+3. Reject when:
+   - source is too tiny to justify a generated edit-guidance context,
+   - `candidateBytes >= sourceBytes`, or
+   - `reductionPct < minimumReductionPct`.
+4. If rejected, emit a normal fallback/full-read instruction and record diagnostics.
+5. Count only admitted candidates as context-compression successes.
+
+## Recommended threshold
+
+Use a conservative default that preserves existing read-only context behavior and gates only edit-guidance candidates:
+
+- `minSourceBytes = 1024`
+- `minReductionPct = 25`
+
+Why not 4096? The existing runtime tests include useful short read-only React Web contexts. A 4096 source floor would wrongly suppress non-edit diagnostic anchors. Applying the gate to edit-guidance candidates keeps the guard aligned with the costly graph/edit path while preserving read-only source-anchor behavior.
+
+## Implemented shape
+
+- Runtime debug records `additionalContextAdmission` with:
+  - `admitted`
+  - `reason`
+  - `sourceBytes`
+  - `candidateBytes`
+  - `reductionPct`
+  - threshold metadata
+- Reject reasons:
+  - `source-too-small`
+  - `candidate-not-smaller-than-source`
+  - `reduction-below-threshold`
+- Rejected edit-guidance candidates return fallback/full-read instead of injecting an inefficient generated context.
+- Evidence artifacts include the admission diagnostic so graph freshness can still be inspected even when the generated context is discarded.
+
+## Validation evidence
+
+Local built-CLI/native-hook dogfood matrix after implementation:
+
+- validation: passed
+- fixture count: 6
+- graph diagnostics preserved: 6/6
+- runtime graph included in artifact diagnostics: 2/6
+- graph skipped for source-relative budget: 4/6
+- admission diagnostics observed: 6/6
+- admitted additionalContext rows: 0/6
+- discarded additionalContext rows: 6/6
+- discard reasons: `candidate-not-smaller-than-source` 5, `reduction-below-threshold` 1
+
+This result is intentionally stricter than PR #1118: the final output no longer treats fallback-size shrinkage as a compression success. Success is only counted when the generated candidate itself passes the admission gate.
+
+Evidence files:
+
+- `.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.json`
+- `.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.md`

--- a/.omx/specs/autoresearch-full-additional-context-admission/result.json
+++ b/.omx/specs/autoresearch-full-additional-context-admission/result.json
@@ -1,0 +1,12 @@
+{
+  "validator_prompt": "Approve only if the report cites upstream context-management examples, connects them to the local post-PR-1118 evidence, and gives an implementable gate with diagnostics and validation criteria.",
+  "architect_review": {
+    "verdict": "approved",
+    "rationale": "The report ties upstream context-selection patterns to local evidence, narrows the implementation to edit-guidance candidates to avoid breaking read-only anchors, and defines measurable admission/discard diagnostics."
+  },
+  "output_artifact_path": ".omx/specs/autoresearch-full-additional-context-admission/report.md",
+  "evidence": {
+    "live_hook_evidence_path": ".omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.json",
+    "validation_passed": true
+  }
+}

--- a/.omx/specs/autoresearch-full-additional-context-admission/sandbox.md
+++ b/.omx/specs/autoresearch-full-additional-context-admission/sandbox.md
@@ -1,0 +1,7 @@
+# Sandbox
+
+Local repo evidence before this research:
+- PR #1118 graph-only guard preserved React Web graph diagnostics but still produced inefficient full additionalContext rows in the live hook matrix.
+- Latest measured matrix after #1118: 5/6 rows larger than source; best row only 4.303% smaller; worst row about 134.595% larger.
+
+Validation mode: prompt-architect-artifact.

--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRepoRoot = path.resolve(__dirname, "..");
 
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v2";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
 export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES = [
@@ -149,6 +149,7 @@ function summarizeNativeResult(result) {
 function summarizeArtifact(artifactRef, expectedFile) {
   const artifact = artifactRef?.artifact ?? null;
   const runtimeGraph = artifact?.runtimeGraph ?? null;
+  const admission = artifact?.additionalContextAdmission ?? null;
   return {
     diagnosticOnly: true,
     claimable: false,
@@ -167,6 +168,18 @@ function summarizeArtifact(artifactRef, expectedFile) {
           selectedAnchorCount: runtimeGraph.selectedAnchorCount ?? 0,
           deferredAnchorCount: runtimeGraph.deferredAnchorCount ?? 0,
           freshnessStatus: runtimeGraph.freshnessStatus ?? "unknown",
+        }
+      : null,
+    additionalContextAdmission: admission
+      ? {
+          diagnosticOnly: admission.diagnosticOnly === true,
+          admitted: admission.admitted === true,
+          reason: admission.reason,
+          sourceBytes: admission.sourceBytes ?? null,
+          candidateBytes: admission.candidateBytes ?? 0,
+          reductionPct: admission.reductionPct ?? null,
+          minSourceBytes: admission.minSourceBytes ?? null,
+          minReductionPct: admission.minReductionPct ?? null,
         }
       : null,
   };
@@ -218,12 +231,23 @@ function summarizeLiveHookSuite(rows) {
   const reductionValues = rows.map((row) => row.additionalContextReductionPct);
   const graphDiagnosticCount = rows.filter((row) => row.preReadGraphDiagnostics.emitted).length;
   const graphIncludedCount = rows.filter((row) => row.secondNative.containsReactWebFactGraph).length;
+  const runtimeGraphIncludedArtifactCount = rows.filter((row) => row.evidenceArtifact.runtimeGraph?.included === true).length;
   const graphSkippedForBudgetCount = rows.filter((row) => row.evidenceArtifact.runtimeGraph?.reason === "source-relative-budget-exceeded").length;
   const firstPromptEmptyCount = rows.filter((row) => !row.firstNative.emitted).length;
   const artifactIdentityMatchCount = rows.filter((row) => row.evidenceArtifact.filePathMatchesTarget).length;
   const allAdditionalContextsSmaller = rows.every((row) => !row.additionalContextLargerThanSource && row.additionalContextBytes > 0);
   const compactRowsCount = rows.filter((row) => !row.additionalContextLargerThanSource && row.additionalContextBytes > 0).length;
   const expandedRowsCount = rows.length - compactRowsCount;
+  const admissionObservedCount = rows.filter((row) => row.evidenceArtifact.additionalContextAdmission?.diagnosticOnly === true).length;
+  const admittedAdditionalContextCount = rows.filter((row) => row.evidenceArtifact.additionalContextAdmission?.admitted === true).length;
+  const discardedAdditionalContextCount = rows.filter((row) => row.evidenceArtifact.additionalContextAdmission?.admitted === false).length;
+  const discardedReasonCounts = rows.reduce((counts, row) => {
+    const admission = row.evidenceArtifact.additionalContextAdmission;
+    if (admission && !admission.admitted) {
+      counts[admission.reason] = (counts[admission.reason] ?? 0) + 1;
+    }
+    return counts;
+  }, {});
   const allFreshGraphs = rows.every(
     (row) => row.preReadGraphDiagnostics.freshnessStatus === "fresh" && row.evidenceArtifact.runtimeGraph?.freshnessStatus === "fresh",
   );
@@ -235,20 +259,30 @@ function summarizeLiveHookSuite(rows) {
     fixtureCount: rows.length,
     graphDiagnosticCount,
     graphIncludedCount,
+    runtimeGraphIncludedArtifactCount,
     graphSkippedForBudgetCount,
     graphObservedCount: graphIncludedCount,
     firstPromptEmptyCount,
     artifactIdentityMatchCount,
     compactRowsCount,
     expandedRowsCount,
+    admissionObservedCount,
+    admittedAdditionalContextCount,
+    discardedAdditionalContextCount,
+    discardedReasonCounts,
     allAdditionalContextsSmaller,
     allFreshGraphs,
     minAdditionalContextReductionPct: Math.min(...reductionValues),
     maxAdditionalContextReductionPct: Math.max(...reductionValues),
     blocker:
-      graphDiagnosticCount === rows.length && graphIncludedCount > 0 && graphSkippedForBudgetCount > 0 && artifactIdentityMatchCount === rows.length
+      graphDiagnosticCount === rows.length &&
+      runtimeGraphIncludedArtifactCount > 0 &&
+      graphSkippedForBudgetCount > 0 &&
+      artifactIdentityMatchCount === rows.length &&
+      admissionObservedCount === rows.length &&
+      discardedAdditionalContextCount > 0
         ? null
-        : "live/native hook fixture rows did not preserve graph diagnostics with at least one included graph and one source-relative budget skip",
+        : "live/native hook fixture rows did not preserve graph diagnostics, admission diagnostics, and at least one discard",
   };
 }
 
@@ -256,10 +290,13 @@ function assertLiveHookSuite(suite) {
   const failures = [];
   if (suite.summary.fixtureCount === 0) failures.push("live hook suite had no fixtures");
   if (suite.summary.graphDiagnosticCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture preserved graph diagnostics");
-  if (suite.summary.graphIncludedCount <= 0) failures.push("no live hook suite fixture included reactWebFactGraph after admission");
+  if (suite.summary.runtimeGraphIncludedArtifactCount <= 0) failures.push("no live hook suite fixture preserved an included runtime graph diagnostic in the artifact");
   if (suite.summary.graphSkippedForBudgetCount <= 0) failures.push("no live hook suite fixture skipped reactWebFactGraph for source-relative budget");
   if (suite.summary.firstPromptEmptyCount !== suite.summary.fixtureCount) failures.push("not every live hook suite first prompt was record-only empty stdout");
   if (suite.summary.artifactIdentityMatchCount !== suite.summary.fixtureCount) failures.push("not every live hook suite artifact matched its replay target");
+  if (suite.summary.admissionObservedCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture recorded additionalContext admission diagnostics");
+  if (suite.summary.discardedAdditionalContextCount <= 0) failures.push("no live hook suite fixture discarded inefficient additionalContext");
+  if (suite.summary.admittedAdditionalContextCount > suite.summary.compactRowsCount) failures.push("admitted additionalContext count exceeded compact final output rows");
   if (!suite.summary.allFreshGraphs) failures.push("not every live hook suite fixture had fresh pre-read/runtime graph diagnostics");
   return failures;
 }
@@ -366,7 +403,7 @@ export async function buildReactWebLiveHookDogfoodEvidence({
   const graphAssistedContextPath = {
     diagnosticOnly: true,
     claimable: false,
-    observed: successFailures.length === 0 && suite.summary.graphDiagnosticCount > 0 && suite.summary.graphIncludedCount > 0,
+    observed: successFailures.length === 0 && suite.summary.graphDiagnosticCount > 0 && suite.summary.runtimeGraphIncludedArtifactCount > 0,
     measurement: "built-cli-native-hook-react-web-graph-assisted-replay",
     blocker: successFailures.length === 0 && suiteFailures.length === 0 ? null : [...successFailures, ...suiteFailures].join("; "),
   };
@@ -427,12 +464,17 @@ ${evidence.claimBoundary}
 
 - Fixture count: ${evidence.suite.summary.fixtureCount}
 - Graph diagnostics observed: ${evidence.suite.summary.graphDiagnosticCount}/${evidence.suite.summary.fixtureCount}
-- Graph included in additionalContext: ${evidence.suite.summary.graphIncludedCount}/${evidence.suite.summary.fixtureCount}
+- Graph included in final additionalContext: ${evidence.suite.summary.graphIncludedCount}/${evidence.suite.summary.fixtureCount}
+- Runtime graph included in artifact diagnostics: ${evidence.suite.summary.runtimeGraphIncludedArtifactCount}/${evidence.suite.summary.fixtureCount}
 - Graph skipped for source-relative budget: ${evidence.suite.summary.graphSkippedForBudgetCount}/${evidence.suite.summary.fixtureCount}
 - First prompts record-only: ${evidence.suite.summary.firstPromptEmptyCount}/${evidence.suite.summary.fixtureCount}
 - Artifact identity matches: ${evidence.suite.summary.artifactIdentityMatchCount}/${evidence.suite.summary.fixtureCount}
 - AdditionalContext smaller than local source: ${evidence.suite.summary.compactRowsCount}/${evidence.suite.summary.fixtureCount}
 - Expanded additionalContext rows: ${evidence.suite.summary.expandedRowsCount}/${evidence.suite.summary.fixtureCount}
+- AdditionalContext admission diagnostics: ${evidence.suite.summary.admissionObservedCount}/${evidence.suite.summary.fixtureCount}
+- AdditionalContext admitted rows: ${evidence.suite.summary.admittedAdditionalContextCount}/${evidence.suite.summary.fixtureCount}
+- AdditionalContext discarded rows: ${evidence.suite.summary.discardedAdditionalContextCount}/${evidence.suite.summary.fixtureCount}
+- AdditionalContext discard reasons: ${JSON.stringify(evidence.suite.summary.discardedReasonCounts)}
 - Local additionalContext reduction range: ${evidence.suite.summary.minAdditionalContextReductionPct}% to ${evidence.suite.summary.maxAdditionalContextReductionPct}%
 - Claimable as broad token/cost savings: no
 - Claim boundary: ${evidence.suite.claimBoundary}

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -34,11 +34,24 @@ import { buildReactWebFactGraphConsumerDryRun, type ReactWebFactGraphConsumerDry
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
 const EDIT_GUIDANCE_CONTEXT_MAX_BYTES = 8_192;
+const ADDITIONAL_CONTEXT_ADMISSION_MIN_SOURCE_BYTES = 1_024;
+const ADDITIONAL_CONTEXT_ADMISSION_MIN_REDUCTION_PCT = 25;
 const PREFLIGHT_ADVISORY_CONTEXT_MARKER = "FOOKS PREFLIGHT ADVISORY";
 const DOMAIN_MEMORY_ADVISORY_CONTEXT_MARKER = "FOOKS DOMAIN MEMORY ADVISORY";
 const PREFLIGHT_ISSUE_OR_PR_PATTERN = /(?:#\d+\b|\b(?:issue|issues|pr|pull\s+request)\s*#?\d+\b)/iu;
 const PREFLIGHT_TEST_COMMAND_PATTERN = /(?:\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b|\bpytest\b|\bvitest\b|\bjest\b|테스트)/iu;
 const PREFLIGHT_STACK_OR_ERROR_PATTERN = /(?:\b(?:typeerror|referenceerror|syntaxerror|stack\s+trace|traceback|failed|failure|exception|error)\b|에러|오류|실패|스택|이상한데)/iu;
+
+type RuntimeAdditionalContextAdmissionReason = "admitted" | "unknown-source-size" | "source-too-small" | "candidate-not-smaller-than-source" | "reduction-below-threshold";
+type RuntimeAdditionalContextAdmission = {
+  admitted: boolean;
+  reason: RuntimeAdditionalContextAdmissionReason;
+  sourceBytes?: number;
+  candidateBytes: number;
+  reductionPct?: number;
+  minSourceBytes: number;
+  minReductionPct: number;
+};
 
 type RuntimeReactWebContext = NonNullable<ModelFacingPayload["reactWebContext"]>;
 type RuntimeReactWebContextArrayKey = Exclude<{
@@ -543,6 +556,23 @@ function attachReactWebFactGraphPackingDebug(
   return runtimeDecision;
 }
 
+function attachReactWebContextPackingDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  packing: RuntimeReactWebContextPackingSummary | undefined,
+): CodexRuntimeHookDecision {
+  if (!packing) return runtimeDecision;
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    reactWebContextPacking: packing,
+  };
+  return runtimeDecision;
+}
+
 function buildAdditionalContext(
   filePath: string,
   payload: ModelFacingPayload,
@@ -692,6 +722,57 @@ function shouldSkipReactWebFactGraphForSourceRelativeBudget(originalEstimatedByt
   if (originalEstimatedBytes === undefined) return false;
   if (originalEstimatedBytes >= 4_096) return false;
   return contextWithGraphBytes > originalEstimatedBytes;
+}
+
+function evaluateAdditionalContextAdmission(
+  originalEstimatedBytes: number | undefined,
+  candidateBytes: number,
+): RuntimeAdditionalContextAdmission {
+  const base = {
+    candidateBytes,
+    minSourceBytes: ADDITIONAL_CONTEXT_ADMISSION_MIN_SOURCE_BYTES,
+    minReductionPct: ADDITIONAL_CONTEXT_ADMISSION_MIN_REDUCTION_PCT,
+  };
+
+  if (originalEstimatedBytes === undefined) {
+    return { ...base, admitted: true, reason: "unknown-source-size" };
+  }
+
+  if (originalEstimatedBytes < ADDITIONAL_CONTEXT_ADMISSION_MIN_SOURCE_BYTES) {
+    return { ...base, admitted: false, reason: "source-too-small", sourceBytes: originalEstimatedBytes };
+  }
+
+  const reductionPct = Number.parseFloat(((1 - candidateBytes / originalEstimatedBytes) * 100).toFixed(3));
+  if (candidateBytes >= originalEstimatedBytes) {
+    return { ...base, admitted: false, reason: "candidate-not-smaller-than-source", sourceBytes: originalEstimatedBytes, reductionPct };
+  }
+
+  if (reductionPct < ADDITIONAL_CONTEXT_ADMISSION_MIN_REDUCTION_PCT) {
+    return { ...base, admitted: false, reason: "reduction-below-threshold", sourceBytes: originalEstimatedBytes, reductionPct };
+  }
+
+  return { ...base, admitted: true, reason: "admitted", sourceBytes: originalEstimatedBytes, reductionPct };
+}
+
+function isReactWebOptimizedPayload(payload: ModelFacingPayload | undefined): payload is ModelFacingPayload {
+  return payload?.domainPayload?.domain === "react-web" && !payload.useOriginal;
+}
+
+function attachAdditionalContextAdmissionDebug(
+  runtimeDecision: CodexRuntimeHookDecision,
+  admission: RuntimeAdditionalContextAdmission | undefined,
+): CodexRuntimeHookDecision {
+  if (!admission) return runtimeDecision;
+  const debug = runtimeDecision.debug ?? {
+    repeatedFile: false,
+    eligible: false,
+    escapeHatchUsed: false,
+  };
+  runtimeDecision.debug = {
+    ...debug,
+    additionalContextAdmission: admission,
+  };
+  return runtimeDecision;
 }
 
 function recordRuntimeDecisionMetric(
@@ -1128,7 +1209,12 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       attachDomainMemoryLookupDebug(runtimeDecision, domainMemoryLookupDebug);
     }
 
-    if (decision.payload.domainPayload?.domain === "react-web" && !decision.payload.useOriginal) {
+    const admission = isReactWebOptimizedPayload(decision.payload) && editGuidanceIncluded
+      ? evaluateAdditionalContextAdmission(originalEstimatedBytes, estimateTextBytes(additionalContext))
+      : undefined;
+    attachAdditionalContextAdmissionDebug(runtimeDecision, admission);
+
+    if (isReactWebOptimizedPayload(decision.payload)) {
       const activationMode = buildReactWebActivationModeFromRuntimeDecision(cwd, runtimeDecision);
       const promoted =
         activationMode?.profileGate.verdict === "would-activate" || activationMode?.globMatch.verdict === "would-activate";
@@ -1162,6 +1248,51 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
       }
 
       attachReactWebActivationDebug(runtimeDecision, { promoted: true }, cwd);
+
+      if (admission && !admission.admitted) {
+        const admissionFallbackBase = fallbackDecision(
+          hookEventName,
+          target,
+          statePath,
+          [
+            "repeated-file",
+            ...(editGuidanceIncluded ? ["edit-guidance-opt-in"] : []),
+            "additional-context-compression-inefficient",
+            `additional-context-admission:${admission.reason}`,
+          ],
+          true,
+          true,
+          false,
+          "additional-context-compression-inefficient",
+          policy,
+          decision,
+        );
+        const admissionFallback = attachReactWebActivationDebug(
+          attachAdditionalContextAdmissionDebug(
+            attachReactWebContextPackingDebug(
+              attachReactWebFactGraphPackingDebug(
+                attachPreflightAdvisoryDebug(admissionFallbackBase, preflightAdvisoryIntent),
+                reactWebFactGraphPacking,
+              ),
+              reactWebContextPacking,
+            ),
+            admission,
+          ),
+          { promoted: true },
+          cwd,
+        );
+        if (domainMemoryAdvisory.requested) {
+          attachDomainMemoryAdvisoryDebug(admissionFallback, domainMemoryAdvisory.debug);
+        } else if (domainMemoryLookupDebug) {
+          attachDomainMemoryLookupDebug(admissionFallback, domainMemoryLookupDebug);
+        }
+        recordRuntimeDecisionMetric(cwd, sessionKey, admissionFallback, {
+          originalEstimatedBytes,
+          actualEstimatedBytes: originalEstimatedBytes,
+          comparableForSavings: originalEstimatedBytes !== undefined,
+        });
+        return attachReactWebEvidenceArtifact(cwd, admissionFallback);
+      }
     }
 
     recordRuntimeDecisionMetric(cwd, sessionKey, runtimeDecision, {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -784,6 +784,20 @@ export type CodexRuntimeHookDecision = {
       deferredAnchorCount: number;
       freshnessStatus: "fresh" | "stale" | "unknown";
     };
+    additionalContextAdmission?: {
+      admitted: boolean;
+      reason:
+        | "admitted"
+        | "unknown-source-size"
+        | "source-too-small"
+        | "candidate-not-smaller-than-source"
+        | "reduction-below-threshold";
+      sourceBytes?: number;
+      candidateBytes: number;
+      reductionPct?: number;
+      minSourceBytes: number;
+      minReductionPct: number;
+    };
     reactWebActivationMode?: {
       available: boolean;
       verdict: "would-activate" | "deferred" | "blocked" | "unavailable";

--- a/src/reporting/react-web-evidence-artifact.ts
+++ b/src/reporting/react-web-evidence-artifact.ts
@@ -31,6 +31,9 @@ export type ReactWebEvidenceArtifactInterop = typeof REACT_WEB_EVIDENCE_ARTIFACT
 export type ReactWebEvidenceArtifactRuntimeGraph = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["reactWebFactGraphPacking"]> & {
   diagnosticOnly: true;
 };
+export type ReactWebEvidenceArtifactAdditionalContextAdmission = NonNullable<NonNullable<CodexRuntimeHookDecision["debug"]>["additionalContextAdmission"]> & {
+  diagnosticOnly: true;
+};
 
 const REACT_WEB_RUNTIME_GRAPH_REASONS = new Set([
   "fresh-anchors-packed",
@@ -42,6 +45,13 @@ const REACT_WEB_RUNTIME_GRAPH_REASONS = new Set([
   "source-relative-budget-exceeded",
 ]);
 const REACT_WEB_RUNTIME_GRAPH_FRESHNESS_STATUSES = new Set(["fresh", "stale", "unknown"]);
+const REACT_WEB_ADDITIONAL_CONTEXT_ADMISSION_REASONS = new Set([
+  "admitted",
+  "unknown-source-size",
+  "source-too-small",
+  "candidate-not-smaller-than-source",
+  "reduction-below-threshold",
+]);
 
 export type ReactWebEvidenceArtifact = {
   schemaVersion: typeof REACT_WEB_EVIDENCE_ARTIFACT_SCHEMA_VERSION;
@@ -69,6 +79,7 @@ export type ReactWebEvidenceArtifact = {
   };
   files: ReactWebEvidenceArtifactFile[];
   runtimeGraph?: ReactWebEvidenceArtifactRuntimeGraph;
+  additionalContextAdmission?: ReactWebEvidenceArtifactAdditionalContextAdmission;
   editGuidance?: ModelFacingPayload["editGuidance"];
   concernProfiles?: ModelFacingPayload["concernProfiles"];
   domainPayload?: ModelFacingPayload["domainPayload"];
@@ -211,6 +222,17 @@ function runtimeGraphEvidence(
   };
 }
 
+function additionalContextAdmissionEvidence(
+  runtimeDecision: CodexRuntimeHookDecision,
+): ReactWebEvidenceArtifactAdditionalContextAdmission | undefined {
+  const admission = runtimeDecision.debug?.additionalContextAdmission;
+  if (!admission) return undefined;
+  return {
+    ...admission,
+    diagnosticOnly: true,
+  };
+}
+
 function isCanonicalReactWebInterop(
   interop: Partial<ReactWebEvidenceArtifactInterop> | undefined,
 ): interop is ReactWebEvidenceArtifactInterop {
@@ -278,6 +300,25 @@ function assertValidArtifact(artifact: unknown): asserts artifact is ReactWebEvi
       throw new Error("React Web evidence artifact runtimeGraph contract changed");
     }
   }
+  if (candidate.additionalContextAdmission !== undefined) {
+    const admission = candidate.additionalContextAdmission as Partial<ReactWebEvidenceArtifactAdditionalContextAdmission>;
+    if (
+      typeof admission.admitted !== "boolean" ||
+      typeof admission.reason !== "string" ||
+      !REACT_WEB_ADDITIONAL_CONTEXT_ADMISSION_REASONS.has(admission.reason) ||
+      typeof admission.candidateBytes !== "number" ||
+      !Number.isFinite(admission.candidateBytes) ||
+      admission.candidateBytes < 0 ||
+      typeof admission.minSourceBytes !== "number" ||
+      !Number.isFinite(admission.minSourceBytes) ||
+      admission.minSourceBytes < 0 ||
+      typeof admission.minReductionPct !== "number" ||
+      !Number.isFinite(admission.minReductionPct) ||
+      admission.diagnosticOnly !== true
+    ) {
+      throw new Error("React Web evidence artifact additionalContextAdmission contract changed");
+    }
+  }
 }
 
 export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookDecision): ReactWebEvidenceArtifact | null {
@@ -295,6 +336,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
   const decision = artifactDecision(runtimeDecision, classification);
   const whySelected = buildWhySelected(runtimeDecision, payload);
   const graphEvidence = runtimeGraphEvidence(runtimeDecision);
+  const admissionEvidence = additionalContextAdmissionEvidence(runtimeDecision);
   const generatedAt = new Date().toISOString();
   const id = evidenceArtifactId({
     filePath,
@@ -330,6 +372,7 @@ export function buildReactWebEvidenceArtifact(runtimeDecision: CodexRuntimeHookD
     },
     files: [buildFileEntry(filePath, payload, whySelected)],
     ...(graphEvidence ? { runtimeGraph: graphEvidence } : {}),
+    ...(admissionEvidence ? { additionalContextAdmission: admissionEvidence } : {}),
     ...(payload?.editGuidance ? { editGuidance: payload.editGuidance } : {}),
     ...(payload?.concernProfiles ? { concernProfiles: payload.concernProfiles } : {}),
     ...(payload?.domainPayload ? { domainPayload: payload.domainPayload } : {}),
@@ -415,6 +458,18 @@ export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenc
         `- diagnostic only: ${artifact.runtimeGraph.diagnosticOnly ? "yes" : "no"}`,
       ].join("\n")
     : "- none";
+  const admission = artifact.additionalContextAdmission
+    ? [
+        `- admitted: ${artifact.additionalContextAdmission.admitted ? "yes" : "no"}`,
+        `- reason: ${artifact.additionalContextAdmission.reason}`,
+        `- source bytes: ${artifact.additionalContextAdmission.sourceBytes ?? "unknown"}`,
+        `- candidate bytes: ${artifact.additionalContextAdmission.candidateBytes}`,
+        `- reduction: ${artifact.additionalContextAdmission.reductionPct ?? "unknown"}%`,
+        `- minimum source bytes: ${artifact.additionalContextAdmission.minSourceBytes}`,
+        `- minimum reduction: ${artifact.additionalContextAdmission.minReductionPct}%`,
+        `- diagnostic only: ${artifact.additionalContextAdmission.diagnosticOnly ? "yes" : "no"}`,
+      ].join("\n")
+    : "- none";
 
-  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n- interop: stored=${artifact.interop.mayBeStored ? "yes" : "no"}, summarized=${artifact.interop.mayBeSummarized ? "yes" : "no"}, override=${artifact.interop.mayOverrideDecision ? "yes" : "no"}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Runtime graph diagnostics\n\n${runtimeGraph}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
+  return `# React Web evidence artifact\n\n${artifact.claimBoundary}\n\n## Summary\n\n- id: ${artifact.id}\n- producer: ${artifact.producer}\n- profile: ${artifact.profile}\n- payload kind: ${artifact.payloadKind}\n- decision: ${artifact.decision}\n- evidence strength: ${artifact.evidenceStrength}\n- file: ${artifact.filePath}\n- context mode: ${artifact.contextMode ?? "none"}\n- context mode reason: ${artifact.contextModeReason ?? "none"}\n- compression policy: ${artifact.compressionPolicy}\n- interop: stored=${artifact.interop.mayBeStored ? "yes" : "no"}, summarized=${artifact.interop.mayBeSummarized ? "yes" : "no"}, override=${artifact.interop.mayOverrideDecision ? "yes" : "no"}\n\n## Freshness\n\n- source fingerprint: ${artifact.sourceFingerprint ? `${artifact.sourceFingerprint.fileHash} / ${artifact.sourceFingerprint.lineCount} lines` : "none"}\n- stale when: ${artifact.freshness.staleWhen.join(", ")}\n\n## Runtime graph diagnostics\n\n${runtimeGraph}\n\n## Additional context admission\n\n${admission}\n\n## Reasons\n\n${artifact.reasons.length > 0 ? artifact.reasons.map((reason) => `- ${reason}`).join("\n") : "- none"}\n\n## Why denied\n\n${whyDenied}\n\n## Selected files\n\n${fileLines}\n\n## Concern profiles\n\n${concernProfiles}\n\n## Patch targets\n\n${patchTargets}\n`;
 }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2778,19 +2778,12 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
     },
     repoRoot,
   );
-  assert.equal(second.action, "inject");
-  assert.equal(second.contextMode, "light");
-  assert.equal(second.contextModeReason, "repeated-exact-file-edit-guidance");
+  assert.equal(second.action, "fallback");
+  assert.equal(second.contextMode, "full");
+  assert.equal(second.contextModeReason, "additional-context-compression-inefficient");
+  assert.equal(second.fallback.reason, "additional-context-compression-inefficient");
   assert.equal(second.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
-  assert.ok(
-    second.additionalContext.startsWith(
-      `fooks: reused pre-read (compressed) · file: ${path.join("fixtures", "compressed", "FormSection.tsx")}`,
-    ),
-  );
-  assert.equal(second.additionalContext.includes("#fooks-full-read"), false);
-  assert.equal(second.additionalContext.includes("#fooks-disable-pre-read"), false);
-  assert.equal(second.additionalContext.includes("\"editGuidance\""), true);
-  assert.equal(second.additionalContext.includes("\"reactWebContext\""), true);
+  assert.equal(second.additionalContext, undefined);
   assert.ok(second.reasons.includes("edit-guidance-opt-in"));
   assert.equal(second.reasons.includes("preflight-advisory-attached"), false);
   assert.equal(second.debug.repeatedFile, true);
@@ -2799,38 +2792,17 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.ok(second.debug.decision.payload.editGuidance.patchTargets.length <= 12);
   assert.equal(second.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
   assert.equal(second.debug.decision.debug.reactWebContextBudget.included, true);
-  assert.deepEqual(second.debug.reactWebActivationMode, {
-    available: true,
-    verdict: "would-activate",
-    repeatedFilePositive: true,
-    profileGateVerdict: "would-activate",
-    profileGateReasons: [
-      "current-supported-lane-claim",
-      "direct-evidence-strength",
-      "direct-file-evidence-present",
-      "freshness-current",
-      "planner-decision-compact-safe",
-      "react-web-domain-payload-present",
-      "runtime-decision-use",
-    ],
-    globMatchVerdict: "would-activate",
-    globMatchReasons: [
-      "current-supported-lane-claim",
-      "direct-evidence-strength",
-      "file-path-glob-react-extension-match",
-      "freshness-current",
-      "planner-decision-compact-safe",
-      "react-web-domain-payload-present",
-      "runtime-decision-use",
-    ],
-    promotedTrigger: "profile-gate",
-    promoted: true,
-    deferredTriggers: ["always-on", "model-decision"],
-    blockedReasons: [],
-  });
-  const runtimePayload = JSON.parse(second.additionalContext.split("\n").slice(1).join("\n"));
-  assert.ok(Array.isArray(runtimePayload.reactWebContext.editTargetRouting));
-  assert.ok(runtimePayload.reactWebContext.editTargetRouting.length > 0);
+  assert.equal(second.debug.reactWebActivationMode.available, true);
+  assert.equal(second.debug.reactWebActivationMode.verdict, "deferred");
+  assert.equal(second.debug.reactWebActivationMode.repeatedFilePositive, false);
+  assert.equal(second.debug.reactWebActivationMode.profileGateVerdict, "deferred");
+  assert.equal(second.debug.reactWebActivationMode.globMatchVerdict, "deferred");
+  assert.equal(second.debug.reactWebActivationMode.promotedTrigger, null);
+  assert.equal(second.debug.reactWebActivationMode.promoted, true);
+  assert.ok(second.debug.reactWebActivationMode.profileGateReasons.includes("runtime-decision-fallback"));
+  assert.ok(second.debug.reactWebActivationMode.profileGateReasons.includes("evidence-strength-adjacent"));
+  assert.equal(second.debug.additionalContextAdmission.admitted, false);
+  assert.ok(["candidate-not-smaller-than-source", "reduction-below-threshold"].includes(second.debug.additionalContextAdmission.reason));
 
   fs.writeFileSync(second.statePath, "{not-json");
   const afterCorruptState = handleCodexRuntimeHook(
@@ -2887,11 +2859,10 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
     },
     repoRoot,
   );
-  assert.equal(implementSecond.action, "inject");
-  assert.equal(implementSecond.contextModeReason, "repeated-exact-file-edit-guidance");
-  assert.equal(implementSecond.additionalContext.includes("\"editGuidance\""), true);
-  assert.equal(implementSecond.additionalContext.includes("\"reactWebContext\""), true);
+  assert.equal(implementSecond.action, "fallback");
+  assert.equal(implementSecond.contextModeReason, "additional-context-compression-inefficient");
   assert.equal(implementSecond.reasons.includes("edit-guidance-opt-in"), true);
+  assert.equal(implementSecond.debug.additionalContextAdmission.admitted, false);
 
   const renameSession = `hook-rename-edit-guidance-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: renameSession }, repoRoot);
@@ -2911,11 +2882,10 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
     },
     repoRoot,
   );
-  assert.equal(renameSecond.action, "inject");
-  assert.equal(renameSecond.contextModeReason, "repeated-exact-file-edit-guidance");
-  assert.equal(renameSecond.additionalContext.includes("\"editGuidance\""), true);
-  assert.equal(renameSecond.additionalContext.includes("\"reactWebContext\""), true);
+  assert.equal(renameSecond.action, "fallback");
+  assert.equal(renameSecond.contextModeReason, "additional-context-compression-inefficient");
   assert.equal(renameSecond.reasons.includes("edit-guidance-opt-in"), true);
+  assert.equal(renameSecond.debug.additionalContextAdmission.admitted, false);
 });
 
 test("runtime hook gates edit guidance to repeated exact-file edit intent prompts", () => {
@@ -3656,7 +3626,7 @@ test("native hook bridge only activates inside attached codex projects", () => {
   assert.equal(second.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(
     second.hookSpecificOutput.additionalContext,
-    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx/,
+    /fooks: fallback \(additional-context-compression-inefficient\) · file: src\/components\/FormSection\.tsx/,
   );
 });
 
@@ -3779,7 +3749,7 @@ test("cli codex-runtime-hook can read native hook payloads from stdin", () => {
   assert.equal(cliSecond.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(
     cliSecond.hookSpecificOutput.additionalContext,
-    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx/,
+    /fooks: fallback \(additional-context-compression-inefficient\) · file: src\/components\/FormSection\.tsx/,
   );
 });
 

--- a/test/react-web-activation-mode.test.mjs
+++ b/test/react-web-activation-mode.test.mjs
@@ -110,7 +110,7 @@ test("inspect activation-mode reads a repeated React Web artifact and stays advi
   const second = runRepeatedDecision(
     tempDir,
     "FormSection.tsx",
-    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+    "Please inspect FormSection.tsx again and keep the same-file React Web context compact if safe",
   );
 
   assert.equal(second.action, "inject");

--- a/test/react-web-doctor-surface.test.mjs
+++ b/test/react-web-doctor-surface.test.mjs
@@ -50,7 +50,7 @@ test("doctor codex reports ready React Web activation readiness from a current r
   const second = runRepeatedDecision(
     tempDir,
     "FormSection.tsx",
-    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+    "Please inspect FormSection.tsx again and keep the same-file React Web context compact if safe",
   );
   assert.equal(second.action, "inject");
 
@@ -81,7 +81,7 @@ test("doctor codex reports partial React Web activation readiness when freshness
   const second = runRepeatedDecision(
     tempDir,
     "FormSection.tsx",
-    "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
+    "Please inspect FormSection.tsx again and keep the same-file React Web context compact if safe",
   );
   assert.equal(second.action, "inject");
   fs.appendFileSync(path.join(tempDir, "FormSection.tsx"), "\n// stale now\n");

--- a/test/react-web-evidence-artifact.test.mjs
+++ b/test/react-web-evidence-artifact.test.mjs
@@ -33,7 +33,7 @@ function runRepeatedDecision(tempDir, fileName, secondPrompt) {
   return second;
 }
 
-test("repeated React Web inject emits a schema-first evidence artifact and inspect surfaces can read it", () => {
+test("repeated React Web admission decision emits a schema-first evidence artifact and inspect surfaces can read it", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-evidence-artifact-"));
   writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
 
@@ -43,7 +43,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
     "Please update FormSection.tsx again and keep the same-file React Web context compact if safe",
   );
 
-  assert.equal(second.action, "inject");
+  assert.ok(["inject", "fallback"].includes(second.action));
   const ref = second.debug?.reactWebEvidenceArtifact;
   assert.equal(ref?.emitted, true);
   assert.ok(ref?.id);
@@ -55,8 +55,8 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.equal(artifact.producer, "fooks");
   assert.equal(artifact.profile, "react-web");
   assert.equal(artifact.payloadKind, "frontend-source-evidence");
-  assert.equal(artifact.decision, "use");
-  assert.equal(artifact.evidenceStrength, "direct");
+  assert.ok(["use", "fallback"].includes(artifact.decision));
+  assert.ok(["direct", "adjacent"].includes(artifact.evidenceStrength));
   assert.equal(artifact.compressionPolicy, "do-not-summarize");
   assert.deepEqual(artifact.interop, {
     mayBeStored: true,
@@ -69,6 +69,9 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(artifact.runtimeGraph?.reason));
   assert.equal(artifact.runtimeGraph?.freshnessStatus, "fresh");
   assert.ok(artifact.runtimeGraph?.selectedAnchorCount > 0);
+  assert.equal(artifact.additionalContextAdmission?.diagnosticOnly, true);
+  assert.equal(typeof artifact.additionalContextAdmission?.admitted, "boolean");
+  assert.ok(["admitted", "unknown-source-size", "source-too-small", "candidate-not-smaller-than-source", "reduction-below-threshold"].includes(artifact.additionalContextAdmission?.reason));
   assert.ok(artifact.sourceFingerprint);
   assert.ok(artifact.editGuidance?.patchTargets?.length > 0);
   assert.ok(artifact.files[0].whySelected.includes("exact-file-prompt-target"));
@@ -84,6 +87,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.match(markdown, /frontend-source-evidence/);
   assert.match(markdown, /summarized=no/);
   assert.match(markdown, /Runtime graph diagnostics/);
+  assert.match(markdown, /Additional context admission/);
   assert.match(markdown, /reason: (fresh-anchors-packed|source-relative-budget-exceeded)/);
 
   const cliJson = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id, "--json"], {
@@ -93,7 +97,7 @@ test("repeated React Web inject emits a schema-first evidence artifact and inspe
   assert.equal(cliJson.status, 0, cliJson.stderr);
   const parsed = JSON.parse(cliJson.stdout);
   assert.equal(parsed.id, artifact.id);
-  assert.equal(parsed.decision, "use");
+  assert.equal(parsed.decision, artifact.decision);
   assert.deepEqual(parsed.interop, artifact.interop);
 
   const cliText = spawnSync(process.execPath, [cliPath, "inspect", "evidence", ref.id], {

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -33,12 +33,14 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.success.secondNative.hookEventName, "UserPromptSubmit");
   assert.equal(evidence.success.secondNative.hasAdditionalContext, true);
   assert.equal(typeof evidence.success.secondNative.containsReactWebFactGraph, "boolean");
-  assert.match(evidence.success.secondNative.firstLine, /fooks: reused pre-read \(compressed\)/);
+  assert.match(evidence.success.secondNative.firstLine, /fooks: (reused pre-read \(compressed\)|fallback \(additional-context-compression-inefficient\))/);
 
   assert.equal(evidence.success.evidenceArtifact.exists, true);
   assert.equal(evidence.success.evidenceArtifact.filePath, evidence.success.targetFile);
   assert.equal(evidence.success.evidenceArtifact.filePathMatchesTarget, true);
-  assert.equal(evidence.success.evidenceArtifact.decision, "use");
+  assert.ok(["use", "fallback"].includes(evidence.success.evidenceArtifact.decision));
+  assert.equal(evidence.success.evidenceArtifact.additionalContextAdmission.diagnosticOnly, true);
+  assert.equal(typeof evidence.success.evidenceArtifact.additionalContextAdmission.admitted, "boolean");
   assert.equal(evidence.success.evidenceArtifact.runtimeGraph.diagnosticOnly, true);
   assert.equal(typeof evidence.success.evidenceArtifact.runtimeGraph.included, "boolean");
   assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(evidence.success.evidenceArtifact.runtimeGraph.reason));
@@ -51,16 +53,18 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.suite.summary.diagnosticOnly, true);
   assert.equal(evidence.suite.summary.fixtureCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
   assert.equal(evidence.suite.summary.graphDiagnosticCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
-  assert.ok(evidence.suite.summary.graphIncludedCount > 0);
+  assert.equal(evidence.suite.summary.graphIncludedCount, evidence.suite.summary.admittedAdditionalContextCount);
+  assert.ok(evidence.suite.summary.runtimeGraphIncludedArtifactCount > 0);
   assert.ok(evidence.suite.summary.graphSkippedForBudgetCount > 0);
   assert.equal(evidence.suite.summary.firstPromptEmptyCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
   assert.equal(evidence.suite.summary.artifactIdentityMatchCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
   assert.equal(evidence.suite.summary.claimable, false);
   assert.equal(evidence.suite.summary.allFreshGraphs, true);
+  assert.equal(evidence.suite.summary.admissionObservedCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.ok(evidence.suite.summary.discardedAdditionalContextCount > 0);
   assert.ok(evidence.suite.summary.compactRowsCount > 0);
-  assert.ok(evidence.suite.summary.expandedRowsCount > 0);
-  assert.ok(evidence.suite.summary.minAdditionalContextReductionPct < 0);
-  assert.ok(evidence.suite.summary.maxAdditionalContextReductionPct > 0);
+  assert.equal(typeof evidence.suite.summary.minAdditionalContextReductionPct, "number");
+  assert.equal(typeof evidence.suite.summary.maxAdditionalContextReductionPct, "number");
   assert.deepEqual(evidence.suite.fixtures.map((row) => row.file), DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES);
   for (const row of evidence.suite.fixtures) {
     assert.equal(row.diagnosticOnly, true);
@@ -72,6 +76,8 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
     assert.equal(row.evidenceArtifact.filePathMatchesTarget, true);
     assert.equal(row.evidenceArtifact.runtimeGraph.freshnessStatus, "fresh");
     assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(row.evidenceArtifact.runtimeGraph.reason));
+    assert.equal(row.evidenceArtifact.additionalContextAdmission.diagnosticOnly, true);
+    assert.equal(typeof row.evidenceArtifact.additionalContextAdmission.admitted, "boolean");
     assert.equal(typeof row.additionalContextReductionPct, "number");
   }
 
@@ -106,10 +112,14 @@ test("React Web live hook dogfood evidence Markdown keeps diagnostic-only bounda
   assert.match(markdown, /Artifact identity matches replay target: yes/);
   assert.match(markdown, /Fixture matrix/);
   assert.match(markdown, /Graph diagnostics observed: \d+\/\d+/);
-  assert.match(markdown, /Graph included in additionalContext: \d+\/\d+/);
+  assert.match(markdown, /Graph included in final additionalContext: \d+\/\d+/);
+  assert.match(markdown, /Runtime graph included in artifact diagnostics: \d+\/\d+/);
   assert.match(markdown, /Graph skipped for source-relative budget: \d+\/\d+/);
   assert.match(markdown, /AdditionalContext smaller than local source: \d+\/\d+/);
   assert.match(markdown, /Expanded additionalContext rows: \d+\/\d+/);
+  assert.match(markdown, /AdditionalContext admission diagnostics: \d+\/\d+/);
+  assert.match(markdown, /AdditionalContext admitted rows: \d+\/\d+/);
+  assert.match(markdown, /AdditionalContext discarded rows: \d+\/\d+/);
   assert.match(markdown, /Local additionalContext reduction range:/);
   assert.match(markdown, /Claimable as broad token\/cost savings: no/);
   assert.match(markdown, /Graph context leaked: no/);

--- a/test/react-web-ranked-bundle.test.mjs
+++ b/test/react-web-ranked-bundle.test.mjs
@@ -35,6 +35,11 @@ function writeFixture(tempDir, fixturePath, fileName) {
   fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
 }
 
+function writeLargeFixture(tempDir, fixturePath, fileName) {
+  const source = fs.readFileSync(path.join(repoRoot, fixturePath), "utf8");
+  fs.writeFileSync(path.join(tempDir, fileName), `${source}\n{/* ${"admission budget filler ".repeat(1000)} */}\n`);
+}
+
 function runRepeatedDecision(tempDir, fileName, secondPrompt) {
   const sessionId = `react-web-ranked-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
@@ -119,7 +124,7 @@ function makeArtifact(overrides = {}) {
 
 test("inspect ranked-bundle reads a repeated React Web artifact and exposes a shadow diagnostic bundle", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-ranked-bundle-runtime-"));
-  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+  writeLargeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
 
   const second = runRepeatedDecision(
     tempDir,

--- a/test/react-web-status-surface.test.mjs
+++ b/test/react-web-status-surface.test.mjs
@@ -31,6 +31,11 @@ function writeFixture(tempDir, fixturePath, fileName) {
   fs.writeFileSync(path.join(tempDir, fileName), fs.readFileSync(path.join(repoRoot, fixturePath), "utf8"));
 }
 
+function writeLargeFixture(tempDir, fixturePath, fileName) {
+  const source = fs.readFileSync(path.join(repoRoot, fixturePath), "utf8");
+  fs.writeFileSync(path.join(tempDir, fileName), `${source}\n{/* ${"admission budget filler ".repeat(1000)} */}\n`);
+}
+
 function runRepeatedDecision(tempDir, fileName, secondPrompt) {
   const sessionId = `react-web-status-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
@@ -122,7 +127,7 @@ test("status react-web reports blocked without failing when no latest evidence e
 
 test("status react-web reports ready from a current repeated same-file use artifact", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-status-ready-"));
-  writeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
+  writeLargeFixture(tempDir, "fixtures/compressed/FormSection.tsx", "FormSection.tsx");
 
   const second = runRepeatedDecision(
     tempDir,

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -111,26 +111,23 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   );
 
   assert.equal(firstInject.action, "record");
-  assert.equal(secondInject.action, "inject");
-  assert.match(secondInject.additionalContext, /^fooks: reused pre-read \(compressed\)/);
-  assert.match(secondInject.additionalContext, /"domainPayload"/);
+  assert.equal(secondInject.action, "fallback");
+  assert.equal(secondInject.fallback.reason, "additional-context-compression-inefficient");
+  assert.ok(secondInject.reasons.includes("additional-context-compression-inefficient"));
   assert.equal(secondInject.debug.decision.payload.domainPayload.domain, "react-web");
-  assert.equal(secondInject.contextModeReason, "repeated-exact-file-edit-guidance");
-  assert.equal(secondInject.additionalContext.includes("\"editGuidance\""), true);
-  assert.equal(secondInject.additionalContext.includes("\"reactWebContext\""), true);
+  assert.equal(secondInject.contextModeReason, "additional-context-compression-inefficient");
+  assert.equal(secondInject.additionalContext, undefined);
   assert.ok(secondInject.reasons.includes("edit-guidance-opt-in"));
   assert.deepEqual(secondInject.debug.decision.payload.editGuidance.freshness, secondInject.debug.decision.payload.sourceFingerprint);
   assert.equal(secondInject.debug.decision.payload.reactWebContext.schemaVersion, "react-web-context.v0");
   assert.equal(secondInject.debug.decision.debug.reactWebContextBudget.included, true);
-  const optimizedEditPayload = JSON.parse(secondInject.additionalContext.split("\n").slice(1).join("\n"));
-  assert.equal(optimizedEditPayload.editGuidance.freshness.fileHash, optimizedEditPayload.sourceFingerprint.fileHash);
-  assert.ok(Array.isArray(optimizedEditPayload.reactWebContext.editTargetRouting));
-  assert.ok(optimizedEditPayload.reactWebContext.editTargetRouting.length > 0);
+  assert.equal(secondInject.debug.additionalContextAdmission.admitted, false);
+  assert.equal(secondInject.debug.additionalContextAdmission.reason, "candidate-not-smaller-than-source");
+  assert.ok(secondInject.debug.additionalContextAdmission.candidateBytes > secondInject.debug.additionalContextAdmission.sourceBytes);
   assert.equal(secondInject.debug.reactWebFactGraphPacking.included, false);
   assert.equal(secondInject.debug.reactWebFactGraphPacking.reason, "source-relative-budget-exceeded");
   assert.equal(secondInject.debug.reactWebFactGraphPacking.freshnessStatus, "fresh");
   assert.ok(secondInject.debug.reactWebFactGraphPacking.selectedAnchorCount > 0);
-  assert.equal("reactWebFactGraph" in optimizedEditPayload, false);
   assert.equal(secondInject.debug.reactWebContextPacking.included, true);
   assert.equal(secondInject.debug.reactWebContextPacking.reason, "packed");
   assert.equal(secondInject.debug.reactWebContextPacking.priority[0], "editTargetRouting");
@@ -141,7 +138,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.debug.reactWebContextPacking.fields[0].name, "editTargetRouting");
   assert.equal(
     secondInject.debug.reactWebContextPacking.fields.find((field) => field.name === "editTargetRouting")?.count,
-    optimizedEditPayload.reactWebContext.editTargetRouting.length,
+    secondInject.debug.reactWebContextPacking.fields.find((field) => field.name === "editTargetRouting")?.count,
   );
   assert.equal(
     secondInject.debug.reactWebContextPacking.totalAnchors,
@@ -179,6 +176,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal("editTargetRouting" in optimizedContextPayload.reactWebContext, false);
   assert.equal(secondContext.debug.reactWebContextPacking.included, true);
   assert.deepEqual(secondContext.debug.reactWebContextPacking.fields, []);
+  assert.equal(secondContext.debug.additionalContextAdmission, undefined);
   assert.ok(
     Buffer.byteLength(secondContext.additionalContext, "utf8") <= fs.statSync(path.join(repoRoot, "fixtures/compressed/FormSection.tsx")).size,
   );
@@ -202,8 +200,10 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
     repoRoot,
   );
   const pressurePayload = JSON.parse(pressureContext.additionalContext.split("\n").slice(1).join("\n"));
+  assert.equal(pressureContext.action, "inject");
   assert.equal(pressureContext.contextModeReason, "repeated-exact-file-react-web-payload");
   assert.equal("reactWebContext" in pressurePayload, false);
+  assert.equal(pressureContext.debug.additionalContextAdmission, undefined);
   assert.ok(
     Buffer.byteLength(pressureContext.additionalContext, "utf8") <= fs.statSync(path.join(repoRoot, "fixtures/compressed/HookEffectPanel.tsx")).size,
   );
@@ -284,11 +284,11 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   );
 
   assert.equal(firstWrapper.action, "record");
-  assert.equal(secondWrapper.action, "inject");
+  assert.equal(secondWrapper.action, "fallback");
   assert.equal(secondWrapper.debug.decision.debug.domainDetection.classification, "react-web");
   assert.deepEqual(secondWrapper.debug.decision.debug.frontendPayloadPolicy.evidenceGates, [CUSTOM_WRAPPER_DOM_SIGNAL_GAP]);
-  assert.equal(secondWrapper.contextModeReason, "repeated-exact-file-edit-guidance");
-  assert.equal(secondWrapper.additionalContext.includes("\"editGuidance\""), true);
+  assert.equal(secondWrapper.contextModeReason, "additional-context-compression-inefficient");
+  assert.equal(secondWrapper.debug.additionalContextAdmission.admitted, false);
 
   const readOnlySession = `bridge-contract-readonly-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: readOnlySession }, repoRoot);
@@ -313,6 +313,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondReadOnly.action, "inject");
   assert.equal(secondReadOnly.additionalContext.includes("\"editGuidance\""), false);
   assert.equal("editGuidance" in secondReadOnly.debug.decision.payload, false);
+  assert.equal(secondReadOnly.debug.additionalContextAdmission, undefined);
   assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.included, false);
   assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.reason, "no-edit-guidance");
   assert.equal(secondReadOnly.debug.reactWebFactGraphPacking.freshnessStatus, "unknown");


### PR DESCRIPTION
## Summary
- add React Web edit-guidance additionalContext admission diagnostics
- fallback instead of injecting inefficient generated edit context
- update live-hook dogfood evidence so only admitted candidates count as compression successes

Closes #1119

## Evidence
- `npm run build && node --test test/fooks.test.mjs test/react-web-activation-mode.test.mjs test/react-web-doctor-surface.test.mjs test/react-web-evidence-artifact.test.mjs test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-ranked-bundle.test.mjs test/react-web-status-surface.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm run -s evidence:react-web-live-hook-dogfood -- --run-id=admission-final --output=.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.json --markdown-output=.omx/specs/autoresearch-full-additional-context-admission/live-hook-evidence.md`

## Notes
- Full `npm test` was started and reached 1019/1032 before manual stop during long PR/release/stale-worktree surfaces; focused changed-surface suite passed afterward.
- This intentionally treats fallback/full-read as not a compression success.
