### PR TITLE
Surface React Web dogfood metric interpretation in release reports

### DIFF
--- a/scripts/react-web-release-report-surface.mjs
+++ b/scripts/react-web-release-report-surface.mjs
@@ -9,6 +9,7 @@ import {
 import {
   buildReleaseBenchmarkEvidence,
   buildReleaseBenchmarkSmokeSummary,
+  renderReactWebDogfoodMetricInterpretationMarkdown,
 } from "./release-benchmark-evidence.mjs";
 import { assertPublicSurfaceClaimBoundaries } from "./release-claim-guards.mjs";
 
@@ -144,6 +145,8 @@ ${evidence.claimBoundary}
 - React Web artifact count: ${evidence.summary.profileArtifactCount}
 - Artifact keys: ${evidence.summary.artifactKeys.join(", ")}
 - React Web only: ${evidence.summary.reactWebOnly ? "yes" : "no"}
+
+${renderReactWebDogfoodMetricInterpretationMarkdown()}
 
 ## Non-claims
 

--- a/scripts/release-benchmark-evidence.mjs
+++ b/scripts/release-benchmark-evidence.mjs
@@ -22,6 +22,15 @@ function claimLine(contextEvidence, reuseEvidence) {
   return `React Web same-file reuse is routed correctly, and current-lane fixtures show ${min}% to ${max}% smaller actual injected additionalContext by local byte-size evidence.`;
 }
 
+export function renderReactWebDogfoodMetricInterpretationMarkdown() {
+  return `## React Web dogfood metric interpretation
+
+- Dogfood metrics are advisory-only and diagnostic-only; they do not block merge or release.
+- candidate_* metrics describe candidates, admission, and candidate compression before final host-facing hook output.
+- final_injection_byte_reduction is final hook-output size after admission/fallback and is not proof of candidate compression success.
+- Dogfood metrics are local byte diagnostics, not provider tokenizer output, and do not prove provider token/cost/billing, runtime-token, latency, invoice, charged-cost, or numeric gate outcomes.`;
+}
+
 export async function buildReleaseBenchmarkEvidence({
   repoRoot = defaultRepoRoot,
   runId = new Date().toISOString().replace(/[:.]/g, "-"),
@@ -205,6 +214,8 @@ ${evidence.releaseClaims.headline}
 - React Web runtime graph diagnostics: ${evidence.context.runtimeGraphDiagnostics.emittedCount}/${evidence.context.runtimeGraphDiagnostics.fixtureCount} emitted, diagnostic-only=yes
 - React Web graph-assisted context path: ${evidence.context.graphAssistedContextPath.correlatedFreshPathCount}/${evidence.context.graphAssistedContextPath.fixtureCount} correlated, diagnostic-only=yes
 - React Web reuse correctness: ${evidence.reuse.reuseCorrectnessClaimable ? "yes" : "no"}
+
+${renderReactWebDogfoodMetricInterpretationMarkdown()}
 
 ## Fixture context-size measurements
 

--- a/test/react-web-release-report-surface.test.mjs
+++ b/test/react-web-release-report-surface.test.mjs
@@ -74,12 +74,20 @@ test("React Web release report markdown keeps release-facing wording and explici
   assert.match(markdown, /Advisory only: yes/);
   assert.match(markdown, /Consumer: release/);
   assert.match(markdown, /Release-safe headline:/);
+  assert.match(markdown, /React Web dogfood metric interpretation/);
+  assert.match(markdown, /Dogfood metrics are advisory-only and diagnostic-only; they do not block merge or release/);
+  assert.match(markdown, /candidate_\* metrics describe candidates, admission, and candidate compression before final host-facing hook output/);
+  assert.match(markdown, /final_injection_byte_reduction is final hook-output size after admission\/fallback and is not proof of candidate compression success/);
+  assert.match(markdown, /not provider tokenizer output/);
+  assert.match(markdown, /do not prove provider token\/cost\/billing, runtime-token, latency, invoice, charged-cost, or numeric gate outcomes/);
   assert.match(markdown, /Cache performance proof: no/);
   assert.match(markdown, /Runtime-token savings proof: no/);
   assert.match(markdown, /Provider billing\/cost savings proof: no/);
   assert.match(markdown, /Broad React\/RN\/WebView\/TUI support proof: no/);
   assert.match(markdown, /does not block merge or release/i);
   assert.doesNotMatch(markdown, /Cache performance proof: yes/i);
+  assert.doesNotMatch(markdown, /Candidate compression proof from final_injection_byte_reduction: yes/i);
+  assert.doesNotMatch(markdown, /numeric gate outcomes: yes/i);
 });
 
 test("React Web release report contract fails closed on malformed upstream inputs", () => {

--- a/test/release-benchmark-evidence.test.mjs
+++ b/test/release-benchmark-evidence.test.mjs
@@ -130,6 +130,12 @@ test("release benchmark evidence Markdown gives safe public wording and explicit
   assert.match(markdown, /React Web runtime graph diagnostics:/);
   assert.match(markdown, /React Web graph-assisted context path:/);
   assert.match(markdown, /React Web reuse correctness: yes/);
+  assert.match(markdown, /React Web dogfood metric interpretation/);
+  assert.match(markdown, /Dogfood metrics are advisory-only and diagnostic-only; they do not block merge or release/);
+  assert.match(markdown, /candidate_\* metrics describe candidates, admission, and candidate compression before final host-facing hook output/);
+  assert.match(markdown, /final_injection_byte_reduction is final hook-output size after admission\/fallback and is not proof of candidate compression success/);
+  assert.match(markdown, /not provider tokenizer output/);
+  assert.match(markdown, /do not prove provider token\/cost\/billing, runtime-token, latency, invoice, charged-cost, or numeric gate outcomes/);
   assert.match(markdown, /Cache performance improvement: no/);
   assert.match(markdown, /Runtime-token savings: no/);
   assert.match(markdown, /Provider billing\/cost savings: no/);
@@ -140,4 +146,6 @@ test("release benchmark evidence Markdown gives safe public wording and explicit
   assert.doesNotMatch(markdown, /Cache performance improvement: yes/i);
   assert.doesNotMatch(markdown, /Runtime-token savings: yes/i);
   assert.doesNotMatch(markdown, /Provider billing\/cost savings: yes/i);
+  assert.doesNotMatch(markdown, /Candidate compression proof from final_injection_byte_reduction: yes/i);
+  assert.doesNotMatch(markdown, /numeric gate outcomes: yes/i);
 });


### PR DESCRIPTION
## Summary

- Adds a shared release-facing Markdown fragment for React Web dogfood metric interpretation.
- Surfaces that interpretation in both release benchmark evidence and React Web release report Markdown.
- Pins tests so release readers see candidate-vs-final-injection semantics without provider/runtime/cost/billing/token/gate claim widening.

Closes #1153.

## Verification

- `node --test --test-reporter=spec test/release-benchmark-evidence.test.mjs test/react-web-release-report-surface.test.mjs` (8/8)
- `npm run build && npm test` (1080/1080)
- `npm run lint`
- AI slop cleanup pass on changed files: passed/no-op
- Independent code review: APPROVE
- Independent architect review: CLEAR

## Claim boundaries

- Markdown/report surface only.
- Metrics remain advisory-only and diagnostic-only.
- No provider tokenizer, provider-token, provider-cost, billing, invoice, charged-cost, latency, numeric gate, or broad runtime-token savings claim is introduced.
