### PR TITLE
Add React Web field-array dogfood priority evidence

### DIFF
--- a/docs/dogfood/react-web-field-array-priority-decision-1161.md
+++ b/docs/dogfood/react-web-field-array-priority-decision-1161.md
@@ -1,0 +1,55 @@
+# React Web field-array dogfood priority evidence
+
+Local diagnostic dogfood evidence only: checks whether React Web fact graph consumer dry-run exposes useFieldArray patch-target and dynamic-fields role coverage. It is not task-success evidence, not runtime authorization, not token/cost/billing proof, and not a claim that priority promotion improves model edits.
+
+## Fixture
+
+- Fixture: `test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx`
+- Contains useFieldArray: yes
+- Contains fields.map: yes
+- Contains append/remove: yes
+
+## Default consumer budget
+
+- maxAnchors: 8
+- selected/deferred: 8/67
+- useFieldArray patch-target selected: no
+- dynamic-fields role selected: no
+- dynamic-fields role coverage: deferred; selected=0; deferred=1; reasons=budget-deferred
+
+## Wide inspection budget
+
+- maxAnchors: 20
+- selected/deferred: 20/55
+- useFieldArray patch-target selected: yes
+- dynamic-fields role selected: no
+- dynamic-fields role coverage: deferred; selected=0; deferred=1; reasons=budget-deferred
+
+## Priority decision
+
+- Verdict: defer-promotion-pending-task-outcome
+- Reason: default consumer budget does not select useFieldArray patch-target evidence, but a wider inspection budget does; this shows a budget pressure risk, not proof that role-priority promotion improves edits
+- Next action: run task-outcome dogfood for a field-array edit before promoting dynamic-fields or useFieldArray priority
+
+## Selected anchors sample
+
+- #1 targets: FieldArrayContactsForm targets FieldArrayContactsForm (priority=100)
+- #2 targets: FieldArrayContactsForm targets FieldArrayContactsForm (priority=100)
+- #3 patch-target:component: FieldArrayContactsForm (priority=100)
+- #4 targets: FieldArrayContactsForm targets useForm (priority=100)
+- #5 targets: FieldArrayContactsForm targets useForm (priority=100)
+- #6 patch-target:validation-anchor: useForm (priority=100)
+- #7 targets: FieldArrayContactsForm targets defaultValues (priority=100)
+- #8 patch-target:validation-anchor: defaultValues (priority=100)
+
+## Deferred form-state role anchors under wide budget
+
+- #47 form-state-role:validation-defaults: defaultValues; reason=budget-deferred
+- #48 form-state-role:submit-flow: handleSubmit(() => undefined), form onSubmit=handleSubmit(() => undefined); reason=budget-deferred
+- #49 form-state-role:field-registration: register, form, input; reason=budget-deferred
+- #50 form-state-role:dynamic-fields: useFieldArray; reason=budget-deferred
+- #51 form-state-role:form-root: useForm; reason=budget-deferred
+
+## Boundary
+
+This artifact decides whether priority promotion is justified by consumer visibility evidence only. It does not prove model edit success.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "evidence:react-web-pr-advisory": "npm run build && node scripts/react-web-pr-advisory-surface.mjs",
     "evidence:react-web-pr-gate": "npm run build && node scripts/react-web-pr-gate-surface.mjs",
     "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs",
