### PR TITLE
Make dogfood snapshot drift auditable

### DIFF
--- a/fixtures/react-web-live-hook-dogfood.snapshot.json
+++ b/fixtures/react-web-live-hook-dogfood.snapshot.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "react-web-live-hook-dogfood-snapshot.v1",
+  "generatedFrom": "buildReactWebLiveHookDogfoodCoverageSummary",
+  "advisoryOnly": true,
+  "diagnosticOnly": true,
+  "claimable": false,
+  "manifestFingerprintAlgorithm": "sha256-json-stable-v1",
+  "manifestFingerprint": "6fde19cd4073bfad3c678e188b90503d97b09daf1e2ee7b2224a0f4caffeaa28",
+  "fixtureSourceFingerprintAlgorithm": "sha256-file-set-v1",
+  "fixtureSourceFingerprint": "7383230f670eb5373e7eb6493afed432baecef78b10ff17e174ef7aa5caed8bd",
+  "fixtureCount": 10,
+  "requiredLabels": [
+    "baseline-component",
+    "effect-hooks",
+    "source-too-small-control",
+    "hybrid-dashboard",
+    "form-state",
+    "data-fetching",
+    "custom-hook-state",
+    "context-provider",
+    "client-state"
+  ],
+  "claimBoundary": "Advisory reviewed baseline only: not runtime/pre-read authorization, not a merge gate, and not provider token/cost/billing evidence."
+}

--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -12,8 +12,11 @@ const defaultRepoRoot = path.resolve(__dirname, "..");
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION =
   "react-web-live-hook-dogfood-fixture-manifest.v1";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION =
