### PR TITLE
Make dogfood fixture sources auditable

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -13,6 +13,7 @@ export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-d
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION =
   "react-web-live-hook-dogfood-fixture-manifest.v1";
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM = "sha256-json-stable-v1";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM = "sha256-file-set-v1";
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
 export const LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS = [
@@ -411,8 +412,38 @@ export function buildReactWebLiveHookDogfoodManifestFingerprint({
     .digest("hex");
 }
 
+export function buildReactWebLiveHookDogfoodFixtureSourceFingerprint({
+  manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+  repoRoot = defaultRepoRoot,
+} = {}) {
+  const files = manifest.map((entry) => {
+    const fixturePath = path.resolve(repoRoot, entry.file);
+    const content = fs.readFileSync(fixturePath);
+    return {
+      file: entry.file,
+      bytes: content.length,
+      sha256: crypto.createHash("sha256").update(content).digest("hex"),
+    };
+  });
+  const identity = {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+    files,
+  };
+
+  return {
+    fingerprint: crypto
+      .createHash("sha256")
+      .update(stableJson(identity))
+      .digest("hex"),
+    fileCount: files.length,
+    byteCount: files.reduce((sum, file) => sum + file.bytes, 0),
+    files,
+  };
+}
+
 export function buildReactWebLiveHookDogfoodCoverageSummary({
   manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+  repoRoot = defaultRepoRoot,
 } = {}) {
   const requiredLabels = [...LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS];
   const expectedLabels = [...requiredLabels];
@@ -430,6 +461,7 @@ export function buildReactWebLiveHookDogfoodCoverageSummary({
   }
 
   const manifestFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint({ manifest });
+  const fixtureSourceIdentity = buildReactWebLiveHookDogfoodFixtureSourceFingerprint({ manifest, repoRoot });
 
   return {
     schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
@@ -449,6 +481,17 @@ export function buildReactWebLiveHookDogfoodCoverageSummary({
       "manifest[].expectation.metricBoundary",
     ],
     manifestFileCount: manifest.length,
+    fixtureSourceFreshnessStatus: "fresh",
+    fixtureSourceFingerprintAlgorithm: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM,
+    fixtureSourceFingerprint: fixtureSourceIdentity.fingerprint,
+    fixtureSourceFingerprintShort: fixtureSourceIdentity.fingerprint.slice(0, 12),
+    fixtureSourceFileCount: fixtureSourceIdentity.fileCount,
+    fixtureSourceByteCount: fixtureSourceIdentity.byteCount,
+    fixtureSourceFingerprintInput: [
+      "manifest[].file",
+      "sha256(file bytes)",
+      "file byte length",
+    ],
     diagnosticOnly: true,
     claimable: false,
     advisoryOnly: true,

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -125,6 +125,8 @@ ${evidence.claimBoundary}
 - Fixture count: ${evidence.summary.liveHookDogfoodCoverage.fixtureCount}
 - Freshness status: ${evidence.summary.liveHookDogfoodCoverage.freshnessStatus}
 - Manifest fingerprint: ${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintShort} (${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintAlgorithm})
+- Fixture source freshness: ${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus}
+- Fixture source fingerprint: ${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintShort} (${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm})
 - Required labels: ${evidence.summary.liveHookDogfoodCoverage.requiredLabels.join(", ")}
 - Missing labels: ${evidence.summary.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"}
 - Counts by label: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByLabel)}

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -138,6 +138,7 @@ ${evidence.claimBoundary}
 - Knowledge-context boundary evidence claimable: ${evidence.summary.childSignals.knowledgeContextBoundaryEvidenceClaimable ? "yes" : "no"}
 - Live-hook dogfood coverage advisory-only: ${evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount} fixtures, missing labels: ${evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"})
 - Live-hook dogfood coverage freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.freshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintShort})
+- Live-hook dogfood fixture source freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintShort})
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -1,13 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES,
   LIVE_HOOK_DOGFOOD_ALLOWED_ROLES,
   LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  buildReactWebLiveHookDogfoodFixtureSourceFingerprint,
   buildReactWebLiveHookDogfoodManifestFingerprint,
   buildReactWebLiveHookDogfoodCoverageSummary,
   buildReactWebLiveHookDogfoodEvidence,
@@ -65,6 +70,17 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
     "manifest[].expectation.admission",
     "manifest[].expectation.metricBoundary",
   ]);
