### PR TITLE
Expand React Web fixture matrix coverage

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -16,9 +16,12 @@ export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES = [
   "fixtures/compressed/HookEffectPanel.tsx",
   "fixtures/compressed/TinyEditCard.tsx",
   "fixtures/hybrid/DashboardPanel.tsx",
+  "fixtures/compressed/FormControls.tsx",
   "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
   "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
   "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+  "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx",
+  "test/fixtures/react-web-context-expansion/client-state-release-store.tsx",
 ];
 
 const NON_CLAIMS = [

--- a/src/core/payload/readiness.ts
+++ b/src/core/payload/readiness.ts
@@ -26,7 +26,10 @@ export function assessPayloadReadiness(result: ExtractionResult, payload: ModelF
   }
 
   if (result.mode === "raw") reasons.push("raw-mode");
-  if (!moduleLanguage && !payload.contract) reasons.push("missing-contract");
+  const hasReactWebReuseShape =
+    result.domainDetection?.classification === "react-web" &&
+    (payload.domainPayload?.domain === "react-web" || Boolean(payload.reactWebContext) || Boolean(payload.editGuidance));
+  if (!moduleLanguage && !payload.contract && !hasReactWebReuseShape) reasons.push("missing-contract");
   if (!payload.behavior) reasons.push("missing-behavior");
   if (!payload.structure) reasons.push("missing-structure");
   if (result.mode === "hybrid" && (!payload.snippets || payload.snippets.length === 0)) {

--- a/test/fixtures/react-web-context-expansion/client-state-release-store.tsx
+++ b/test/fixtures/react-web-context-expansion/client-state-release-store.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { create } from "zustand";
+
+interface ReleaseStoreState {
+  selectedReleaseId: string;
+  showBlockedOnly: boolean;
+  selectRelease: (releaseId: string) => void;
+  toggleBlockedOnly: () => void;
+}
+
+const useReleaseStore = create<ReleaseStoreState>((set) => ({
+  selectedReleaseId: "release-2026-06",
+  showBlockedOnly: false,
+  selectRelease: (selectedReleaseId) => set({ selectedReleaseId }),
+  toggleBlockedOnly: () => set((state) => ({ showBlockedOnly: !state.showBlockedOnly })),
+}));
+
+export interface ReleaseOption {
+  id: string;
+  label: string;
+  blocked: boolean;
+}
+
+export interface ReleaseStorePanelProps {
+  releases: ReleaseOption[];
+}
+
+export function ReleaseStorePanel({ releases }: ReleaseStorePanelProps) {
+  const selectedReleaseId = useReleaseStore((state) => state.selectedReleaseId);
+  const showBlockedOnly = useReleaseStore((state) => state.showBlockedOnly);
+  const selectRelease = useReleaseStore((state) => state.selectRelease);
+  const toggleBlockedOnly = useReleaseStore((state) => state.toggleBlockedOnly);
+
+  const visibleReleases = showBlockedOnly ? releases.filter((release) => release.blocked) : releases;
+
+  return (
+    <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <header className="flex items-center justify-between gap-3">
+        <div className="grid gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Client state</span>
+          <h2 className="text-lg font-semibold text-slate-900">Release store selector</h2>
+        </div>
+        <button className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700" type="button" onClick={toggleBlockedOnly}>
+          {showBlockedOnly ? "Show all" : "Blocked only"}
+        </button>
+      </header>
+
+      <ul className="grid gap-2">
+        {visibleReleases.map((release) => (
+          <li key={release.id}>
+            <button
+              className={
+                release.id === selectedReleaseId
+                  ? "flex w-full items-center justify-between rounded-xl border border-emerald-300 bg-emerald-50 px-4 py-3 text-left"
+                  : "flex w-full items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 text-left"
+              }
+              type="button"
+              onClick={() => selectRelease(release.id)}
+            >
+              <span className="text-sm font-medium text-slate-900">{release.label}</span>
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{release.blocked ? "blocked" : "ready"}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx
+++ b/test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext } from "react";
+
+export interface WorkspacePreferencesValue {
+  density: "comfortable" | "compact";
+  emailDigest: boolean;
+  setDensity: (value: "comfortable" | "compact") => void;
+  setEmailDigest: (value: boolean) => void;
+}
+
+const WorkspacePreferencesContext = createContext<WorkspacePreferencesValue | null>(null);
+
+export interface WorkspacePreferencesPanelProps {
+  density: "comfortable" | "compact";
+  emailDigest: boolean;
+  onDensityChange: (value: "comfortable" | "compact") => void;
+  onEmailDigestChange: (value: boolean) => void;
+}
+
+function WorkspacePreferencesConsumer() {
+  const preferences = useContext(WorkspacePreferencesContext);
+
+  if (!preferences) {
+    return <p className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-700">Preferences provider missing.</p>;
+  }
+
+  return (
+    <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <header className="grid gap-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-violet-600">Workspace context</span>
+        <h2 className="text-lg font-semibold text-slate-900">Preference provider boundary</h2>
+      </header>
+
+      <label className="grid gap-2 text-sm text-slate-700" htmlFor="workspace-density">
+        <span className="font-medium text-slate-900">Density</span>
+        <select
+          id="workspace-density"
+          className="rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200"
+          value={preferences.density}
+          onChange={(event) => preferences.setDensity(event.currentTarget.value as WorkspacePreferencesValue["density"])}
+        >
+          <option value="comfortable">Comfortable</option>
+          <option value="compact">Compact</option>
+        </select>
+      </label>
+
+      <label className="flex items-start gap-3 rounded-xl border border-slate-200 p-4" htmlFor="workspace-email-digest">
+        <input
+          id="workspace-email-digest"
+          checked={preferences.emailDigest}
+          className="mt-1 h-4 w-4 rounded border-slate-300 text-violet-600 focus:ring-violet-500"
+          type="checkbox"
+          onChange={(event) => preferences.setEmailDigest(event.currentTarget.checked)}
+        />
+        <span className="grid gap-1">
+          <span className="text-sm font-medium text-slate-900">Send digest email</span>
+          <span className="text-sm text-slate-600">Provider value flows into this nested consumer control.</span>
+        </span>
+      </label>
+    </section>
+  );
+}
+
+export function WorkspacePreferencesPanel({
+  density,
+  emailDigest,
+  onDensityChange,
+  onEmailDigestChange,
+}: WorkspacePreferencesPanelProps) {
+  return (
+    <WorkspacePreferencesContext.Provider
+      value={{ density, emailDigest, setDensity: onDensityChange, setEmailDigest: onEmailDigestChange }}
+    >
+      <WorkspacePreferencesConsumer />
+    </WorkspacePreferencesContext.Provider>
+  );
+}

--- a/test/fooks.test.mjs
+++ b/test/fooks.test.mjs
@@ -1297,6 +1297,19 @@ test("readiness helper uses stable reasons and ignores debug metadata", () => {
   const missingContract = assessPayloadReadiness(compressed, { ...compressedPayload, contract: undefined });
   assert.ok(missingContract.reasons.includes("missing-contract"));
 
+  const formControls = extractFile(path.join(repoRoot, "fixtures", "compressed", "FormControls.tsx"));
+  const formControlsPayload = toModelFacingPayload(formControls, repoRoot, { includeEditGuidance: true });
+  assert.equal(formControlsPayload.contract, undefined);
+  const reactWebContractless = assessPayloadReadiness(formControls, formControlsPayload);
+  assert.equal(reactWebContractless.ready, true);
+  assert.deepEqual(reactWebContractless.reasons, []);
+
+  const genericContractlessForm = assessPayloadReadiness(
+    { ...formControls, domainDetection: { ...formControls.domainDetection, classification: "unknown", domain: "unknown" } },
+    formControlsPayload,
+  );
+  assert.ok(genericContractlessForm.reasons.includes("missing-contract"));
+
   const missingBehavior = assessPayloadReadiness(compressed, { ...compressedPayload, behavior: undefined });
   assert.ok(missingBehavior.reasons.includes("missing-behavior"));
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -65,6 +65,23 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.ok(evidence.suite.summary.compactRowsCount > 0);
   assert.equal(typeof evidence.suite.summary.minAdditionalContextReductionPct, "number");
   assert.equal(typeof evidence.suite.summary.maxAdditionalContextReductionPct, "number");
+  assert.equal(DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length, 10);
+  assert.ok(DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.includes("fixtures/compressed/FormControls.tsx"));
+  assert.ok(
+    DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.includes(
+      "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+    ),
+  );
+  assert.ok(
+    DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.includes(
+      "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx",
+    ),
+  );
+  assert.ok(
+    DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.includes(
+      "test/fixtures/react-web-context-expansion/client-state-release-store.tsx",
+    ),
+  );
   assert.deepEqual(evidence.suite.fixtures.map((row) => row.file), DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES);
   for (const row of evidence.suite.fixtures) {
     assert.equal(row.diagnosticOnly, true);


### PR DESCRIPTION
## Summary
- Expand React Web live-hook dogfood fixture matrix from 7 to exactly 10 fixtures.
- Add RHF/FormControls, React Context provider/consumer, and Zustand-style client-state component coverage while reusing existing data-fetching fixture.
- Keep contractless readiness scoped to React Web reuse-shape evidence and add positive/negative boundary regressions.

## Evidence
- Dogfood evidence: `.omx/specs/react-web-fixture-matrix-expansion/evidence.json`
  - `fixtureCount`: 10
  - `candidate_admission_rate`: 0.9
  - `candidate_compression_success_rate`: 0.9
  - `fallback_used_rate`: 0.1
  - `final_injection_byte_reduction.avg`: 68.284
- Independent review: code-reviewer APPROVE, architect CLEAR.

## Verification
- [x] `npm run build`
- [x] `npm run typecheck -- --pretty false`
- [x] `node --test test/react-web-live-hook-dogfood-evidence.test.mjs`
- [x] `node scripts/react-web-live-hook-dogfood-evidence.mjs --json > .omx/specs/react-web-fixture-matrix-expansion/evidence.json`
- [x] `node --test test/fooks.test.mjs test/react-web-context-evidence.test.mjs test/react-web-domain-payload-expansion.test.mjs test/client-state-concern-profile.test.mjs test/form-state-concern-profile.test.mjs`
- [x] `git diff --check`

## Claim boundary
This PR supports local fixture-matrix and byte/artifact diagnostics only. It does not claim provider-token, billing, cost, latency, or broad runtime savings.

Fixes #1134