+  "react-web-live-hook-dogfood-snapshot.v1";
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM = "sha256-json-stable-v1";
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM = "sha256-file-set-v1";
+export const DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH = path.join("fixtures", "react-web-live-hook-dogfood.snapshot.json");
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
 export const LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS = [
@@ -441,9 +444,148 @@ export function buildReactWebLiveHookDogfoodFixtureSourceFingerprint({
   };
 }
 
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function arraysEqual(left = [], right = []) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function buildReactWebLiveHookDogfoodCoverageSnapshot(summary) {
+  return {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
+    generatedFrom: "buildReactWebLiveHookDogfoodCoverageSummary",
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    manifestFingerprintAlgorithm: summary.manifestFingerprintAlgorithm,
+    manifestFingerprint: summary.manifestFingerprint,
+    fixtureSourceFingerprintAlgorithm: summary.fixtureSourceFingerprintAlgorithm,
+    fixtureSourceFingerprint: summary.fixtureSourceFingerprint,
+    fixtureCount: summary.fixtureCount,
+    requiredLabels: summary.requiredLabels,
+    claimBoundary:
+      "Advisory reviewed baseline only: not runtime/pre-read authorization, not a merge gate, and not provider token/cost/billing evidence.",
+  };
+}
+
+export function readReactWebLiveHookDogfoodCoverageSnapshot({
+  repoRoot = defaultRepoRoot,
+  snapshotPath = DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+} = {}) {
+  return readJsonIfExists(path.resolve(repoRoot, snapshotPath));
+}
+
+export function buildReactWebLiveHookDogfoodSnapshotDrift({
+  summary,
+  expectedSnapshot,
+  snapshotPath = DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+} = {}) {
+  if (!expectedSnapshot) {
+    return {
+      advisoryOnly: true,
+      diagnosticOnly: true,
+      claimable: false,
+      snapshotPath,
+      driftStatus: "missing-baseline",
+      reasons: ["snapshot-baseline-missing"],
+      snapshotSchema: {
+        expected: null,
+        actual: REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
+        matched: false,
+      },
+      fixtureCount: {
+        expected: null,
+        actual: summary.fixtureCount,
+        matched: false,
+      },
+      requiredLabels: {
+        expected: null,
+        actual: summary.requiredLabels,
+        matched: false,
+      },
+      manifest: {
+        expectedFingerprint: null,
+        actualFingerprint: summary.manifestFingerprint,
+        matched: false,
+        algorithm: summary.manifestFingerprintAlgorithm,
+      },
+      fixtureSource: {
+        expectedFingerprint: null,
+        actualFingerprint: summary.fixtureSourceFingerprint,
+        matched: false,
+        algorithm: summary.fixtureSourceFingerprintAlgorithm,
+      },
+      updateCommandHint: `node scripts/react-web-live-hook-dogfood-evidence.mjs --write-coverage-snapshot=${snapshotPath}`,
+      claimBoundary:
+        "Advisory drift comparison only: not runtime/pre-read authorization and not a merge gate.",
+    };
+  }
+
+  const manifestMatched =
+    expectedSnapshot.manifestFingerprintAlgorithm === summary.manifestFingerprintAlgorithm
+    && expectedSnapshot.manifestFingerprint === summary.manifestFingerprint;
+  const fixtureSourceMatched =
+    expectedSnapshot.fixtureSourceFingerprintAlgorithm === summary.fixtureSourceFingerprintAlgorithm
+    && expectedSnapshot.fixtureSourceFingerprint === summary.fixtureSourceFingerprint;
+  const schemaMatched = expectedSnapshot.schemaVersion === REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION;
+  const fixtureCountMatched = expectedSnapshot.fixtureCount === summary.fixtureCount;
+  const requiredLabelsMatched = arraysEqual(expectedSnapshot.requiredLabels, summary.requiredLabels);
+  const reasons = [
+    ...(schemaMatched ? [] : ["snapshot-schema-mismatch"]),
+    ...(fixtureCountMatched ? [] : ["fixture-count-mismatch"]),
+    ...(requiredLabelsMatched ? [] : ["required-labels-mismatch"]),
+    ...(manifestMatched ? [] : ["manifest-fingerprint-mismatch"]),
+    ...(fixtureSourceMatched ? [] : ["fixture-source-fingerprint-mismatch"]),
+  ];
+
+  return {
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    snapshotPath,
+    driftStatus: reasons.length === 0 ? "fresh" : "drifted",
+    reasons,
+    snapshotSchema: {
+      expected: expectedSnapshot.schemaVersion,
+      actual: REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
+      matched: schemaMatched,
+    },
+    fixtureCount: {
+      expected: expectedSnapshot.fixtureCount,
+      actual: summary.fixtureCount,
+      matched: fixtureCountMatched,
+    },
+    requiredLabels: {
+      expected: expectedSnapshot.requiredLabels,
+      actual: summary.requiredLabels,
+      matched: requiredLabelsMatched,
+    },
+    manifest: {
+      expectedFingerprint: expectedSnapshot.manifestFingerprint,
+      actualFingerprint: summary.manifestFingerprint,
+      matched: manifestMatched,
+      algorithm: summary.manifestFingerprintAlgorithm,
+    },
+    fixtureSource: {
+      expectedFingerprint: expectedSnapshot.fixtureSourceFingerprint,
+      actualFingerprint: summary.fixtureSourceFingerprint,
+      matched: fixtureSourceMatched,
+      algorithm: summary.fixtureSourceFingerprintAlgorithm,
+    },
+    updateCommandHint: `node scripts/react-web-live-hook-dogfood-evidence.mjs --write-coverage-snapshot=${snapshotPath}`,
+    claimBoundary:
+      "Advisory drift comparison only: not runtime/pre-read authorization and not a merge gate.",
+  };
+}
+
 export function buildReactWebLiveHookDogfoodCoverageSummary({
   manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
   repoRoot = defaultRepoRoot,
+  snapshotPath = DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+  expectedSnapshot = readReactWebLiveHookDogfoodCoverageSnapshot({ repoRoot, snapshotPath }),
 } = {}) {
   const requiredLabels = [...LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS];
   const expectedLabels = [...requiredLabels];
@@ -463,7 +605,7 @@ export function buildReactWebLiveHookDogfoodCoverageSummary({
   const manifestFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint({ manifest });
   const fixtureSourceIdentity = buildReactWebLiveHookDogfoodFixtureSourceFingerprint({ manifest, repoRoot });
 
-  return {
+  const summary = {
     schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
     source: "react-web-live-hook-dogfood-fixture-manifest",
     freshnessStatus: "fresh",
@@ -505,9 +647,11 @@ export function buildReactWebLiveHookDogfoodCoverageSummary({
     claimBoundary:
       "Local fixture-intent coverage summary only: not broad React Web support, not provider token/cost savings, and not runtime, pre-read, cache, or model-facing authorization.",
   };
+  summary.snapshotDrift = buildReactWebLiveHookDogfoodSnapshotDrift({ summary, expectedSnapshot, snapshotPath });
+  return summary;
 }
 
-function summarizeLiveHookSuite(rows) {
+function summarizeLiveHookSuite(rows, { repoRoot = defaultRepoRoot } = {}) {
   const reductionValues = rows.map((row) => row.additionalContextReductionPct);
   const candidateReductionValues = rows
     .map((row) => row.evidenceArtifact.additionalContextAdmission?.reductionPct)
@@ -588,7 +732,7 @@ function summarizeLiveHookSuite(rows) {
       candidate_byte_reduction: distribution(candidateReductionValues),
       final_injection_byte_reduction: distribution(finalInjectionReductionValues),
     },
-    coverage: buildReactWebLiveHookDogfoodCoverageSummary(),
+    coverage: buildReactWebLiveHookDogfoodCoverageSummary({ repoRoot }),
     allAdditionalContextsSmaller,
     allFreshGraphs,
     minAdditionalContextReductionPct: Math.min(...reductionValues),
@@ -732,7 +876,7 @@ export async function buildReactWebLiveHookDogfoodEvidence({
     claimBoundary:
       "Live/native hook fixture-matrix evidence only: local source bytes are compared with host-facing additionalContext bytes after built CLI replay. This is not provider tokenizer output, not provider billing/cost proof, and not a broad runtime-token claim.",
     fixtures: suiteRows,
-    summary: summarizeLiveHookSuite(suiteRows),
+    summary: summarizeLiveHookSuite(suiteRows, { repoRoot }),
   };
   const boundary = {
     targetFile: DEFAULT_LIVE_HOOK_BOUNDARY_TARGET,
@@ -871,6 +1015,24 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
   const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
   const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const writeSnapshotArg = process.argv
+    .find((arg) => arg.startsWith("--write-coverage-snapshot="))
+    ?.slice("--write-coverage-snapshot=".length);
+
+  if (writeSnapshotArg) {
+    const snapshotPath = path.resolve(defaultRepoRoot, writeSnapshotArg);
+    const summary = buildReactWebLiveHookDogfoodCoverageSummary({
+      repoRoot: defaultRepoRoot,
+      expectedSnapshot: null,
+      snapshotPath: writeSnapshotArg,
+    });
+    const snapshot = buildReactWebLiveHookDogfoodCoverageSnapshot(summary);
+    fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+    fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+    process.exit(0);
+  }
+
   const evidence = await buildReactWebLiveHookDogfoodEvidence({ repoRoot: defaultRepoRoot, runId });
 
   if (outputArg) {

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -127,6 +127,8 @@ ${evidence.claimBoundary}
 - Manifest fingerprint: ${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintShort} (${evidence.summary.liveHookDogfoodCoverage.manifestFingerprintAlgorithm})
 - Fixture source freshness: ${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus}
 - Fixture source fingerprint: ${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintShort} (${evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm})
+- Snapshot drift status: ${evidence.summary.liveHookDogfoodCoverage.snapshotDrift.driftStatus}
+- Snapshot drift reasons: ${evidence.summary.liveHookDogfoodCoverage.snapshotDrift.reasons.length > 0 ? evidence.summary.liveHookDogfoodCoverage.snapshotDrift.reasons.join(", ") : "none"}
 - Required labels: ${evidence.summary.liveHookDogfoodCoverage.requiredLabels.join(", ")}
 - Missing labels: ${evidence.summary.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"}
 - Counts by label: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByLabel)}

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -54,7 +54,7 @@ export async function buildReactWebProfileSurface({
   const stability = await buildReactWebStabilityEvidence({ repoRoot, runId: `${runId}-stability` });
   const mixedRouting = await buildReactWebMixedRoutingEvidence({ repoRoot, runId: `${runId}-mixed-routing` });
   const knowledgeContext = await buildReactWebKnowledgeContextEvidence({ repoRoot, runId: `${runId}-knowledge-context` });
-  const liveHookDogfoodCoverage = buildReactWebLiveHookDogfoodCoverageSummary();
+  const liveHookDogfoodCoverage = buildReactWebLiveHookDogfoodCoverageSummary({ repoRoot });
 
   const artifacts = {
     context,
@@ -139,6 +139,7 @@ ${evidence.claimBoundary}
 - Live-hook dogfood coverage advisory-only: ${evidence.summary.childSignals.liveHookDogfoodCoverage.advisoryOnly ? "yes" : "no"} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount} fixtures, missing labels: ${evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels.join(", ") : "none"})
 - Live-hook dogfood coverage freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.freshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintShort})
 - Live-hook dogfood fixture source freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintShort})
+- Live-hook dogfood snapshot drift: ${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.driftStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.join(", ") : "none"})
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -6,14 +6,17 @@ import path from "node:path";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
   DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES,
   LIVE_HOOK_DOGFOOD_ALLOWED_ROLES,
   LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  buildReactWebLiveHookDogfoodCoverageSnapshot,
   buildReactWebLiveHookDogfoodFixtureSourceFingerprint,
   buildReactWebLiveHookDogfoodManifestFingerprint,
+  buildReactWebLiveHookDogfoodSnapshotDrift,
   buildReactWebLiveHookDogfoodCoverageSummary,
   buildReactWebLiveHookDogfoodEvidence,
   renderReactWebLiveHookDogfoodEvidenceMarkdown,
@@ -81,6 +84,13 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
     "sha256(file bytes)",
     "file byte length",
   ]);
+  assert.equal(summary.snapshotDrift.driftStatus, "fresh");
+  assert.equal(summary.snapshotDrift.advisoryOnly, true);
+  assert.equal(summary.snapshotDrift.diagnosticOnly, true);
+  assert.equal(summary.snapshotDrift.claimable, false);
+  assert.deepEqual(summary.snapshotDrift.reasons, []);
+  assert.equal(summary.snapshotDrift.manifest.matched, true);
+  assert.equal(summary.snapshotDrift.fixtureSource.matched, true);
   assert.equal(summary.diagnosticOnly, true);
   assert.equal(summary.claimable, false);
   assert.equal(summary.advisoryOnly, true);
@@ -95,6 +105,97 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
   assert.match(summary.claimBoundary, /not broad React Web support/);
   assert.match(summary.claimBoundary, /not provider token\/cost savings/);
   assert.match(summary.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
+});
+
+test("React Web live hook dogfood coverage snapshot captures reviewed identity fields", () => {
+  const summary = buildReactWebLiveHookDogfoodCoverageSummary();
+  const snapshot = buildReactWebLiveHookDogfoodCoverageSnapshot(summary);
+
+  assert.equal(snapshot.schemaVersion, REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION);
+  assert.equal(snapshot.generatedFrom, "buildReactWebLiveHookDogfoodCoverageSummary");
+  assert.equal(snapshot.manifestFingerprint, summary.manifestFingerprint);
+  assert.equal(snapshot.fixtureSourceFingerprint, summary.fixtureSourceFingerprint);
+  assert.deepEqual(snapshot.requiredLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
+  assert.match(snapshot.claimBoundary, /not runtime\/pre-read authorization/);
+});
+
+test("React Web live hook dogfood snapshot drift distinguishes missing and mismatched baselines", () => {
+  const summary = buildReactWebLiveHookDogfoodCoverageSummary();
+  const snapshot = buildReactWebLiveHookDogfoodCoverageSnapshot(summary);
+
+  const missing = buildReactWebLiveHookDogfoodSnapshotDrift({ summary, expectedSnapshot: null });
+  assert.equal(missing.driftStatus, "missing-baseline");
+  assert.deepEqual(missing.reasons, ["snapshot-baseline-missing"]);
+  assert.equal(missing.snapshotSchema.matched, false);
+  assert.equal(missing.fixtureCount.matched, false);
+  assert.equal(missing.requiredLabels.matched, false);
+
+  const schemaDrift = buildReactWebLiveHookDogfoodSnapshotDrift({
+    summary,
+    expectedSnapshot: { ...snapshot, schemaVersion: "react-web-live-hook-dogfood-snapshot.v0" },
+  });
+  assert.equal(schemaDrift.driftStatus, "drifted");
+  assert.deepEqual(schemaDrift.reasons, ["snapshot-schema-mismatch"]);
+  assert.equal(schemaDrift.snapshotSchema.matched, false);
+
+  const fixtureCountDrift = buildReactWebLiveHookDogfoodSnapshotDrift({
+    summary,
+    expectedSnapshot: { ...snapshot, fixtureCount: snapshot.fixtureCount - 1 },
+  });
+  assert.equal(fixtureCountDrift.driftStatus, "drifted");
+  assert.deepEqual(fixtureCountDrift.reasons, ["fixture-count-mismatch"]);
+  assert.equal(fixtureCountDrift.fixtureCount.matched, false);
+
+  const requiredLabelsDrift = buildReactWebLiveHookDogfoodSnapshotDrift({
+    summary,
+    expectedSnapshot: { ...snapshot, requiredLabels: snapshot.requiredLabels.slice(1) },
+  });
+  assert.equal(requiredLabelsDrift.driftStatus, "drifted");
+  assert.deepEqual(requiredLabelsDrift.reasons, ["required-labels-mismatch"]);
+  assert.equal(requiredLabelsDrift.requiredLabels.matched, false);
+
+  const manifestDrift = buildReactWebLiveHookDogfoodSnapshotDrift({
+    summary,
+    expectedSnapshot: { ...snapshot, manifestFingerprint: "0".repeat(64) },
+  });
+  assert.equal(manifestDrift.driftStatus, "drifted");
+  assert.deepEqual(manifestDrift.reasons, ["manifest-fingerprint-mismatch"]);
+  assert.equal(manifestDrift.manifest.matched, false);
+  assert.equal(manifestDrift.fixtureSource.matched, true);
+
+  const fixtureSourceDrift = buildReactWebLiveHookDogfoodSnapshotDrift({
+    summary,
+    expectedSnapshot: { ...snapshot, fixtureSourceFingerprint: "1".repeat(64) },
+  });
+  assert.equal(fixtureSourceDrift.driftStatus, "drifted");
+  assert.deepEqual(fixtureSourceDrift.reasons, ["fixture-source-fingerprint-mismatch"]);
+  assert.equal(fixtureSourceDrift.manifest.matched, true);
+  assert.equal(fixtureSourceDrift.fixtureSource.matched, false);
+});
+
+test("React Web live hook dogfood coverage summary uses the supplied repoRoot for snapshots", () => {
+  const baseline = buildReactWebLiveHookDogfoodCoverageSummary();
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-coverage-summary-root-"));
+  for (const entry of DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST) {
+    const source = path.join(process.cwd(), entry.file);
+    const target = path.join(tempDir, entry.file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+  }
+  const snapshotPath = path.join(tempDir, "fixtures", "react-web-live-hook-dogfood.snapshot.json");
+  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+  const driftedSnapshot = {
+    ...buildReactWebLiveHookDogfoodCoverageSnapshot(baseline),
+    fixtureSourceFingerprint: "2".repeat(64),
+  };
+  fs.writeFileSync(snapshotPath, `${JSON.stringify(driftedSnapshot, null, 2)}\n`);
+
+  const alternateRootSummary = buildReactWebLiveHookDogfoodCoverageSummary({ repoRoot: tempDir });
+
+  assert.equal(alternateRootSummary.snapshotDrift.driftStatus, "drifted");
+  assert.deepEqual(alternateRootSummary.snapshotDrift.reasons, ["fixture-source-fingerprint-mismatch"]);
+  assert.equal(alternateRootSummary.snapshotDrift.fixtureSource.expectedFingerprint, "2".repeat(64));
+  assert.equal(alternateRootSummary.snapshotDrift.fixtureSource.actualFingerprint, baseline.fixtureSourceFingerprint);
 });
 
 test("React Web live hook dogfood manifest fingerprint detects fixture intent drift", () => {

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -59,6 +59,8 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
   assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
   assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm, "sha256-file-set-v1");
   assert.match(evidence.summary.liveHookDogfoodCoverage.fixtureSourceFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(evidence.summary.liveHookDogfoodCoverage.snapshotDrift.driftStatus, "fresh");
+  assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.snapshotDrift.reasons, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
@@ -88,6 +90,8 @@ test("React Web PR advisory markdown keeps advisory wording and explicit non-cla
   assert.match(markdown, /Manifest fingerprint: [a-f0-9]{12} \(sha256-json-stable-v1\)/);
   assert.match(markdown, /Fixture source freshness: fresh/);
   assert.match(markdown, /Fixture source fingerprint: [a-f0-9]{12} \(sha256-file-set-v1\)/);
+  assert.match(markdown, /Snapshot drift status: fresh/);
+  assert.match(markdown, /Snapshot drift reasons: none/);
   assert.match(markdown, /Missing labels: none/);
   assert.match(markdown, /Counts by label: .*form-state/);
   assert.match(markdown, /Claim boundary: .*not broad React Web support/);

--- a/test/react-web-pr-gate-surface.test.mjs
+++ b/test/react-web-pr-gate-surface.test.mjs
@@ -49,6 +49,7 @@ test("React Web PR gate passes on the approved bounded advisory surface", async 
   );
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.snapshotDrift.driftStatus, "fresh");
   assert.deepEqual(evidence.advisorySurface.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.reactWebOnly, true);
   assert.equal(evidence.summary.advisoryStatusRemainsUpstreamOnly, true);

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -70,6 +70,8 @@ test("React Web profile surface aggregates exactly the approved six evidence art
     "sha256-file-set-v1",
   );
   assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.driftStatus, "fresh");
+  assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureCount, 10);
   assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
@@ -93,6 +95,7 @@ test("React Web profile surface markdown keeps the top-level non-claims explicit
   assert.match(markdown, /Live-hook dogfood coverage advisory-only: yes \(10 fixtures, missing labels: none\)/);
   assert.match(markdown, /Live-hook dogfood coverage freshness: fresh \(sha256-json-stable-v1, [a-f0-9]{12}\)/);
   assert.match(markdown, /Live-hook dogfood fixture source freshness: fresh \(sha256-file-set-v1, [a-f0-9]{12}\)/);
+  assert.match(markdown, /Live-hook dogfood snapshot drift: fresh \(none\)/);
   assert.match(markdown, /Context reduction claimable at top level: no/);
   assert.match(markdown, /Cache performance claimable at top level: no/);
   assert.match(markdown, /Provider billing savings claimable at top level: no/);


### PR DESCRIPTION
## Summary\n\n- Add a checked-in React Web live-hook dogfood reviewed snapshot baseline\n- Compare current manifest/source identities plus snapshot contract fields against that baseline\n- Surface fresh/drifted/missing-baseline drift status in React Web profile and PR advisory reports\n- Keep drift advisory-only and leave PR gate/runtime/pre-read authority unchanged\n\nCloses #1145\n\n## Tests\n\n- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs`\n- `npm run typecheck`\n- `npm run lint -- --pretty false`\n- `git diff --check`\n\n## Review\n\n- Code-reviewer initial blockers resolved: snapshot contract fields compared, snapshot fixture tracked, repoRoot forwarding fixed\n- Architect re-review: CLEAR\n\n## Boundaries\n\n- No runtime/pre-read injection or authorization change\n- No merge-blocking drift gate\n- No provider token/cost/billing claim\n