### PR TITLE
Make React Web v2 candidate variants measurable

### DIFF
--- a/scripts/react-web-live-hook-dogfood-evidence.mjs
+++ b/scripts/react-web-live-hook-dogfood-evidence.mjs
@@ -23,7 +23,15 @@ const {
 } = require(path.join(defaultRepoRoot, "dist", "core", "react-web-live-hook-dogfood-snapshot.js"));
 
 export const REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION = "react-web-live-hook-dogfood-evidence.v3";
-export const REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION = "react-web-live-hook-dogfood-metric-summary.v1";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION = "react-web-live-hook-dogfood-metric-summary.v2";
+export const REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS = [
+  "full",
+  "no-graph",
+  "no-dependencies",
+  "targets-roles-hooks",
+  "targets-roles",
+  "fallback-or-no-candidate",
+];
 export {
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
@@ -249,6 +257,37 @@ function summarizeLiveHookSuiteRow({ projectRoot, relativeFile, preRead, firstNa
     diagnosticOnly: true,
     claimable: false,
   };
+}
+
+
+function emptyCandidateVariantDistribution() {
+  return Object.fromEntries(REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS.map((bucket) => [bucket, 0]));
+}
+
+function buildCandidateVariantDistribution(rows) {
+  const distribution = emptyCandidateVariantDistribution();
+  for (const row of rows) {
+    const admission = row.evidenceArtifact.additionalContextAdmission;
+    const variant = admission?.candidateVariant;
+    if (variant && Object.hasOwn(distribution, variant)) {
+      distribution[variant] += 1;
+    } else {
+      distribution["fallback-or-no-candidate"] += 1;
+    }
+  }
+  return distribution;
+}
+
+function candidateVariantDistributionTotal(distribution) {
+  return REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS.reduce((total, bucket) => total + (distribution?.[bucket] ?? 0), 0);
+}
+
+function isCandidateVariantDistribution(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS.every((bucket) => Number.isInteger(value[bucket]) && value[bucket] >= 0)
+  );
 }
 
 function distribution(values) {
@@ -528,6 +567,8 @@ function summarizeLiveHookSuite(rows, { repoRoot = defaultRepoRoot } = {}) {
   const candidateCompressionSuccessRate = rate(compressionSuccessCount, admissionObservedCount);
   const badCandidateBlockRate = rate(badCandidateBlockCount, badCandidateObservedCount);
   const fallbackUsageRate = rate(fallbackUsedCount, rows.length);
+  const candidateVariantDistribution = buildCandidateVariantDistribution(rows);
+  const candidateVariantDistributionTotalCount = candidateVariantDistributionTotal(candidateVariantDistribution);
 
   const discardedReasonCounts = rows.reduce((counts, row) => {
     const admission = row.evidenceArtifact.additionalContextAdmission;
@@ -572,6 +613,8 @@ function summarizeLiveHookSuite(rows, { repoRoot = defaultRepoRoot } = {}) {
       usedCount: fallbackUsedCount,
       usageRate: fallbackUsageRate,
     },
+    candidateVariantDistribution,
+    candidateVariantDistributionTotalCount,
     finalInjectionMetrics: {
       byteReduction: distribution(finalInjectionReductionValues),
     },
@@ -642,6 +685,15 @@ function assertMetricSummaryInput(summary) {
     throw new Error(`React Web live-hook dogfood metric summary requires rate alias ${invalidRateAlias}`);
   }
 
+  const candidateVariantDistribution = summary.candidateVariantDistribution ?? summary.candidateMetrics?.variantDistribution;
+  if (!isCandidateVariantDistribution(candidateVariantDistribution)) {
+    throw new Error("React Web live-hook dogfood metric summary requires candidateVariantDistribution with stable v2 buckets");
+  }
+  const variantTotal = summary.candidateVariantDistributionTotalCount ?? candidateVariantDistributionTotal(candidateVariantDistribution);
+  if (!Number.isInteger(variantTotal) || variantTotal !== summary.fixtureCount) {
+    throw new Error("React Web live-hook dogfood metric summary requires candidateVariantDistribution total to match fixtureCount");
+  }
+
   for (const field of ["candidate_byte_reduction", "final_injection_byte_reduction"]) {
     if (!isDistribution(aliases[field])) {
       throw new Error(`React Web live-hook dogfood metric summary requires distribution alias ${field}`);
@@ -690,7 +742,13 @@ export function buildReactWebLiveHookDogfoodMetricSummary(input) {
     admittedAdditionalContextCount: summary.admittedAdditionalContextCount ?? candidateMetrics.admittedCount ?? 0,
     discardedAdditionalContextCount: summary.discardedAdditionalContextCount ?? candidateMetrics.discardedCount ?? 0,
     discardedReasonCounts: summary.discardedReasonCounts ?? candidateMetrics.discardReasons ?? {},
-    candidateMetrics,
+    candidateVariantDistribution: summary.candidateVariantDistribution ?? candidateMetrics.variantDistribution,
+    candidateVariantDistributionTotalCount:
+      summary.candidateVariantDistributionTotalCount ?? candidateVariantDistributionTotal(summary.candidateVariantDistribution ?? candidateMetrics.variantDistribution),
+    candidateMetrics: {
+      ...candidateMetrics,
+      variantDistribution: summary.candidateVariantDistribution ?? candidateMetrics.variantDistribution,
+    },
     fallbackMetrics,
     finalInjectionMetrics,
     metricAliases: {
@@ -709,6 +767,7 @@ export function buildReactWebLiveHookDogfoodMetricSummary(input) {
       badCandidateBlockRateMeans: "share of observed rejected candidates blocked by the admission gate",
       fallbackUsedRateMeans: "share of fixture rows where final hook output used fallback text instead of an admitted candidate",
       finalInjectionByteReductionMeans: "final host-facing additionalContext byte reduction after admission/fallback",
+      candidateVariantDistributionMeans: "diagnostic generator-health distribution of the selected react-web-edit-card.v2 variant, including rejected candidates, before fallback/final-size claims",
       finalInjectionByteReductionIsCandidateCompressionProof: false,
       providerTokenSavingsClaimable: false,
       providerCostSavingsClaimable: false,
@@ -732,6 +791,8 @@ function assertLiveHookSuite(suite) {
   if (suite.summary.admissionObservedCount !== suite.summary.fixtureCount) failures.push("not every live hook suite fixture recorded additionalContext admission diagnostics");
   if (suite.summary.admittedAdditionalContextCount <= 0) failures.push("no live hook suite fixture admitted compact additionalContext");
   if (suite.summary.admittedAdditionalContextCount > suite.summary.compactRowsCount) failures.push("admitted additionalContext count exceeded compact final output rows");
+  if (!isCandidateVariantDistribution(suite.summary.candidateVariantDistribution)) failures.push("live hook suite candidate variant distribution was missing stable v2 buckets");
+  if (suite.summary.candidateVariantDistributionTotalCount !== suite.summary.fixtureCount) failures.push("live hook suite candidate variant distribution did not reconcile to fixture count");
   if (!suite.summary.allFreshGraphs) failures.push("not every live hook suite fixture had fresh pre-read/runtime graph diagnostics");
   if (suite.summary.coverage?.missingLabels?.length > 0) failures.push(`live hook suite manifest missing required labels: ${suite.summary.coverage.missingLabels.join(", ")}`);
 
@@ -952,6 +1013,9 @@ ${evidence.claimBoundary}
 - candidate_admission_rate: ${metricSummary.metricAliases.candidate_admission_rate}
 - candidate_compression_success_rate: ${metricSummary.metricAliases.candidate_compression_success_rate}
 - candidate_byte_reduction: ${JSON.stringify(metricSummary.metricAliases.candidate_byte_reduction)}
+- candidate variant distribution: ${JSON.stringify(metricSummary.candidateVariantDistribution)}
+- candidate variant distribution total: ${metricSummary.candidateVariantDistributionTotalCount}/${evidence.suite.summary.fixtureCount}
+- Variant distribution interpretation: diagnostic generator-health evidence for selected v2 variants, including rejected candidates; not provider token/cost proof.
 
 ### Gate/admission outcome
 

--- a/scripts/react-web-pr-advisory-surface.mjs
+++ b/scripts/react-web-pr-advisory-surface.mjs
@@ -151,7 +151,9 @@ ${evidence.summary.liveHookDogfoodMetrics.status === "supplied" ? `- candidate_a
 - bad_candidate_block_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.bad_candidate_block_rate}
 - fallback_used_rate: ${evidence.summary.liveHookDogfoodMetrics.metricAliases.fallback_used_rate}
 - candidate_byte_reduction: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_byte_reduction)}
-- final_injection_byte_reduction: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.metricAliases.final_injection_byte_reduction)}` : `- Reason: ${evidence.summary.liveHookDogfoodMetrics.reason}`}
+- final_injection_byte_reduction: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.metricAliases.final_injection_byte_reduction)}
+- candidate_variant_distribution: ${JSON.stringify(evidence.summary.liveHookDogfoodMetrics.candidateVariantDistribution)}
+- candidate_variant_distribution_total: ${evidence.summary.liveHookDogfoodMetrics.candidateVariantDistributionTotalCount}` : `- Reason: ${evidence.summary.liveHookDogfoodMetrics.reason}`}
 - Note: final_injection_byte_reduction is final hook-output size after admission/fallback and is not proof of candidate compression success.
 - Candidate compression proof from final_injection_byte_reduction: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof ? "yes" : "no"}
 - Provider token savings claimable: ${evidence.summary.liveHookDogfoodMetrics.metricInterpretation.providerTokenSavingsClaimable ? "yes" : "no"}

--- a/scripts/react-web-profile-surface.mjs
+++ b/scripts/react-web-profile-surface.mjs
@@ -177,6 +177,8 @@ ${evidence.claimBoundary}
 - Live-hook dogfood snapshot drift: ${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.driftStatus} (${evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.length > 0 ? evidence.summary.childSignals.liveHookDogfoodCoverage.snapshotDrift.reasons.join(", ") : "none"})
 - Live-hook dogfood metrics status: ${evidence.summary.childSignals.liveHookDogfoodMetrics.status} (replay executed by profile: ${evidence.summary.childSignals.liveHookDogfoodMetrics.replayExecuted ? "yes" : "no"})
 - Live-hook dogfood metrics advisory-only: ${evidence.summary.childSignals.liveHookDogfoodMetrics.advisoryOnly ? "yes" : "no"}
+${evidence.summary.childSignals.liveHookDogfoodMetrics.status === "supplied" ? `- Live-hook dogfood candidate variant distribution: ${JSON.stringify(evidence.summary.childSignals.liveHookDogfoodMetrics.candidateVariantDistribution)}
+- Live-hook dogfood candidate variant distribution total: ${evidence.summary.childSignals.liveHookDogfoodMetrics.candidateVariantDistributionTotalCount}` : ""}
 
 ## Top-level non-claims
 

--- a/test/react-web-live-hook-dogfood-evidence.test.mjs
+++ b/test/react-web-live-hook-dogfood-evidence.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   REACT_WEB_LIVE_HOOK_DOGFOOD_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_METRIC_SUMMARY_SCHEMA_VERSION,
+  REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_SNAPSHOT_SCHEMA_VERSION,
   REACT_WEB_LIVE_HOOK_DOGFOOD_FIXTURE_MANIFEST_FINGERPRINT_ALGORITHM,
@@ -129,6 +130,14 @@ test("React Web live hook dogfood metric summary separates candidate fallback an
       badCandidateBlockRate: 1,
       byteReduction: { min: 33.3, max: 66.6, avg: 49.95 },
       discardReasons: { "source-too-small": 1 },
+      variantDistribution: {
+        full: 1,
+        "no-graph": 0,
+        "no-dependencies": 0,
+        "targets-roles-hooks": 0,
+        "targets-roles": 0,
+        "fallback-or-no-candidate": 1,
+      },
     },
     fallbackMetrics: {
       usedCount: 1,
@@ -156,6 +165,16 @@ test("React Web live hook dogfood metric summary separates candidate fallback an
   assert.equal(summary.metricAliases.candidate_compression_success_rate, 0.5);
   assert.equal(summary.metricAliases.bad_candidate_block_rate, 1);
   assert.equal(summary.metricAliases.fallback_used_rate, 0.5);
+  assert.deepEqual(summary.candidateVariantDistribution, {
+    full: 1,
+    "no-graph": 0,
+    "no-dependencies": 0,
+    "targets-roles-hooks": 0,
+    "targets-roles": 0,
+    "fallback-or-no-candidate": 1,
+  });
+  assert.equal(summary.candidateVariantDistributionTotalCount, 2);
+  assert.deepEqual(summary.candidateMetrics.variantDistribution, summary.candidateVariantDistribution);
   assert.deepEqual(summary.metricAliases.candidate_byte_reduction, { min: 33.3, max: 66.6, avg: 49.95 });
   assert.deepEqual(summary.metricAliases.final_injection_byte_reduction, { min: 20, max: 80, avg: 50 });
   assert.equal(summary.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof, false);
@@ -181,6 +200,15 @@ test("React Web live hook dogfood metric summary rejects malformed precomputed m
       admissionObservedCount: 1,
       admittedAdditionalContextCount: 1,
       discardedAdditionalContextCount: 0,
+      candidateVariantDistribution: {
+        full: 1,
+        "no-graph": 0,
+        "no-dependencies": 0,
+        "targets-roles-hooks": 0,
+        "targets-roles": 0,
+        "fallback-or-no-candidate": 0,
+      },
+      candidateVariantDistributionTotalCount: 1,
       metricAliases: {
         candidate_admission_rate: 1,
         candidate_compression_success_rate: 1,
@@ -384,6 +412,14 @@ test("React Web live hook dogfood evidence replays built CLI native hook graph p
   assert.equal(evidence.suite.summary.claimable, false);
   assert.equal(evidence.suite.summary.allFreshGraphs, true);
   assert.equal(evidence.suite.summary.admissionObservedCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.deepEqual(Object.keys(evidence.suite.summary.candidateVariantDistribution), REACT_WEB_LIVE_HOOK_DOGFOOD_CANDIDATE_VARIANT_BUCKETS);
+  assert.equal(evidence.suite.summary.candidateVariantDistributionTotalCount, DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length);
+  assert.equal(
+    Object.values(evidence.suite.summary.candidateVariantDistribution).reduce((total, count) => total + count, 0),
+    DEFAULT_LIVE_HOOK_DOGFOOD_SUITE_FIXTURES.length,
+  );
+  assert.ok(evidence.suite.summary.candidateVariantDistribution["no-graph"] >= 1);
+  assert.equal(evidence.suite.summary.candidateVariantDistribution["fallback-or-no-candidate"], 0);
   assert.ok(evidence.suite.summary.admittedAdditionalContextCount > 0);
   assert.ok(evidence.suite.summary.compactRowsCount > 0);
   assert.equal(typeof evidence.suite.summary.minAdditionalContextReductionPct, "number");
@@ -517,6 +553,8 @@ test("React Web live hook dogfood evidence Markdown keeps diagnostic-only bounda
   assert.match(markdown, /AdditionalContext admitted rows: \d+\/\d+/);
   assert.match(markdown, /AdditionalContext discarded rows: \d+\/\d+/);
   assert.match(markdown, /candidate_compression_success_rate:/);
+  assert.match(markdown, /candidate variant distribution:/);
+  assert.match(markdown, /Variant distribution interpretation: diagnostic generator-health evidence for selected v2 variants, including rejected candidates; not provider token\/cost proof/);
   assert.match(markdown, /final_injection_byte_reduction:/);
   assert.match(markdown, /not proof of candidate compression success/);
   assert.match(markdown, /Claimable as broad token\/cost savings: no/);

--- a/test/react-web-pr-advisory-surface.test.mjs
+++ b/test/react-web-pr-advisory-surface.test.mjs
@@ -65,7 +65,7 @@ test("React Web PR advisory surface stays advisory-only over the existing full p
   assert.deepEqual(evidence.summary.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.liveHookDogfoodCoverage.countsByLabel["form-state"], 4);
   assert.match(evidence.summary.liveHookDogfoodCoverage.claimBoundary, /not runtime, pre-read, cache, or model-facing authorization/);
-  assert.equal(evidence.summary.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v1");
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v2");
   assert.equal(evidence.summary.liveHookDogfoodMetrics.status, "not-supplied");
   assert.equal(evidence.summary.liveHookDogfoodMetrics.advisoryOnly, true);
   assert.equal(evidence.summary.liveHookDogfoodMetrics.diagnosticOnly, true);
@@ -132,6 +132,15 @@ test("React Web PR advisory renders supplied precomputed live hook metrics witho
       admissionObservedCount: 1,
       admittedAdditionalContextCount: 1,
       discardedAdditionalContextCount: 0,
+      candidateVariantDistribution: {
+        full: 1,
+        "no-graph": 0,
+        "no-dependencies": 0,
+        "targets-roles-hooks": 0,
+        "targets-roles": 0,
+        "fallback-or-no-candidate": 0,
+      },
+      candidateVariantDistributionTotalCount: 1,
       metricAliases: {
         candidate_admission_rate: 1,
         candidate_compression_success_rate: 1,
@@ -149,6 +158,8 @@ test("React Web PR advisory renders supplied precomputed live hook metrics witho
   assert.equal(evidence.summary.liveHookDogfoodMetrics.metricAliases.candidate_admission_rate, 1);
   assert.match(markdown, /candidate_admission_rate: 1/);
   assert.match(markdown, /fallback_used_rate: 0/);
+  assert.equal(evidence.summary.liveHookDogfoodMetrics.candidateVariantDistribution.full, 1);
+  assert.match(markdown, /candidate_variant_distribution:/);
   assert.match(markdown, /final_injection_byte_reduction: /);
   assert.match(markdown, /Candidate compression proof from final_injection_byte_reduction: no/);
 });
@@ -165,6 +176,15 @@ test("React Web PR advisory rejects malformed precomputed live hook metrics", as
         admissionObservedCount: 1,
         admittedAdditionalContextCount: 1,
         discardedAdditionalContextCount: 0,
+        candidateVariantDistribution: {
+          full: 1,
+          "no-graph": 0,
+          "no-dependencies": 0,
+          "targets-roles-hooks": 0,
+          "targets-roles": 0,
+          "fallback-or-no-candidate": 0,
+        },
+        candidateVariantDistributionTotalCount: 1,
         metricAliases: {
           candidate_admission_rate: 1,
           candidate_compression_success_rate: 1,

--- a/test/react-web-profile-surface.test.mjs
+++ b/test/react-web-profile-surface.test.mjs
@@ -76,7 +76,7 @@ test("React Web profile surface aggregates exactly the approved six evidence art
   assert.deepEqual(evidence.summary.childSignals.liveHookDogfoodCoverage.missingLabels, []);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodCoverage.countsByRole.positive, 8);
   assert.match(evidence.summary.childSignals.liveHookDogfoodCoverage.claimBoundary, /not broad React Web support/);
-  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v1");
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.schemaVersion, "react-web-live-hook-dogfood-metric-summary.v2");
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.status, "not-supplied");
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.advisoryOnly, true);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.diagnosticOnly, true);
@@ -103,6 +103,15 @@ test("React Web profile surface accepts precomputed live hook metrics without re
       admissionObservedCount: 1,
       admittedAdditionalContextCount: 1,
       discardedAdditionalContextCount: 0,
+      candidateVariantDistribution: {
+        full: 1,
+        "no-graph": 0,
+        "no-dependencies": 0,
+        "targets-roles-hooks": 0,
+        "targets-roles": 0,
+        "fallback-or-no-candidate": 0,
+      },
+      candidateVariantDistributionTotalCount: 1,
       metricAliases: {
         candidate_admission_rate: 1,
         candidate_compression_success_rate: 1,
@@ -118,6 +127,8 @@ test("React Web profile surface accepts precomputed live hook metrics without re
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.replayExecuted, false);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricAliases.candidate_admission_rate, 1);
   assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.metricAliases.fallback_used_rate, 0);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.candidateVariantDistribution.full, 1);
+  assert.equal(evidence.summary.childSignals.liveHookDogfoodMetrics.candidateVariantDistributionTotalCount, 1);
   assert.equal(
     evidence.summary.childSignals.liveHookDogfoodMetrics.metricInterpretation.finalInjectionByteReductionIsCandidateCompressionProof,
     false,


### PR DESCRIPTION
## Summary
- add diagnostic React Web live-hook dogfood candidate variant distribution for existing `react-web-edit-card.v2`
- count selected v2 variants across admitted and rejected candidates, reserving fallback/no-candidate for missing variants
- bump supplied dogfood metric summary schema to v2 and render precomputed distribution in PR advisory/profile surfaces without replay

Closes #1155

## Verification
- `npm run build`
- `node --test test/react-web-live-hook-dogfood-evidence.test.mjs test/react-web-profile-surface.test.mjs test/react-web-pr-advisory-surface.test.mjs test/react-web-pr-gate-surface.test.mjs` — 29/29 pass
- `npm run typecheck`
- `npm run lint -- --pretty false`
- `git diff --check`
- ai-slop-cleaner report: `.omx/specs/react-web-v2-dogfood-variant-distribution/ai-slop-cleaner-report.md`
- independent code-reviewer: APPROVE
- independent architect: CLEAR

## Non-claims
- no provider token/cost/billing/latency claim
- no runtime behavior change
- no numeric PR gate threshold
