### PR TITLE
Make dogfood coverage freshness auditable

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
@@ -11,6 +12,7 @@ const defaultRepoRoot = path.resolve(__dirname, "..");
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION =
   "react-web-live-hook-dogfood-fixture-manifest.v1";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM = "sha256-json-stable-v1";
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
 export const LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS = [
@@ -369,6 +371,46 @@ function uniqueSorted(values) {
   return [...new Set(values)].sort();
 }
 
+function stableJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeManifestFingerprintEntry(entry) {
+  return {
+    file: entry.file,
+    coverage: [...(entry.coverage ?? [])].sort(),
+    purpose: entry.purpose,
+    role: entry.role,
+    expectation: {
+      admission: entry.expectation?.admission,
+      classification: entry.expectation?.classification,
+      metricBoundary: entry.expectation?.metricBoundary,
+    },
+  };
+}
+
+export function buildReactWebLiveHookDogfoodManifestFingerprint({
+  manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+} = {}) {
+  const identity = {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+    manifest: manifest.map(normalizeManifestFingerprintEntry),
+  };
+  return crypto
+    .createHash("sha256")
+    .update(stableJson(identity))
+    .digest("hex");
+}
+
 export function buildReactWebLiveHookDogfoodCoverageSummary({
   manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
 } = {}) {
@@ -387,9 +429,26 @@ export function buildReactWebLiveHookDogfoodCoverageSummary({
     }
   }
 
+  const manifestFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint({ manifest });
+
   return {
     schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
     source: "react-web-live-hook-dogfood-fixture-manifest",
+    freshnessStatus: "fresh",
+    manifestFingerprintAlgorithm: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
+    manifestFingerprint,
+    manifestFingerprintShort: manifestFingerprint.slice(0, 12),
+    manifestFingerprintInput: [
+      "schemaVersion",
+      "manifest[].file",
+      "manifest[].coverage",
+      "manifest[].purpose",
+      "manifest[].role",
+      "manifest[].expectation.classification",
+      "manifest[].expectation.admission",
+      "manifest[].expectation.metricBoundary",
+    ],
+    manifestFileCount: manifest.length,
     diagnosticOnly: true,
     claimable: false,
     advisoryOnly: true,

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -123,6 +123,8 @@ ${evidence.claimBoundary}
 - Advisory-only: ${evidence.summary.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"}
 - Diagnostic-only: ${evidence.summary.liveHookDogfoodCoverage.diagnosticOnly ? "yes" : "no"}
 - Fixture count: ${evidence.summary.liveHookDogfoodCoverage.fixtureCount}
+- Freshness status: ${evidence.summary.liveHookDogfoodCoverage.freshnessStatus}
+- Manifest fingerprint: ${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintShort} (${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintAlgorithm})
 - Required labels: ${evidence.summary.liveHookDogfoodCoverage.requiredLabels.join(", ")}
 - Missing labels: ${evidence.summary.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"}
 - Counts by label: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByLabel)}

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -137,6 +137,7 @@ ${evidence.claimBoundary}
 - Mixed-routing boundary isolation claimable: ${evidence.summary.childSignals.mixedRoutingBoundaryIsolationClaimable ? "yes" : "no"}
 - Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
 - Live-hook dogfood coverage advisory-only: ${evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount} fixtures, missing labels: ${evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"})
+- Live-hook dogfood coverage freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.freshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintShort})
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES,
   LIVE_HOOK_DOGFOOD_ALLOWED_ROLES,
   LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  buildReactWebLiveHookDogfoodManifestFingerprint,
   buildReactWebLiveHookDogfoodCoverageSummary,
   buildReactWebLiveHookDogfoodEvidence,
   renderReactWebLiveHookDogfoodEvidenceMarkdown,
@@ -48,6 +50,21 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
 
   assert.equal(summary.schemaVersion, REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION);
   assert.equal(summary.source, "react-web-live-hook-dogfood-fixture-manifest");
+  assert.equal(summary.freshnessStatus, "fresh");
+  assert.equal(summary.manifestFingerprintAlgorithm, REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM);
+  assert.match(summary.manifestFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(summary.manifestFingerprintShort, summary.manifestFingerprint.slice(0, 12));
+  assert.equal(summary.manifestFileCount, 10);
+  assert.deepEqual(summary.manifestFingerprintInput, [
+    "schemaVersion",
+    "manifest[].file",
+    "manifest[].coverage",
+    "manifest[].purpose",
+    "manifest[].role",
+    "manifest[].expectation.classification",
+    "manifest[].expectation.admission",
+    "manifest[].expectation.metricBoundary",
+  ]);
   assert.equal(summary.diagnosticOnly, true);
   assert.equal(summary.claimable, false);
   assert.equal(summary.advisoryOnly, true);
@@ -62,6 +79,30 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
   assert.match(summary.claimBoundary, /not broad React Web support/);
   assert.match(summary.claimBoundary, /not provider token\/cost savings/);
   assert.match(summary.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
+});
+
+test("React Web live hook dogfood manifest fingerprint detects fixture intent drift", () => {
+  const defaultFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint();
+  const repeatedFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint({
+    manifest: DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+  });
+  const coverageDriftManifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST.map((entry, index) => (index === 0
+    ? { ...entry, coverage: [...entry.coverage, "new-form-intent"] }
+    : entry));
+  const expectationDriftManifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST.map((entry, index) => (index === 1
+    ? { ...entry, expectation: { ...entry.expectation, admission: "discarded-source-too-small" } }
+    : entry));
+
+  assert.equal(repeatedFingerprint, defaultFingerprint);
+  assert.match(defaultFingerprint, /^[a-f0-9]{64}$/);
+  assert.notEqual(
+    buildReactWebLiveHookDogfoodManifestFingerprint({ manifest: coverageDriftManifest }),
+    defaultFingerprint,
+  );
+  assert.notEqual(
+    buildReactWebLiveHookDogfoodManifestFingerprint({ manifest: expectationDriftManifest }),
+    defaultFingerprint,
+  );
 });
 
 test("React Web live hook dogfood evidence replays built CLI native hook graph path", async () => {

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -53,6 +53,9 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
   assert.equal(evidence.summary.liveHookDogfoodCoverage.advisoryOnly, true);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.diagnosticOnly, true);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.claimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.manifestFingerprintAlgorithm, "sha256-json-stable-v1");
+  assert.match(evidence.summary.liveHookDogfoodCoverage.manifestFingerprint, /^[a-f0-9]{64}$/);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
@@ -78,6 +81,8 @@ test("React Web PR advisory markdown keeps advisory wording and explicit non-cla
   assert.match(markdown, /Live-hook dogfood coverage snapshot/);
   assert.match(markdown, /Advisory-only: yes/);
   assert.match(markdown, /Fixture count: 10/);
+  assert.match(markdown, /Freshness status: fresh/);
+  assert.match(markdown, /Manifest fingerprint: [a-f0-9]{12} \(sha256-json-stable-v1\)/);
   assert.match(markdown, /Missing labels: none/);
   assert.match(markdown, /Counts by label: .*form-state/);
   assert.match(markdown, /Claim boundary: .*not broad React Web support/);

--- a/test/react-web-pr-gate-surface.test.mjs
+++ b/test/react-web-pr-gate-surface.test.mjs
@@ -47,6 +47,7 @@ test("React Web PR gate passes on the approved bounded advisory surface", async 
     evidence.advisorySurface.summary.liveHookDogfoodCoverage.advisoryOnly,
     true,
   );
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
   assert.deepEqual(evidence.advisorySurface.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.reactWebOnly, true);
   assert.equal(evidence.summary.advisoryStatusRemainsUpstreamOnly, true);

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -58,6 +58,12 @@ test("React Web profile surface aggregates exactly the approved six evidence art
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.diagnosticOnly, true);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.claimable, false);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.freshnessStatus, "fresh");
+  assert.equal(
+    evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintAlgorithm,
+    "sha256-json-stable-v1",
+  );
+  assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprint, /^[a-f0-9]{64}$/);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
@@ -79,6 +85,7 @@ test("React Web profile surface markdown keeps the top-level non-claims explicit
   assert.match(markdown, /Over-caching audit verdict: react-web-small-edit-refresh-no-repro/);
   assert.match(markdown, /Over-caching audit bug reproduced: no/);
   assert.match(markdown, /Live-hook dogfood coverage advisory-only: yes \(10 fixtures, missing labels: none\)/);
+  assert.match(markdown, /Live-hook dogfood coverage freshness: fresh \(sha256-json-stable-v1, [a-f0-9]{12}\)/);
   assert.match(markdown, /Context reduction claimable at top level: no/);
   assert.match(markdown, /Cache performance claimable at top level: no/);
   assert.match(markdown, /Provider billing savings claimable at top level: no/);


### PR DESCRIPTION
## Summary\n\n- Add a deterministic SHA-256 fixture manifest fingerprint to the canonical React Web live-hook dogfood coverage summary\n- Surface freshness status and short manifest identity in the React Web profile and PR advisory markdown\n- Keep coverage freshness advisory-only/diagnostic-only and leave PR gate blocker categories unchanged\n\nCloses #1141\n\n## Tests\n\n- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs`\n- `npm run typecheck`\n- `npm run lint -- --pretty false`\n- `git diff --check`\n\n## Boundaries\n\n- No runtime/pre-read injection change\n- No merge-blocking coverage gate\n- No provider token/cost/billing claim\n