### PR TITLE
Treat merged PR merge-gate echoes as stale

### DIFF
--- a/scripts/triage-ci-alerts.mjs
+++ b/scripts/triage-ci-alerts.mjs
@@ -136,9 +136,81 @@ function fetchRunJobs(repoSlug, runId, spawn = spawnSync) {
   }
 }
 
+function fetchPullRequestsForBranch(repoSlug, branch, spawn = spawnSync) {
+  if (!repoSlug || !branch || branch === "unknown-branch") return [];
+  const result = spawn("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repoSlug,
+    "--head",
+    branch,
+    "--state",
+    "all",
+    "--limit",
+    "20",
+    "--json",
+    "number,state,headRefName,baseRefName,mergedAt,closedAt,url",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) return [];
+  try {
+    const payload = JSON.parse(result.stdout);
+    return Array.isArray(payload) ? payload : [];
+  } catch {
+    return [];
+  }
+}
+
 function isMergeGateRun(run) {
   return String(run.event || "") === "pull_request_target"
     && String(run.workflowName || run.name || "") === "Merge Gate";
+}
+
+function enrichRunsWithPullRequestState(rawRuns, options, spawn = spawnSync) {
+  if (options.input) return rawRuns;
+  const mergeGateBranches = [
+    ...new Set(rawRuns
+      .filter((run) => isMergeGateRun(run))
+      .map((run) => run.headBranch)
+      .filter(Boolean)),
+  ];
+  if (mergeGateBranches.length === 0) return rawRuns;
+
+  const repoSlug = repoSlugFromOrigin(spawn);
+  if (!repoSlug) return rawRuns;
+
+  const prsByBranch = new Map();
+  for (const branch of mergeGateBranches) {
+    const prs = fetchPullRequestsForBranch(repoSlug, branch, spawn)
+      .filter((pr) => pr?.headRefName === branch)
+      .sort((left, right) => {
+        const leftOpen = String(left.state || "").toUpperCase() === "OPEN" ? 1 : 0;
+        const rightOpen = String(right.state || "").toUpperCase() === "OPEN" ? 1 : 0;
+        if (leftOpen !== rightOpen) return rightOpen - leftOpen;
+        const leftTime = Date.parse(left.mergedAt || left.closedAt || "") || 0;
+        const rightTime = Date.parse(right.mergedAt || right.closedAt || "") || 0;
+        return rightTime - leftTime || Number(right.number ?? 0) - Number(left.number ?? 0);
+      });
+    if (prs.length > 0) prsByBranch.set(branch, prs[0]);
+  }
+
+  return rawRuns.map((run) => {
+    if (!isMergeGateRun(run)) return run;
+    const pr = prsByBranch.get(run.headBranch);
+    if (!pr) return run;
+    return {
+      ...run,
+      pullRequestNumber: pr.number ?? run.pullRequestNumber,
+      pullRequestState: pr.state ?? run.pullRequestState,
+      pullRequestUrl: pr.url ?? run.pullRequestUrl,
+      pullRequestMergedAt: pr.mergedAt ?? run.pullRequestMergedAt,
+      pullRequestClosedAt: pr.closedAt ?? run.pullRequestClosedAt,
+    };
+  });
 }
 
 function enrichRunsWithAlertJobs(rawRuns, alertRefs, options, spawn = spawnSync) {
@@ -301,6 +373,11 @@ function normalizeRun(run) {
     latestJobUrl: run.latestJobUrl ?? run.currentJobUrl ?? latestJob?.url ?? "",
     jobs,
     ciLane: ciLaneForRun(run),
+    pullRequestNumber: normalizePositiveInteger(run.pullRequestNumber ?? run.prNumber ?? run.pr),
+    pullRequestState: String(run.pullRequestState ?? run.prState ?? "").toUpperCase(),
+    pullRequestUrl: run.pullRequestUrl ?? run.prUrl ?? "",
+    pullRequestMergedAt: run.pullRequestMergedAt ?? run.prMergedAt ?? "",
+    pullRequestClosedAt: run.pullRequestClosedAt ?? run.prClosedAt ?? "",
     createdAt: run.createdAt || "",
     updatedAt: run.updatedAt || run.createdAt || "",
     url: run.url || "",
@@ -697,6 +774,17 @@ function runTime(run) {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
+function closedPullRequestReason(run) {
+  if (run.ciLane !== "pull_request_target:merge-gate") return "";
+  if (run.pullRequestState !== "MERGED" && run.pullRequestState !== "CLOSED") return "";
+  const pr = run.pullRequestNumber ? `PR #${run.pullRequestNumber}` : "matching PR";
+  const terminal = run.pullRequestState === "MERGED" ? "merged" : "closed";
+  const at = run.pullRequestState === "MERGED"
+    ? run.pullRequestMergedAt
+    : (run.pullRequestClosedAt || run.pullRequestMergedAt);
+  return at ? `${pr} ${terminal} at ${at}` : `${pr} ${terminal}`;
+}
+
 function classifyRuns(rawRuns) {
   const runs = rawRuns.map(normalizeRun).sort((left, right) => runTime(right) - runTime(left));
   const latestByKey = new Map();
@@ -709,12 +797,16 @@ function classifyRuns(rawRuns) {
   const rows = runs.map((run) => {
     const latest = latestByKey.get(runKey(run));
     const isLatest = latest === run;
+    const prClosedReason = closedPullRequestReason(run);
     let bucket = "informational";
     let reason = "not failing";
 
     if (STALE_CONCLUSIONS.has(run.conclusion)) {
       bucket = "stale";
       reason = `completed ${run.conclusion}`;
+    } else if (prClosedReason) {
+      bucket = "stale";
+      reason = prClosedReason;
     } else if (!isLatest) {
       bucket = "stale";
       reason = `superseded by run ${latest.id ?? "unknown"}`;
@@ -879,7 +971,9 @@ function runCli(argv = process.argv.slice(2), io = {}) {
   if (!Array.isArray(baseRuns)) throw new Error("Expected an array of GitHub Actions runs");
   const rawRuns = enrichRunsWithAlertJobs(baseRuns, alertRefs, options, spawn);
   if (!Array.isArray(rawRuns)) throw new Error("Expected an array of GitHub Actions runs");
-  const result = classifyRuns(rawRuns);
+  const enrichedRuns = enrichRunsWithPullRequestState(rawRuns, options, spawn);
+  if (!Array.isArray(enrichedRuns)) throw new Error("Expected an array of GitHub Actions runs");
+  const result = classifyRuns(enrichedRuns);
   const alertEvidence = buildAlertEvidence(alertRefs, result.rows, options);
   const tmuxHistoryEvidence = buildTmuxHistoryEvidence(alertText);
   result.alerts = alertEvidence.alerts;

--- a/test/ci-alert-triage.test.mjs
+++ b/test/ci-alert-triage.test.mjs
@@ -1138,6 +1138,199 @@ test("CI alert triage marks superseded pull_request_target Merge Gate job failur
   }
 });
 
+test("CI alert triage marks merged PR Merge Gate failures as stale closed-PR echoes", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merged-pr-"));
+  const runsPath = path.join(tempDir, "runs.json");
+
+  fs.writeFileSync(runsPath, JSON.stringify([
+    {
+      databaseId: 26636594921,
+      workflowName: "Merge Gate",
+      name: "Merge Gate",
+      headBranch: "dogfood/backlog-scout-20260529T1200",
+      headSha: "df251c9133ce8334a0155d4426a867ae11981241",
+      event: "pull_request_target",
+      status: "completed",
+      conclusion: "failure",
+      createdAt: "2026-05-29T12:13:42Z",
+      updatedAt: "2026-05-29T12:13:54Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26636594921",
+      pullRequestNumber: 1124,
+      pullRequestState: "MERGED",
+      pullRequestMergedAt: "2026-05-30T04:04:25Z",
+      pullRequestUrl: "https://github.com/minislively/fooks/pull/1124",
+    },
+    {
+      databaseId: 26674008990,
+      workflowName: "CI",
+      name: "CI",
+      headBranch: "main",
+      headSha: "676c77f47496bea3cfe908f8b49a7f9c2fee1a1f",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      createdAt: "2026-05-30T04:04:28Z",
+      updatedAt: "2026-05-30T04:07:34Z",
+      url: "https://github.com/minislively/fooks/actions/runs/26674008990",
+    },
+  ]));
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      triageScript,
+      "--input",
+      runsPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const result = JSON.parse(stdout);
+    const row = result.rows.find((entry) => entry.id === 26636594921);
+
+    assert.equal(row.bucket, "stale");
+    assert.match(row.reason, /PR #1124 merged at 2026-05-30T04:04:25Z/);
+    assert.equal(result.counts.actionable ?? 0, 0);
+    assert.equal(result.counts.stale, 1);
+    assert.equal(result.counts.informational, 1);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CI alert triage live PR enrichment marks merged PR Merge Gate failures stale", () => {
+  const chunks = [];
+  const spawn = (command, args) => {
+    if (command === "git" && args.join(" ") === "config --get remote.origin.url") {
+      return { status: 0, stdout: "https://github.com/minislively/fooks.git\n", stderr: "" };
+    }
+    if (command === "gh" && args[0] === "run" && args[1] === "list") {
+      return {
+        status: 0,
+        stdout: JSON.stringify([
+          {
+            databaseId: 26636594921,
+            workflowName: "Merge Gate",
+            name: "Merge Gate",
+            headBranch: "dogfood/backlog-scout-20260529T1200",
+            headSha: "df251c9133ce8334a0155d4426a867ae11981241",
+            event: "pull_request_target",
+            status: "completed",
+            conclusion: "failure",
+            createdAt: "2026-05-29T12:13:42Z",
+            updatedAt: "2026-05-29T12:13:54Z",
+            url: "https://github.com/minislively/fooks/actions/runs/26636594921",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+      assert.equal(args[args.indexOf("--head") + 1], "dogfood/backlog-scout-20260529T1200");
+      return {
+        status: 0,
+        stdout: JSON.stringify([
+          {
+            number: 1124,
+            state: "MERGED",
+            headRefName: "dogfood/backlog-scout-20260529T1200",
+            baseRefName: "main",
+            mergedAt: "2026-05-30T04:04:25Z",
+            closedAt: "2026-05-30T04:04:25Z",
+            url: "https://github.com/minislively/fooks/pull/1124",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    return { status: 1, stdout: "", stderr: `unexpected spawn ${command} ${JSON.stringify(args)}` };
+  };
+
+  runCli(["--json"], {
+    stdout: { write: (chunk) => chunks.push(String(chunk)) },
+    spawn,
+  });
+  const result = JSON.parse(chunks.join(""));
+  const row = result.rows.find((entry) => entry.id === 26636594921);
+
+  assert.equal(row.bucket, "stale");
+  assert.match(row.reason, /PR #1124 merged at 2026-05-30T04:04:25Z/);
+  assert.equal(result.counts.actionable ?? 0, 0);
+  assert.equal(result.counts.stale, 1);
+});
+
+test("CI alert triage prefers open PR state over older closed same-branch matches", () => {
+  const chunks = [];
+  const spawn = (command, args) => {
+    if (command === "git" && args.join(" ") === "config --get remote.origin.url") {
+      return { status: 0, stdout: "https://github.com/minislively/fooks.git\n", stderr: "" };
+    }
+    if (command === "gh" && args[0] === "run" && args[1] === "list") {
+      return {
+        status: 0,
+        stdout: JSON.stringify([
+          {
+            databaseId: 26600000001,
+            workflowName: "Merge Gate",
+            name: "Merge Gate",
+            headBranch: "reused-branch",
+            headSha: "openprsha",
+            event: "pull_request_target",
+            status: "completed",
+            conclusion: "failure",
+            createdAt: "2026-05-30T05:00:00Z",
+            updatedAt: "2026-05-30T05:05:00Z",
+            url: "https://github.com/minislively/fooks/actions/runs/26600000001",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+      return {
+        status: 0,
+        stdout: JSON.stringify([
+          {
+            number: 1100,
+            state: "MERGED",
+            headRefName: "reused-branch",
+            baseRefName: "main",
+            mergedAt: "2026-05-29T04:04:25Z",
+            closedAt: "2026-05-29T04:04:25Z",
+            url: "https://github.com/minislively/fooks/pull/1100",
+          },
+          {
+            number: 1126,
+            state: "OPEN",
+            headRefName: "reused-branch",
+            baseRefName: "main",
+            mergedAt: null,
+            closedAt: null,
+            url: "https://github.com/minislively/fooks/pull/1126",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    return { status: 1, stdout: "", stderr: `unexpected spawn ${command} ${JSON.stringify(args)}` };
+  };
+
+  runCli(["--json"], {
+    stdout: { write: (chunk) => chunks.push(String(chunk)) },
+    spawn,
+  });
+  const result = JSON.parse(chunks.join(""));
+  const row = result.rows.find((entry) => entry.id === 26600000001);
+
+  assert.equal(row.bucket, "actionable");
+  assert.equal(row.pullRequestNumber, 1126);
+  assert.equal(row.pullRequestState, "OPEN");
+  assert.equal(row.reason, "latest failure");
+  assert.equal(result.counts.actionable, 1);
+  assert.equal(result.counts.stale ?? 0, 0);
+});
+
 
 test("CI alert triage marks superseded pull_request_target Merge Gate job cancellations as stale rerun echoes", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-ci-alert-merge-gate-cancelled-rerun-"));


### PR DESCRIPTION
## Summary

- enrich Merge Gate CI alert runs with matching PR state by branch
- classify pull_request_target Merge Gate failures for already merged/closed PRs as stale closed-PR echoes
- add regression coverage for merged PR #1124-style false actionable alerts and open-PR branch preference

Fixes #1125

## Validation

- `node --test test/ci-alert-triage.test.mjs`
- `npm run -s typecheck -- --pretty false`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
