### PR TITLE
Expose React Web useFieldArray form-state anchors

### DIFF
--- a/src/core/concern-profiles/form-state.ts
+++ b/src/core/concern-profiles/form-state.ts
@@ -32,6 +32,10 @@ export function collectFormStateConcernProfile(result: ExtractionResult): Fronte
     signals.add("useForm");
   }
 
+  if (result.behavior?.hooks?.includes("useFieldArray") || sourceText.includes("useFieldArray(")) {
+    signals.add("useFieldArray");
+  }
+
   if (sourceText.includes("register(") || sourceText.includes("...register(") || /\bregister\b/.test(sourceText)) {
     signals.add("register");
   }

--- a/src/core/concern-profiles/types.ts
+++ b/src/core/concern-profiles/types.ts
@@ -40,6 +40,7 @@ export type FrontendConcernProfileId =
 export type FrontendConcernSignal =
   | "react-hook-form"
   | "useForm"
+  | "useFieldArray"
   | "register"
   | "control"
   | "handleSubmit"

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -1256,7 +1256,7 @@ function collectBehaviorAndStructure(sourceFile: ts.SourceFile): Pick<Extraction
         repeatedBlocks.add("array-map-render");
         addSnippet("repeated-block", textOf(sourceFile, node.parent), "repeated-rendering", node.parent);
       }