-    "evidence:react-web-live-hook-dogfood": "npm run build && node scripts/react-web-live-hook-dogfood-evidence.mjs"
+    "evidence:react-web-live-hook-dogfood": "npm run build && node scripts/react-web-live-hook-dogfood-evidence.mjs",
+    "evidence:react-web-field-array-dogfood": "npm run build && node scripts/react-web-field-array-dogfood-evidence.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-field-array-dogfood-evidence.mjs
+++ b/scripts/react-web-field-array-dogfood-evidence.mjs
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_FIELD_ARRAY_DOGFOOD_SCHEMA_VERSION = "react-web-field-array-dogfood-evidence.v1";
+export const DEFAULT_FIELD_ARRAY_FIXTURE = "test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx";
+
+async function loadBuiltIndex(repoRoot) {
+  return import(path.join(repoRoot, "dist", "index.js"));
+}
+
+function selectedUseFieldArrayPatchTarget(dryRun) {
+  return dryRun.selectedAnchors.some(
+    (anchor) => anchor.kind === "patch-target:validation-anchor" && anchor.label === "useFieldArray",
+  );
+}
+
+function selectedDynamicFieldRole(dryRun) {
+  return dryRun.selectedAnchors.some(
+    (anchor) => anchor.kind === "form-state-role:dynamic-fields" && /useFieldArray/.test(anchor.label),
+  );
+}
+
+function dynamicFieldRoleCoverage(dryRun) {
+  return dryRun.formStateRoleCoverage.find((item) => item.role === "dynamic-fields") ?? null;
+}
+
+function anchorSnapshot(dryRun) {
+  return dryRun.selectedAnchors.map((anchor) => ({
+    rank: anchor.rank,
+    anchorType: anchor.anchorType,
+    kind: anchor.kind,
+    label: anchor.label,
+    priority: anchor.priority,
+    confidence: anchor.confidence,
+  }));
+}
+
+function deferredRoleSnapshot(dryRun) {
+  return dryRun.deferredAnchors
+    .filter((anchor) => anchor.kind.startsWith("form-state-role:"))
+    .map((anchor) => ({
+      rank: anchor.rank,
+      kind: anchor.kind,
+      label: anchor.label,
+      priority: anchor.priority,
+      deferredReason: anchor.deferredReason,
+    }));
+}
+
+function decidePriorityAction(defaultRun, wideRun) {
+  const defaultPatchTargetSelected = selectedUseFieldArrayPatchTarget(defaultRun);
+  const widePatchTargetSelected = selectedUseFieldArrayPatchTarget(wideRun);
+  const defaultRole = dynamicFieldRoleCoverage(defaultRun);
+  const wideRole = dynamicFieldRoleCoverage(wideRun);
+
+  if (!defaultPatchTargetSelected && !widePatchTargetSelected) {
+    return {
+      verdict: "promote-or-fix-required",
+      reason: "useFieldArray patch-target evidence is not selected even under a wider anchor budget",
+      nextAction: "fix extraction or raise useFieldArray patch-target visibility before changing role priority",
+    };
+  }
+
+  if (!defaultPatchTargetSelected && widePatchTargetSelected) {
+    return {
+      verdict: "defer-promotion-pending-task-outcome",
+      reason: "default consumer budget does not select useFieldArray patch-target evidence, but a wider inspection budget does; this shows a budget pressure risk, not proof that role-priority promotion improves edits",
+      nextAction: "run task-outcome dogfood for a field-array edit before promoting dynamic-fields or useFieldArray priority",
+    };
+  }
+
+  if (defaultPatchTargetSelected && defaultRole?.status === "selected") {
+    return {
+      verdict: "promotion-not-needed",
+      reason: "default consumer budget already selects both useFieldArray patch-target and dynamic-fields role evidence",
+      nextAction: "keep current priority and gather task-outcome evidence only if failures appear",
+    };
+  }
+
+  if (defaultPatchTargetSelected && wideRole?.status === "deferred") {
+    return {
+      verdict: "defer-promotion-pending-task-outcome",
+      reason: "useFieldArray patch-target evidence is selected, while dynamic-fields role remains budget-deferred even in the inspected wide budget; this is a measurement signal, not proof that priority promotion improves edits",
+      nextAction: "run task-outcome dogfood before promoting dynamic-fields priority",
+    };
+  }
+
+  return {
+    verdict: "defer-promotion-pending-task-outcome",
+    reason: "useFieldArray patch-target evidence is selected, and role coverage is now observable; no task-outcome miss has been shown yet",
+    nextAction: "keep role coverage diagnostic-only until a dogfood edit task demonstrates missed dynamic-field semantics",
+  };
+}
+
+export async function buildReactWebFieldArrayDogfoodEvidence({
+  repoRoot = defaultRepoRoot,
+  fixture = DEFAULT_FIELD_ARRAY_FIXTURE,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const { buildReactWebFactGraphConsumerDryRun } = await loadBuiltIndex(repoRoot);
+  const absoluteFixture = path.join(repoRoot, fixture);
+  const source = fs.readFileSync(absoluteFixture, "utf8");
+  const defaultDryRun = buildReactWebFactGraphConsumerDryRun(absoluteFixture, repoRoot);
+  const wideDryRun = buildReactWebFactGraphConsumerDryRun(absoluteFixture, repoRoot, { maxAnchors: 20 });
+  const priorityDecision = decidePriorityAction(defaultDryRun, wideDryRun);
+
+  return {
+    schemaVersion: REACT_WEB_FIELD_ARRAY_DOGFOOD_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "react-web-field-array-consumer-priority-dogfood",
+    fixture,
+    claimBoundary:
+      "Local diagnostic dogfood evidence only: checks whether React Web fact graph consumer dry-run exposes useFieldArray patch-target and dynamic-fields role coverage. It is not task-success evidence, not runtime authorization, not token/cost/billing proof, and not a claim that priority promotion improves model edits.",
+    source: {
+      byteLength: Buffer.byteLength(source, "utf8"),
+      containsUseFieldArray: /\buseFieldArray\b/.test(source),
+      containsFieldsMap: /\bfields\.map\s*\(/.test(source),
+      containsAppendOrRemove: /\b(?:append|remove)\s*\(/.test(source),
+    },
+    defaultBudget: {
+      maxAnchors: defaultDryRun.selectionPolicy.maxAnchors,
+      selectedAnchorCount: defaultDryRun.selectedAnchors.length,
+      deferredAnchorCount: defaultDryRun.deferredAnchors.length,
+      useFieldArrayPatchTargetSelected: selectedUseFieldArrayPatchTarget(defaultDryRun),
+      dynamicFieldsRoleSelected: selectedDynamicFieldRole(defaultDryRun),
+      dynamicFieldsRoleCoverage: dynamicFieldRoleCoverage(defaultDryRun),
+      selectedAnchors: anchorSnapshot(defaultDryRun),
+      deferredFormStateRoles: deferredRoleSnapshot(defaultDryRun),
+    },
+    wideBudget: {
+      maxAnchors: wideDryRun.selectionPolicy.maxAnchors,
+      selectedAnchorCount: wideDryRun.selectedAnchors.length,
+      deferredAnchorCount: wideDryRun.deferredAnchors.length,
+      useFieldArrayPatchTargetSelected: selectedUseFieldArrayPatchTarget(wideDryRun),
+      dynamicFieldsRoleSelected: selectedDynamicFieldRole(wideDryRun),
+      dynamicFieldsRoleCoverage: dynamicFieldRoleCoverage(wideDryRun),
+      selectedAnchors: anchorSnapshot(wideDryRun),
+      deferredFormStateRoles: deferredRoleSnapshot(wideDryRun),
+    },
+    priorityDecision,
+  };
+}
+
+export function renderReactWebFieldArrayDogfoodMarkdown(evidence) {
+  const role = evidence.defaultBudget.dynamicFieldsRoleCoverage;
+  const wideRole = evidence.wideBudget.dynamicFieldsRoleCoverage;
+  const defaultAnchors = evidence.defaultBudget.selectedAnchors
+    .slice(0, 12)
+    .map((anchor) => `- #${anchor.rank} ${anchor.kind}: ${anchor.label} (priority=${anchor.priority})`)
+    .join("\n");
+  const deferredRoles = evidence.wideBudget.deferredFormStateRoles.length > 0
+    ? evidence.wideBudget.deferredFormStateRoles
+      .map((anchor) => `- #${anchor.rank} ${anchor.kind}: ${anchor.label}; reason=${anchor.deferredReason}`)
+      .join("\n")
+    : "- none";
+
+  return `# React Web field-array dogfood priority evidence\n\n${evidence.claimBoundary}\n\n## Fixture\n\n- Fixture: \`${evidence.fixture}\`\n- Contains useFieldArray: ${evidence.source.containsUseFieldArray ? "yes" : "no"}\n- Contains fields.map: ${evidence.source.containsFieldsMap ? "yes" : "no"}\n- Contains append/remove: ${evidence.source.containsAppendOrRemove ? "yes" : "no"}\n\n## Default consumer budget\n\n- maxAnchors: ${evidence.defaultBudget.maxAnchors}\n- selected/deferred: ${evidence.defaultBudget.selectedAnchorCount}/${evidence.defaultBudget.deferredAnchorCount}\n- useFieldArray patch-target selected: ${evidence.defaultBudget.useFieldArrayPatchTargetSelected ? "yes" : "no"}\n- dynamic-fields role selected: ${evidence.defaultBudget.dynamicFieldsRoleSelected ? "yes" : "no"}\n- dynamic-fields role coverage: ${role ? `${role.status}; selected=${role.selectedCount}; deferred=${role.deferredCount}; reasons=${role.reasons.join(", ")}` : "missing"}\n\n## Wide inspection budget\n\n- maxAnchors: ${evidence.wideBudget.maxAnchors}\n- selected/deferred: ${evidence.wideBudget.selectedAnchorCount}/${evidence.wideBudget.deferredAnchorCount}\n- useFieldArray patch-target selected: ${evidence.wideBudget.useFieldArrayPatchTargetSelected ? "yes" : "no"}\n- dynamic-fields role selected: ${evidence.wideBudget.dynamicFieldsRoleSelected ? "yes" : "no"}\n- dynamic-fields role coverage: ${wideRole ? `${wideRole.status}; selected=${wideRole.selectedCount}; deferred=${wideRole.deferredCount}; reasons=${wideRole.reasons.join(", ")}` : "missing"}\n\n## Priority decision\n\n- Verdict: ${evidence.priorityDecision.verdict}\n- Reason: ${evidence.priorityDecision.reason}\n- Next action: ${evidence.priorityDecision.nextAction}\n\n## Selected anchors sample\n\n${defaultAnchors}\n\n## Deferred form-state role anchors under wide budget\n\n${deferredRoles}\n\n## Boundary\n\nThis artifact decides whether priority promotion is justified by consumer visibility evidence only. It does not prove model edit success.\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const fixtureArg = process.argv.find((arg) => arg.startsWith("--fixture="))?.slice("--fixture=".length);
+  const evidence = await buildReactWebFieldArrayDogfoodEvidence({ repoRoot: defaultRepoRoot, runId, fixture: fixtureArg ?? DEFAULT_FIELD_ARRAY_FIXTURE });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebFieldArrayDogfoodMarkdown(evidence));
+  }
+  if (!outputArg && !markdownArg) {
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  }
+}

--- a/test/react-web-field-array-dogfood-evidence.test.mjs
+++ b/test/react-web-field-array-dogfood-evidence.test.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REACT_WEB_FIELD_ARRAY_DOGFOOD_SCHEMA_VERSION,
+  buildReactWebFieldArrayDogfoodEvidence,
+  renderReactWebFieldArrayDogfoodMarkdown,
+} from "../scripts/react-web-field-array-dogfood-evidence.mjs";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+test("React Web field-array dogfood evidence records priority decision boundary", async () => {
+  const evidence = await buildReactWebFieldArrayDogfoodEvidence({ repoRoot, runId: "test" });
+
+  assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_DOGFOOD_SCHEMA_VERSION);
+  assert.equal(evidence.measurement, "react-web-field-array-consumer-priority-dogfood");
+  assert.equal(evidence.source.containsUseFieldArray, true);
+  assert.equal(evidence.source.containsFieldsMap, true);
+  assert.equal(evidence.defaultBudget.useFieldArrayPatchTargetSelected, false);
+  assert.equal(evidence.wideBudget.useFieldArrayPatchTargetSelected, true);
+  assert.equal(evidence.defaultBudget.dynamicFieldsRoleSelected, false);
+  assert.equal(evidence.defaultBudget.dynamicFieldsRoleCoverage.status, "deferred");
+  assert.equal(evidence.priorityDecision.verdict, "defer-promotion-pending-task-outcome");
+  assert.match(evidence.claimBoundary, /not task-success evidence/);
+  assert.match(evidence.claimBoundary, /not token\/cost\/billing proof/);
+
+  const markdown = renderReactWebFieldArrayDogfoodMarkdown(evidence);
+  assert.match(markdown, /React Web field-array dogfood priority evidence/);
+  assert.match(markdown, /useFieldArray patch-target selected: no/);
+  assert.match(markdown, /Wide inspection budget/);
+  assert.match(markdown, /useFieldArray patch-target selected: yes/);
+  assert.match(markdown, /dynamic-fields role selected: no/);
+  assert.match(markdown, /defer-promotion-pending-task-outcome/);
+});
+
+test("React Web field-array dogfood evidence CLI writes JSON and markdown", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-field-array-dogfood-"));
+  try {
+    const outputPath = path.join(tempDir, "evidence.json");
+    const markdownPath = path.join(tempDir, "evidence.md");
+    const result = spawnSync(process.execPath, [
+      path.join(repoRoot, "scripts", "react-web-field-array-dogfood-evidence.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ], { cwd: repoRoot, encoding: "utf8" });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    const markdown = fs.readFileSync(markdownPath, "utf8");
+    assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_DOGFOOD_SCHEMA_VERSION);
+    assert.match(markdown, /Priority decision/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add `scripts/react-web-field-array-dogfood-evidence.mjs` for reproducible field-array consumer visibility evidence
- record default vs wide-budget behavior for `useFieldArray` and `dynamic-fields`
- add a dogfood markdown decision artifact and tests for the diagnostic-only boundary

Closes #1161

## Key result
- default maxAnchors=8: `useFieldArray` patch-target not selected; `dynamic-fields` role deferred
- wide maxAnchors=20: `useFieldArray` patch-target selected; `dynamic-fields` role still deferred
- priority verdict: defer promotion pending task-outcome dogfood

## Tests
- npm run build
- node scripts/react-web-field-array-dogfood-evidence.mjs --run-id=smoke
- node --test test/react-web-field-array-dogfood-evidence.test.mjs test/react-web-fact-graph-consumer.test.mjs
- npm run typecheck
- npm run lint -- --pretty false
- git diff --check
