### PR TITLE
Gate runtime graph packing on fresh snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,18 @@
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",
-    "docs/stale-context.md"
+    "docs/stale-context.md",
+    "fixtures/react-web-live-hook-dogfood.snapshot.json",
+    "fixtures/compressed/FormSection.tsx",
+    "fixtures/compressed/HookEffectPanel.tsx",
+    "fixtures/compressed/TinyEditCard.tsx",
+    "fixtures/compressed/FormControls.tsx",
+    "fixtures/hybrid/DashboardPanel.tsx",
+    "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+    "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+    "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+    "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx",
+    "test/fixtures/react-web-context-expansion/client-state-release-store.tsx"
   ],
   "repository": {
     "type": "git",

--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -4,145 +4,37 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRepoRoot = path.resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const {
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM,
+  DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+  LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+  buildReactWebLiveHookDogfoodManifestFingerprint: buildCoreReactWebLiveHookDogfoodManifestFingerprint,
+  buildReactWebLiveHookDogfoodFixtureSourceFingerprint: buildCoreReactWebLiveHookDogfoodFixtureSourceFingerprint,
+} = require(path.join(defaultRepoRoot, "dist", "core", "react-web-live-hook-dogfood-snapshot.js"));
 
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION =
-  "react-web-live-hook-dogfood-fixture-manifest.v1";
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION =
-  "react-web-live-hook-dogfood-snapshot.v1";
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM = "sha256-json-stable-v1";
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM = "sha256-file-set-v1";
-export const DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH = path.join("fixtures", "react-web-live-hook-dogfood.snapshot.json");
+export {
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM,
+  DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+  LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS,
+  DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+};
+export const LIVE_HOOK_DOGFOOD_ALLOWED_ROLES = ["positive", "boundary-control", "reuse-baseline"];
 export const DEFAULT_LIVE_HOOK_REACT_WEB_TARGET = path.join("src", "components", "FormSection.tsx");
 export const DEFAULT_LIVE_HOOK_BOUNDARY_TARGET = path.join("src", "components", "SimpleButton.tsx");
-export const LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS = [
-  "baseline-component",
-  "effect-hooks",
-  "source-too-small-control",
-  "hybrid-dashboard",
-  "form-state",
-  "data-fetching",
-  "custom-hook-state",
-  "context-provider",
-  "client-state",
-];
-export const LIVE_HOOK_DOGFOOD_ALLOWED_ROLES = ["positive", "boundary-control", "reuse-baseline"];
-export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST = [
-  {
-    file: "fixtures/compressed/FormSection.tsx",
-    coverage: ["baseline-component", "form-state"],
-    purpose: "Primary React Web form-section reuse-shape baseline with same-file helpers.",
-    role: "reuse-baseline",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "fixtures/compressed/HookEffectPanel.tsx",
-    coverage: ["effect-hooks", "custom-hook-state"],
-    purpose: "Hook/effect-heavy React Web row for graph-assisted context diagnostics.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "fixtures/compressed/TinyEditCard.tsx",
-    coverage: ["source-too-small-control"],
-    purpose: "Small-source control that proves candidate admission can safely fall back.",
-    role: "boundary-control",
-    expectation: {
-      classification: "react-web",
-      admission: "discarded-source-too-small",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "fixtures/hybrid/DashboardPanel.tsx",
-    coverage: ["hybrid-dashboard", "custom-hook-state"],
-    purpose: "Hybrid dashboard row for mixed presentation/state graph diagnostics.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "fixtures/compressed/FormControls.tsx",
-    coverage: ["form-state", "react-hook-form"],
-    purpose: "React Hook Form/form-state reuse-shape baseline.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
-    coverage: ["form-state", "modal-form"],
-    purpose: "Modal preferences form row for nested local form-state diagnostics.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
-    coverage: ["data-fetching"],
-    purpose: "Server/data-fetching shaped React Web row reused as the suite baseline.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
-    coverage: ["custom-hook-state", "effect-hooks"],
-    purpose: "Custom hook-heavy review inbox row for local state transition diagnostics.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx",
-    coverage: ["context-provider", "form-state"],
-    purpose: "React Context provider/consumer row for workspace preference state.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-  {
-    file: "test/fixtures/react-web-context-expansion/client-state-release-store.tsx",
-    coverage: ["client-state", "zustand"],
-    purpose: "Client-state/store-hook component row for release store diagnostics.",
-    role: "positive",
-    expectation: {
-      classification: "react-web",
-      admission: "admitted",
-      metricBoundary: "diagnostic-local-bytes-only",
-    },
-  },
-];
 export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST.map(
   (entry) => entry.file,
 );
@@ -375,44 +267,10 @@ function uniqueSorted(values) {
   return [...new Set(values)].sort();
 }
 
-function stableJson(value) {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`;
-  }
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
-
-function normalizeManifestFingerprintEntry(entry) {
-  return {
-    file: entry.file,
-    coverage: [...(entry.coverage ?? [])].sort(),
-    purpose: entry.purpose,
-    role: entry.role,
-    expectation: {
-      admission: entry.expectation?.admission,
-      classification: entry.expectation?.classification,
-      metricBoundary: entry.expectation?.metricBoundary,
-    },
-  };
-}
-
 export function buildReactWebLiveHookDogfoodManifestFingerprint({
   manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
 } = {}) {
-  const identity = {
-    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
-    manifest: manifest.map(normalizeManifestFingerprintEntry),
-  };
-  return crypto
-    .createHash("sha256")
-    .update(stableJson(identity))
-    .digest("hex");
+  return buildCoreReactWebLiveHookDogfoodManifestFingerprint(manifest);
 }
 
 export function buildReactWebLiveHookDogfoodFixtureSourceFingerprint({
@@ -428,16 +286,8 @@ export function buildReactWebLiveHookDogfoodFixtureSourceFingerprint({
       sha256: crypto.createHash("sha256").update(content).digest("hex"),
     };
   });
-  const identity = {
-    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
-    files,
-  };
-
   return {
-    fingerprint: crypto
-      .createHash("sha256")
-      .update(stableJson(identity))
-      .digest("hex"),
+    fingerprint: buildCoreReactWebLiveHookDogfoodFixtureSourceFingerprint({ repoRoot, manifest }),
     fileCount: files.length,
     byteCount: files.reduce((sum, file) => sum + file.bytes, 0),
     files,

--- a/scripts/react-web-snapshot-aware-inspect.mjs
+++ b/scripts/react-web-snapshot-aware-inspect.mjs
@@ -1,26 +1,32 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import { buildReactWebLiveHookDogfoodCoverageSummary } from "./react-web-live-hook-dogfood-evidence.mjs";
 import { measureReactWebPreReadGraphDiagnosticFixture } from "./react-web-context-evidence.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRepoRoot = path.resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const {
+  REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION,
+  REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_CLAIM_BOUNDARY,
+  evaluateReactWebSnapshotAwareConsumerGate,
+} = require(path.join(defaultRepoRoot, "dist", "core", "react-web-snapshot-aware-consumer-gate.js"));
 
 export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_SCHEMA_VERSION = "react-web-snapshot-aware-inspect.v1";
 export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_COMMAND = "inspect react-web-snapshot-aware-anchors";
 export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_MODE = "snapshot-aware-dry-run";
-export const REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION = "react-web-fact-graph-consumer-dry-run.v1";
-export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_CLAIM_BOUNDARY =
-  "React Web snapshot-aware inspect is a read-only dry-run report: it does not authorize runtime/pre-read injection, does not change PR gate policy, does not prove provider token/cost/billing savings, and does not claim broad React Web support.";
+export { REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION };
+export const REACT_WEB_SNAPSHOT_AWARE_INSPECT_CLAIM_BOUNDARY = REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_CLAIM_BOUNDARY;
 export const DEFAULT_REACT_WEB_SNAPSHOT_AWARE_INSPECT_FIXTURE = "fixtures/compressed/FormSection.tsx";
 
 function emptyArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-function normalizedSnapshot(snapshotDrift = {}) {
+function snapshotInput(snapshotDrift = {}) {
   return {
     driftStatus: snapshotDrift.driftStatus ?? "missing-baseline",
     reasons: emptyArray(snapshotDrift.reasons),
@@ -29,73 +35,8 @@ function normalizedSnapshot(snapshotDrift = {}) {
   };
 }
 
-function normalizedGraph(graphConsumer) {
-  if (!graphConsumer) return null;
-  return {
-    schemaVersion: graphConsumer.schemaVersion,
-    freshnessStatus: graphConsumer.freshnessStatus ?? "unknown",
-    selectedAnchorCount: graphConsumer.selectedAnchorCount ?? 0,
-    deferredAnchorCount: graphConsumer.deferredAnchorCount ?? 0,
-    maxAnchors: graphConsumer.maxAnchors ?? 0,
-    countsPresent:
-      typeof graphConsumer.selectedAnchorCount === "number" &&
-      typeof graphConsumer.deferredAnchorCount === "number" &&
-      typeof graphConsumer.maxAnchors === "number",
-    staleBehavior: graphConsumer.staleBehavior ?? "defer-all",
-    authorization: graphConsumer.authorization,
-    advisoryOnly: graphConsumer.advisoryOnly === true,
-  };
-}
-
-function normalizedProbeBoundary(probeBoundary) {
-  if (!probeBoundary) return null;
-  return {
-    payloadContainsGraph: probeBoundary.payloadContainsGraph,
-    diagnosticOnly: probeBoundary.diagnosticOnly,
-    claimable: probeBoundary.claimable,
-  };
-}
-
-function probeBoundaryBlockers(probeBoundary) {
-  if (!probeBoundary) return ["pre-read-probe-boundary-missing"];
-  return [
-    ...(probeBoundary.payloadContainsGraph === false ? [] : ["pre-read-payload-graph-leak"]),
-    ...(probeBoundary.diagnosticOnly === true ? [] : ["pre-read-probe-not-diagnostic-only"]),
-    ...(probeBoundary.claimable === false ? [] : ["pre-read-probe-claimable"]),
-  ];
-}
-
-function decideInspectStatus({ snapshot, graph, probeBoundary = null }) {
-  const blockedReasons = [];
-  if (snapshot.driftStatus !== "fresh") {
-    blockedReasons.push("snapshot-drift-not-fresh");
-  }
-  blockedReasons.push(...probeBoundaryBlockers(probeBoundary));
-  if (!graph) {
-    return { inspectStatus: "unavailable", blockedReasons: [...blockedReasons, "graph-consumer-unavailable"] };
-  }
-  if (graph.schemaVersion !== REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION) {
-    blockedReasons.push("graph-consumer-schema-mismatch");
-  }
-  if (graph.countsPresent !== true) {
-    blockedReasons.push("graph-consumer-counts-missing");
-  }
-  if (graph.staleBehavior !== "defer-all") {
-    blockedReasons.push("graph-consumer-stale-behavior-mismatch");
-  }
-  if (graph.authorization !== "none" || graph.advisoryOnly !== true) {
-    blockedReasons.push("graph-consumer-authority-widened");
-  }
-  if (graph.freshnessStatus !== "fresh") {
-    blockedReasons.push("graph-consumer-not-fresh");
-  }
-  if (blockedReasons.length > 0) {
-    return { inspectStatus: "blocked", blockedReasons };
-  }
-  if (graph.selectedAnchorCount <= 0) {
-    return { inspectStatus: "unavailable", blockedReasons: ["no-anchors-selected"] };
-  }
-  return { inspectStatus: "ready", blockedReasons: [] };
+function inspectStatusFromGate(status) {
+  return status === "allowed" ? "ready" : status;
 }
 
 export function buildReactWebSnapshotAwareInspect({
@@ -106,11 +47,17 @@ export function buildReactWebSnapshotAwareInspect({
   selectedAnchors = [],
   deferredAnchors = [],
 } = {}) {
-  const snapshot = normalizedSnapshot(coverageSummary.snapshotDrift);
-  const graph = normalizedGraph(graphConsumer);
-  const normalizedProbe = normalizedProbeBoundary(probeBoundary);
-  const { inspectStatus, blockedReasons } = decideInspectStatus({ snapshot, graph, probeBoundary: normalizedProbe });
-  const wouldSelectAnchorCount = inspectStatus === "ready" ? graph.selectedAnchorCount : 0;
+  const gate = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: snapshotInput(coverageSummary.snapshotDrift),
+    graphConsumer,
+    probeBoundary,
+  });
+  const snapshot = gate.snapshot;
+  const graph = gate.graphConsumer;
+  const normalizedProbe = gate.probeBoundary;
+  const inspectStatus = inspectStatusFromGate(gate.status);
+  const blockedReasons = gate.blockedReasons;
+  const wouldSelectAnchorCount = gate.allowed ? gate.wouldSelectAnchorCount : 0;
   const selectedAnchorDetails = emptyArray(selectedAnchors);
   const deferredAnchorDetails = emptyArray(deferredAnchors);
 
@@ -126,6 +73,14 @@ export function buildReactWebSnapshotAwareInspect({
     file,
     inspectStatus,
     claimBoundary: REACT_WEB_SNAPSHOT_AWARE_INSPECT_CLAIM_BOUNDARY,
+    consumerGate: {
+      schemaVersion: gate.schemaVersion,
+      status: gate.status,
+      allowed: gate.allowed,
+      authorization: gate.authorization,
+      blockedReasons: gate.blockedReasons,
+      wouldSelectAnchorCount: gate.wouldSelectAnchorCount,
+    },
     snapshot,
     graphConsumer: graph,
     probeBoundary: normalizedProbe,

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -180,6 +180,17 @@ function assertPackedFiles(packEntry) {
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",
+    "fixtures/react-web-live-hook-dogfood.snapshot.json",
+    "fixtures/compressed/FormSection.tsx",
+    "fixtures/compressed/HookEffectPanel.tsx",
+    "fixtures/compressed/TinyEditCard.tsx",
+    "fixtures/compressed/FormControls.tsx",
+    "fixtures/hybrid/DashboardPanel.tsx",
+    "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx",
+    "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx",
+    "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx",
+    "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx",
+    "test/fixtures/react-web-context-expansion/client-state-release-store.tsx",
   ];
 
   for (const filePath of required) {

--- a/src/adapters/codex-runtime-hook.ts
+++ b/src/adapters/codex-runtime-hook.ts
@@ -30,6 +30,12 @@ import { finalizeWorktreeEvidenceSafe, initializeWorktreeEvidenceSafe } from "..
 import { emitReactWebEvidenceArtifact } from "../reporting/react-web-evidence-artifact";
 import { buildReactWebActivationModeFromRuntimeDecision, summarizeReactWebActivationMode } from "../reporting/react-web-activation-mode";
 import { buildReactWebFactGraphConsumerDryRun, type ReactWebFactGraphConsumerDryRun } from "../core/react-web-fact-graph-consumer";
+import {
+  evaluateReactWebSnapshotAwareConsumerGate,
+  type ReactWebSnapshotAwareConsumerGateInput,
+  type ReactWebSnapshotAwareConsumerGateResult,
+} from "../core/react-web-snapshot-aware-consumer-gate";
+import { buildReactWebRuntimeSnapshotGateInput } from "../core/react-web-live-hook-dogfood-snapshot";
 
 const EDIT_INTENT_PATTERN = /\b(?:update|fix|change|add|remove|refactor|patch|modify|implement|rename|replace|adjust|simplify|rewrite)\b/i;
 const FRONTEND_EXTENSIONS = new Set([".tsx", ".jsx"]);
@@ -41,6 +47,7 @@ const DOMAIN_MEMORY_ADVISORY_CONTEXT_MARKER = "FOOKS DOMAIN MEMORY ADVISORY";
 const PREFLIGHT_ISSUE_OR_PR_PATTERN = /(?:#\d+\b|\b(?:issue|issues|pr|pull\s+request)\s*#?\d+\b)/iu;
 const PREFLIGHT_TEST_COMMAND_PATTERN = /(?:\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b|\bpytest\b|\bvitest\b|\bjest\b|테스트)/iu;
 const PREFLIGHT_STACK_OR_ERROR_PATTERN = /(?:\b(?:typeerror|referenceerror|syntaxerror|stack\s+trace|traceback|failed|failure|exception|error)\b|에러|오류|실패|스택|이상한데)/iu;
+const FOOKS_PACKAGE_ROOT = path.resolve(__dirname, "..", "..");
 
 type RuntimeAdditionalContextAdmissionReason = "admitted" | "unknown-source-size" | "source-too-small" | "candidate-not-smaller-than-source" | "reduction-below-threshold";
 type RuntimeAdditionalContextAdmission = {
@@ -709,10 +716,12 @@ export function runtimeReactWebFactGraphPackingSummary(
   reason: RuntimeReactWebFactGraphPackingReason,
   reactWebFactGraph?: PackedRuntimeReactWebFactGraph,
   dryRun?: ReactWebFactGraphConsumerDryRun,
+  gate?: ReactWebSnapshotAwareConsumerGateResult,
 ): RuntimeReactWebFactGraphPackingSummary {
   return {
     included: reason === "fresh-anchors-packed",
     reason,
+    ...(gate ? { gateStatus: gate.status, gateBlockedReasons: gate.blockedReasons } : {}),
     selectedAnchorCount: reactWebFactGraph?.selectedAnchors.length ?? dryRun?.selectedAnchors.length ?? 0,
     deferredAnchorCount: reactWebFactGraph?.deferredAnchorCount ?? dryRun?.deferredAnchors.length ?? 0,
     freshnessStatus: reactWebFactGraph?.freshnessStatus ?? dryRun?.graphSummary.freshnessStatus ?? "unknown",
@@ -721,8 +730,11 @@ export function runtimeReactWebFactGraphPackingSummary(
 
 export function summarizeRuntimeReactWebFactGraphDryRun(
   dryRun: ReactWebFactGraphConsumerDryRun,
-  options: { budgetExceeded?: boolean; sourceRelativeBudgetExceeded?: boolean } = {},
+  options: { budgetExceeded?: boolean; sourceRelativeBudgetExceeded?: boolean; snapshotAwareGate?: ReactWebSnapshotAwareConsumerGateResult } = {},
 ): RuntimeReactWebFactGraphPackingSummary {
+  if (options.snapshotAwareGate && !options.snapshotAwareGate.allowed) {
+    return runtimeReactWebFactGraphPackingSummary("snapshot-aware-gate-blocked", undefined, dryRun, options.snapshotAwareGate);
+  }
   if (!dryRun.inScope) {
     return runtimeReactWebFactGraphPackingSummary("out-of-scope", undefined, dryRun);
   }
@@ -738,7 +750,20 @@ export function summarizeRuntimeReactWebFactGraphDryRun(
   if (options.sourceRelativeBudgetExceeded) {
     return runtimeReactWebFactGraphPackingSummary("source-relative-budget-exceeded", undefined, dryRun);
   }
-  return runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", undefined, dryRun);
+  return runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", undefined, dryRun, options.snapshotAwareGate);
+}
+
+function graphInputFromDryRun(dryRun: ReactWebFactGraphConsumerDryRun): NonNullable<ReactWebSnapshotAwareConsumerGateInput["graphConsumer"]> {
+  return {
+    schemaVersion: dryRun.schemaVersion,
+    freshnessStatus: dryRun.graphSummary.freshnessStatus,
+    selectedAnchorCount: dryRun.selectedAnchors.length,
+    deferredAnchorCount: dryRun.deferredAnchors.length,
+    maxAnchors: dryRun.selectionPolicy.maxAnchors,
+    staleBehavior: dryRun.selectionPolicy.staleBehavior,
+    authorization: dryRun.selectionPolicy.authorization,
+    advisoryOnly: dryRun.advisoryOnly,
+  };
 }
 
 function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): {
@@ -749,7 +774,16 @@ function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): {
     verifyFreshness: true,
     maxAnchors: 3,
   });
-  const basePacking = summarizeRuntimeReactWebFactGraphDryRun(dryRun);
+  const gate = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: buildReactWebRuntimeSnapshotGateInput({ repoRoot: FOOKS_PACKAGE_ROOT }),
+    graphConsumer: graphInputFromDryRun(dryRun),
+    probeBoundary: {
+      payloadContainsGraph: false,
+      diagnosticOnly: true,
+      claimable: false,
+    },
+  });
+  const basePacking = summarizeRuntimeReactWebFactGraphDryRun(dryRun, { snapshotAwareGate: gate });
   if (basePacking.reason !== "fresh-anchors-packed") {
     return { packing: basePacking };
   }
@@ -770,7 +804,7 @@ function compactRuntimeReactWebFactGraph(filePath: string, cwd: string): {
     deferredAnchorCount: dryRun.deferredAnchors.length,
     boundary: "advisory-current-source-only",
   };
-  return { graph, packing: runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", graph, dryRun) };
+  return { graph, packing: runtimeReactWebFactGraphPackingSummary("fresh-anchors-packed", graph, dryRun, gate) };
 }
 
 function runtimeReactWebFactGraphOutOfScopePacking(): RuntimeReactWebFactGraphPackingSummary {

--- a/src/core/react-web-live-hook-dogfood-snapshot.ts
+++ b/src/core/react-web-live-hook-dogfood-snapshot.ts
@@ -1,0 +1,156 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ReactWebSnapshotAwareConsumerGateSnapshotInput } from "./react-web-snapshot-aware-consumer-gate";
+
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION = "react-web-live-hook-dogfood-fixture-manifest.v1" as const;
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION = "react-web-live-hook-dogfood-snapshot.v1" as const;
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM = "sha256-json-stable-v1" as const;
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM = "sha256-file-set-v1" as const;
+export const DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH = path.join("fixtures", "react-web-live-hook-dogfood.snapshot.json");
+
+export const LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS = [
+  "baseline-component",
+  "effect-hooks",
+  "source-too-small-control",
+  "hybrid-dashboard",
+  "form-state",
+  "data-fetching",
+  "custom-hook-state",
+  "context-provider",
+  "client-state",
+] as const;
+
+export const DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST = [
+  { file: "fixtures/compressed/FormSection.tsx", coverage: ["baseline-component", "form-state"], purpose: "Primary React Web form-section reuse-shape baseline with same-file helpers.", role: "reuse-baseline", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "fixtures/compressed/HookEffectPanel.tsx", coverage: ["effect-hooks", "custom-hook-state"], purpose: "Hook/effect-heavy React Web row for graph-assisted context diagnostics.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "fixtures/compressed/TinyEditCard.tsx", coverage: ["source-too-small-control"], purpose: "Small-source control that proves candidate admission can safely fall back.", role: "boundary-control", expectation: { classification: "react-web", admission: "discarded-source-too-small", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "fixtures/hybrid/DashboardPanel.tsx", coverage: ["hybrid-dashboard", "custom-hook-state"], purpose: "Hybrid dashboard row for mixed presentation/state graph diagnostics.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "fixtures/compressed/FormControls.tsx", coverage: ["form-state", "react-hook-form"], purpose: "React Hook Form/form-state reuse-shape baseline.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "test/fixtures/react-web-context-expansion/modal-dialog-preferences-form.tsx", coverage: ["form-state", "modal-form"], purpose: "Modal preferences form row for nested local form-state diagnostics.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "test/fixtures/react-web-context-expansion/data-fetching-user-table.tsx", coverage: ["data-fetching"], purpose: "Server/data-fetching shaped React Web row reused as the suite baseline.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "test/fixtures/react-web-context-expansion/custom-hook-heavy-review-inbox.tsx", coverage: ["custom-hook-state", "effect-hooks"], purpose: "Custom hook-heavy review inbox row for local state transition diagnostics.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "test/fixtures/react-web-context-expansion/context-provider-workspace-preferences.tsx", coverage: ["context-provider", "form-state"], purpose: "React Context provider/consumer row for workspace preference state.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+  { file: "test/fixtures/react-web-context-expansion/client-state-release-store.tsx", coverage: ["client-state", "zustand"], purpose: "Client-state/store-hook component row for release store diagnostics.", role: "positive", expectation: { classification: "react-web", admission: "admitted", metricBoundary: "diagnostic-local-bytes-only" } },
+] as const;
+
+type ManifestEntry = (typeof DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST)[number];
+
+type Snapshot = {
+  schemaVersion?: string;
+  manifestFingerprintAlgorithm?: string;
+  manifestFingerprint?: string;
+  fixtureSourceFingerprintAlgorithm?: string;
+  fixtureSourceFingerprint?: string;
+  fixtureCount?: number;
+  requiredLabels?: string[];
+};
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeManifestFingerprintEntry(entry: ManifestEntry) {
+  return {
+    file: entry.file,
+    coverage: [...entry.coverage].sort(),
+    purpose: entry.purpose,
+    role: entry.role,
+    expectation: {
+      admission: entry.expectation.admission,
+      classification: entry.expectation.classification,
+      metricBoundary: entry.expectation.metricBoundary,
+    },
+  };
+}
+
+export function buildReactWebLiveHookDogfoodManifestFingerprint(
+  manifest: readonly ManifestEntry[] = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+): string {
+  return crypto
+    .createHash("sha256")
+    .update(stableJson({ schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION, manifest: manifest.map(normalizeManifestFingerprintEntry) }))
+    .digest("hex");
+}
+
+export function buildReactWebLiveHookDogfoodFixtureSourceFingerprint({
+  repoRoot = process.cwd(),
+  manifest = DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST,
+}: {
+  repoRoot?: string;
+  manifest?: readonly ManifestEntry[];
+} = {}): string {
+  const files = manifest.map((entry) => {
+    const content = fs.readFileSync(path.resolve(repoRoot, entry.file));
+    return {
+      file: entry.file,
+      bytes: content.length,
+      sha256: crypto.createHash("sha256").update(content).digest("hex"),
+    };
+  });
+  return crypto
+    .createHash("sha256")
+    .update(stableJson({ schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION, files }))
+    .digest("hex");
+}
+
+function readSnapshot(repoRoot: string, snapshotPath = DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH): Snapshot | null {
+  const resolved = path.resolve(repoRoot, snapshotPath);
+  if (!fs.existsSync(resolved)) return null;
+  return JSON.parse(fs.readFileSync(resolved, "utf8")) as Snapshot;
+}
+
+function arraysEqual(left: readonly string[] = [], right: readonly string[] = []): boolean {
+  return JSON.stringify([...left]) === JSON.stringify([...right]);
+}
+
+export function buildReactWebRuntimeSnapshotGateInput({
+  repoRoot = process.cwd(),
+  snapshotPath = DEFAULT_LIVE_HOOK_DOGFOOD_SNAPSHOT_PATH,
+}: {
+  repoRoot?: string;
+  snapshotPath?: string;
+} = {}): ReactWebSnapshotAwareConsumerGateSnapshotInput {
+  const expected = readSnapshot(repoRoot, snapshotPath);
+  const manifestFingerprint = buildReactWebLiveHookDogfoodManifestFingerprint();
+  const fixtureSourceFingerprint = buildReactWebLiveHookDogfoodFixtureSourceFingerprint({ repoRoot });
+  if (!expected) {
+    return {
+      driftStatus: "missing-baseline",
+      reasons: ["snapshot-baseline-missing"],
+      manifestMatched: false,
+      fixtureSourceMatched: false,
+    };
+  }
+
+  const schemaMatched = expected.schemaVersion === REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION;
+  const fixtureCountMatched = expected.fixtureCount === DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURE_MANIFEST.length;
+  const requiredLabelsMatched = arraysEqual(expected.requiredLabels, LIVE_HOOK_DOGFOOD_REQUIRED_COVERAGE_LABELS);
+  const manifestMatched =
+    expected.manifestFingerprintAlgorithm === REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM &&
+    expected.manifestFingerprint === manifestFingerprint;
+  const fixtureSourceMatched =
+    expected.fixtureSourceFingerprintAlgorithm === REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_SOURCE_FINGERPRINT_ALGORITHM &&
+    expected.fixtureSourceFingerprint === fixtureSourceFingerprint;
+  const reasons = [
+    ...(schemaMatched ? [] : ["snapshot-schema-mismatch"]),
+    ...(fixtureCountMatched ? [] : ["fixture-count-mismatch"]),
+    ...(requiredLabelsMatched ? [] : ["required-labels-mismatch"]),
+    ...(manifestMatched ? [] : ["manifest-fingerprint-mismatch"]),
+    ...(fixtureSourceMatched ? [] : ["fixture-source-fingerprint-mismatch"]),
+  ];
+
+  return {
+    driftStatus: reasons.length === 0 ? "fresh" : "drifted",
+    reasons,
+    manifestMatched,
+    fixtureSourceMatched,
+  };
+}

--- a/src/core/react-web-snapshot-aware-consumer-gate.ts
+++ b/src/core/react-web-snapshot-aware-consumer-gate.ts
@@ -1,0 +1,225 @@
+export const REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_SCHEMA_VERSION = "react-web-snapshot-aware-consumer-gate.v1" as const;
+export const REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION = "react-web-fact-graph-consumer-dry-run.v1" as const;
+export const REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_CLAIM_BOUNDARY =
+  "React Web snapshot-aware consumer gate is a pure readiness check: it keeps authorization none, does not authorize pre-read payload graph injection, does not change merge-gate policy, and does not claim provider token/cost/billing savings." as const;
+
+export type ReactWebSnapshotAwareConsumerGateStatus = "allowed" | "blocked" | "unavailable";
+export type ReactWebSnapshotDriftStatus = "fresh" | "drifted" | "missing-baseline" | "unknown" | string;
+export type ReactWebFactGraphConsumerFreshnessStatus = "fresh" | "stale" | "unknown" | string;
+
+export type ReactWebSnapshotAwareConsumerGateSnapshotInput = {
+  driftStatus?: ReactWebSnapshotDriftStatus;
+  reasons?: string[];
+  manifestMatched?: boolean;
+  fixtureSourceMatched?: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateGraphInput = {
+  schemaVersion?: string;
+  freshnessStatus?: ReactWebFactGraphConsumerFreshnessStatus;
+  selectedAnchorCount?: number;
+  deferredAnchorCount?: number;
+  maxAnchors?: number;
+  staleBehavior?: string;
+  authorization?: string;
+  advisoryOnly?: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateProbeBoundaryInput = {
+  payloadContainsGraph?: boolean;
+  diagnosticOnly?: boolean;
+  claimable?: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateInput = {
+  snapshot?: ReactWebSnapshotAwareConsumerGateSnapshotInput;
+  graphConsumer?: ReactWebSnapshotAwareConsumerGateGraphInput | null;
+  probeBoundary?: ReactWebSnapshotAwareConsumerGateProbeBoundaryInput | null;
+};
+
+export type ReactWebSnapshotAwareConsumerGateSnapshot = {
+  driftStatus: ReactWebSnapshotDriftStatus;
+  reasons: string[];
+  manifestMatched: boolean;
+  fixtureSourceMatched: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateGraph = {
+  schemaVersion?: string;
+  freshnessStatus: ReactWebFactGraphConsumerFreshnessStatus;
+  selectedAnchorCount: number;
+  deferredAnchorCount: number;
+  maxAnchors: number;
+  countsPresent: boolean;
+  staleBehavior: string;
+  authorization?: string;
+  advisoryOnly: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateProbeBoundary = {
+  payloadContainsGraph?: boolean;
+  diagnosticOnly?: boolean;
+  claimable?: boolean;
+};
+
+export type ReactWebSnapshotAwareConsumerGateResult = {
+  schemaVersion: typeof REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_SCHEMA_VERSION;
+  claimBoundary: typeof REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_CLAIM_BOUNDARY;
+  profile: "react-web";
+  authorization: "none";
+  advisoryOnly: true;
+  diagnosticOnly: true;
+  claimable: false;
+  status: ReactWebSnapshotAwareConsumerGateStatus;
+  allowed: boolean;
+  blockedReasons: string[];
+  snapshot: ReactWebSnapshotAwareConsumerGateSnapshot;
+  graphConsumer: ReactWebSnapshotAwareConsumerGateGraph | null;
+  probeBoundary: ReactWebSnapshotAwareConsumerGateProbeBoundary | null;
+  wouldSelectAnchorCount: number;
+  nonClaims: {
+    preReadPayloadGraphInjection: false;
+    mergeGatePolicy: false;
+    providerTokenCostSavings: false;
+    broadReactWebSupport: false;
+  };
+};
+
+function arrayOrEmpty(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+export function normalizeReactWebSnapshotAwareGateSnapshot(
+  snapshot: ReactWebSnapshotAwareConsumerGateSnapshotInput = {},
+): ReactWebSnapshotAwareConsumerGateSnapshot {
+  return {
+    driftStatus: snapshot.driftStatus ?? "missing-baseline",
+    reasons: arrayOrEmpty(snapshot.reasons),
+    manifestMatched: snapshot.manifestMatched === true,
+    fixtureSourceMatched: snapshot.fixtureSourceMatched === true,
+  };
+}
+
+export function normalizeReactWebSnapshotAwareGateGraph(
+  graphConsumer?: ReactWebSnapshotAwareConsumerGateGraphInput | null,
+): ReactWebSnapshotAwareConsumerGateGraph | null {
+  if (!graphConsumer) return null;
+  return {
+    schemaVersion: graphConsumer.schemaVersion,
+    freshnessStatus: graphConsumer.freshnessStatus ?? "unknown",
+    selectedAnchorCount: graphConsumer.selectedAnchorCount ?? 0,
+    deferredAnchorCount: graphConsumer.deferredAnchorCount ?? 0,
+    maxAnchors: graphConsumer.maxAnchors ?? 0,
+    countsPresent:
+      typeof graphConsumer.selectedAnchorCount === "number" &&
+      typeof graphConsumer.deferredAnchorCount === "number" &&
+      typeof graphConsumer.maxAnchors === "number",
+    staleBehavior: graphConsumer.staleBehavior ?? "defer-all",
+    authorization: graphConsumer.authorization,
+    advisoryOnly: graphConsumer.advisoryOnly === true,
+  };
+}
+
+export function normalizeReactWebSnapshotAwareGateProbeBoundary(
+  probeBoundary?: ReactWebSnapshotAwareConsumerGateProbeBoundaryInput | null,
+): ReactWebSnapshotAwareConsumerGateProbeBoundary | null {
+  if (!probeBoundary) return null;
+  return {
+    payloadContainsGraph: probeBoundary.payloadContainsGraph,
+    diagnosticOnly: probeBoundary.diagnosticOnly,
+    claimable: probeBoundary.claimable,
+  };
+}
+
+function probeBoundaryBlockers(probeBoundary: ReactWebSnapshotAwareConsumerGateProbeBoundary | null): string[] {
+  if (!probeBoundary) return ["pre-read-probe-boundary-missing"];
+  return [
+    ...(probeBoundary.payloadContainsGraph === false ? [] : ["pre-read-payload-graph-leak"]),
+    ...(probeBoundary.diagnosticOnly === true ? [] : ["pre-read-probe-not-diagnostic-only"]),
+    ...(probeBoundary.claimable === false ? [] : ["pre-read-probe-claimable"]),
+  ];
+}
+
+export function evaluateReactWebSnapshotAwareConsumerGate(
+  input: ReactWebSnapshotAwareConsumerGateInput = {},
+): ReactWebSnapshotAwareConsumerGateResult {
+  const snapshot = normalizeReactWebSnapshotAwareGateSnapshot(input.snapshot);
+  const graph = normalizeReactWebSnapshotAwareGateGraph(input.graphConsumer);
+  const probeBoundary = normalizeReactWebSnapshotAwareGateProbeBoundary(input.probeBoundary);
+  const blockedReasons: string[] = [];
+
+  if (snapshot.driftStatus !== "fresh") {
+    blockedReasons.push("snapshot-drift-not-fresh");
+  }
+  if (snapshot.manifestMatched !== true) {
+    blockedReasons.push("snapshot-manifest-not-matched");
+  }
+  if (snapshot.fixtureSourceMatched !== true) {
+    blockedReasons.push("snapshot-fixture-source-not-matched");
+  }
+  if (snapshot.reasons.length > 0) {
+    blockedReasons.push("snapshot-reasons-present");
+  }
+  blockedReasons.push(...probeBoundaryBlockers(probeBoundary));
+
+  if (!graph) {
+    const reasons = [...blockedReasons, "graph-consumer-unavailable"];
+    return result("unavailable", reasons, snapshot, graph, probeBoundary, 0);
+  }
+
+  if (graph.schemaVersion !== REACT_WEB_FACT_GRAPH_CONSUMER_DRY_RUN_SCHEMA_VERSION) {
+    blockedReasons.push("graph-consumer-schema-mismatch");
+  }
+  if (graph.countsPresent !== true) {
+    blockedReasons.push("graph-consumer-counts-missing");
+  }
+  if (graph.staleBehavior !== "defer-all") {
+    blockedReasons.push("graph-consumer-stale-behavior-mismatch");
+  }
+  if (graph.authorization !== "none" || graph.advisoryOnly !== true) {
+    blockedReasons.push("graph-consumer-authority-widened");
+  }
+  if (graph.freshnessStatus !== "fresh") {
+    blockedReasons.push("graph-consumer-not-fresh");
+  }
+  if (blockedReasons.length > 0) {
+    return result("blocked", blockedReasons, snapshot, graph, probeBoundary, 0);
+  }
+  if (graph.selectedAnchorCount <= 0) {
+    return result("unavailable", ["no-anchors-selected"], snapshot, graph, probeBoundary, 0);
+  }
+
+  return result("allowed", [], snapshot, graph, probeBoundary, graph.selectedAnchorCount);
+}
+
+function result(
+  status: ReactWebSnapshotAwareConsumerGateStatus,
+  blockedReasons: string[],
+  snapshot: ReactWebSnapshotAwareConsumerGateSnapshot,
+  graphConsumer: ReactWebSnapshotAwareConsumerGateGraph | null,
+  probeBoundary: ReactWebSnapshotAwareConsumerGateProbeBoundary | null,
+  wouldSelectAnchorCount: number,
+): ReactWebSnapshotAwareConsumerGateResult {
+  return {
+    schemaVersion: REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_SCHEMA_VERSION,
+    claimBoundary: REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_CLAIM_BOUNDARY,
+    profile: "react-web",
+    authorization: "none",
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    status,
+    allowed: status === "allowed",
+    blockedReasons,
+    snapshot,
+    graphConsumer,
+    probeBoundary,
+    wouldSelectAnchorCount,
+    nonClaims: {
+      preReadPayloadGraphInjection: false,
+      mergeGatePolicy: false,
+      providerTokenCostSavings: false,
+      broadReactWebSupport: false,
+    },
+  };
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -779,7 +779,10 @@ export type CodexRuntimeHookDecision = {
         | "freshness-not-fresh"
         | "no-anchors-selected"
         | "budget-exceeded"
-        | "source-relative-budget-exceeded";
+        | "source-relative-budget-exceeded"
+        | "snapshot-aware-gate-blocked";
+      gateStatus?: "allowed" | "blocked" | "unavailable";
+      gateBlockedReasons?: string[];
       selectedAnchorCount: number;
       deferredAnchorCount: number;
       freshnessStatus: "fresh" | "stale" | "unknown";

--- a/src/reporting/react-web-evidence-artifact.ts
+++ b/src/reporting/react-web-evidence-artifact.ts
@@ -43,6 +43,7 @@ const REACT_WEB_RUNTIME_GRAPH_REASONS = new Set([
   "no-anchors-selected",
   "budget-exceeded",
   "source-relative-budget-exceeded",
+  "snapshot-aware-gate-blocked",
 ]);
 const REACT_WEB_RUNTIME_GRAPH_FRESHNESS_STATUSES = new Set(["fresh", "stale", "unknown"]);
 const REACT_WEB_ADDITIONAL_CONTEXT_ADMISSION_REASONS = new Set([

--- a/test/react-web-live-hook-dogfood-snapshot.test.mjs
+++ b/test/react-web-live-hook-dogfood-snapshot.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const {
+  buildReactWebRuntimeSnapshotGateInput,
+} = await import(path.join(repoRoot, "dist", "core", "react-web-live-hook-dogfood-snapshot.js"));
+
+test("runtime snapshot gate input is fresh for current dogfood snapshot", () => {
+  const snapshot = buildReactWebRuntimeSnapshotGateInput({ repoRoot });
+
+  assert.equal(snapshot.driftStatus, "fresh");
+  assert.deepEqual(snapshot.reasons, []);
+  assert.equal(snapshot.manifestMatched, true);
+  assert.equal(snapshot.fixtureSourceMatched, true);
+});
+
+test("runtime snapshot gate input fails closed when baseline is missing", () => {
+  const tempSnapshotPath = path.join(".tmp-react-web-missing-snapshot", `missing-${Date.now()}.json`);
+  fs.rmSync(path.join(repoRoot, ".tmp-react-web-missing-snapshot"), { recursive: true, force: true });
+  const snapshot = buildReactWebRuntimeSnapshotGateInput({ repoRoot, snapshotPath: tempSnapshotPath });
+
+  assert.equal(snapshot.driftStatus, "missing-baseline");
+  assert.deepEqual(snapshot.reasons, ["snapshot-baseline-missing"]);
+  assert.equal(snapshot.manifestMatched, false);
+  assert.equal(snapshot.fixtureSourceMatched, false);
+});

--- a/test/react-web-snapshot-aware-consumer-gate.test.mjs
+++ b/test/react-web-snapshot-aware-consumer-gate.test.mjs
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const {
+  REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_SCHEMA_VERSION,
+  evaluateReactWebSnapshotAwareConsumerGate,
+} = await import(path.join(repoRoot, "dist", "core", "react-web-snapshot-aware-consumer-gate.js"));
+
+function snapshot(overrides = {}) {
+  return {
+    driftStatus: "fresh",
+    reasons: [],
+    manifestMatched: true,
+    fixtureSourceMatched: true,
+    ...overrides,
+  };
+}
+
+function graph(overrides = {}) {
+  return {
+    schemaVersion: "react-web-fact-graph-consumer-dry-run.v1",
+    freshnessStatus: "fresh",
+    selectedAnchorCount: 3,
+    deferredAnchorCount: 1,
+    maxAnchors: 4,
+    staleBehavior: "defer-all",
+    authorization: "none",
+    advisoryOnly: true,
+    ...overrides,
+  };
+}
+
+function probe(overrides = {}) {
+  return {
+    payloadContainsGraph: false,
+    diagnosticOnly: true,
+    claimable: false,
+    ...overrides,
+  };
+}
+
+test("snapshot-aware consumer gate allows only fresh graph with safe boundary", () => {
+  const gate = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph(), probeBoundary: probe() });
+
+  assert.equal(gate.schemaVersion, REACT_WEB_SNAPSHOT_AWARE_CONSUMER_GATE_SCHEMA_VERSION);
+  assert.equal(gate.status, "allowed");
+  assert.equal(gate.allowed, true);
+  assert.equal(gate.authorization, "none");
+  assert.equal(gate.advisoryOnly, true);
+  assert.equal(gate.diagnosticOnly, true);
+  assert.equal(gate.claimable, false);
+  assert.deepEqual(gate.blockedReasons, []);
+  assert.equal(gate.wouldSelectAnchorCount, 3);
+  assert.equal(gate.nonClaims.preReadPayloadGraphInjection, false);
+});
+
+test("snapshot-aware consumer gate blocks drifted, mismatched, or reason-bearing snapshots and stale graphs", () => {
+  const drifted = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: snapshot({ driftStatus: "drifted", reasons: ["fixture-source-fingerprint-mismatch"] }),
+    graphConsumer: graph(),
+    probeBoundary: probe(),
+  });
+  const mismatched = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: snapshot({ manifestMatched: false, fixtureSourceMatched: false }),
+    graphConsumer: graph(),
+    probeBoundary: probe(),
+  });
+  const reasonBearing = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: snapshot({ reasons: ["fixture-source-fingerprint-mismatch"] }),
+    graphConsumer: graph(),
+    probeBoundary: probe(),
+  });
+  const staleGraph = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: snapshot(),
+    graphConsumer: graph({ freshnessStatus: "stale" }),
+    probeBoundary: probe(),
+  });
+
+  assert.equal(drifted.status, "blocked");
+  assert.deepEqual(drifted.blockedReasons, ["snapshot-drift-not-fresh", "snapshot-reasons-present"]);
+  assert.deepEqual(mismatched.blockedReasons, ["snapshot-manifest-not-matched", "snapshot-fixture-source-not-matched"]);
+  assert.deepEqual(reasonBearing.blockedReasons, ["snapshot-reasons-present"]);
+  assert.equal(staleGraph.status, "blocked");
+  assert.deepEqual(staleGraph.blockedReasons, ["graph-consumer-not-fresh"]);
+});
+
+test("snapshot-aware consumer gate fails closed on malformed graph or widened authority", () => {
+  const missingSchema = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph({ schemaVersion: undefined }), probeBoundary: probe() });
+  const missingCounts = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph({ selectedAnchorCount: undefined }), probeBoundary: probe() });
+  const staleBehaviorMismatch = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph({ staleBehavior: "reuse-stale" }), probeBoundary: probe() });
+  const widenedAuthority = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph({ authorization: "runtime" }), probeBoundary: probe() });
+
+  assert.deepEqual(missingSchema.blockedReasons, ["graph-consumer-schema-mismatch"]);
+  assert.deepEqual(missingCounts.blockedReasons, ["graph-consumer-counts-missing"]);
+  assert.deepEqual(staleBehaviorMismatch.blockedReasons, ["graph-consumer-stale-behavior-mismatch"]);
+  assert.deepEqual(widenedAuthority.blockedReasons, ["graph-consumer-authority-widened"]);
+});
+
+test("snapshot-aware consumer gate blocks probe boundary violations and unavailable graph", () => {
+  const missingProbe = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph() });
+  const leaked = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph(), probeBoundary: probe({ payloadContainsGraph: true }) });
+  const notDiagnostic = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph(), probeBoundary: probe({ diagnosticOnly: false }) });
+  const claimable = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph(), probeBoundary: probe({ claimable: true }) });
+  const missingGraph = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: null, probeBoundary: probe() });
+  const noAnchors = evaluateReactWebSnapshotAwareConsumerGate({ snapshot: snapshot(), graphConsumer: graph({ selectedAnchorCount: 0 }), probeBoundary: probe() });
+
+  assert.deepEqual(missingProbe.blockedReasons, ["pre-read-probe-boundary-missing"]);
+  assert.deepEqual(leaked.blockedReasons, ["pre-read-payload-graph-leak"]);
+  assert.deepEqual(notDiagnostic.blockedReasons, ["pre-read-probe-not-diagnostic-only"]);
+  assert.deepEqual(claimable.blockedReasons, ["pre-read-probe-claimable"]);
+  assert.equal(missingGraph.status, "unavailable");
+  assert.deepEqual(missingGraph.blockedReasons, ["graph-consumer-unavailable"]);
+  assert.equal(noAnchors.status, "unavailable");
+  assert.deepEqual(noAnchors.blockedReasons, ["no-anchors-selected"]);
+});

--- a/test/react-web-snapshot-aware-inspect.test.mjs
+++ b/test/react-web-snapshot-aware-inspect.test.mjs
@@ -94,10 +94,10 @@ test("React Web snapshot-aware inspect blocks on drifted or missing snapshot", (
   const missingEvidence = buildReactWebSnapshotAwareInspect({ coverageSummary: missing, graphConsumer: graph(), probeBoundary: cleanProbeBoundary() });
 
   assert.equal(driftedEvidence.inspectStatus, "blocked");
-  assert.deepEqual(driftedEvidence.blockedReasons, ["snapshot-drift-not-fresh"]);
+  assert.deepEqual(driftedEvidence.blockedReasons, ["snapshot-drift-not-fresh", "snapshot-fixture-source-not-matched", "snapshot-reasons-present"]);
   assert.equal(driftedEvidence.wouldSelectAnchorCount, 0);
   assert.equal(missingEvidence.inspectStatus, "blocked");
-  assert.deepEqual(missingEvidence.blockedReasons, ["snapshot-drift-not-fresh"]);
+  assert.deepEqual(missingEvidence.blockedReasons, ["snapshot-drift-not-fresh", "snapshot-manifest-not-matched", "snapshot-fixture-source-not-matched", "snapshot-reasons-present"]);
   assert.equal(missingEvidence.wouldSelectAnchorCount, 0);
 });
 

--- a/test/runtime-bridge-contract.test.mjs
+++ b/test/runtime-bridge-contract.test.mjs
@@ -23,6 +23,7 @@ const {
   selectReactWebEditCardV2VariantForBudget,
   summarizeRuntimeReactWebFactGraphDryRun,
 } = await import(path.join(repoRoot, "dist", "adapters", "codex-runtime-hook.js"));
+const { evaluateReactWebSnapshotAwareConsumerGate } = await import(path.join(repoRoot, "dist", "core", "react-web-snapshot-aware-consumer-gate.js"));
 const {
   CUSTOM_WRAPPER_DOM_SIGNAL_GAP,
   REACT_NATIVE_WEBVIEW_BOUNDARY_REASON,
@@ -64,6 +65,9 @@ test.after(async () => {
 function graphDryRunFixture(overrides = {}) {
   return {
     inScope: true,
+    schemaVersion: "react-web-fact-graph-consumer-dry-run.v1",
+    advisoryOnly: true,
+    selectionPolicy: { authorization: "none", maxAnchors: 3, staleBehavior: "defer-all" },
     graphSummary: {
       freshnessStatus: "fresh",
     },
@@ -90,6 +94,26 @@ test("runtime graph packing reasons cover every canonical omission and success s
     summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture(), { sourceRelativeBudgetExceeded: true }).reason,
     "source-relative-budget-exceeded",
   );
+
+  const blockedGate = evaluateReactWebSnapshotAwareConsumerGate({
+    snapshot: { driftStatus: "drifted", manifestMatched: false, fixtureSourceMatched: false },
+    graphConsumer: {
+      schemaVersion: "react-web-fact-graph-consumer-dry-run.v1",
+      freshnessStatus: "fresh",
+      selectedAnchorCount: 1,
+      deferredAnchorCount: 0,
+      maxAnchors: 3,
+      staleBehavior: "defer-all",
+      authorization: "none",
+      advisoryOnly: true,
+    },
+    probeBoundary: { payloadContainsGraph: false, diagnosticOnly: true, claimable: false },
+  });
+  const blockedPacking = summarizeRuntimeReactWebFactGraphDryRun(graphDryRunFixture(), { snapshotAwareGate: blockedGate });
+  assert.equal(blockedPacking.reason, "snapshot-aware-gate-blocked");
+  assert.equal(blockedPacking.included, false);
+  assert.equal(blockedPacking.gateStatus, "blocked");
+  assert.deepEqual(blockedPacking.gateBlockedReasons, ["snapshot-drift-not-fresh", "snapshot-manifest-not-matched", "snapshot-fixture-source-not-matched"]);
 });
 
 test("React Web edit-card v2 selector follows ordered first-fit degradation ladder", () => {
@@ -220,6 +244,8 @@ test("runtime bridge contract keeps repeated-read inject and fallback semantics 
   assert.equal(secondInject.debug.reactWebFactGraphPacking.included, true);
   assert.equal(secondInject.debug.reactWebFactGraphPacking.reason, "fresh-anchors-packed");
   assert.equal(secondInject.debug.reactWebFactGraphPacking.freshnessStatus, "fresh");
+  assert.equal(secondInject.debug.reactWebFactGraphPacking.gateStatus, "allowed");
+  assert.deepEqual(secondInject.debug.reactWebFactGraphPacking.gateBlockedReasons, []);
   assert.ok(secondInject.debug.reactWebFactGraphPacking.selectedAnchorCount > 0);
   assert.equal(secondInject.debug.reactWebContextPacking.included, true);
   assert.equal(secondInject.debug.reactWebContextPacking.reason, "packed");


### PR DESCRIPTION
## Summary

- Add a shared pure React Web snapshot-aware consumer gate
- Reuse the gate from snapshot-aware inspect and runtime graph packing
- Keep authorization as none and preserve graph-free pre-read payloads
- Centralize dogfood snapshot/manifest/fingerprint inputs and ship required package assets
- Add release-smoke pack assertions for runtime gate assets

Closes #1149

## Tests

- `npm run build`
- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-live-hook-dogfood-snapshot.test.mjs test/react-web-snapshot-aware-consumer-gate.test.mjs test/react-web-snapshot-aware-inspect.test.mjs test/runtime-bridge-contract.test.mjs test/payload-policy-profile-gate.test.mjs`
- `npm run typecheck`
- `npm run lint -- --pretty false`
- `node scripts/release-smoke.mjs --prepack`
- `npm pack --dry-run --json` asset check
- `git diff --check`

## Review

- RALPLAN Architect: APPROVE after erratum
- RALPLAN Critic: APPROVE
- Final code review: APPROVE
- Final architect review: CLEAR

## Boundaries

- No new runtime authorization class
- No pre-read payload graph injection
- No PR gate policy change
- No provider token/cost/billing claim