+  assert.equal(summary.fixtureSourceFreshnessStatus, "fresh");
+  assert.equal(summary.fixtureSourceFingerprintAlgorithm, REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM);
+  assert.match(summary.fixtureSourceFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(summary.fixtureSourceFingerprintShort, summary.fixtureSourceFingerprint.slice(0, 12));
+  assert.equal(summary.fixtureSourceFileCount, 10);
+  assert.ok(summary.fixtureSourceByteCount > 0);
+  assert.deepEqual(summary.fixtureSourceFingerprintInput, [
+    "manifest[].file",
+    "sha256(file bytes)",
+    "file byte length",
+  ]);
   assert.equal(summary.diagnosticOnly, true);
   assert.equal(summary.claimable, false);
   assert.equal(summary.advisoryOnly, true);
@@ -103,6 +119,24 @@ test("React Web live hook dogfood manifest fingerprint detects fixture intent dr
     buildReactWebLiveHookDogfoodManifestFingerprint({ manifest: expectationDriftManifest }),
     defaultFingerprint,
   );
+});
+
+test("React Web live hook dogfood fixture source fingerprint detects source drift", () => {
+  const defaultSourceIdentity = buildReactWebLiveHookDogfoodFixtureSourceFingerprint();
+  const repeatedSourceIdentity = buildReactWebLiveHookDogfoodFixtureSourceFingerprint();
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-fixture-source-fingerprint-"));
+  const manifest = [{ ...DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST[0], file: "Fixture.tsx" }];
+  fs.writeFileSync(path.join(tempDir, "Fixture.tsx"), "export function Fixture() { return <div>one</div>; }\n");
+  const first = buildReactWebLiveHookDogfoodFixtureSourceFingerprint({ manifest, repoRoot: tempDir });
+  fs.writeFileSync(path.join(tempDir, "Fixture.tsx"), "export function Fixture() { return <div>two</div>; }\n");
+  const second = buildReactWebLiveHookDogfoodFixtureSourceFingerprint({ manifest, repoRoot: tempDir });
+
+  assert.equal(repeatedSourceIdentity.fingerprint, defaultSourceIdentity.fingerprint);
+  assert.match(defaultSourceIdentity.fingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(defaultSourceIdentity.fileCount, 10);
+  assert.ok(defaultSourceIdentity.byteCount > 0);
+  assert.notEqual(first.fingerprint, second.fingerprint);
+  assert.notEqual(first.files[0].sha256, second.files[0].sha256);
 });
 
 test("React Web live hook dogfood evidence replays built CLI native hook graph path", async () => {

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -56,6 +56,9 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
   assert.equal(evidence.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
   assert.equal(evidence.summary.liveHookDogfoodCoverage.manifestFingerprintAlgorithm, "sha256-json-stable-v1");
   assert.match(evidence.summary.liveHookDogfoodCoverage.manifestFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm, "sha256-file-set-v1");
+  assert.match(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprint, /^[a-f0-9]{64}$/);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
@@ -83,6 +86,8 @@ test("React Web PR advisory markdown keeps advisory wording and explicit non-cla
   assert.match(markdown, /Fixture count: 10/);
   assert.match(markdown, /Freshness status: fresh/);
   assert.match(markdown, /Manifest fingerprint: [a-f0-9]{12} \(sha256-json-stable-v1\)/);
+  assert.match(markdown, /Fixture source freshness: fresh/);
+  assert.match(markdown, /Fixture source fingerprint: [a-f0-9]{12} \(sha256-file-set-v1\)/);
   assert.match(markdown, /Missing labels: none/);
   assert.match(markdown, /Counts by label: .*form-state/);
   assert.match(markdown, /Claim boundary: .*not broad React Web support/);

--- a/test/react-web-pr-gate-surface.test.mjs
+++ b/test/react-web-pr-gate-surface.test.mjs
@@ -48,6 +48,7 @@ test("React Web PR gate passes on the approved bounded advisory surface", async 
     true,
   );
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
   assert.deepEqual(evidence.advisorySurface.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.reactWebOnly, true);
   assert.equal(evidence.summary.advisoryStatusRemainsUpstreamOnly, true);

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -64,6 +64,12 @@ test("React Web profile surface aggregates exactly the approved six evidence art
     "sha256-json-stable-v1",
   );
   assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
+  assert.equal(
+    evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm,
+    "sha256-file-set-v1",
+  );
+  assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprint, /^[a-f0-9]{64}$/);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
@@ -86,6 +92,7 @@ test("React Web profile surface markdown keeps the top-level non-claims explicit
   assert.match(markdown, /Over-caching audit bug reproduced: no/);
   assert.match(markdown, /Live-hook dogfood coverage advisory-only: yes \(10 fixtures, missing labels: none\)/);
   assert.match(markdown, /Live-hook dogfood coverage freshness: fresh \(sha256-json-stable-v1, [a-f0-9]{12}\)/);
+  assert.match(markdown, /Live-hook dogfood fixture source freshness: fresh \(sha256-file-set-v1, [a-f0-9]{12}\)/);
   assert.match(markdown, /Context reduction claimable at top level: no/);
   assert.match(markdown, /Cache performance claimable at top level: no/);
   assert.match(markdown, /Provider billing savings claimable at top level: no/);


### PR DESCRIPTION
## Summary\n\n- Add a deterministic fixture source file-set fingerprint to the React Web live-hook dogfood coverage summary\n- Surface fixture source freshness and short source identity in React Web profile and PR advisory markdown\n- Keep freshness diagnostic/advisory-only and leave PR gate policy unchanged\n\nCloses #1143\n\n## Tests\n\n- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs`\n- `npm run typecheck`\n- `npm run lint -- --pretty false`\n- `git diff --check`\n\n## Boundaries\n\n- No runtime/pre-read injection change\n- No merge-blocking coverage/freshness gate\n- No provider token/cost/billing claim\n