### PR TITLE
Expose React Web consumer role coverage

### DIFF
--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -30,6 +30,17 @@ export const REACT_WEB_FACT_GRAPH_CONSUMER_CLAIM_BOUNDARY =
 export type ReactWebFactGraphConsumerAuthorization = "none";
 export type ReactWebFactGraphAnchorType = "node" | "edge";
 export type ReactWebFactGraphAnchorDeferredReason = "budget-deferred" | "stale-or-unknown-freshness";
+export type ReactWebFactGraphRoleCoverageStatus = "selected" | "deferred";
+
+export type ReactWebFactGraphRoleCoverage = {
+  role: string;
+  labels: string[];
+  selectedCount: number;
+  deferredCount: number;
+  totalCount: number;
+  status: ReactWebFactGraphRoleCoverageStatus;
+  reasons: string[];
+};
 
 export type ReactWebFactGraphAnchor = {
   rank: number;
@@ -78,6 +89,7 @@ export type ReactWebFactGraphConsumerDryRun = {
   };
   selectedAnchors: ReactWebFactGraphAnchor[];
   deferredAnchors: ReactWebFactGraphAnchor[];
+  formStateRoleCoverage: ReactWebFactGraphRoleCoverage[];
   warnings: string[];
   nonClaims: string[];
 };
@@ -201,6 +213,59 @@ function compareCandidates(left: Candidate, right: Candidate): number {
   return left.anchorId.localeCompare(right.anchorId);
 }
 
