### PR TITLE
Keep blocked React Web edit-card reductions measurable

### DIFF
--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -829,11 +829,14 @@ function evaluateAdditionalContextAdmission(
     return { ...base, admitted: true, reason: "unknown-source-size" };
   }
 
+  const reductionPct = originalEstimatedBytes > 0
+    ? Number.parseFloat(((1 - candidateBytes / originalEstimatedBytes) * 100).toFixed(3))
+    : 0;
+
   if (originalEstimatedBytes < ADDITIONAL_CONTEXT_ADMISSION_MIN_SOURCE_BYTES) {
-    return { ...base, admitted: false, reason: "source-too-small", sourceBytes: originalEstimatedBytes };
+    return { ...base, admitted: false, reason: "source-too-small", sourceBytes: originalEstimatedBytes, reductionPct };
   }
 
-  const reductionPct = Number.parseFloat(((1 - candidateBytes / originalEstimatedBytes) * 100).toFixed(3));
   if (candidateBytes >= originalEstimatedBytes) {
     return { ...base, admitted: false, reason: "candidate-not-smaller-than-source", sourceBytes: originalEstimatedBytes, reductionPct };
   }

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2888,6 +2888,78 @@ test("runtime hook admits raw edit-card candidate before project knowledge appen
   assert.ok(withKnowledge.debug.additionalContextAdmission.candidateBytes < Buffer.byteLength(withKnowledge.additionalContext, "utf8"));
 });
 
+test("runtime hook keeps zero-byte source-too-small edit-card reductions finite", () => {
+  const tempDir = makeTempProject();
+  const target = path.join("src", "components", "EmptyEditCard.tsx");
+  fs.writeFileSync(path.join(tempDir, target), "");
+  const donorDecision = decideCodexPreRead(path.join(tempDir, "src", "components", "FormSection.tsx"), tempDir);
+  assert.equal(donorDecision.decision, "payload");
+  const emptySourceFingerprint = {
+    fileHash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    lineCount: 1,
+  };
+
+  withPatchedCodexPreRead((decision) => {
+    if (decision.filePath !== target) return decision;
+    return {
+      ...donorDecision,
+      filePath: target,
+      debug: {
+        ...donorDecision.debug,
+        domainDetection: {
+          ...donorDecision.debug.domainDetection,
+          filePath: target,
+        },
+      },
+      payload: {
+        ...donorDecision.payload,
+        filePath: target,
+        sourceFingerprint: emptySourceFingerprint,
+        reactWebContext: {
+          ...donorDecision.payload.reactWebContext,
+          freshness: emptySourceFingerprint,
+          scope: {
+            ...donorDecision.payload.reactWebContext.scope,
+            filePath: target,
+          },
+        },
+        editGuidance: {
+          freshness: emptySourceFingerprint,
+          patchTargets: donorDecision.payload.reactWebContext.editTargetRouting,
+        },
+      },
+    };
+  }, () => {
+    const sessionId = `hook-edit-card-zero-byte-${Date.now()}`;
+    handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId }, tempDir);
+    handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: `Please update ${target}`,
+      },
+      tempDir,
+    );
+    const second = handleCodexRuntimeHook(
+      {
+        hookEventName: "UserPromptSubmit",
+        sessionId,
+        prompt: `Again, update ${target}`,
+      },
+      tempDir,
+    );
+
+    assert.equal(second.action, "fallback");
+    assert.ok(second.debug.additionalContextAdmission, JSON.stringify(second, null, 2));
+    assert.equal(second.debug.additionalContextAdmission.reason, "source-too-small");
+    assert.equal(second.debug.additionalContextAdmission.sourceBytes, 0);
+    assert.equal(second.debug.additionalContextAdmission.reductionPct, 0);
+    assert.equal(Number.isFinite(second.debug.additionalContextAdmission.reductionPct), true);
+    const artifact = JSON.parse(fs.readFileSync(second.debug.reactWebEvidenceArtifact.path, "utf8"));
+    assert.equal(artifact.additionalContextAdmission.reductionPct, 0);
+  });
+});
+
 test("edit intent detection includes common exact-file coding verbs used by Codex prompts", () => {
   for (const prompt of [
     "Please implement fixtures/compressed/FormSection.tsx",

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -78,8 +78,22 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
     assert.ok(["fresh-anchors-packed", "source-relative-budget-exceeded"].includes(row.evidenceArtifact.runtimeGraph.reason));
     assert.equal(row.evidenceArtifact.additionalContextAdmission.diagnosticOnly, true);
     assert.equal(typeof row.evidenceArtifact.additionalContextAdmission.admitted, "boolean");
+    assert.equal(typeof row.evidenceArtifact.additionalContextAdmission.reductionPct, "number");
     assert.equal(typeof row.additionalContextReductionPct, "number");
   }
+  const sourceTooSmallRows = evidence.suite.fixtures.filter(
+    (row) => row.evidenceArtifact.additionalContextAdmission.reason === "source-too-small",
+  );
+  assert.ok(sourceTooSmallRows.length > 0);
+  for (const row of sourceTooSmallRows) {
+    const admission = row.evidenceArtifact.additionalContextAdmission;
+    const expectedReductionPct = Number.parseFloat(((1 - admission.candidateBytes / admission.sourceBytes) * 100).toFixed(3));
+    assert.equal(admission.reductionPct, expectedReductionPct);
+  }
+  assert.equal(
+    evidence.suite.summary.metricAliases.candidate_byte_reduction.min,
+    Math.min(...evidence.suite.fixtures.map((row) => row.evidenceArtifact.additionalContextAdmission.reductionPct)),
+  );
 
   assert.equal(evidence.boundary.diagnosticOnly, true);
   assert.equal(evidence.boundary.claimable, false);


### PR DESCRIPTION
## Summary

- keep `reductionPct` populated for known-size `source-too-small` edit-card candidates
- keep zero-byte candidates finite (`reductionPct: 0`) instead of serializing non-finite evidence
- lock the React Web dogfood evidence so candidate byte-reduction metrics include blocked candidates

Fixes #1123

## Validation

- `npm run -s typecheck -- --pretty false`
- `npm run -s build && node --test test/fooks.test.mjs test/react-web-live-hook-dogfood-evidence.test.mjs test/runtime-bridge-contract.test.mjs`
- `npm run -s build && node scripts/react-web-live-hook-dogfood-evidence.mjs --run-id=backlog-scout-1121-zero-finite --output=.omx/reports/backlog-scout-react-web-live-hook-zero-finite.json --markdown-output=.omx/reports/backlog-scout-react-web-live-hook-zero-finite.md`

## Evidence

After the fix, the TinyEditCard blocked candidate reports `reductionPct: 13.471`, and `candidate_byte_reduction.min` includes that value instead of starting at the admitted-row minimum. A zero-byte regression test also verifies `source-too-small` persists finite `reductionPct: 0` into the evidence artifact.