### PR TITLE
Make post-clean-merge whip activity auditable

### DIFF
--- a/docs/dogfood/post-clean-merge-session-whip-activity-1137.md
+++ b/docs/dogfood/post-clean-merge-session-whip-activity-1137.md
@@ -1,0 +1,88 @@
+# Issue #1137 post-clean-merge session-whip activity cue
+
+This is a narrow read-only dogfood docs/test/help fixture for issue #1137. It
+covers the clean state after fooks#1135 closed and PR #1136 merged, when the
+repository backlog was empty: zero open issues, zero open PRs, and zero mapped
+fooks tmux sessions before the new whip target was created.
+
+## Cue rule
+
+A post-clean-merge session whip must not treat the merged PR receipt, green CI
+receipt, or zero-backlog inventory as current active development. If idle is
+forbidden, the operator must create or adopt exactly one bounded live artifact
+and then report only source-backed current evidence for that target.
+
+For this issue, the source-backed activity cue is the adopted issue/branch/worktree
+pair:
+
+- open issue `#1137`;
+- non-`main` branch `fooks-session-whip-post-merge-activity`;
+- worktree `/home/bellman/Workspace/fooks.omx-worktrees/fooks-issue-1137-post-merge-session-whip`.
+
+A mapped session, open PR, active process, or concrete blocker may also satisfy
+future whips when present, but receipt-only evidence never does.
+
+## Captured read-only report shape
+
+```json
+{
+  "issue": "#1137",
+  "readOnly": true,
+  "postCleanMergeReceipt": {
+    "closedIssue": "#1135",
+    "mergedPullRequest": "#1136",
+    "receiptOnlyEvidence": true,
+    "activeDevelopmentEvidence": false
+  },
+  "preCueInventory": {
+    "openIssues": 0,
+    "openPullRequests": 0,
+    "mappedFooksTmuxSessions": 0,
+    "classification": "post-clean-merge-session-whip-idle"
+  },
+  "currentActivityCue": {
+    "classification": "source-backed-session-whip-activity-cue",
+    "adoptedIssue": "#1137",
+    "adoptedBranch": "fooks-session-whip-post-merge-activity",
+    "adoptedWorktree": "/home/bellman/Workspace/fooks.omx-worktrees/fooks-issue-1137-post-merge-session-whip",
+    "activeEvidenceKinds": [
+      "open-issue",
+      "active-branch",
+      "active-worktree"
+    ],
+    "requiredBeforeActiveDevelopment": [
+      "open-issue",
+      "active-branch",
+      "active-session",
+      "open-pull-request",
+      "active-worktree",
+      "active-process",
+      "concrete-blocker"
+    ]
+  },
+  "mutationBoundary": {
+    "createsIssuesFromCli": false,
+    "mutatesGitHubFromStatusSurfaces": false,
+    "mutatesWorktreesFromStatusSurfaces": false,
+    "changesRuntimeProviderFrontendOrMergeGatePolicy": false,
+    "changesReactWebBehavior": false,
+    "inventsBacklog": false
+  },
+  "rule": "A clean post-merge session whip with zero open issues/PRs/sessions is idle until exactly one bounded live artifact is created or adopted; after adoption, report active development only from the source-backed issue, branch, session, PR, worktree/process, or blocker evidence."
+}
+```
+
+## Non-goals
+
+This cue does not change runtime/provider behavior, merge-gate policy, detector
+scope, React Web/RN/TUI/WebView behavior, cleanup authority, performance claims,
+product claims, release criteria, or GitHub mutation behavior. It does not make
+`fooks check`, `fooks status activity`, or CLI help create issues, sessions,
+branches, worktrees, or PRs. It only documents and tests the post-clean-merge
+session-whip activity report boundary.
+
+## Focused verification
+
+```sh
+node --test test/post-clean-merge-session-whip-activity-1137-doc.test.mjs test/operator-activity.test.mjs
+```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -707,6 +707,7 @@ Everyday commands:
 
 Remote-counts boundary: --include-remote-counts belongs only to status activity.
 Use ${displayCliName} status activity --include-remote-counts --json for remote counts, or ${displayCliName} check --json for the operator/check source-of-truth projection.