+
+function formStateRoleFor(anchor: ReactWebFactGraphAnchor): string | undefined {
+  const match = anchor.kind.match(/^form-state-role:(.+)$/);
+  return match?.[1];
+}
+
+function labelsForRoleAnchor(anchor: ReactWebFactGraphAnchor): string[] {
+  const value = anchor.label.trim();
+  if (!value) return [];
+  return value.split(/,\s*/).map((label) => label.trim()).filter(Boolean);
+}
+
+function buildFormStateRoleCoverage(
+  selectedAnchors: ReactWebFactGraphAnchor[],
+  deferredAnchors: ReactWebFactGraphAnchor[],
+): ReactWebFactGraphRoleCoverage[] {
+  const coverage = new Map<string, {
+    labels: Set<string>;
+    selectedCount: number;
+    deferredCount: number;
+    reasons: Set<string>;
+  }>();
+
+  const add = (anchor: ReactWebFactGraphAnchor, bucket: "selected" | "deferred") => {
+    const role = formStateRoleFor(anchor);
+    if (!role) return;
+    const current = coverage.get(role) ?? { labels: new Set<string>(), selectedCount: 0, deferredCount: 0, reasons: new Set<string>() };
+    for (const label of labelsForRoleAnchor(anchor)) current.labels.add(label);
+    if (bucket === "selected") current.selectedCount += 1;
+    else current.deferredCount += 1;
+    current.reasons.add(bucket === "selected" ? "selected-within-anchor-budget" : anchor.deferredReason ?? "deferred");
+    coverage.set(role, current);
+  };
+
+  selectedAnchors.forEach((anchor) => add(anchor, "selected"));
+  deferredAnchors.forEach((anchor) => add(anchor, "deferred"));
+
+  return [...coverage.entries()]
+    .map(([role, item]) => ({
+      role,
+      labels: [...item.labels].sort(),
+      selectedCount: item.selectedCount,
+      deferredCount: item.deferredCount,
+      totalCount: item.selectedCount + item.deferredCount,
+      status: item.selectedCount > 0 ? "selected" as const : "deferred" as const,
+      reasons: [...item.reasons].sort(),
+    }))
+    .sort((left, right) => {
+      if (left.status !== right.status) return left.status === "selected" ? -1 : 1;
+      return left.role.localeCompare(right.role);
+    });
+}
+
 function ranked(anchor: Candidate, rank: number, deferredReason?: ReactWebFactGraphAnchorDeferredReason): ReactWebFactGraphAnchor {
   const { firstLine: _firstLine, ...publicAnchor } = anchor;
   return {
@@ -250,6 +315,8 @@ export function selectReactWebFactGraphAnchors(
     warnings.push(`React Web fact graph freshness verification is ${verification.status}; all source-backed anchors were deferred.`);
   }
 
+  const formStateRoleCoverage = buildFormStateRoleCoverage(selectedAnchors, deferredAnchors);
+
   return {
     schemaVersion: REACT_WEB_FACT_GRAPH_CONSUMER_SCHEMA_VERSION,
     command: REACT_WEB_FACT_GRAPH_CONSUMER_COMMAND,
@@ -277,6 +344,7 @@ export function selectReactWebFactGraphAnchors(
     },
     selectedAnchors,
     deferredAnchors,
+    formStateRoleCoverage,
     warnings,
     nonClaims: [...FACT_GRAPH_REPORT_NON_CLAIMS],
   };
@@ -305,6 +373,14 @@ export function renderReactWebFactGraphConsumerDryRunText(dryRun: ReactWebFactGr
     ...dryRun.selectedAnchors.map((anchor) => `- #${anchor.rank} ${anchor.anchorType}:${anchor.kind} ${anchor.label} (${anchor.confidence}, priority=${anchor.priority})`),
     `Deferred anchors: ${dryRun.deferredAnchors.length}`,
   ];
+  if (dryRun.formStateRoleCoverage.length > 0) {
+    lines.push(
+      "Form-state role coverage:",
+      ...dryRun.formStateRoleCoverage.map((item) =>
+        `- ${item.role}: ${item.status} selected=${item.selectedCount} deferred=${item.deferredCount} labels=${item.labels.join(",") || "none"}`,
+      ),
+    );
+  }
   if (dryRun.freshnessVerification) {
     lines.push(`Freshness verification: ${dryRun.freshnessVerification.status}`);
     for (const [check, status] of Object.entries(dryRun.freshnessVerification.checks)) {

--- a/test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx
+++ b/test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+
+type Contact = { email: string };
+
+type ContactsFormValues = {
+  contacts: Contact[];
+};
+
+export function FieldArrayContactsForm() {
+  const { control, register, handleSubmit } = useForm<ContactsFormValues>({
+    defaultValues: { contacts: [{ email: "" }] },
+  });
+  const { fields, append, remove } = useFieldArray({ control, name: "contacts" });
+
+  return (
+    <form onSubmit={handleSubmit(() => undefined)}>
+      <p className="text-sm text-slate-500">
+        Keep this fixture long enough to exercise React Web context extraction while representing dynamic field arrays.
+      </p>
+      {fields.map((field, index) => (
+        <div key={field.id} className="grid gap-2">
+          <label htmlFor={`contacts-${index}-email`}>Email</label>
+          <input id={`contacts-${index}-email`} {...register(`contacts.${index}.email`)} />
+          <button type="button" onClick={() => remove(index)}>Remove</button>
+        </div>
+      ))}
+      <button type="button" onClick={() => append({ email: "" })}>Add contact</button>
+      <button type="submit">Save</button>
+    </form>
+  );
+}

--- a/test/react-web-fact-graph-consumer.test.mjs
+++ b/test/react-web-fact-graph-consumer.test.mjs
@@ -226,3 +226,46 @@ test("CLI inspect react-web-fact-graph-consumer parses JSON and max-anchors flag
   const invalid = runCli(["inspect", "react-web-fact-graph-consumer", "--max-anchors", "0", file, "--json"], 1);
   assert.match(invalid.stderr || invalid.stdout, /max-anchors must be an integer between 1 and 20/i);
 });
+
+
+test("consumer dry-run summarizes form-state role coverage for dynamic field anchors", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(
+    fixture("test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx"),
+    repoRoot,
+    { maxAnchors: 20 },
+  );
+
+  const dynamicFields = dryRun.formStateRoleCoverage.find((item) => item.role === "dynamic-fields");
+  assert.ok(dynamicFields, "expected dynamic-fields role coverage");
+  assert.equal(dynamicFields.status, "deferred");
+  assert.equal(dynamicFields.selectedCount, 0);
+  assert.equal(dynamicFields.deferredCount, 1);
+  assert.ok(dynamicFields.labels.includes("useFieldArray"));
+  assert.ok(dynamicFields.reasons.includes("budget-deferred"));
+  assert.ok(dryRun.selectedAnchors.some((anchor) => anchor.kind === "patch-target:validation-anchor" && anchor.label === "useFieldArray"));
+
+  const text = runCli([
+    "inspect",
+    "react-web-fact-graph-consumer",
+    "test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx",
+    "--max-anchors",
+    "20",
+  ]).stdout;
+  assert.match(text, /Form-state role coverage:/);
+  assert.match(text, /dynamic-fields: deferred/);
+});
+
+test("consumer dry-run marks form-state role coverage deferred when anchor budget excludes it", () => {
+  const dryRun = buildReactWebFactGraphConsumerDryRun(
+    fixture("test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx"),
+    repoRoot,
+    { maxAnchors: 1 },
+  );
+
+  const dynamicFields = dryRun.formStateRoleCoverage.find((item) => item.role === "dynamic-fields");
+  assert.ok(dynamicFields, "expected dynamic-fields role coverage");
+  assert.equal(dynamicFields.status, "deferred");
+  assert.equal(dynamicFields.selectedCount, 0);
+  assert.equal(dynamicFields.deferredCount, 1);
+  assert.ok(dynamicFields.reasons.includes("budget-deferred"));
+});


### PR DESCRIPTION
## Summary
- add `formStateRoleCoverage` to React Web fact graph consumer dry-run output
- show selected/deferred counts and reasons for form-state roles like `dynamic-fields`
- add a field-array fixture proving `useFieldArray` patch evidence is selected while role-node budget deferral remains auditable

Closes #1159

## Tests
- npm run build
- npm run typecheck
- npm run lint -- --pretty false
- node --test test/react-web-context-metadata.test.mjs test/react-web-fact-graph.test.mjs test/react-web-fact-graph-consumer.test.mjs test/pre-read-payload-builder.test.mjs test/runtime-bridge-contract.test.mjs
- git diff --check
