### PR TITLE
Clarify React Web dogfood metric interpretation

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -23,6 +23,7 @@ const {
 } = require(path.join(defaultRepoRoot, "dist", "core", "react-web-live-hook-dogfood-snapshot.js"));
 
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION = "react-web-live-hook-dogfood-metric-summary.v1";
 export {
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
@@ -598,6 +599,127 @@ function summarizeLiveHookSuite(rows, { repoRoot = defaultRepoRoot } = {}) {
   };
 }
 
+function isDistribution(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    ["min", "max", "avg"].every((key) => value[key] === null || typeof value[key] === "number")
+  );
+}
+
+function isRate(value) {
+  return value === null || typeof value === "number";
+}
+
+function assertMetricSummaryInput(summary) {
+  const requiredNumberFields = [
+    "fixtureCount",
+    "graphDiagnosticCount",
+    "runtimeGraphIncludedArtifactCount",
+    "graphSkippedForBudgetCount",
+    "admissionObservedCount",
+    "admittedAdditionalContextCount",
+    "discardedAdditionalContextCount",
+  ];
+  const missingNumberField = requiredNumberFields.find((field) => typeof summary[field] !== "number");
+  if (missingNumberField) {
+    throw new Error(`React Web live-hook dogfood metric summary requires numeric ${missingNumberField}`);
+  }
+
+  const aliases = summary.metricAliases;
+  if (!aliases || typeof aliases !== "object") {
+    throw new Error("React Web live-hook dogfood metric summary requires metricAliases");
+  }
+
+  const requiredRateAliases = [
+    "candidate_admission_rate",
+    "candidate_compression_success_rate",
+    "bad_candidate_block_rate",
+    "fallback_used_rate",
+  ];
+  const invalidRateAlias = requiredRateAliases.find((field) => !isRate(aliases[field]));
+  if (invalidRateAlias) {
+    throw new Error(`React Web live-hook dogfood metric summary requires rate alias ${invalidRateAlias}`);
+  }
+
+  for (const field of ["candidate_byte_reduction", "final_injection_byte_reduction"]) {
+    if (!isDistribution(aliases[field])) {
+      throw new Error(`React Web live-hook dogfood metric summary requires distribution alias ${field}`);
+    }
+  }
+}
+
+export function buildReactWebLiveHookDogfoodMetricSummary(input) {
+  const summary = input?.suite?.summary ?? input?.summary ?? input;
+  if (!summary || typeof summary !== "object") {
+    throw new Error("React Web live-hook dogfood metric summary requires an evidence or suite summary object");
+  }
+  assertMetricSummaryInput(summary);
+  const metricAliases = summary.metricAliases ?? {};
+  const candidateMetrics = summary.candidateMetrics ?? {
+    observedCount: summary.admissionObservedCount ?? 0,
+    admittedCount: summary.admittedAdditionalContextCount ?? 0,
+    discardedCount: summary.discardedAdditionalContextCount ?? 0,
+    admissionRate: metricAliases.candidate_admission_rate ?? null,
+    compressionSuccessRate: metricAliases.candidate_compression_success_rate ?? null,
+    badCandidateBlockRate: metricAliases.bad_candidate_block_rate ?? null,
+    byteReduction: metricAliases.candidate_byte_reduction ?? { min: null, max: null, avg: null },
+    discardReasons: summary.discardedReasonCounts ?? {},
+  };
+  const fallbackMetrics = summary.fallbackMetrics ?? {
+    usedCount: null,
+    usageRate: metricAliases.fallback_used_rate ?? null,
+  };
+  const finalInjectionMetrics = summary.finalInjectionMetrics ?? {
+    byteReduction: metricAliases.final_injection_byte_reduction ?? { min: null, max: null, avg: null },
+  };
+
+  return {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION,
+    source: "react-web-live-hook-dogfood-evidence",
+    status: "supplied",
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    measurement: summary.measurement ?? "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+    fixtureCount: summary.fixtureCount ?? 0,
+    graphDiagnosticCount: summary.graphDiagnosticCount ?? 0,
+    runtimeGraphIncludedArtifactCount: summary.runtimeGraphIncludedArtifactCount ?? 0,
+    graphSkippedForBudgetCount: summary.graphSkippedForBudgetCount ?? 0,
+    admissionObservedCount: summary.admissionObservedCount ?? candidateMetrics.observedCount ?? 0,
+    admittedAdditionalContextCount: summary.admittedAdditionalContextCount ?? candidateMetrics.admittedCount ?? 0,
+    discardedAdditionalContextCount: summary.discardedAdditionalContextCount ?? candidateMetrics.discardedCount ?? 0,
+    discardedReasonCounts: summary.discardedReasonCounts ?? candidateMetrics.discardReasons ?? {},
+    candidateMetrics,
+    fallbackMetrics,
+    finalInjectionMetrics,
+    metricAliases: {
+      candidate_admission_rate: metricAliases.candidate_admission_rate ?? candidateMetrics.admissionRate ?? null,
+      candidate_compression_success_rate:
+        metricAliases.candidate_compression_success_rate ?? candidateMetrics.compressionSuccessRate ?? null,
+      bad_candidate_block_rate: metricAliases.bad_candidate_block_rate ?? candidateMetrics.badCandidateBlockRate ?? null,
+      fallback_used_rate: metricAliases.fallback_used_rate ?? fallbackMetrics.usageRate ?? null,
+      candidate_byte_reduction: metricAliases.candidate_byte_reduction ?? candidateMetrics.byteReduction ?? { min: null, max: null, avg: null },
+      final_injection_byte_reduction:
+        metricAliases.final_injection_byte_reduction ?? finalInjectionMetrics.byteReduction ?? { min: null, max: null, avg: null },
+    },
+    metricInterpretation: {
+      candidateAdmissionRateMeans: "share of observed candidates admitted by the local additionalContext admission gate",
+      candidateCompressionSuccessRateMeans: "share of observed candidates whose own source-relative byte reduction passed admission",
+      badCandidateBlockRateMeans: "share of observed rejected candidates blocked by the admission gate",
+      fallbackUsedRateMeans: "share of fixture rows where final hook output used fallback text instead of an admitted candidate",
+      finalInjectionByteReductionMeans: "final host-facing additionalContext byte reduction after admission/fallback",
+      finalInjectionByteReductionIsCandidateCompressionProof: false,
+      providerTokenSavingsClaimable: false,
+      providerCostSavingsClaimable: false,
+      providerBillingSavingsClaimable: false,
+      numericPrGateThreshold: false,
+    },
+    claimBoundary:
+      "Diagnostic local byte metric summary only: separates candidate, admission, fallback, and final injection metrics; not provider tokenizer output, not provider token/cost/billing proof, not runtime/pre-read authorization, and not a numeric PR gate.",
+  };
+}
+
 function assertLiveHookSuite(suite) {
   const failures = [];
   const manifestEntries = suite.manifest?.entries ?? [];
@@ -778,6 +900,7 @@ export async function buildReactWebLiveHookDogfoodEvidence({
 }
 
 export function renderReactWebLiveHookDogfoodEvidenceMarkdown(evidence) {
+  const metricSummary = buildReactWebLiveHookDogfoodMetricSummary(evidence);
   return `# React Web live/native hook dogfood evidence
 
 ${evidence.claimBoundary}
@@ -822,27 +945,36 @@ ${evidence.claimBoundary}
 
 ### Candidate generation quality
 
-- candidate_admission_rate: ${evidence.suite.summary.metricAliases.candidate_admission_rate}
-- candidate_compression_success_rate: ${evidence.suite.summary.metricAliases.candidate_compression_success_rate}
-- candidate_byte_reduction: ${JSON.stringify(evidence.suite.summary.metricAliases.candidate_byte_reduction)}
+- Metric summary schema: ${metricSummary.schemaVersion}
+- Advisory-only: ${metricSummary.advisoryOnly ? "yes" : "no"}
+- Diagnostic-only: ${metricSummary.diagnosticOnly ? "yes" : "no"}
+- Claimable: ${metricSummary.claimable ? "yes" : "no"}
+- candidate_admission_rate: ${metricSummary.metricAliases.candidate_admission_rate}
+- candidate_compression_success_rate: ${metricSummary.metricAliases.candidate_compression_success_rate}
+- candidate_byte_reduction: ${JSON.stringify(metricSummary.metricAliases.candidate_byte_reduction)}
 
 ### Gate/admission outcome
 
 - AdditionalContext admission diagnostics: ${evidence.suite.summary.admissionObservedCount}/${evidence.suite.summary.fixtureCount}
 - AdditionalContext admitted rows: ${evidence.suite.summary.admittedAdditionalContextCount}/${evidence.suite.summary.fixtureCount}
 - AdditionalContext discarded rows: ${evidence.suite.summary.discardedAdditionalContextCount}/${evidence.suite.summary.fixtureCount}
-- bad_candidate_block_rate: ${evidence.suite.summary.metricAliases.bad_candidate_block_rate}
+- bad_candidate_block_rate: ${metricSummary.metricAliases.bad_candidate_block_rate}
 - AdditionalContext discard reasons: ${JSON.stringify(evidence.suite.summary.discardedReasonCounts)}
 
 ### Fallback behavior
 
-- fallback_used_rate: ${evidence.suite.summary.metricAliases.fallback_used_rate}
+- fallback_used_rate: ${metricSummary.metricAliases.fallback_used_rate}
 
 ### Final injection size
 
-- final_injection_byte_reduction: ${JSON.stringify(evidence.suite.summary.metricAliases.final_injection_byte_reduction)}
+- final_injection_byte_reduction: ${JSON.stringify(metricSummary.metricAliases.final_injection_byte_reduction)}
 - Note: final_injection_byte_reduction is final hook-output size after admission/fallback and is not proof of candidate compression success.
+- Candidate compression proof from final_injection_byte_reduction: ${metricSummary.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof ? "yes" : "no"}
 - Claimable as broad token/cost savings: no
+- Provider token savings claimable: ${metricSummary.metricInterpretation.providerTokenSavingsClaimable ? "yes" : "no"}
+- Provider cost savings claimable: ${metricSummary.metricInterpretation.providerCostSavingsClaimable ? "yes" : "no"}
+- Provider billing savings claimable: ${metricSummary.metricInterpretation.providerBillingSavingsClaimable ? "yes" : "no"}
+- Numeric PR gate threshold: ${metricSummary.metricInterpretation.numericPrGateThreshold ? "yes" : "no"}
 - Claim boundary: ${evidence.suite.claimBoundary}
 
 ## Boundary replay

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -46,16 +46,18 @@ export function assertReactWebPrAdvisoryContract({ profileSurface, releaseBenchm
 export async function buildReactWebPrAdvisorySurface({
   repoRoot = defaultRepoRoot,
   runId = new Date().toISOString().replace(/[:.]/g, "-"),
+  liveHookDogfoodMetrics,
   profileSurfaceBuilder = buildReactWebProfileSurface,
   releaseBenchmarkBuilder = buildReleaseBenchmarkEvidence,
 } = {}) {
-  const profileSurface = await profileSurfaceBuilder({ repoRoot, runId: `${runId}-profile` });
+  const profileSurface = await profileSurfaceBuilder({ repoRoot, runId: `${runId}-profile`, liveHookDogfoodMetrics });
   const releaseBenchmarkEvidence = await releaseBenchmarkBuilder({ repoRoot, runId: `${runId}-release-benchmark` });
 
   assertReactWebPrAdvisoryContract({ profileSurface, releaseBenchmarkEvidence });
 
   const releaseBenchmarkSummary = buildReleaseBenchmarkSmokeSummary(releaseBenchmarkEvidence);
   const liveHookDogfoodCoverage = profileSurface.summary.childSignals.liveHookDogfoodCoverage;
+  const liveHookDogfoodMetricsSummary = profileSurface.summary.childSignals.liveHookDogfoodMetrics;
 
   return {
     schemaVersion: "react-web-pr-advisory-surface.v1",
@@ -79,6 +81,7 @@ export async function buildReactWebPrAdvisorySurface({
       warnings: profileSurface.summary.warnings,
       releaseSafeHeadline: releaseBenchmarkSummary.headline,
       liveHookDogfoodCoverage,
+      liveHookDogfoodMetrics: liveHookDogfoodMetricsSummary,
       nonClaims: {
         profileTopLevelContextReduction: profileSurface.claimability.contextReduction,
         cachePerformance: releaseBenchmarkSummary.nonClaims.cachePerformanceImprovement,
@@ -134,6 +137,27 @@ ${evidence.claimBoundary}
 - Counts by label: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByLabel)}
 - Counts by role: ${JSON.stringify(evidence.summary.liveHookDogfoodCoverage.countsByRole)}
 - Claim boundary: ${evidence.summary.liveHookDogfoodCoverage.claimBoundary}
+
+## Live-hook dogfood metric summary
+
+- Status: ${evidence.summary.liveHookDogfoodMetrics.status}
+- Schema: ${evidence.summary.liveHookDogfoodMetrics.schemaVersion}
+- Advisory-only: ${evidence.summary.liveHookDogfoodMetrics.advisoryOnly ? "yes" : "no"}
+- Diagnostic-only: ${evidence.summary.liveHookDogfoodMetrics.diagnosticOnly ? "yes" : "no"}
+- Claimable: ${evidence.summary.liveHookDogfoodMetrics.claimable ? "yes" : "no"}
+- Replay executed by profile/advisory: ${evidence.summary.liveHookDogfoodMetrics.replayExecuted ? "yes" : "no"}
+${evidence.summary.liveHookDogfoodMetrics.status === "supplied" ? `- candidate_admission_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_admission_rate}
+- candidate_compression_success_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_compression_success_rate}
+- bad_candidate_block_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.bad_candidate_block_rate}
+- fallback_used_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.fallback_used_rate}
+- candidate_byte_reduction: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_byte_reduction)}
+- final_injection_byte_reduction: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.metricAliases.final_injection_byte_reduction)}` : `- Reason: ${evidence.summary.liveHookDogfoodMetrics.reason}`}
+- Note: final_injection_byte_reduction is final hook-output size after admission/fallback and is not proof of candidate compression success.
+- Candidate compression proof from final_injection_byte_reduction: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof ? "yes" : "no"}
+- Provider token savings claimable: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerTokenSavingsClaimable ? "yes" : "no"}
+- Provider cost savings claimable: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerCostSavingsClaimable ? "yes" : "no"}
+- Provider billing savings claimable: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerBillingSavingsClaimable ? "yes" : "no"}
+- Numeric PR gate threshold: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.numericPrGateThreshold ? "yes" : "no"}
 
 ## Non-claims
 

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -7,7 +7,11 @@ import { buildReactWebOverCachingAuditEvidence } from "./react-web-over-caching-
 import { buildReactWebStabilityEvidence } from "./react-web-stability-evidence.mjs";
 import { buildReactWebMixedRoutingEvidence } from "./react-web-mixed-routing-evidence.mjs";
 import { buildReactWebKnowledgeContextEvidence } from "./react-web-knowledge-context-evidence.mjs";
-import { buildReactWebLiveHookDogfoodCoverageSummary } from "./react-web-live-hook-dogfood-evidence.mjs";
+import {
+  buildReactWebLiveHookDogfoodCoverageSummary,
+  buildReactWebLiveHookDogfoodMetricSummary,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION,
+} from "./react-web-live-hook-dogfood-evidence.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,10 +48,40 @@ function prefixedWarnings(prefix, warnings = []) {
   return warnings.map((warning) => `${prefix}: ${warning}`);
 }
 
+export function reactWebLiveHookDogfoodMetricsNotSupplied() {
+  return {
+    schemaVersion: REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION,
+    source: "react-web-profile-surface",
+    status: "not-supplied",
+    advisoryOnly: true,
+    diagnosticOnly: true,
+    claimable: false,
+    replayExecuted: false,
+    reason: "live-hook dogfood metrics require precomputed evidence and are never replayed by the default profile surface",
+    metricInterpretation: {
+      finalInjectionByteReductionIsCandidateCompressionProof: false,
+      providerTokenSavingsClaimable: false,
+      providerCostSavingsClaimable: false,
+      providerBillingSavingsClaimable: false,
+      numericPrGateThreshold: false,
+    },
+  };
+}
+
+function resolveLiveHookDogfoodMetrics(input) {
+  if (input === undefined || input === null) return reactWebLiveHookDogfoodMetricsNotSupplied();
+  return {
+    ...buildReactWebLiveHookDogfoodMetricSummary(input),
+    replayExecuted: false,
+  };
+}
+
 export async function buildReactWebProfileSurface({
   repoRoot = defaultRepoRoot,
   runId = new Date().toISOString().replace(/[:.]/g, "-"),
+  liveHookDogfoodMetrics,
 } = {}) {
+  const liveHookDogfoodMetricsSummary = resolveLiveHookDogfoodMetrics(liveHookDogfoodMetrics);
   const context = await buildReactWebContextEvidence({ repoRoot, runId: `${runId}-context` });
   const reuse = await buildReactWebReuseEvidence({ repoRoot, runId: `${runId}-reuse` });
   const overCachingAudit = await buildReactWebOverCachingAuditEvidence({ repoRoot, runId: `${runId}-over-caching-audit` });
@@ -95,6 +129,7 @@ export async function buildReactWebProfileSurface({
         mixedRoutingBoundaryIsolationClaimable: mixedRouting.summary.boundaryIsolationClaimable,
         knowledgeContextBoundaryEvidenceClaimable: knowledgeContext.summary.boundaryEvidenceOnlyClaimable,
         liveHookDogfoodCoverage,
+        liveHookDogfoodMetrics: liveHookDogfoodMetricsSummary,
       },
       warnings: [
         ...(overCachingAudit.summary.bugReproduced
@@ -140,6 +175,8 @@ ${evidence.claimBoundary}
 - Live-hook dogfood coverage freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.freshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.manifestFingerprintShort})
 - Live-hook dogfood fixture source freshness: ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintAlgorithm}, ${evidence.summary.childSignals.liveHookDogfoodCoverage.fixtureSourceFingerprintShort})
 - Live-hook dogfood snapshot drift: ${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.driftStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.join(", ") : "none"})
+- Live-hook dogfood metrics status: ${evidence.summary.childSignals.liveHookDogfoodMetrics.status} (replay executed by profile: ${evidence.summary.childSignals.liveHookDogfoodMetrics.replayExecuted ? "yes" : "no"})
+- Live-hook dogfood metrics advisory-only: ${evidence.summary.childSignals.liveHookDogfoodMetrics.advisoryOnly ? "yes" : "no"}
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
@@ -19,6 +20,7 @@ import {
   buildReactWebLiveHookDogfoodSnapshotDrift,
   buildReactWebLiveHookDogfoodCoverageSummary,
   buildReactWebLiveHookDogfoodEvidence,
+  buildReactWebLiveHookDogfoodMetricSummary,
   renderReactWebLiveHookDogfoodEvidenceMarkdown,
 } from "../scripts/react-web-live-hook-dogfood-evidence.mjs";
 
@@ -105,6 +107,90 @@ test("React Web live hook dogfood coverage summary is canonical and advisory-onl
   assert.match(summary.claimBoundary, /not broad React Web support/);
   assert.match(summary.claimBoundary, /not provider token\/cost savings/);
   assert.match(summary.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
+});
+
+test("React Web live hook dogfood metric summary separates candidate fallback and final metrics", () => {
+  const summary = buildReactWebLiveHookDogfoodMetricSummary({
+    measurement: "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+    fixtureCount: 2,
+    graphDiagnosticCount: 2,
+    runtimeGraphIncludedArtifactCount: 1,
+    graphSkippedForBudgetCount: 1,
+    admissionObservedCount: 2,
+    admittedAdditionalContextCount: 1,
+    discardedAdditionalContextCount: 1,
+    discardedReasonCounts: { "source-too-small": 1 },
+    candidateMetrics: {
+      observedCount: 2,
+      admittedCount: 1,
+      discardedCount: 1,
+      admissionRate: 0.5,
+      compressionSuccessRate: 0.5,
+      badCandidateBlockRate: 1,
+      byteReduction: { min: 33.3, max: 66.6, avg: 49.95 },
+      discardReasons: { "source-too-small": 1 },
+    },
+    fallbackMetrics: {
+      usedCount: 1,
+      usageRate: 0.5,
+    },
+    finalInjectionMetrics: {
+      byteReduction: { min: 20, max: 80, avg: 50 },
+    },
+    metricAliases: {
+      candidate_admission_rate: 0.5,
+      candidate_compression_success_rate: 0.5,
+      bad_candidate_block_rate: 1,
+      fallback_used_rate: 0.5,
+      candidate_byte_reduction: { min: 33.3, max: 66.6, avg: 49.95 },
+      final_injection_byte_reduction: { min: 20, max: 80, avg: 50 },
+    },
+  });
+
+  assert.equal(summary.schemaVersion, REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION);
+  assert.equal(summary.status, "supplied");
+  assert.equal(summary.advisoryOnly, true);
+  assert.equal(summary.diagnosticOnly, true);
+  assert.equal(summary.claimable, false);
+  assert.equal(summary.metricAliases.candidate_admission_rate, 0.5);
+  assert.equal(summary.metricAliases.candidate_compression_success_rate, 0.5);
+  assert.equal(summary.metricAliases.bad_candidate_block_rate, 1);
+  assert.equal(summary.metricAliases.fallback_used_rate, 0.5);
+  assert.deepEqual(summary.metricAliases.candidate_byte_reduction, { min: 33.3, max: 66.6, avg: 49.95 });
+  assert.deepEqual(summary.metricAliases.final_injection_byte_reduction, { min: 20, max: 80, avg: 50 });
+  assert.equal(summary.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof, false);
+  assert.equal(summary.metricInterpretation.providerTokenSavingsClaimable, false);
+  assert.equal(summary.metricInterpretation.providerCostSavingsClaimable, false);
+  assert.equal(summary.metricInterpretation.providerBillingSavingsClaimable, false);
+  assert.equal(summary.metricInterpretation.numericPrGateThreshold, false);
+  assert.match(summary.claimBoundary, /not provider tokenizer output/);
+  assert.match(summary.claimBoundary, /not a numeric PR gate/);
+});
+
+test("React Web live hook dogfood metric summary rejects malformed precomputed metrics", () => {
+  assert.throws(
+    () => buildReactWebLiveHookDogfoodMetricSummary({}),
+    /requires numeric fixtureCount/,
+  );
+  assert.throws(
+    () => buildReactWebLiveHookDogfoodMetricSummary({
+      fixtureCount: 1,
+      graphDiagnosticCount: 1,
+      runtimeGraphIncludedArtifactCount: 1,
+      graphSkippedForBudgetCount: 0,
+      admissionObservedCount: 1,
+      admittedAdditionalContextCount: 1,
+      discardedAdditionalContextCount: 0,
+      metricAliases: {
+        candidate_admission_rate: 1,
+        candidate_compression_success_rate: 1,
+        bad_candidate_block_rate: null,
+        fallback_used_rate: 0,
+        candidate_byte_reduction: { min: 50, max: 50, avg: 50 },
+      },
+    }),
+    /requires distribution alias final_injection_byte_reduction/,
+  );
 });
 
 test("React Web live hook dogfood coverage snapshot captures reviewed identity fields", () => {

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -65,6 +65,17 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
   assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
   assert.match(evidence.summary.liveHookDogfoodCoverage.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v1");
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.status, "not-supplied");
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.advisoryOnly, true);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.diagnosticOnly, true);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.claimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.replayExecuted, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerTokenSavingsClaimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerCostSavingsClaimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerBillingSavingsClaimable, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricInterpretation.numericPrGateThreshold, false);
   assert.equal(evidence.summary.nonClaims.profileTopLevelContextReduction, false);
   assert.equal(evidence.summary.nonClaims.cachePerformance, false);
   assert.equal(evidence.summary.nonClaims.runtimeTokenSavings, false);
@@ -95,9 +106,76 @@ test("React Web PR advisory markdown keeps advisory wording and explicit non-cla
   assert.match(markdown, /Missing labels: none/);
   assert.match(markdown, /Counts by label: .*form-state/);
   assert.match(markdown, /Claim boundary: .*not broad React Web support/);
+  assert.match(markdown, /Live-hook dogfood metric summary/);
+  assert.match(markdown, /Status: not-supplied/);
+  assert.match(markdown, /Replay executed by profile\/advisory: no/);
+  assert.match(markdown, /not proof of candidate compression success/);
+  assert.match(markdown, /Candidate compression proof from final_injection_byte_reduction: no/);
+  assert.match(markdown, /Provider token savings claimable: no/);
+  assert.match(markdown, /Provider cost savings claimable: no/);
+  assert.match(markdown, /Provider billing savings claimable: no/);
+  assert.match(markdown, /Numeric PR gate threshold: no/);
   assert.match(markdown, /Provider billing\/cost savings proof: no/);
   assert.match(markdown, /Broad React\/RN\/WebView\/TUI support proof: no/);
   assert.doesNotMatch(markdown, /Cache performance proof: yes/i);
+});
+
+test("React Web PR advisory renders supplied precomputed live hook metrics without replay", async () => {
+  const evidence = await buildReactWebPrAdvisorySurface({
+    runId: `precomputed-${Date.now()}-${Math.random()}`,
+    liveHookDogfoodMetrics: {
+      measurement: "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+      fixtureCount: 1,
+      graphDiagnosticCount: 1,
+      runtimeGraphIncludedArtifactCount: 1,
+      graphSkippedForBudgetCount: 0,
+      admissionObservedCount: 1,
+      admittedAdditionalContextCount: 1,
+      discardedAdditionalContextCount: 0,
+      metricAliases: {
+        candidate_admission_rate: 1,
+        candidate_compression_success_rate: 1,
+        bad_candidate_block_rate: null,
+        fallback_used_rate: 0,
+        candidate_byte_reduction: { min: 42, max: 42, avg: 42 },
+        final_injection_byte_reduction: { min: 52, max: 52, avg: 52 },
+      },
+    },
+  });
+  const markdown = renderReactWebPrAdvisoryMarkdown(evidence);
+
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.status, "supplied");
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.replayExecuted, false);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_admission_rate, 1);
+  assert.match(markdown, /candidate_admission_rate: 1/);
+  assert.match(markdown, /fallback_used_rate: 0/);
+  assert.match(markdown, /final_injection_byte_reduction: /);
+  assert.match(markdown, /Candidate compression proof from final_injection_byte_reduction: no/);
+});
+
+test("React Web PR advisory rejects malformed precomputed live hook metrics", async () => {
+  await assert.rejects(
+    () => buildReactWebPrAdvisorySurface({
+      runId: `malformed-${Date.now()}-${Math.random()}`,
+      liveHookDogfoodMetrics: {
+        fixtureCount: 1,
+        graphDiagnosticCount: 1,
+        runtimeGraphIncludedArtifactCount: 1,
+        graphSkippedForBudgetCount: 0,
+        admissionObservedCount: 1,
+        admittedAdditionalContextCount: 1,
+        discardedAdditionalContextCount: 0,
+        metricAliases: {
+          candidate_admission_rate: 1,
+          candidate_compression_success_rate: 1,
+          bad_candidate_block_rate: null,
+          fallback_used_rate: 0,
+          final_injection_byte_reduction: { min: 50, max: 50, avg: 50 },
+        },
+      },
+    }),
+    /requires distribution alias candidate_byte_reduction/,
+  );
 });
 
 test("React Web PR advisory contract fails closed on malformed upstream inputs", () => {

--- a/test/react-web-pr-gate-surface.test.mjs
+++ b/test/react-web-pr-gate-surface.test.mjs
@@ -43,10 +43,15 @@ test("React Web PR gate passes on the approved bounded advisory surface", async 
     "routing-boundary-leakage",
     "advisory-status-inconsistency",
   ]);
+  assert.equal(evidence.summary.blockerCategories.includes("metric-threshold"), false);
+  assert.equal(evidence.summary.blockerCategories.includes("live-hook-dogfood-metric-threshold"), false);
   assert.equal(
     evidence.advisorySurface.summary.liveHookDogfoodCoverage.advisoryOnly,
     true,
   );
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodMetrics.status, "not-supplied");
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodMetrics.replayExecuted, false);
+  assert.equal(evidence.advisorySurface.summary.liveHookDogfoodMetrics.metricInterpretation.numericPrGateThreshold, false);
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.freshnessStatus, "fresh");
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.fixtureSourceFreshnessStatus, "fresh");
   assert.equal(evidence.advisorySurface.summary.liveHookDogfoodCoverage.snapshotDrift.driftStatus, "fresh");

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -76,6 +76,62 @@ test("React Web profile surface aggregates exactly the approved six evidence art
   assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
   assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.claimBoundary, /not broad React Web support/);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v1");
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.status, "not-supplied");
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.advisoryOnly, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.diagnosticOnly, true);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.claimable, false);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.replayExecuted, false);
+  assert.match(evidence.summary.childSignals.liveHookDogfoodMetrics.reason, /never replayed by the default profile surface/);
+  assert.equal(
+    evidence.summary.childSignals.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof,
+    false,
+  );
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricInterpretation.providerTokenSavingsClaimable, false);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricInterpretation.numericPrGateThreshold, false);
+});
+
+test("React Web profile surface accepts precomputed live hook metrics without replaying", async () => {
+  const evidence = await buildReactWebProfileSurface({
+    runId: `precomputed-${Date.now()}-${Math.random()}`,
+    liveHookDogfoodMetrics: {
+      measurement: "built-cli-native-hook-fixture-matrix-additional-context-bytes",
+      fixtureCount: 1,
+      graphDiagnosticCount: 1,
+      runtimeGraphIncludedArtifactCount: 1,
+      graphSkippedForBudgetCount: 0,
+      admissionObservedCount: 1,
+      admittedAdditionalContextCount: 1,
+      discardedAdditionalContextCount: 0,
+      metricAliases: {
+        candidate_admission_rate: 1,
+        candidate_compression_success_rate: 1,
+        bad_candidate_block_rate: null,
+        fallback_used_rate: 0,
+        candidate_byte_reduction: { min: 50, max: 50, avg: 50 },
+        final_injection_byte_reduction: { min: 50, max: 50, avg: 50 },
+      },
+    },
+  });
+
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.status, "supplied");
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.replayExecuted, false);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricAliases.candidate_admission_rate, 1);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricAliases.fallback_used_rate, 0);
+  assert.equal(
+    evidence.summary.childSignals.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof,
+    false,
+  );
+});
+
+test("React Web profile surface rejects malformed precomputed live hook metrics before replay-prone work", async () => {
+  await assert.rejects(
+    () => buildReactWebProfileSurface({
+      runId: `malformed-${Date.now()}-${Math.random()}`,
+      liveHookDogfoodMetrics: {},
+    }),
+    /requires numeric fixtureCount/,
+  );
 });
 
 test("React Web profile surface markdown keeps the top-level non-claims explicit", async () => {
@@ -96,6 +152,8 @@ test("React Web profile surface markdown keeps the top-level non-claims explicit
   assert.match(markdown, /Live-hook dogfood coverage freshness: fresh \(sha256-json-stable-v1, [a-f0-9]{12}\)/);
   assert.match(markdown, /Live-hook dogfood fixture source freshness: fresh \(sha256-file-set-v1, [a-f0-9]{12}\)/);
   assert.match(markdown, /Live-hook dogfood snapshot drift: fresh \(none\)/);
+  assert.match(markdown, /Live-hook dogfood metrics status: not-supplied \(replay executed by profile: no\)/);
+  assert.match(markdown, /Live-hook dogfood metrics advisory-only: yes/);
   assert.match(markdown, /Context reduction claimable at top level: no/);
   assert.match(markdown, /Cache performance claimable at top level: no/);
   assert.match(markdown, /Provider billing savings claimable at top level: no/);


### PR DESCRIPTION
Closes #1151

## Summary

- Add `buildReactWebLiveHookDogfoodMetricSummary()` with `react-web-live-hook-dogfood-metric-summary.v1`.
- Split candidate/admission/fallback/final injection metrics and make interpretation flags explicit.
- Keep profile/PR advisory metric surfacing absent/not-supplied by default, with supplied metrics precomputed-only and `replayExecuted:false`.
- Fail closed on malformed precomputed metrics before expensive evidence builders run.
- Preserve PR gate as threshold-free and provider token/cost/billing non-claiming.

## Verification

- `npm run build`
- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs`
- `npm run typecheck`
- `npm run lint -- --pretty false`
- `git diff --check`
- ai-slop-cleaner report: `.omx/specs/react-web-live-hook-dogfood-metric-summary-surface/ai-slop-cleaner-report.md`
- independent code-reviewer: APPROVE
- independent architect: CLEAR

## Non-claims

- No runtime/pre-read behavior change.
- No default live/native hook replay from profile or PR advisory.
- No provider token/cost/billing claims.
- No numeric PR gate threshold.