+Post-clean-merge session whip cue: receipt-only zero-backlog states stay idle until a source-backed issue, branch/session, PR, worktree/process, or blocker is named; help is read-only and creates no artifacts.
   ${displayCliName} codex-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]
   ${displayCliName} codex-runtime-hook --native-hook
   ${displayCliName} claude-runtime-hook --event <SessionStart|UserPromptSubmit|Stop> [--session-id <id>] [--prompt <text>] [--json]

--- a/test/helpers/stale-epic-checklist-boundary.mjs
+++ b/test/helpers/stale-epic-checklist-boundary.mjs
@@ -209,6 +209,73 @@ export function classifyCleanEpicAdvisoryInventorySessionWhip(input) {
   };
 }
 
+
+function hasConcreteBlocker(evidence) {
+  return (evidence?.blockers ?? []).some((blocker) => normalizeRef(blocker?.reason ?? blocker));
+}
+
+function postCleanMergeActiveEvidenceKinds(evidence) {
+  return [
+    openIssueNumbers(evidence?.issues ?? evidence?.childIssues).length > 0 ? "open-issue" : null,
+    hasActiveBranch(evidence) ? "active-branch" : null,
+    hasActiveWorktree(evidence) ? "active-worktree" : null,
+    hasActiveSession(evidence) ? "active-session" : null,
+    hasOpenPullRequest(evidence) ? "open-pull-request" : null,
+    (evidence?.processes ?? []).some((process) =>
+      isOpenState(process?.state) || process?.active === true
+    ) ? "active-process" : null,
+    hasConcreteBlocker(evidence) ? "concrete-blocker" : null,
+  ].filter(Boolean);
+}
+
+export function classifyPostCleanMergeSessionWhipActivityCue(input) {
+  const evidence = input?.evidence ?? {};
+  const issues = openIssueNumbers(evidence.issues ?? evidence.childIssues);
+  const openIssueCount = typeof input?.openIssueCount === "number" ? input.openIssueCount : issues.length;
+  const openPullRequestCount = typeof input?.openPullRequestCount === "number"
+    ? input.openPullRequestCount
+    : (evidence.pullRequests ?? []).filter((pr) => isOpenState(pr?.state)).length;
+  const cleanPostMergeEcho = Boolean(input?.clean === true && input?.branch === "main" && input?.ahead === 0 && input?.behind === 0);
+  const zeroBacklog = openIssueCount === 0 && openPullRequestCount === 0;
+  const activeKinds = postCleanMergeActiveEvidenceKinds(evidence);
+  const sourceBackedActivityCue = activeKinds.length > 0;
+  const idleCueRequired = cleanPostMergeEcho && zeroBacklog && !sourceBackedActivityCue;
+
+  return {
+    issue: "#1137",
+    classification: sourceBackedActivityCue
+      ? "source-backed-session-whip-activity-cue"
+      : idleCueRequired
+        ? "post-clean-merge-session-whip-idle"
+        : "session-whip-activity-cue-unproven",
+    cleanPostMergeEcho,
+    zeroBacklog,
+    activeDevelopmentAllowed: sourceBackedActivityCue,
+    sourceBackedActivityCue,
+    activeEvidenceKinds: activeKinds,
+    requiredBeforeActiveDevelopment: [
+      "open-issue",
+      "active-branch",
+      "active-session",
+      "open-pull-request",
+      "active-worktree",
+      "active-process",
+      "concrete-blocker",
+    ],
+    mutationBoundary: {
+      createsIssuesFromCli: false,
+      mutatesGitHub: false,
+      mutatesWorktrees: false,
+      changesRuntimeProviderFrontendOrMergeGatePolicy: false,
+      changesReactWebBehavior: false,
+      inventsBacklog: false,
+    },
+    rule: sourceBackedActivityCue
+      ? "After a clean merge with an empty backlog, session whip activity is auditable only from the named issue, branch, session, PR, worktree/process, or blocker evidence; receipt-only closeout remains historical context."
+      : "A clean post-merge session whip with zero open issues, zero open PRs, and no concrete issue/branch/session/PR/worktree/process/blocker evidence remains idle; create or adopt exactly one bounded live artifact before claiming active development.",
+  };
+}
+
 export function classifyAdvisoryOnlyQueueAfterCompletedChild(input) {
   const epicNumber = issueNumber(input?.epic) ?? 960;
   const evidence = input?.evidence ?? {};

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -4297,6 +4297,9 @@ test("status activity CLI route preserves existing status contracts", () => {
   assert.match(help, /fooks status activity \[--include-remote-counts\] \[--json\] \[--receipt-json\]/);
   assert.match(help, /--include-remote-counts belongs only to status activity/);
   assert.match(help, /fooks check --json for the operator\/check source-of-truth projection/);
+  assert.match(help, /Post-clean-merge session whip cue/);
+  assert.match(help, /receipt-only zero-backlog states stay idle/);
+  assert.match(help, /help is read-only and creates no artifacts/);
 
   let output = "";
   try {

--- a/test/post-clean-merge-session-whip-activity-1137-doc.test.mjs
+++ b/test/post-clean-merge-session-whip-activity-1137-doc.test.mjs
@@ -1,0 +1,140 @@
+// @ts-check
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { classifyPostCleanMergeSessionWhipActivityCue } from "./helpers/stale-epic-checklist-boundary.mjs";
+
+const repoRoot = process.cwd();
+const docPath = path.join(repoRoot, "docs", "dogfood", "post-clean-merge-session-whip-activity-1137.md");
+const doc = fs.readFileSync(docPath, "utf8");
+const compactDoc = doc.replace(/\s+/gu, " ");
+
+function extractJsonFence(markdown) {
+  const match = markdown.match(/```json\n([\s\S]*?)\n```/u);
+  assert.ok(match, "expected a fenced JSON report-shape example");
+  return JSON.parse(match[1]);
+}
+
+function assertDocsInclude(text) {
+  assert.ok(compactDoc.includes(text), `missing issue #1137 doc text: ${text}`);
+}
+
+test("issue #1137 helper treats zero-backlog clean post-merge whip as idle", () => {
+  assert.deepEqual(
+    classifyPostCleanMergeSessionWhipActivityCue({
+      branch: "main",
+      clean: true,
+      ahead: 0,
+      behind: 0,
+      openIssueCount: 0,
+      openPullRequestCount: 0,
+      evidence: {
+        issues: [],
+        branches: [],
+        worktrees: [],
+        sessions: [],
+        pullRequests: [],
+        processes: [],
+        blockers: [],
+      },
+    }),
+    {
+      issue: "#1137",
+      classification: "post-clean-merge-session-whip-idle",
+      cleanPostMergeEcho: true,
+      zeroBacklog: true,
+      activeDevelopmentAllowed: false,
+      sourceBackedActivityCue: false,
+      activeEvidenceKinds: [],
+      requiredBeforeActiveDevelopment: [
+        "open-issue",
+        "active-branch",
+        "active-session",
+        "open-pull-request",
+        "active-worktree",
+        "active-process",
+        "concrete-blocker",
+      ],
+      mutationBoundary: {
+        createsIssuesFromCli: false,
+        mutatesGitHub: false,
+        mutatesWorktrees: false,
+        changesRuntimeProviderFrontendOrMergeGatePolicy: false,
+        changesReactWebBehavior: false,
+        inventsBacklog: false,
+      },
+      rule: "A clean post-merge session whip with zero open issues, zero open PRs, and no concrete issue/branch/session/PR/worktree/process/blocker evidence remains idle; create or adopt exactly one bounded live artifact before claiming active development.",
+    },
+  );
+});
+
+test("issue #1137 helper treats the adopted issue branch worktree as source-backed activity", () => {
+  const result = classifyPostCleanMergeSessionWhipActivityCue({
+    branch: "fooks-session-whip-post-merge-activity",
+    clean: false,
+    ahead: 0,
+    behind: 0,
+    openIssueCount: 1,
+    openPullRequestCount: 0,
+    evidence: {
+      issues: [{ number: 1137, state: "open" }],
+      branches: [{ name: "fooks-session-whip-post-merge-activity", active: true }],
+      worktrees: [{ path: "/home/bellman/Workspace/fooks.omx-worktrees/fooks-issue-1137-post-merge-session-whip", active: true }],
+      sessions: [],
+      pullRequests: [],
+      processes: [],
+      blockers: [],
+    },
+  });
+
+  assert.equal(result.issue, "#1137");
+  assert.equal(result.classification, "source-backed-session-whip-activity-cue");
+  assert.equal(result.activeDevelopmentAllowed, true);
+  assert.equal(result.sourceBackedActivityCue, true);
+  assert.deepEqual(result.activeEvidenceKinds, ["open-issue", "active-branch", "active-worktree"]);
+  assert.match(result.rule, /receipt-only closeout remains historical context/);
+});
+
+test("issue #1137 dogfood doc preserves the post-clean-merge activity cue contract", () => {
+  const report = extractJsonFence(doc);
+
+  assert.equal(report.issue, "#1137");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.postCleanMergeReceipt.closedIssue, "#1135");
+  assert.equal(report.postCleanMergeReceipt.mergedPullRequest, "#1136");
+  assert.equal(report.postCleanMergeReceipt.activeDevelopmentEvidence, false);
+  assert.equal(report.preCueInventory.openIssues, 0);
+  assert.equal(report.preCueInventory.openPullRequests, 0);
+  assert.equal(report.preCueInventory.mappedFooksTmuxSessions, 0);
+  assert.equal(report.preCueInventory.classification, "post-clean-merge-session-whip-idle");
+  assert.equal(report.currentActivityCue.classification, "source-backed-session-whip-activity-cue");
+  assert.equal(report.currentActivityCue.adoptedIssue, "#1137");
+  assert.equal(report.currentActivityCue.adoptedBranch, "fooks-session-whip-post-merge-activity");
+  assert.deepEqual(report.currentActivityCue.activeEvidenceKinds, ["open-issue", "active-branch", "active-worktree"]);
+  assert.equal(report.mutationBoundary.createsIssuesFromCli, false);
+  assert.equal(report.mutationBoundary.changesReactWebBehavior, false);
+  assert.equal(report.mutationBoundary.inventsBacklog, false);
+  assert.match(report.rule, /zero open issues\/PRs\/sessions is idle/);
+  assert.match(report.rule, /source-backed issue, branch, session, PR, worktree\/process, or blocker evidence/);
+
+  for (const required of [
+    "narrow read-only dogfood docs/test/help fixture for issue #1137",
+    "fooks#1135 closed and PR #1136 merged",
+    "repository backlog was empty",
+    "zero open issues, zero open PRs, and zero mapped fooks tmux sessions",
+    "must not treat the merged PR receipt",
+    "create or adopt exactly one bounded live artifact",
+    "open issue `#1137`",
+    "non-`main` branch `fooks-session-whip-post-merge-activity`",
+    "receipt-only evidence never does",
+    "does not change runtime/provider behavior",
+    "React Web/RN/TUI/WebView behavior",
+    "does not make `fooks check`, `fooks status activity`, or CLI help create issues",
+    "post-clean-merge session-whip activity report boundary",
+  ]) {
+    assertDocsInclude(required);
+  }
+});


### PR DESCRIPTION
## Summary

- Add a read-only post-clean-merge session-whip cue to CLI help
- Add an issue #1137 dogfood report fixture documenting idle vs source-backed activity evidence
- Add helper/tests covering zero-backlog idle and adopted issue/branch/worktree activity cue paths

Closes #1137

## Tests

- `npm run build && node --test test/post-clean-merge-session-whip-activity-1137-doc.test.mjs test/operator-activity.test.mjs`
- `npm run lint -- --pretty false`
- `npm test`

## Review

- Code-reviewer: APPROVE
- Architect: CLEAR