-      if (shortName === "useForm" || shortName === "register") {
+      if (shortName === "useForm" || shortName === "register" || shortName === "useFieldArray") {
         addLocatedAnchor(validationAnchors, shortName, node);
       }
       if (RN_NAVIGATION_HOOK_NAMES.has(shortName as Extract<ReactNativeNavigationConcernSignal, { kind: "navigation-hook" }>["hook"]) && reactNavigationImportedNames.has(shortName)) {

--- a/src/core/react-web-context-metadata.ts
+++ b/src/core/react-web-context-metadata.ts
@@ -781,6 +781,9 @@ function buildFormStateRoles(
     if (anchor.value === "register" || anchor.value === "Controller") {
       pushRole(roles, "field-registration", anchor.value, "extraction", `behavior.formSurface.validationAnchors.${anchor.value}`);
     }
+    if (anchor.value === "useFieldArray") {
+      pushRole(roles, "dynamic-fields", anchor.value, "extraction", "behavior.formSurface.validationAnchors.useFieldArray");
+    }
     if (validationDefaultAnchor(anchor.value)) {
       pushRole(
         roles,
@@ -838,6 +841,9 @@ function buildFormStateRoles(
       if (target.label === "useForm") pushRole(roles, "form-root", target.label, "editGuidance", "editGuidance.patchTargets.validation-anchor");
       if (target.label === "register" || target.label === "Controller") {
         pushRole(roles, "field-registration", target.label, "editGuidance", "editGuidance.patchTargets.validation-anchor");
+      }
+      if (target.label === "useFieldArray") {
+        pushRole(roles, "dynamic-fields", target.label, "editGuidance", "editGuidance.patchTargets.validation-anchor");
       }
       if (validationDefaultAnchor(target.label)) {
         pushRole(roles, "validation-defaults", target.label, "editGuidance", "editGuidance.patchTargets.validation-anchor");

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -488,7 +488,8 @@ export type ReactWebContextFormStateRole = {
     | "submit-flow"
     | "error-display"
     | "value-control-relation"
-    | "validation-defaults";
+    | "validation-defaults"
+    | "dynamic-fields";
   labels: string[];
   source: "formStateFlow" | "editGuidance" | "extraction";
   evidence: string[];

--- a/test/form-state-concern-profile.test.mjs
+++ b/test/form-state-concern-profile.test.mjs
@@ -66,6 +66,28 @@ test("concern-only form-state source emits non-authorizing form-state concern ev
   });
 });
 
+test("form-state concern profile records useFieldArray without authorizing domain reuse", () => {
+  const source = `
+    import { useFieldArray, useForm } from "react-hook-form";
+    export function ConcernOnlyFieldArrayNote() {
+      const { control } = useForm({ defaultValues: { contacts: [] } });
+      const { fields, append } = useFieldArray({ control, name: "contacts" });
+      return { fields, append };
+    }
+  `;
+  const { domainDetection, policy, payload } = buildPayloadForSource(source, "ConcernOnlyFieldArrayNote.tsx");
+
+  assert.equal(domainDetection.classification, "unknown");
+  assert.equal(policy.allowed, false);
+  assert.equal(payload.reactWebContext, undefined);
+  assert.ok(payload.concernProfiles?.[0].signals.includes("useFieldArray"));
+  assert.ok(payload.concernProfiles?.[0].signals.includes("useForm"));
+  assert.deepEqual(assessFrontendProfilePayloadReuse(".tsx", domainDetection, payload, policy), {
+    allowed: false,
+    reason: UNSUPPORTED_FRONTEND_DOMAIN_PROFILE_REASON,
+  });
+});
+
 test("React Web plus form-state concern keeps concern metadata separate from authorization", () => {
   const source = `
     import { useForm } from "react-hook-form";

--- a/test/react-web-context-metadata.test.mjs
+++ b/test/react-web-context-metadata.test.mjs
@@ -390,6 +390,39 @@ test("React Web formStateRoles normalize source-backed form roles without deferr
   );
 });
 
+test("React Web formStateRoles expose useFieldArray as dynamic field evidence", () => {
+  const source = `
+    import React from "react";
+    import { useFieldArray, useForm } from "react-hook-form";
+
+    export function ContactsFieldArrayForm() {
+      const { control, register } = useForm({ defaultValues: { contacts: [{ email: "" }] } });
+      const { fields, append } = useFieldArray({ control, name: "contacts" });
+
+      return (
+        <form>
+          {fields.map((field, index) => (
+            <input key={field.id} {...register("contacts." + index + ".email")} />
+          ))}
+          <button type="button" onClick={() => append({ email: "" })}>Add contact</button>
+        </form>
+      );
+    }
+  `;
+  const result = extractSource(path.join(repoRoot, "fixtures", "compressed", "ContactsFieldArrayForm.tsx"), source);
+  const payload = toModelFacingPayload(result, repoRoot, {
+    includeEditGuidance: true,
+    includeReactWebContextMetadata: true,
+  });
+
+  const validationAnchors = result.behavior?.formSurface?.validationAnchors?.map((item) => item.value) ?? [];
+  assert.ok(validationAnchors.includes("useFieldArray"));
+  assert.ok(payload.editGuidance?.patchTargets.some((item) => item.kind === "validation-anchor" && item.label === "useFieldArray"));
+  assert.ok(payload.reactWebContext?.formStateRoles?.some((item) => item.role === "dynamic-fields" && item.labels.includes("useFieldArray")));
+  assert.ok(payload.reactWebContext?.formStateRoles?.some((item) => item.role === "field-registration"));
+  assert.ok(payload.behavior?.hooks?.includes("useFieldArray"));
+});
+
 test("React Web formStateRoles do not emit validation-defaults from import-only validation evidence", () => {
   const source = `
     import React from "react";


### PR DESCRIPTION
## Summary
- collect `useFieldArray` as a React Hook Form validation/form-state anchor
- expose `dynamic-fields` as source-backed React Web form-state role evidence
- include `useFieldArray` in concern profiles while keeping concern-only sources non-authorizing

Closes #1157

## Verification
- `npm run build`
- `node --test test/form-state-concern-profile.test.mjs test/react-web-context-metadata.test.mjs`
- `node --test test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs test/fooks.test.mjs` — 215/215 pass
- `npm run typecheck`
- `npm run lint -- --pretty false`
- `git diff --check`

## Non-claims
- no provider token/cost/billing claim
- no runtime authorization broadening
- concern-only form-state evidence remains non-authorizing
