### PR TITLE
Surface React Web dogfood coverage in advisories

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -369,7 +369,9 @@ function uniqueSorted(values) {
   return [...new Set(values)].sort();
 }
 
-function summarizeFixtureManifestCoverage(manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST) {
+export function buildReactWebLiveHookDogfoodCoverageSummary({
+  manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+} = {}) {
   const requiredLabels = [...LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS];
   const expectedLabels = [...requiredLabels];
   const observedLabels = uniqueSorted(manifest.flatMap((entry) => entry.coverage ?? []));
@@ -386,12 +388,20 @@ function summarizeFixtureManifestCoverage(manifest = DEFAULT_LIVE_HOOK_DOGFOOD_S
   }
 
   return {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+    source: "react-web-live-hook-dogfood-fixture-manifest",
+    diagnosticOnly: true,
+    claimable: false,
+    advisoryOnly: true,
+    fixtureCount: manifest.length,
     requiredLabels,
     expectedLabels,
     observedLabels,
     missingLabels,
     countsByLabel: Object.fromEntries(Object.entries(countsByLabel).sort(([left], [right]) => left.localeCompare(right))),
     countsByRole: Object.fromEntries(Object.entries(countsByRole).sort(([left], [right]) => left.localeCompare(right))),
+    claimBoundary:
+      "Local fixture-intent coverage summary only: not broad React Web support, not provider token/cost savings, and not runtime, pre-read, cache, or model-facing authorization.",
   };
 }
 
@@ -476,7 +486,7 @@ function summarizeLiveHookSuite(rows) {
       candidate_byte_reduction: distribution(candidateReductionValues),
       final_injection_byte_reduction: distribution(finalInjectionReductionValues),
     },
-    coverage: summarizeFixtureManifestCoverage(),
+    coverage: buildReactWebLiveHookDogfoodCoverageSummary(),
     allAdditionalContextsSmaller,
     allFreshGraphs,
     minAdditionalContextReductionPct: Math.min(...reductionValues),

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -55,6 +55,7 @@ export async function buildReactWebPrAdvisorySurface({
   assertReactWebPrAdvisoryContract({ profileSurface, releaseBenchmarkEvidence });
 
   const releaseBenchmarkSummary = buildReleaseBenchmarkSmokeSummary(releaseBenchmarkEvidence);
+  const liveHookDogfoodCoverage = profileSurface.summary.childSignals.liveHookDogfoodCoverage;
 
   return {
     schemaVersion: "react-web-pr-advisory-surface.v1",
@@ -77,6 +78,7 @@ export async function buildReactWebPrAdvisorySurface({
       warningCount: profileSurface.summary.warnings.length,
       warnings: profileSurface.summary.warnings,
       releaseSafeHeadline: releaseBenchmarkSummary.headline,
+      liveHookDogfoodCoverage,
       nonClaims: {
         profileTopLevelContextReduction: profileSurface.claimability.contextReduction,
         cachePerformance: releaseBenchmarkSummary.nonClaims.cachePerformanceImprovement,
@@ -115,6 +117,17 @@ ${evidence.claimBoundary}
 - Stability warning-only: ${evidence.summary.childSignals.stabilityWarningOnly ? "yes" : "no"}
 - Mixed-routing boundary isolation claimable: ${evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable ? "yes" : "no"}
 - Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
+
+## Live-hook dogfood coverage snapshot
+
+- Advisory-only: ${evidence.summary.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"}
+- Diagnostic-only: ${evidence.summary.liveHookDogfoodCoverage.diagnosticOnly ? "yes" : "no"}
+- Fixture count: ${evidence.summary.liveHookDogfoodCoverage.fixtureCount}
+- Required labels: ${evidence.summary.liveHookDogfoodCoverage.requiredLabels.join(", ")}
+- Missing labels: ${evidence.summary.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"}
+- Counts by label: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByLabel)}
+- Counts by role: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByRole)}
+- Claim boundary: ${evidence.summary.liveHookDogfoodCoverage.claimBoundary}
 
 ## Non-claims
 

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -7,6 +7,7 @@ import { buildReactWebOverCachingAuditEvidence } from "./react-web-over-caching-
 import { buildReactWebStabilityEvidence } from "./react-web-stability-evidence.mjs";
 import { buildReactWebMixedRoutingEvidence } from "./react-web-mixed-routing-evidence.mjs";
 import { buildReactWebKnowledgeContextEvidence } from "./react-web-knowledge-context-evidence.mjs";
+import { buildReactWebLiveHookDogfoodCoverageSummary } from "./react-web-live-hook-dogfood-evidence.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -53,6 +54,7 @@ export async function buildReactWebProfileSurface({
   const stability = await buildReactWebStabilityEvidence({ repoRoot, runId: `${runId}-stability` });
   const mixedRouting = await buildReactWebMixedRoutingEvidence({ repoRoot, runId: `${runId}-mixed-routing` });
   const knowledgeContext = await buildReactWebKnowledgeContextEvidence({ repoRoot, runId: `${runId}-knowledge-context` });
+  const liveHookDogfoodCoverage = buildReactWebLiveHookDogfoodCoverageSummary();
 
   const artifacts = {
     context,
@@ -92,6 +94,7 @@ export async function buildReactWebProfileSurface({
         stabilityWarningOnly: stability.summary.primaryMetric.warningOnly,
         mixedRoutingBoundaryIsolationClaimable: mixedRouting.summary.boundaryIsolationClaimable,
         knowledgeContextBoundaryEvidenceClaimable: knowledgeContext.summary.boundaryEvidenceOnlyClaimable,
+        liveHookDogfoodCoverage,
       },
       warnings: [
         ...(overCachingAudit.summary.bugReproduced
@@ -133,6 +136,7 @@ ${evidence.claimBoundary}
 - Stability warning-only: ${evidence.summary.childSignals.stabilityWarningOnly ? "yes" : "no"}
 - Mixed-routing boundary isolation claimable: ${evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable ? "yes" : "no"}
 - Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
+- Live-hook dogfood coverage advisory-only: ${evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount} fixtures, missing labels: ${evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"})
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -7,6 +7,7 @@ import {
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES,
   LIVE_HOOK_DOGFOOD_ALLOWED_ROLES,
   LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  buildReactWebLiveHookDogfoodCoverageSummary,
   buildReactWebLiveHookDogfoodEvidence,
   renderReactWebLiveHookDogfoodEvidenceMarkdown,
 } from "../scripts/react-web-live-hook-dogfood-evidence.mjs";
@@ -40,6 +41,27 @@ test("React Web live hook dogfood fixture manifest is explicit and order-preserv
   for (const requiredLabel of LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS) {
     assert.equal(observedLabels.has(requiredLabel), true, `missing required label ${requiredLabel}`);
   }
+});
+
+test("React Web live hook dogfood coverage summary is canonical and advisory-only", () => {
+  const summary = buildReactWebLiveHookDogfoodCoverageSummary();
+
+  assert.equal(summary.schemaVersion, REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION);
+  assert.equal(summary.source, "react-web-live-hook-dogfood-fixture-manifest");
+  assert.equal(summary.diagnosticOnly, true);
+  assert.equal(summary.claimable, false);
+  assert.equal(summary.advisoryOnly, true);
+  assert.equal(summary.fixtureCount, 10);
+  assert.deepEqual(summary.requiredLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
+  assert.deepEqual(summary.expectedLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
+  assert.equal(summary.missingLabels.length, 0);
+  assert.equal(summary.countsByRole.positive, 8);
+  assert.equal(summary.countsByRole["boundary-control"], 1);
+  assert.equal(summary.countsByRole["reuse-baseline"], 1);
+  assert.match(summary.claimBoundary, /Local fixture-intent coverage summary only/);
+  assert.match(summary.claimBoundary, /not broad React Web support/);
+  assert.match(summary.claimBoundary, /not provider token\/cost savings/);
+  assert.match(summary.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
 });
 
 test("React Web live hook dogfood evidence replays built CLI native hook graph path", async () => {
@@ -172,6 +194,10 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
     Math.min(...evidence.suite.fixtures.map((row) => row.evidenceArtifact.additionalContextAdmission.reductionPct)),
   );
   assert.deepEqual(evidence.suite.summary.coverage.requiredLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
+  assert.equal(evidence.suite.summary.coverage.source, "react-web-live-hook-dogfood-fixture-manifest");
+  assert.equal(evidence.suite.summary.coverage.diagnosticOnly, true);
+  assert.equal(evidence.suite.summary.coverage.claimable, false);
+  assert.equal(evidence.suite.summary.coverage.advisoryOnly, true);
   assert.deepEqual(evidence.suite.summary.coverage.expectedLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
   assert.equal(evidence.suite.summary.coverage.missingLabels.length, 0);
   for (const requiredLabel of LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS) {

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -49,6 +49,14 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
 
   assert.equal(evidence.summary.advisoryOnly, true);
   assert.equal(evidence.summary.profileArtifactCount, 6);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.schemaVersion, "react-web-live-hook-dogfood-fixture-manifest.v1");
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.advisoryOnly, true);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.diagnosticOnly, true);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.claimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureCount, 10);
+  assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
+  assert.match(evidence.summary.liveHookDogfoodCoverage.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
   assert.equal(evidence.summary.nonClaims.profileTopLevelContextReduction, false);
   assert.equal(evidence.summary.nonClaims.cachePerformance, false);
   assert.equal(evidence.summary.nonClaims.runtimeTokenSavings, false);
@@ -67,6 +75,12 @@ test("React Web PR advisory markdown keeps advisory wording and explicit non-cla
   assert.match(markdown, /This advisory does not block merge or release in pass 1/);
   assert.match(markdown, /Cache performance proof: no/);
   assert.match(markdown, /Runtime-token savings proof: no/);
+  assert.match(markdown, /Live-hook dogfood coverage snapshot/);
+  assert.match(markdown, /Advisory-only: yes/);
+  assert.match(markdown, /Fixture count: 10/);
+  assert.match(markdown, /Missing labels: none/);
+  assert.match(markdown, /Counts by label: .*form-state/);
+  assert.match(markdown, /Claim boundary: .*not broad React Web support/);
   assert.match(markdown, /Provider billing\/cost savings proof: no/);
   assert.match(markdown, /Broad React\/RN\/WebView\/TUI support proof: no/);
   assert.doesNotMatch(markdown, /Cache performance proof: yes/i);

--- a/test/react-web-pr-gate-surface.test.mjs
+++ b/test/react-web-pr-gate-surface.test.mjs
@@ -38,6 +38,16 @@ test("React Web PR gate passes on the approved bounded advisory surface", async 
     "knowledgeContext",
   ]);
   assert.equal(evidence.summary.metricsRemainNonBlocking, true);
+  assert.deepEqual(evidence.summary.blockerCategories, [
+    "required-artifact-presence",
+    "routing-boundary-leakage",
+    "advisory-status-inconsistency",
+  ]);
+  assert.equal(
+    evidence.advisorySurface.summary.liveHookDogfoodCoverage.advisoryOnly,
+    true,
+  );
+  assert.deepEqual(evidence.advisorySurface.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.reactWebOnly, true);
   assert.equal(evidence.summary.advisoryStatusRemainsUpstreamOnly, true);
 });

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -54,6 +54,14 @@ test("React Web profile surface aggregates exactly the approved six evidence art
   assert.equal(typeof evidence.summary.childSignals.stabilityWarningOnly, "boolean");
   assert.equal(evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable, true);
   assert.equal(evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.schemaVersion, "react-web-live-hook-dogfood-fixture-manifest.v1");
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.diagnosticOnly, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.claimable, false);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount, 10);
+  assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
+  assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.claimBoundary, /not broad React Web support/);
 });
 
 test("React Web profile surface markdown keeps the top-level non-claims explicit", async () => {
@@ -70,6 +78,7 @@ test("React Web profile surface markdown keeps the top-level non-claims explicit
   assert.match(markdown, /Top-level provider billing savings claim widened: no/);
   assert.match(markdown, /Over-caching audit verdict: react-web-small-edit-refresh-no-repro/);
   assert.match(markdown, /Over-caching audit bug reproduced: no/);
+  assert.match(markdown, /Live-hook dogfood coverage advisory-only: yes \(10 fixtures, missing labels: none\)/);
   assert.match(markdown, /Context reduction claimable at top level: no/);
   assert.match(markdown, /Cache performance claimable at top level: no/);
   assert.match(markdown, /Provider billing savings claimable at top level: no/);


### PR DESCRIPTION
Closes #1138\n\n## Summary\n- export a canonical advisory-only live-hook dogfood coverage summary helper\n- reuse that helper for existing dogfood evidence coverage summary\n- add `liveHookDogfoodCoverage` as an advisory-only React Web profile child signal\n- render compact coverage labels/counts in PR advisory Markdown\n- keep PR gate blocker categories and six profile artifact keys unchanged\n\n## Verification\n- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs`\n- `npm run typecheck`\n- `git diff --check`\n\n## Claim boundary\nCoverage labels remain local fixture-intent diagnostics only; this PR does not add runtime/pre-read authorization, broad React Web support claims, provider token/cost evidence, or merge-blocking coverage policy.\n\nIndependent review evidence: code-reviewer APPROVE and architect CLEAR in the Codex/OMX run.