### PR TITLE
Make React Web inspect snapshot-aware

### DIFF
--- a/scripts/react-web-snapshot-aware-inspect.mjs
+++ b/scripts/react-web-snapshot-aware-inspect.mjs
@@ -1,0 +1,247 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildReactWebLiveHookDogfoodCoverageSummary } from "./react-web-live-hook-dogfood-evidence.mjs";
+import { measureReactWebPreReadGraphDiagnosticFixture } from "./react-web-context-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION = "react-web-snapshot-aware-inspect.v1";
+export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_COMMAND = "inspect react-web-snapshot-aware-anchors";
+export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_MODE = "snapshot-aware-dry-run";
+export const REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION = "react-web-fact-graph-consumer-dry-run.v1";
+export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_CLAIM_BOUNDARY =
+  "React Web snapshot-aware inspect is a read-only dry-run report: it does not authorize runtime/pre-read injection, does not change PR gate policy, does not prove provider token/cost/billing savings, and does not claim broad React Web support.";
+export const DEFAULT_REACT_WEB_SNAPSHOT_AWARE_INSPECT_FIXTURE = "fixtures/compressed/FormSection.tsx";
+
+function emptyArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizedSnapshot(snapshotDrift = {}) {
+  return {
+    driftStatus: snapshotDrift.driftStatus ?? "missing-baseline",
+    reasons: emptyArray(snapshotDrift.reasons),
+    manifestMatched: snapshotDrift.manifest?.matched === true,
+    fixtureSourceMatched: snapshotDrift.fixtureSource?.matched === true,
+  };
+}
+
+function normalizedGraph(graphConsumer) {
+  if (!graphConsumer) return null;
+  return {
+    schemaVersion: graphConsumer.schemaVersion,
+    freshnessStatus: graphConsumer.freshnessStatus ?? "unknown",
+    selectedAnchorCount: graphConsumer.selectedAnchorCount ?? 0,
+    deferredAnchorCount: graphConsumer.deferredAnchorCount ?? 0,
+    maxAnchors: graphConsumer.maxAnchors ?? 0,
+    countsPresent:
+      typeof graphConsumer.selectedAnchorCount === "number" &&
+      typeof graphConsumer.deferredAnchorCount === "number" &&
+      typeof graphConsumer.maxAnchors === "number",
+    staleBehavior: graphConsumer.staleBehavior ?? "defer-all",
+    authorization: graphConsumer.authorization,
+    advisoryOnly: graphConsumer.advisoryOnly === true,
+  };
+}
+
+function normalizedProbeBoundary(probeBoundary) {
+  if (!probeBoundary) return null;
+  return {
+    payloadContainsGraph: probeBoundary.payloadContainsGraph,
+    diagnosticOnly: probeBoundary.diagnosticOnly,
+    claimable: probeBoundary.claimable,
+  };
+}
+
+function probeBoundaryBlockers(probeBoundary) {
+  if (!probeBoundary) return ["pre-read-probe-boundary-missing"];
+  return [
+    ...(probeBoundary.payloadContainsGraph === false ? [] : ["pre-read-payload-graph-leak"]),
+    ...(probeBoundary.diagnosticOnly === true ? [] : ["pre-read-probe-not-diagnostic-only"]),
+    ...(probeBoundary.claimable === false ? [] : ["pre-read-probe-claimable"]),
+  ];
+}
+
+function decideInspectStatus({ snapshot, graph, probeBoundary = null }) {
+  const blockedReasons = [];
+  if (snapshot.driftStatus !== "fresh") {
+    blockedReasons.push("snapshot-drift-not-fresh");
+  }
+  blockedReasons.push(...probeBoundaryBlockers(probeBoundary));
+  if (!graph) {
+    return { inspectStatus: "unavailable", blockedReasons: [...blockedReasons, "graph-consumer-unavailable"] };
+  }
+  if (graph.schemaVersion !== REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION) {
+    blockedReasons.push("graph-consumer-schema-mismatch");
+  }
+  if (graph.countsPresent !== true) {
+    blockedReasons.push("graph-consumer-counts-missing");
+  }
+  if (graph.staleBehavior !== "defer-all") {
+    blockedReasons.push("graph-consumer-stale-behavior-mismatch");
+  }
+  if (graph.authorization !== "none" || graph.advisoryOnly !== true) {
+    blockedReasons.push("graph-consumer-authority-widened");
+  }
+  if (graph.freshnessStatus !== "fresh") {
+    blockedReasons.push("graph-consumer-not-fresh");
+  }
+  if (blockedReasons.length > 0) {
+    return { inspectStatus: "blocked", blockedReasons };
+  }
+  if (graph.selectedAnchorCount <= 0) {
+    return { inspectStatus: "unavailable", blockedReasons: ["no-anchors-selected"] };
+  }
+  return { inspectStatus: "ready", blockedReasons: [] };
+}
+
+export function buildReactWebSnapshotAwareInspect({
+  coverageSummary = buildReactWebLiveHookDogfoodCoverageSummary(),
+  graphConsumer = null,
+  probeBoundary = null,
+  file = null,
+  selectedAnchors = [],
+  deferredAnchors = [],
+} = {}) {
+  const snapshot = normalizedSnapshot(coverageSummary.snapshotDrift);
+  const graph = normalizedGraph(graphConsumer);
+  const normalizedProbe = normalizedProbeBoundary(probeBoundary);
+  const { inspectStatus, blockedReasons } = decideInspectStatus({ snapshot, graph, probeBoundary: normalizedProbe });
+  const wouldSelectAnchorCount = inspectStatus === "ready" ? graph.selectedAnchorCount : 0;
+  const selectedAnchorDetails = emptyArray(selectedAnchors);
+  const deferredAnchorDetails = emptyArray(deferredAnchors);
+
+  return {
+    schemaVersion: REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION,
+    command: REACT_WEB_SNAPSHOT_AWARE_INSPECT_COMMAND,
+    profile: "react-web",
+    mode: REACT_WEB_SNAPSHOT_AWARE_INSPECT_MODE,
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    authorization: "none",
+    file,
+    inspectStatus,
+    claimBoundary: REACT_WEB_SNAPSHOT_AWARE_INSPECT_CLAIM_BOUNDARY,
+    snapshot,
+    graphConsumer: graph,
+    probeBoundary: normalizedProbe,
+    blockedReasons,
+    wouldSelectAnchorCount,
+    selectedAnchorDetailStatus: selectedAnchorDetails.length > 0 ? "provided" : "counts-only",
+    selectedAnchors: inspectStatus === "ready" ? selectedAnchorDetails : [],
+    deferredAnchors: deferredAnchorDetails,
+    nonClaims: {
+      runtimePreReadAuthorization: false,
+      mergeGatePolicy: false,
+      providerTokenCostSavings: false,
+      broadReactWebSupport: false,
+    },
+  };
+}
+
+export async function buildReactWebSnapshotAwareInspectEvidence({
+  repoRoot = defaultRepoRoot,
+  relativeFile = DEFAULT_REACT_WEB_SNAPSHOT_AWARE_INSPECT_FIXTURE,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const coverageSummary = buildReactWebLiveHookDogfoodCoverageSummary({ repoRoot });
+  const graphProbe = await measureReactWebPreReadGraphDiagnosticFixture({ repoRoot, relativeFile });
+  const inspect = buildReactWebSnapshotAwareInspect({
+    coverageSummary,
+    graphConsumer: graphProbe.preReadGraph,
+    probeBoundary: {
+      payloadContainsGraph: graphProbe.payloadContainsGraph,
+      diagnosticOnly: graphProbe.diagnosticOnly,
+      claimable: graphProbe.claimable,
+    },
+    file: relativeFile,
+  });
+
+  return {
+    ...inspect,
+    runId,
+    graphProbe: {
+      decision: graphProbe.decision,
+      classification: graphProbe.classification,
+      payloadContainsGraph: graphProbe.payloadContainsGraph,
+      diagnosticOnly: graphProbe.diagnosticOnly,
+      claimable: graphProbe.claimable,
+    },
+  };
+}
+
+export function renderReactWebSnapshotAwareInspectMarkdown(evidence) {
+  const blockedReasons = evidence.blockedReasons.length > 0 ? evidence.blockedReasons.join(", ") : "none";
+  const snapshotReasons = evidence.snapshot.reasons.length > 0 ? evidence.snapshot.reasons.join(", ") : "none";
+  return `# React Web snapshot-aware inspect
+
+${evidence.claimBoundary}
+
+## Summary
+
+- Profile: ${evidence.profile}
+- Mode: ${evidence.mode}
+- File: ${evidence.file ?? "none"}
+- Inspect status: ${evidence.inspectStatus}
+- Authorization: ${evidence.authorization}
+- Advisory-only: ${evidence.advisoryOnly ? "yes" : "no"}
+- Diagnostic-only: ${evidence.diagnosticOnly ? "yes" : "no"}
+- Claimable: ${evidence.claimable ? "yes" : "no"}
+- Would select anchors: ${evidence.wouldSelectAnchorCount}
+- Selected anchor detail status: ${evidence.selectedAnchorDetailStatus}
+- Blocked reasons: ${blockedReasons}
+
+## Snapshot gate
+
+- Drift status: ${evidence.snapshot.driftStatus}
+- Drift reasons: ${snapshotReasons}
+- Manifest matched: ${evidence.snapshot.manifestMatched ? "yes" : "no"}
+- Fixture source matched: ${evidence.snapshot.fixtureSourceMatched ? "yes" : "no"}
+
+## Graph dry-run gate
+
+- Graph available: ${evidence.graphConsumer ? "yes" : "no"}
+- Graph freshness: ${evidence.graphConsumer?.freshnessStatus ?? "none"}
+- Graph selected count: ${evidence.graphConsumer?.selectedAnchorCount ?? 0}
+- Graph deferred count: ${evidence.graphConsumer?.deferredAnchorCount ?? 0}
+- Graph authorization: ${evidence.graphConsumer?.authorization ?? "none"}
+
+## Pre-read probe boundary
+
+- Payload contains graph: ${evidence.probeBoundary?.payloadContainsGraph === true ? "yes" : "no"}
+- Probe diagnostic-only: ${evidence.probeBoundary?.diagnosticOnly === true ? "yes" : "no"}
+- Probe claimable: ${evidence.probeBoundary?.claimable === true ? "yes" : "no"}
+
+## Non-claims
+
+- Runtime/pre-read authorization: ${evidence.nonClaims.runtimePreReadAuthorization ? "yes" : "no"}
+- Merge gate policy change: ${evidence.nonClaims.mergeGatePolicy ? "yes" : "no"}
+- Provider token/cost savings: ${evidence.nonClaims.providerTokenCostSavings ? "yes" : "no"}
+- Broad React Web support: ${evidence.nonClaims.broadReactWebSupport ? "yes" : "no"}
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const relativeFile = process.argv.find((arg) => arg.startsWith("--file="))?.slice("--file=".length) ?? DEFAULT_REACT_WEB_SNAPSHOT_AWARE_INSPECT_FIXTURE;
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const evidence = await buildReactWebSnapshotAwareInspectEvidence({ repoRoot: defaultRepoRoot, relativeFile, runId });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebSnapshotAwareInspectMarkdown(evidence));
+  }
+
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/test/react-web-snapshot-aware-inspect.test.mjs
+++ b/test/react-web-snapshot-aware-inspect.test.mjs
@@ -1,0 +1,249 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION,
+  buildReactWebSnapshotAwareInspect,
+  renderReactWebSnapshotAwareInspectMarkdown,
+} from "../scripts/react-web-snapshot-aware-inspect.mjs";
+import { buildReactWebLiveHookDogfoodCoverageSummary } from "../scripts/react-web-live-hook-dogfood-evidence.mjs";
+
+const repoRoot = process.cwd();
+
+function freshCoverageSummary() {
+  return buildReactWebLiveHookDogfoodCoverageSummary();
+}
+
+function graph(overrides = {}) {
+  return {
+    schemaVersion: "react-web-fact-graph-consumer-dry-run.v1",
+    advisoryOnly: true,
+    authorization: "none",
+    freshnessStatus: "fresh",
+    selectedAnchorCount: 3,
+    deferredAnchorCount: 1,
+    maxAnchors: 4,
+    staleBehavior: "defer-all",
+    ...overrides,
+  };
+}
+
+function cleanProbeBoundary(overrides = {}) {
+  return {
+    payloadContainsGraph: false,
+    diagnosticOnly: true,
+    claimable: false,
+    ...overrides,
+  };
+}
+
+test("React Web snapshot-aware inspect reports ready only for fresh snapshot and fresh graph", () => {
+  const evidence = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+    probeBoundary: cleanProbeBoundary(),
+    file: "fixtures/compressed/FormSection.tsx",
+    selectedAnchors: [
+      { label: "component: FormSection", source: "graph-consumer", evidence: ["fresh graph"] },
+    ],
+  });
+
+  assert.equal(evidence.schemaVersion, REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION);
+  assert.equal(evidence.inspectStatus, "ready");
+  assert.equal(evidence.authorization, "none");
+  assert.equal(evidence.advisoryOnly, true);
+  assert.equal(evidence.diagnosticOnly, true);
+  assert.equal(evidence.claimable, false);
+  assert.equal(evidence.snapshot.driftStatus, "fresh");
+  assert.equal(evidence.graphConsumer.freshnessStatus, "fresh");
+  assert.equal(evidence.wouldSelectAnchorCount, 3);
+  assert.equal(evidence.selectedAnchorDetailStatus, "provided");
+  assert.equal(evidence.selectedAnchors.length, 1);
+  assert.deepEqual(evidence.blockedReasons, []);
+  assert.equal(evidence.nonClaims.runtimePreReadAuthorization, false);
+  assert.equal(evidence.nonClaims.mergeGatePolicy, false);
+});
+
+test("React Web snapshot-aware inspect blocks on drifted or missing snapshot", () => {
+  const fresh = freshCoverageSummary();
+  const drifted = {
+    ...fresh,
+    snapshotDrift: {
+      ...fresh.snapshotDrift,
+      driftStatus: "drifted",
+      reasons: ["fixture-source-fingerprint-mismatch"],
+      manifest: { matched: true },
+      fixtureSource: { matched: false },
+    },
+  };
+  const missing = {
+    ...fresh,
+    snapshotDrift: {
+      ...fresh.snapshotDrift,
+      driftStatus: "missing-baseline",
+      reasons: ["snapshot-baseline-missing"],
+      manifest: { matched: false },
+      fixtureSource: { matched: false },
+    },
+  };
+
+  const driftedEvidence = buildReactWebSnapshotAwareInspect({ coverageSummary: drifted, graphConsumer: graph(), probeBoundary: cleanProbeBoundary() });
+  const missingEvidence = buildReactWebSnapshotAwareInspect({ coverageSummary: missing, graphConsumer: graph(), probeBoundary: cleanProbeBoundary() });
+
+  assert.equal(driftedEvidence.inspectStatus, "blocked");
+  assert.deepEqual(driftedEvidence.blockedReasons, ["snapshot-drift-not-fresh"]);
+  assert.equal(driftedEvidence.wouldSelectAnchorCount, 0);
+  assert.equal(missingEvidence.inspectStatus, "blocked");
+  assert.deepEqual(missingEvidence.blockedReasons, ["snapshot-drift-not-fresh"]);
+  assert.equal(missingEvidence.wouldSelectAnchorCount, 0);
+});
+
+test("React Web snapshot-aware inspect blocks stale graph and unavailable graph separately", () => {
+  const stale = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ freshnessStatus: "stale" }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const missingGraph = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: null,
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const noAnchors = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ selectedAnchorCount: 0, deferredAnchorCount: 4 }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const widenedAuthority = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ authorization: "runtime" }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const missingAuthorization = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ authorization: undefined }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const missingAdvisoryFlag = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ advisoryOnly: undefined }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+
+  assert.equal(stale.inspectStatus, "blocked");
+  assert.deepEqual(stale.blockedReasons, ["graph-consumer-not-fresh"]);
+  assert.equal(missingGraph.inspectStatus, "unavailable");
+  assert.deepEqual(missingGraph.blockedReasons, ["graph-consumer-unavailable"]);
+  assert.equal(noAnchors.inspectStatus, "unavailable");
+  assert.deepEqual(noAnchors.blockedReasons, ["no-anchors-selected"]);
+  assert.equal(widenedAuthority.inspectStatus, "blocked");
+  assert.deepEqual(widenedAuthority.blockedReasons, ["graph-consumer-authority-widened"]);
+  assert.equal(missingAuthorization.inspectStatus, "blocked");
+  assert.deepEqual(missingAuthorization.blockedReasons, ["graph-consumer-authority-widened"]);
+  assert.equal(missingAdvisoryFlag.inspectStatus, "blocked");
+  assert.deepEqual(missingAdvisoryFlag.blockedReasons, ["graph-consumer-authority-widened"]);
+});
+
+test("React Web snapshot-aware inspect blocks pre-read probe boundary violations", () => {
+  const missingBoundary = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+  });
+  const leakedPayload = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+    probeBoundary: cleanProbeBoundary({ payloadContainsGraph: true }),
+  });
+  const notDiagnostic = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+    probeBoundary: cleanProbeBoundary({ diagnosticOnly: false }),
+  });
+  const claimable = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+    probeBoundary: cleanProbeBoundary({ claimable: true }),
+  });
+
+  assert.equal(missingBoundary.inspectStatus, "blocked");
+  assert.deepEqual(missingBoundary.blockedReasons, ["pre-read-probe-boundary-missing"]);
+  assert.equal(leakedPayload.inspectStatus, "blocked");
+  assert.deepEqual(leakedPayload.blockedReasons, ["pre-read-payload-graph-leak"]);
+  assert.equal(notDiagnostic.inspectStatus, "blocked");
+  assert.deepEqual(notDiagnostic.blockedReasons, ["pre-read-probe-not-diagnostic-only"]);
+  assert.equal(claimable.inspectStatus, "blocked");
+  assert.deepEqual(claimable.blockedReasons, ["pre-read-probe-claimable"]);
+});
+
+test("React Web snapshot-aware inspect blocks malformed graph consumer shape", () => {
+  const missingSchema = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ schemaVersion: undefined }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const missingCounts = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ selectedAnchorCount: undefined }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+  const staleBehaviorMismatch = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph({ staleBehavior: "reuse-stale" }),
+    probeBoundary: cleanProbeBoundary(),
+  });
+
+  assert.equal(missingSchema.inspectStatus, "blocked");
+  assert.deepEqual(missingSchema.blockedReasons, ["graph-consumer-schema-mismatch"]);
+  assert.equal(missingCounts.inspectStatus, "blocked");
+  assert.deepEqual(missingCounts.blockedReasons, ["graph-consumer-counts-missing"]);
+  assert.equal(staleBehaviorMismatch.inspectStatus, "blocked");
+  assert.deepEqual(staleBehaviorMismatch.blockedReasons, ["graph-consumer-stale-behavior-mismatch"]);
+});
+
+test("React Web snapshot-aware inspect markdown keeps non-claims explicit", () => {
+  const evidence = buildReactWebSnapshotAwareInspect({
+    coverageSummary: freshCoverageSummary(),
+    graphConsumer: graph(),
+    probeBoundary: cleanProbeBoundary(),
+    file: "fixtures/compressed/FormSection.tsx",
+  });
+  const markdown = renderReactWebSnapshotAwareInspectMarkdown(evidence);
+
+  assert.match(markdown, /# React Web snapshot-aware inspect/);
+  assert.match(markdown, /Inspect status: ready/);
+  assert.match(markdown, /Authorization: none/);
+  assert.match(markdown, /Runtime\/pre-read authorization: no/);
+  assert.match(markdown, /Merge gate policy change: no/);
+  assert.match(markdown, /Provider token\/cost savings: no/);
+  assert.match(markdown, /Broad React Web support: no/);
+});
+
+test("React Web snapshot-aware inspect CLI writes JSON and Markdown reports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-react-web-snapshot-aware-inspect-"));
+  const outputPath = path.join(tempDir, "inspect.json");
+  const markdownPath = path.join(tempDir, "inspect.md");
+  const cli = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts", "react-web-snapshot-aware-inspect.mjs"),
+      "--run-id=cli-test",
+      "--file=fixtures/compressed/FormSection.tsx",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+  const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+  assert.equal(evidence.schemaVersion, REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION);
+  assert.equal(evidence.authorization, "none");
+  assert.equal(evidence.graphProbe.payloadContainsGraph, false);
+  assert.match(markdown, /React Web snapshot-aware inspect/);
+});


### PR DESCRIPTION
## Summary\n\n- Add a read-only React Web snapshot-aware inspect/dry-run report\n- Combine persisted snapshot drift and graph consumer dry-run diagnostics into ready/blocked/unavailable status\n- Fail closed on drifted/missing snapshots, stale/malformed graph diagnostics, widened authority, and pre-read probe boundary violations\n- Keep authorization as none and leave runtime/pre-read plus PR gate policy unchanged\n\nCloses #1147\n\n## Tests\n\n- `node --test test/react-web-snapshot-aware-inspect.test.mjs`\n- `npm run typecheck`\n- `npm run lint -- --pretty false`\n- `git diff --check`\n\n## Review\n\n- Code-reviewer blockers resolved and re-review: APPROVE\n- Architect review: CLEAR for inspect-only boundary; additional malformed-input WATCH items covered by final regressions\n\n## Boundaries\n\n- No runtime/pre-read injection or authorization change\n- No merge-blocking PR gate change\n- No provider token/cost/billing claim\n