### PR TITLE
Make React Web edit context variants observable

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -178,6 +178,7 @@ function summarizeArtifact(artifactRef, expectedFile) {
           reason: admission.reason,
           sourceBytes: admission.sourceBytes ?? null,
           candidateKind: admission.candidateKind ?? null,
+          candidateVariant: admission.candidateVariant ?? null,
           candidateBytes: admission.candidateBytes ?? 0,
           reductionPct: admission.reductionPct ?? null,
           minSourceBytes: admission.minSourceBytes ?? null,

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -46,7 +46,8 @@ type RuntimeAdditionalContextAdmissionReason = "admitted" | "unknown-source-size
 type RuntimeAdditionalContextAdmission = {
   admitted: boolean;
   reason: RuntimeAdditionalContextAdmissionReason;
-  candidateKind?: "optimized-react-web-runtime-payload" | "react-web-edit-card.v1";
+  candidateKind?: "optimized-react-web-runtime-payload" | "react-web-edit-card.v1" | "react-web-edit-card.v2";
+  candidateVariant?: RuntimeReactWebEditCardV2Variant;
   sourceBytes?: number;
   candidateBytes: number;
   reductionPct?: number;
@@ -66,6 +67,25 @@ type RuntimeReactWebEditCard = {
   hints: string[];
   readIfNeeded: true;
 };
+export type RuntimeReactWebEditCardV2 = {
+  k: "rw.edit.v2";
+  f: string;
+  fp?: string;
+  c?: string;
+  t: Array<[number, number, string, string]>;
+  r?: string[];
+  h?: string[];
+  d?: string[];
+  g?: Array<[number, string, string]>;
+  p?: string[];
+  ri: true;
+};
+export type RuntimeReactWebEditCardV2Variant =
+  | "full"
+  | "no-graph"
+  | "no-dependencies"
+  | "targets-roles-hooks"
+  | "targets-roles";
 
 type PackedRuntimeReactWebFactGraph = {
   schemaVersion: "react-web-fact-graph-runtime-context.v1";
@@ -142,6 +162,10 @@ function uniqueLimited(values: string[], limit: number): string[] {
   return [...new Set(values.filter(Boolean))].slice(0, limit);
 }
 
+function withoutUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}
+
 function buildReactWebEditCard(payload: ModelFacingPayload): RuntimeReactWebEditCard | undefined {
   if (payload.domainPayload?.domain !== "react-web" || !payload.editGuidance || payload.useOriginal) return undefined;
 
@@ -187,6 +211,149 @@ function renderReactWebEditCardAdditionalContext(
     `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · context-mode: ${contextMode} · candidate: react-web-edit-card.v1`,
     JSON.stringify(card),
   ].join("\n");
+}
+
+function compactGraphAnchors(reactWebFactGraph: PackedRuntimeReactWebFactGraph | undefined): RuntimeReactWebEditCardV2["g"] | undefined {
+  const anchors = reactWebFactGraph?.selectedAnchors
+    .map((anchor): [number, string, string] => [anchor.rank, anchor.kind, anchor.label])
+    .slice(0, 3);
+  return anchors && anchors.length > 0 ? anchors : undefined;
+}
+
+function buildReactWebEditCardV2(
+  payload: ModelFacingPayload,
+  reactWebFactGraph?: PackedRuntimeReactWebFactGraph,
+): RuntimeReactWebEditCardV2 | undefined {
+  if (payload.domainPayload?.domain !== "react-web" || !payload.editGuidance || payload.useOriginal) return undefined;
+
+  const patchTargets = payload.editGuidance.patchTargets
+    .map((target) => locTuple(target.loc, target.kind, target.label))
+    .filter((target): target is [number, number, string, string] => Boolean(target))
+    .slice(0, 4);
+  const routingTargets = [...(payload.reactWebContext?.editTargetRouting ?? [])]
+    .sort((left, right) => left.priority - right.priority)
+    .map((target) => locTuple(target.loc, target.kind, target.label))
+    .filter((target): target is [number, number, string, string] => Boolean(target))
+    .slice(0, Math.max(0, 4 - patchTargets.length));
+  const targets = [...patchTargets, ...routingTargets];
+
+  const roles = uniqueLimited([
+    ...(payload.reactWebContext?.formStateRoles ?? []).map((role) => `form:${role.role}`),
+    ...(payload.reactWebContext?.intentTargets ?? []).map((target) => `intent:${target.intent}`),
+    ...(payload.reactWebContext?.formStateFlow ?? []).map((flow) => `flow:${flow.kind}`),
+    ...(payload.reactWebContext?.stateHints ?? []).map((hint) => `state:${hint.kind}`),
+    ...(payload.reactWebContext?.a11yAnchors ?? []).map((anchor) => `a11y:${anchor.kind}`),
+    ...(payload.reactWebContext?.layoutRegionHints ?? []).map((hint) => `layout:${hint.kind}`),
+    ...(payload.reactWebContext?.componentApiHints ?? []).map((hint) => `api:${hint.kind}`),
+    ...(payload.reactWebContext?.stylingVariantHints ?? []).map((hint) => `style:${hint.kind}`),
+  ], 6);
+
+  const hooks = uniqueLimited([
+    ...(payload.behavior?.hooks ?? []),
+    ...(payload.reactWebContext?.formStateFlow ?? []).flatMap((flow) => (flow.hook ? [flow.hook.hook, ...flow.hook.deps] : [])),
+    ...(payload.reactWebContext?.importRoleHints ?? []).flatMap((hint) => [
+      hint.role,
+      hint.moduleSpecifier,
+      ...(hint.importedSymbols ?? []),
+    ]),
+  ], 6);
+
+  const dependencies = uniqueLimited([
+    ...(payload.reactWebContext?.localDependencies ?? []).map((dependency) => dependency.symbol),
+    ...(payload.reactWebContext?.importRoleHints ?? []).map((hint) => hint.moduleSpecifier),
+  ], 6);
+  const graphAnchors = compactGraphAnchors(reactWebFactGraph);
+  const provenance = uniqueLimited([
+    targets.length > 0 ? "source" : "",
+    roles.length > 0 || hooks.length > 0 || dependencies.length > 0 ? "context" : "",
+    graphAnchors ? "graph" : "",
+  ], 3);
+
+  if (targets.length === 0 && roles.length === 0 && hooks.length === 0) return undefined;
+
+  return withoutUndefined({
+    k: "rw.edit.v2" as const,
+    f: payload.filePath,
+    fp: compactFingerprint(payload.sourceFingerprint),
+    c: payload.reactWebContext?.scope.componentName ?? payload.componentName,
+    t: targets,
+    r: roles.length > 0 ? roles : undefined,
+    h: hooks.length > 0 ? hooks : undefined,
+    d: dependencies.length > 0 ? dependencies : undefined,
+    g: graphAnchors,
+    p: provenance.length > 0 ? provenance : undefined,
+    ri: true as const,
+  });
+}
+
+function renderReactWebEditCardV2(card: RuntimeReactWebEditCardV2, prefix: string): string {
+  return [prefix, JSON.stringify(card)].join("\n");
+}
+
+function reactWebEditCardV2Provenance(card: RuntimeReactWebEditCardV2): string[] | undefined {
+  const provenance = uniqueLimited([
+    card.t.length > 0 ? "source" : "",
+    (card.r?.length ?? 0) > 0 || (card.h?.length ?? 0) > 0 || (card.d?.length ?? 0) > 0 ? "context" : "",
+    (card.g?.length ?? 0) > 0 ? "graph" : "",
+  ], 3);
+  return provenance.length > 0 ? provenance : undefined;
+}
+
+function withReactWebEditCardV2Provenance(card: RuntimeReactWebEditCardV2): RuntimeReactWebEditCardV2 {
+  return withoutUndefined({ ...card, p: reactWebEditCardV2Provenance(card) });
+}
+
+export function selectReactWebEditCardV2VariantForBudget(
+  card: RuntimeReactWebEditCardV2,
+  options: { maxCandidateBytes?: number; renderPrefix?: string } = {},
+): { card?: RuntimeReactWebEditCardV2; variant?: RuntimeReactWebEditCardV2Variant; bytes: number } {
+  const prefix = options.renderPrefix ?? "fooks: candidate: react-web-edit-card.v2";
+  const maxCandidateBytes = options.maxCandidateBytes;
+  const variants: Array<{ variant: RuntimeReactWebEditCardV2Variant; card: RuntimeReactWebEditCardV2 }> = [
+    { variant: "full", card: withReactWebEditCardV2Provenance(card) },
+    { variant: "no-graph", card: withReactWebEditCardV2Provenance(withoutUndefined({ ...card, g: undefined })) },
+    { variant: "no-dependencies", card: withReactWebEditCardV2Provenance(withoutUndefined({ ...card, g: undefined, d: undefined })) },
+    {
+      variant: "targets-roles-hooks",
+      card: withoutUndefined({ k: card.k, f: card.f, fp: card.fp, c: card.c, t: card.t, r: card.r, h: card.h, ri: card.ri }),
+    },
+    {
+      variant: "targets-roles",
+      card: withoutUndefined({ k: card.k, f: card.f, fp: card.fp, c: card.c, t: card.t, r: card.r, ri: card.ri }),
+    },
+  ];
+
+  for (const candidate of variants) {
+    if (candidate.card.t.length === 0 && (candidate.card.r?.length ?? 0) === 0 && (candidate.card.h?.length ?? 0) === 0) continue;
+    const bytes = estimateTextBytes(renderReactWebEditCardV2(candidate.card, prefix));
+    if (maxCandidateBytes === undefined || bytes <= maxCandidateBytes) {
+      return { ...candidate, bytes };
+    }
+  }
+
+  return {
+    bytes: estimateTextBytes(renderReactWebEditCardV2(variants[variants.length - 1].card, prefix)),
+  };
+}
+
+function renderReactWebEditCardV2AdditionalContext(
+  filePath: string,
+  payload: ModelFacingPayload,
+  contextMode: ContextMode,
+  reactWebFactGraph?: PackedRuntimeReactWebFactGraph,
+  maxCandidateBytes?: number,
+): { additionalContext?: string; variant?: RuntimeReactWebEditCardV2Variant; bytes?: number; graphIncluded: boolean } {
+  const card = buildReactWebEditCardV2(payload, reactWebFactGraph);
+  if (!card) return { graphIncluded: false };
+  const prefix = `${buildPreReadReuseStatus(payload.mode)} · file: ${filePath} · context-mode: ${contextMode} · candidate: react-web-edit-card.v2`;
+  const selected = selectReactWebEditCardV2VariantForBudget(card, { maxCandidateBytes, renderPrefix: prefix });
+  if (!selected.card) return { graphIncluded: false, bytes: selected.bytes };
+  return {
+    additionalContext: renderReactWebEditCardV2(selected.card, prefix),
+    variant: selected.variant,
+    bytes: selected.bytes,
+    graphIncluded: Boolean(selected.card.g?.length),
+  };
 }
 
 function minimalRuntimeReactWebContext(reactWebContext: RuntimeReactWebContext): PackedRuntimeReactWebContext {
@@ -651,21 +818,50 @@ function buildAdditionalContext(
   maxOptimizedContextBytes?: number,
   cwd = process.cwd(),
   includeReactWebFactGraph = true,
-): { additionalContext: string; reactWebContextPacking?: RuntimeReactWebContextPackingSummary; reactWebFactGraphPacking?: RuntimeReactWebFactGraphPackingSummary; candidateKind?: RuntimeAdditionalContextAdmission["candidateKind"] } {
+): {
+  additionalContext: string;
+  reactWebContextPacking?: RuntimeReactWebContextPackingSummary;
+  reactWebFactGraphPacking?: RuntimeReactWebFactGraphPackingSummary;
+  candidateKind?: RuntimeAdditionalContextAdmission["candidateKind"];
+  candidateVariant?: RuntimeAdditionalContextAdmission["candidateVariant"];
+} {
   if (payload.domainPayload?.domain === "react-web" && !payload.useOriginal) {
     if (payload.editGuidance) {
+      const compactedGraph = includeReactWebFactGraph
+        ? compactRuntimeReactWebFactGraph(filePath, cwd)
+        : { packing: runtimeReactWebFactGraphOutOfScopePacking() };
+      const maxCandidateBytes = maxOptimizedContextBytes === undefined
+        ? EDIT_GUIDANCE_CONTEXT_MAX_BYTES
+        : Math.min(maxOptimizedContextBytes, EDIT_GUIDANCE_CONTEXT_MAX_BYTES);
+      const editCardV2 = renderReactWebEditCardV2AdditionalContext(
+        filePath,
+        payload,
+        contextMode,
+        compactedGraph.graph,
+        maxCandidateBytes,
+      );
+      if (editCardV2.additionalContext) {
+        const editCardGraphPacking =
+          compactedGraph.graph && !editCardV2.graphIncluded
+            ? runtimeReactWebFactGraphPackingSummary(
+                maxOptimizedContextBytes === undefined ? "budget-exceeded" : "source-relative-budget-exceeded",
+                compactedGraph.graph,
+              )
+            : compactedGraph.packing;
+        return {
+          additionalContext: editCardV2.additionalContext,
+          ...(payload.reactWebContext ? { reactWebContextPacking: summarizeRuntimeReactWebContextPacking(minimalRuntimeReactWebContext(payload.reactWebContext)) } : {}),
+          reactWebFactGraphPacking: editCardGraphPacking,
+          candidateKind: "react-web-edit-card.v2",
+          candidateVariant: editCardV2.variant,
+        };
+      }
       const editCardContext = renderReactWebEditCardAdditionalContext(filePath, payload, contextMode);
       if (editCardContext) {
-        let editCardGraphPacking: RuntimeReactWebFactGraphPackingSummary | undefined;
-        if (includeReactWebFactGraph) {
-          editCardGraphPacking = compactRuntimeReactWebFactGraph(filePath, cwd).packing;
-        } else {
-          editCardGraphPacking = runtimeReactWebFactGraphOutOfScopePacking();
-        }
         return {
           additionalContext: editCardContext,
           ...(payload.reactWebContext ? { reactWebContextPacking: summarizeRuntimeReactWebContextPacking(minimalRuntimeReactWebContext(payload.reactWebContext)) } : {}),
-          reactWebFactGraphPacking: editCardGraphPacking,
+          reactWebFactGraphPacking: compactedGraph.packing,
           candidateKind: "react-web-edit-card.v1",
         };
       }
@@ -817,10 +1013,12 @@ function evaluateAdditionalContextAdmission(
   originalEstimatedBytes: number | undefined,
   candidateBytes: number,
   candidateKind?: RuntimeAdditionalContextAdmission["candidateKind"],
+  candidateVariant?: RuntimeAdditionalContextAdmission["candidateVariant"],
 ): RuntimeAdditionalContextAdmission {
   const base = {
     candidateBytes,
     ...(candidateKind ? { candidateKind } : {}),
+    ...(candidateVariant ? { candidateVariant } : {}),
     minSourceBytes: ADDITIONAL_CONTEXT_ADMISSION_MIN_SOURCE_BYTES,
     minReductionPct: ADDITIONAL_CONTEXT_ADMISSION_MIN_REDUCTION_PCT,
   };
@@ -1305,7 +1503,12 @@ export function handleCodexRuntimeHook(input: CodexRuntimeHookInput, cwd = proce
     }
 
     const admission = isReactWebOptimizedPayload(decision.payload) && editGuidanceIncluded
-      ? evaluateAdditionalContextAdmission(originalEstimatedBytes, estimateTextBytes(candidateAdditionalContext), runtimeContext.candidateKind)
+      ? evaluateAdditionalContextAdmission(
+          originalEstimatedBytes,
+          estimateTextBytes(candidateAdditionalContext),
+          runtimeContext.candidateKind,
+          runtimeContext.candidateVariant,
+        )
       : undefined;
     attachAdditionalContextAdmissionDebug(runtimeDecision, admission);
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -794,7 +794,8 @@ export type CodexRuntimeHookDecision = {
         | "reduction-below-threshold";
       sourceBytes?: number;
       candidateBytes: number;
-      candidateKind?: "optimized-react-web-runtime-payload" | "react-web-edit-card.v1";
+      candidateKind?: "optimized-react-web-runtime-payload" | "react-web-edit-card.v1" | "react-web-edit-card.v2";
+      candidateVariant?: "full" | "no-graph" | "no-dependencies" | "targets-roles-hooks" | "targets-roles";
       reductionPct?: number;
       minSourceBytes: number;
       minReductionPct: number;

--- a/src/reporting/react-web-evidence-artifact.ts
+++ b/src/reporting/react-web-evidence-artifact.ts
@@ -311,7 +311,14 @@ function assertValidArtifact(artifact: unknown): asserts artifact is ReactWebEvi
       admission.candidateBytes < 0 ||
       (admission.candidateKind !== undefined &&
         admission.candidateKind !== "optimized-react-web-runtime-payload" &&
-        admission.candidateKind !== "react-web-edit-card.v1") ||
+        admission.candidateKind !== "react-web-edit-card.v1" &&
+        admission.candidateKind !== "react-web-edit-card.v2") ||
+      (admission.candidateVariant !== undefined &&
+        admission.candidateVariant !== "full" &&
+        admission.candidateVariant !== "no-graph" &&
+        admission.candidateVariant !== "no-dependencies" &&
+        admission.candidateVariant !== "targets-roles-hooks" &&
+        admission.candidateVariant !== "targets-roles") ||
       typeof admission.minSourceBytes !== "number" ||
       !Number.isFinite(admission.minSourceBytes) ||
       admission.minSourceBytes < 0 ||
@@ -467,6 +474,7 @@ export function renderReactWebEvidenceArtifactMarkdown(artifact: ReactWebEvidenc
         `- reason: ${artifact.additionalContextAdmission.reason}`,
         `- source bytes: ${artifact.additionalContextAdmission.sourceBytes ?? "unknown"}`,
         `- candidate kind: ${artifact.additionalContextAdmission.candidateKind ?? "unknown"}`,
+        `- candidate variant: ${artifact.additionalContextAdmission.candidateVariant ?? "unknown"}`,
         `- candidate bytes: ${artifact.additionalContextAdmission.candidateBytes}`,
         `- reduction: ${artifact.additionalContextAdmission.reductionPct ?? "unknown"}%`,
         `- minimum source bytes: ${artifact.additionalContextAdmission.minSourceBytes}`,

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -2782,7 +2782,7 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.contextMode, "light");
   assert.equal(second.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(second.filePath, path.join("fixtures", "compressed", "FormSection.tsx"));
-  assert.match(second.additionalContext, /candidate: react-web-edit-card\.v1/);
+  assert.match(second.additionalContext, /candidate: react-web-edit-card\.v2/);
   assert.doesNotMatch(second.additionalContext, /domainPayload|editGuidance/);
   assert.ok(second.reasons.includes("edit-guidance-opt-in"));
   assert.equal(second.reasons.includes("preflight-advisory-attached"), false);
@@ -2798,7 +2798,8 @@ test("runtime hook reuses payload only on repeated same-file prompts in one sess
   assert.equal(second.debug.reactWebActivationMode.promoted, true);
   assert.equal(second.debug.additionalContextAdmission.admitted, true);
   assert.equal(second.debug.additionalContextAdmission.reason, "admitted");
-  assert.equal(second.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(second.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
+  assert.equal(typeof second.debug.additionalContextAdmission.candidateVariant, "string");
 
   fs.writeFileSync(second.statePath, "{not-json");
   const afterCorruptState = handleCodexRuntimeHook(
@@ -2879,7 +2880,7 @@ test("runtime hook admits raw edit-card candidate before project knowledge appen
   assert.equal(withKnowledge.action, "inject");
   assert.match(withKnowledge.additionalContext, /PROJECT KNOWLEDGE CONTEXT/);
   assert.ok(withKnowledge.additionalContext.length > baseline.additionalContext.length);
-  assert.equal(withKnowledge.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(withKnowledge.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
   assert.equal(withKnowledge.debug.additionalContextAdmission.admitted, true);
   assert.equal(
     withKnowledge.debug.additionalContextAdmission.candidateBytes,
@@ -3006,7 +3007,7 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
   assert.equal(implementSecond.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(implementSecond.reasons.includes("edit-guidance-opt-in"), true);
   assert.equal(implementSecond.debug.additionalContextAdmission.admitted, true);
-  assert.equal(implementSecond.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(implementSecond.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
 
   const renameSession = `hook-rename-edit-guidance-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: renameSession }, repoRoot);
@@ -3030,7 +3031,7 @@ test("runtime hook treats implement and rename prompts as safe edit-intent guida
   assert.equal(renameSecond.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(renameSecond.reasons.includes("edit-guidance-opt-in"), true);
   assert.equal(renameSecond.debug.additionalContextAdmission.admitted, true);
-  assert.equal(renameSecond.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(renameSecond.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
 });
 
 test("runtime hook gates edit guidance to repeated exact-file edit intent prompts", () => {
@@ -3771,7 +3772,7 @@ test("native hook bridge only activates inside attached codex projects", () => {
   assert.equal(second.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(
     second.hookSpecificOutput.additionalContext,
-    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx · context-mode: light · candidate: react-web-edit-card\.v1/,
+    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx · context-mode: light · candidate: react-web-edit-card\.v2/,
   );
 });
 
@@ -3894,7 +3895,7 @@ test("cli codex-runtime-hook can read native hook payloads from stdin", () => {
   assert.equal(cliSecond.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(
     cliSecond.hookSpecificOutput.additionalContext,
-    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx · context-mode: light · candidate: react-web-edit-card\.v1/,
+    /fooks: reused pre-read \(compressed\) · file: src\/components\/FormSection\.tsx · context-mode: light · candidate: react-web-edit-card\.v2/,
   );
 });
 

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -18,7 +18,11 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const { handleCodexRuntimeHook, summarizeRuntimeReactWebFactGraphDryRun } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const {
+  handleCodexRuntimeHook,
+  selectReactWebEditCardV2VariantForBudget,
+  summarizeRuntimeReactWebFactGraphDryRun,
+} = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
 const {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
@@ -88,6 +92,92 @@ test("runtime graph packing reasons cover every canonical omission and success s
   );
 });
 
+test("React Web edit-card v2 selector follows ordered first-fit degradation ladder", () => {
+  const card = {
+    k: "rw.edit.v2",
+    f: "src/components/FormSection.tsx",
+    fp: "abcdef123456:120",
+    c: "FormSection",
+    t: [[10, 20, "primary-component", "FormSection"]],
+    r: ["form:form-root", "intent:form"],
+    h: ["useForm", "Controller"],
+    d: ["FieldInput"],
+    g: [[1, "component", "FormSection"]],
+    p: ["source", "context", "graph"],
+    ri: true,
+  };
+  const prefix = "fooks: reused pre-read (compressed) · candidate: react-web-edit-card.v2";
+  const full = selectReactWebEditCardV2VariantForBudget(card, { renderPrefix: prefix });
+  const budgetForVariant = (variant) => {
+    for (let budget = full.bytes - 1; budget > 0; budget -= 1) {
+      const selected = selectReactWebEditCardV2VariantForBudget(card, { renderPrefix: prefix, maxCandidateBytes: budget });
+      if (selected.variant === variant) return budget;
+    }
+    throw new Error(`No budget selected ${variant}`);
+  };
+  const noGraph = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: full.bytes - 1,
+  });
+  const noGraphBytes = selectReactWebEditCardV2VariantForBudget({ ...card, g: undefined, p: ["source", "context"] }, { renderPrefix: prefix }).bytes;
+  const noDependencies = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: noGraphBytes - 1,
+  });
+  const targetsRolesHooksBytes = selectReactWebEditCardV2VariantForBudget(
+    { ...card, g: undefined, d: undefined, p: undefined },
+    { renderPrefix: prefix },
+  ).bytes;
+  const targetsRolesHooks = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: budgetForVariant("targets-roles-hooks"),
+  });
+  const targetsRolesBytes = selectReactWebEditCardV2VariantForBudget(
+    { k: card.k, f: card.f, fp: card.fp, c: card.c, t: card.t, r: card.r, ri: card.ri },
+    { renderPrefix: prefix },
+  ).bytes;
+  const targetsRoles = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: budgetForVariant("targets-roles"),
+  });
+  const fallback = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: 1,
+  });
+
+  assert.equal(full.variant, "full");
+  assert.equal(noGraph.variant, "no-graph");
+  assert.equal(noDependencies.variant, "no-dependencies");
+  assert.equal(targetsRolesHooks.variant, "targets-roles-hooks");
+  assert.equal(targetsRoles.variant, "targets-roles");
+  assert.equal(fallback.card, undefined);
+  assert.equal(fallback.variant, undefined);
+});
+
+test("React Web edit-card v2 selector trims stale provenance before over-degrading", () => {
+  const card = {
+    k: "rw.edit.v2",
+    f: "src/components/FormSection.tsx",
+    t: [[10, 20, "primary-component", "FormSection"]],
+    d: ["VeryLongDependencyOnlyAnchor"],
+    p: ["source", "context"],
+    ri: true,
+  };
+  const prefix = "fooks: reused pre-read (compressed) · candidate: react-web-edit-card.v2";
+  const noDependenciesBytes = selectReactWebEditCardV2VariantForBudget(
+    { k: card.k, f: card.f, t: card.t, ri: card.ri },
+    { renderPrefix: prefix },
+  ).bytes;
+  const selected = selectReactWebEditCardV2VariantForBudget(card, {
+    renderPrefix: prefix,
+    maxCandidateBytes: noDependenciesBytes,
+  });
+
+  assert.equal(selected.variant, "no-dependencies");
+  assert.deepEqual(selected.card.p, ["source"]);
+  assert.equal("d" in selected.card, false);
+});
+
 test("runtime bridge contract keeps repeated-read inject and fallback semantics stable", () => {
   const injectSession = `bridge-contract-inject-${Date.now()}`;
   const start = handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: injectSession }, repoRoot);
@@ -114,7 +204,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.action, "inject");
   assert.equal(secondInject.debug.decision.payload.domainPayload.domain, "react-web");
   assert.equal(secondInject.contextModeReason, "repeated-exact-file-edit-guidance");
-  assert.match(secondInject.additionalContext, /candidate: react-web-edit-card\.v1/);
+  assert.match(secondInject.additionalContext, /candidate: react-web-edit-card\.v2/);
   assert.doesNotMatch(secondInject.additionalContext, /domainPayload/);
   assert.doesNotMatch(secondInject.additionalContext, /editGuidance/);
   assert.ok(secondInject.reasons.includes("edit-guidance-opt-in"));
@@ -123,7 +213,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.debug.decision.debug.reactWebContextBudget.included, true);
   assert.equal(secondInject.debug.additionalContextAdmission.admitted, true);
   assert.equal(secondInject.debug.additionalContextAdmission.reason, "admitted");
-  assert.equal(secondInject.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(secondInject.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
+  assert.equal(typeof secondInject.debug.additionalContextAdmission.candidateVariant, "string");
   assert.ok(secondInject.debug.additionalContextAdmission.candidateBytes < secondInject.debug.additionalContextAdmission.sourceBytes);
   assert.ok(secondInject.debug.additionalContextAdmission.reductionPct >= secondInject.debug.additionalContextAdmission.minReductionPct);
   assert.equal(secondInject.debug.reactWebFactGraphPacking.included, true);
@@ -287,7 +378,7 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.deepEqual(secondWrapper.debug.decision.debug.frontendPayloadPolicy.evidenceGates, [CUSTOM_WRAPPER_DOM_SIGNAL_GAP]);
   assert.equal(secondWrapper.contextModeReason, "repeated-exact-file-edit-guidance");
   assert.equal(secondWrapper.debug.additionalContextAdmission.admitted, true);
-  assert.equal(secondWrapper.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v1");
+  assert.equal(secondWrapper.debug.additionalContextAdmission.candidateKind, "react-web-edit-card.v2");
 
   const readOnlySession = `bridge-contract-readonly-${Date.now()}`;
   handleCodexRuntimeHook({ hookEventName: "SessionStart", sessionId: readOnlySession }, repoRoot);


### PR DESCRIPTION
## Summary

Fixes #1131

- emit `react-web-edit-card.v2` for React Web edit-guidance repeated-read context
- dual-accept v1/v2 candidate kinds in runtime schema and evidence artifact validation
- add ordered first-fit degradation variants and expose `candidateVariant`
- keep fresh-only graph inclusion, admission-before-appenders, fallback behavior, and non-claim boundaries

## Why this design

- v2 is a compact structural card, not a prose summary, so it can carry source anchors/roles/hooks/deps/graph facts with bounded bytes.
- dual-accept keeps rollback/backward compatibility while making v2 the default path.
- the ordered variant ladder makes byte-pressure behavior deterministic instead of silently bloating or dropping all context.
- `candidateVariant` prevents future metric confusion by showing whether the admitted card was full, no-graph, no-dependencies, etc.

## Evidence

- Rebased on latest `main` after #1127/#1129.
- Dogfood evidence: `.omx/specs/react-web-candidate-generator-v2-evidence.json`
  - validation: passed
  - success candidate: `react-web-edit-card.v2`, variant `full`, reduction `63.141%`
  - candidate_admission_rate: `0.857`
  - candidate_compression_success_rate: `0.857`
  - fallback_used_rate: `0.143`

## Validation

- `npm run typecheck -- --pretty false`
- `npm run -s build`
- `node --test --test-name-pattern 'edit-card candidate|additionalContext admission|React Web live hook|runtime bridge contract|ordered first-fit|trims stale provenance' test/fooks.test.mjs test/runtime-bridge-contract.test.mjs test/react-web-live-hook-dogfood-evidence.test.mjs`
- `node scripts/react-web-live-hook-dogfood-evidence.mjs --json > .omx/specs/react-web-candidate-generator-v2-evidence.json`
- `git diff --check`

## Review

- ralplan Architect: APPROVE
- ralplan Critic: APPROVE
- final code-reviewer: APPROVE
- final architect: CLEAR