### PR TITLE
Add React Web field-array task-outcome dogfood evidence

### DIFF
--- a/docs/dogfood/react-web-field-array-task-outcome-1163.md
+++ b/docs/dogfood/react-web-field-array-task-outcome-1163.md
@@ -1,0 +1,42 @@
+# React Web field-array task-outcome dogfood evidence
+
+Deterministic local task-readiness evidence only: evaluates whether selected consumer anchors expose signals required for a field-array edit task. It is not live Codex/Claude model outcome proof, not task accuracy proof, not runtime authorization, and not token/cost/billing evidence.
+
+## Task
+
+- Task id: field-array-add-contact-phone
+- Description: Add a phone field to each contact row while preserving useFieldArray fields.map rendering, register path shape, append/remove controls, and submit flow.
+- Fixture: `test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx`
+
+## Source signals
+
+- containsUseFieldArray: yes
+- containsFieldsMap: yes
+- containsRegisterPath: yes
+- containsAppend: yes
+- containsRemove: yes
+- containsHandleSubmit: yes
+
+## Required task signals
+
+- useFieldArray-anchor: useFieldArray patch target — The edit must recognize the component is a dynamic field-array form, not a static register-only form.
+- dynamic-fields-role: dynamic-fields form-state role — The edit should preserve array-row semantics such as fields.map, append, and remove.
+- field-registration-role: field-registration form-state role — The edit should preserve register path shape such as contacts.${index}.field.
+- submit-flow-role: submit-flow form-state role — The edit should avoid breaking handleSubmit/form submission while adding fields.
+
+## Budget readiness
+
+| Budget | maxAnchors | readiness | present required signals | missing |
+| --- | ---: | --- | ---: | --- |
+| defaultBudget | 8 | insufficient | 0/4 | useFieldArray-anchor, dynamic-fields-role, field-registration-role, submit-flow-role |
+| wideBudget | 20 | partial | 1/4 | dynamic-fields-role, field-registration-role, submit-flow-role |
+
+## Recommendation
+
+- Verdict: promote-useFieldArray-patch-target-before-dynamic-role
+- Reason: The default budget misses the concrete useFieldArray patch target while a wider budget selects it; prioritize the concrete edit target before promoting broader role nodes.
+- Next action: Add a narrow consumer-priority rule for useFieldArray validation-anchor evidence, then rerun this task-outcome dogfood before considering dynamic-fields role promotion.
+
+## Boundary
+
+This artifact is deterministic task-readiness evidence. It does not claim live model edit success or provider token/cost savings.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "evidence:react-web-pr-gate": "npm run build && node scripts/react-web-pr-gate-surface.mjs",
     "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs",
     "evidence:react-web-live-hook-dogfood": "npm run build && node scripts/react-web-live-hook-dogfood-evidence.mjs",
-    "evidence:react-web-field-array-dogfood": "npm run build && node scripts/react-web-field-array-dogfood-evidence.mjs"
+    "evidence:react-web-field-array-dogfood": "npm run build && node scripts/react-web-field-array-dogfood-evidence.mjs",
+    "evidence:react-web-field-array-task-outcome": "npm run build && node scripts/react-web-field-array-task-outcome-evidence.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-field-array-task-outcome-evidence.mjs
+++ b/scripts/react-web-field-array-task-outcome-evidence.mjs
@@ -1,0 +1,236 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_FIELD_ARRAY_FIXTURE,
+  buildReactWebFieldArrayDogfoodEvidence,
+} from "./react-web-field-array-dogfood-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION = "react-web-field-array-task-outcome-evidence.v1";
+
+const TASK = {
+  id: "field-array-add-contact-phone",
+  description:
+    "Add a phone field to each contact row while preserving useFieldArray fields.map rendering, register path shape, append/remove controls, and submit flow.",
+  requiredSignals: [
+    {
+      id: "useFieldArray-anchor",
+      label: "useFieldArray patch target",
+      rationale: "The edit must recognize the component is a dynamic field-array form, not a static register-only form.",
+    },
+    {
+      id: "dynamic-fields-role",
+      label: "dynamic-fields form-state role",
+      rationale: "The edit should preserve array-row semantics such as fields.map, append, and remove.",
+    },
+    {
+      id: "field-registration-role",
+      label: "field-registration form-state role",
+      rationale: "The edit should preserve register path shape such as contacts.${index}.field.",
+    },
+    {
+      id: "submit-flow-role",
+      label: "submit-flow form-state role",
+      rationale: "The edit should avoid breaking handleSubmit/form submission while adding fields.",
+    },
+  ],
+};
+
+function selectedContains(anchors, predicate) {
+  return anchors.some(predicate);
+}
+
+function roleCoverage(evidence, role, budgetName) {
+  return evidence[budgetName]?.dynamicFieldsRoleCoverage?.role === role
+    ? evidence[budgetName].dynamicFieldsRoleCoverage
+    : null;
+}
+
+function formStateRoleCoverage(evidence, role, budgetName) {
+  if (role === "dynamic-fields") return roleCoverage(evidence, role, budgetName);
+  const anchors = evidence[budgetName]?.deferredFormStateRoles ?? [];
+  const deferred = anchors.find((anchor) => anchor.kind === `form-state-role:${role}`);
+  const selected = (evidence[budgetName]?.selectedAnchors ?? []).find((anchor) => anchor.kind === `form-state-role:${role}`);
+  if (selected) {
+    return { role, status: "selected", selectedCount: 1, deferredCount: 0, labels: [selected.label], reasons: ["selected-within-anchor-budget"] };
+  }
+  if (deferred) {
+    return { role, status: "deferred", selectedCount: 0, deferredCount: 1, labels: [deferred.label], reasons: [deferred.deferredReason ?? "deferred"] };
+  }
+  return null;
+}
+
+function evaluateBudget(evidence, budgetName) {
+  const budget = evidence[budgetName];
+  const selected = budget.selectedAnchors;
+  const checks = [
+    {
+      id: "useFieldArray-anchor",
+      present: selectedContains(selected, (anchor) => anchor.kind === "patch-target:validation-anchor" && anchor.label === "useFieldArray"),
+      evidence: selected.find((anchor) => anchor.kind === "patch-target:validation-anchor" && anchor.label === "useFieldArray") ?? null,
+      missingReason: "useFieldArray patch target is outside selected anchor budget",
+    },
+    {
+      id: "dynamic-fields-role",
+      present: formStateRoleCoverage(evidence, "dynamic-fields", budgetName)?.status === "selected",
+      evidence: formStateRoleCoverage(evidence, "dynamic-fields", budgetName),
+      missingReason: "dynamic-fields role is not selected; role coverage is deferred or missing",
+    },
+    {
+      id: "field-registration-role",
+      present: formStateRoleCoverage(evidence, "field-registration", budgetName)?.status === "selected",
+      evidence: formStateRoleCoverage(evidence, "field-registration", budgetName),
+      missingReason: "field-registration role is not selected; register-path semantics remain indirect",
+    },
+    {
+      id: "submit-flow-role",
+      present: formStateRoleCoverage(evidence, "submit-flow", budgetName)?.status === "selected",
+      evidence: formStateRoleCoverage(evidence, "submit-flow", budgetName),
+      missingReason: "submit-flow role is not selected; submission semantics remain indirect",
+    },
+  ];
+  const presentCount = checks.filter((check) => check.present).length;
+  const missing = checks.filter((check) => !check.present).map((check) => ({ id: check.id, reason: check.missingReason, evidence: check.evidence }));
+  const requiredCount = checks.length;
+  const readiness = presentCount === requiredCount
+    ? "ready"
+    : checks[0].present
+      ? "partial"
+      : "insufficient";
+
+  return {
+    budgetName,
+    maxAnchors: budget.maxAnchors,
+    selectedAnchorCount: budget.selectedAnchorCount,
+    deferredAnchorCount: budget.deferredAnchorCount,
+    readiness,
+    presentCount,
+    requiredCount,
+    checks,
+    missing,
+  };
+}
+
+function recommend(defaultEvaluation, wideEvaluation) {
+  const defaultUseFieldArray = defaultEvaluation.checks.find((check) => check.id === "useFieldArray-anchor")?.present ?? false;
+  const wideUseFieldArray = wideEvaluation.checks.find((check) => check.id === "useFieldArray-anchor")?.present ?? false;
+  const wideDynamicRole = wideEvaluation.checks.find((check) => check.id === "dynamic-fields-role")?.present ?? false;
+
+  if (!defaultUseFieldArray && wideUseFieldArray) {
+    return {
+      verdict: "promote-useFieldArray-patch-target-before-dynamic-role",
+      reason:
+        "The default budget misses the concrete useFieldArray patch target while a wider budget selects it; prioritize the concrete edit target before promoting broader role nodes.",
+      nextAction:
+        "Add a narrow consumer-priority rule for useFieldArray validation-anchor evidence, then rerun this task-outcome dogfood before considering dynamic-fields role promotion.",
+    };
+  }
+
+  if (defaultUseFieldArray && !wideDynamicRole) {
+    return {
+      verdict: "consider-dynamic-fields-role-after-task-miss",
+      reason:
+        "The concrete useFieldArray patch target is already visible, but dynamic-fields role is still absent; only promote the role if live task outcome misses row-array semantics.",
+      nextAction: "Keep current priority and gather live edit outcome evidence.",
+    };
+  }
+
+  if (defaultEvaluation.readiness === "ready") {
+    return {
+      verdict: "no-priority-change-needed",
+      reason: "Default selected anchors cover all deterministic field-array task signals.",
+      nextAction: "No-op unless live model edits regress.",
+    };
+  }
+
+  return {
+    verdict: "inspect-priority-manually",
+    reason: "The deterministic signal pattern did not match a known priority recommendation.",
+    nextAction: "Inspect selected/deferred anchors before changing priorities.",
+  };
+}
+
+export async function buildReactWebFieldArrayTaskOutcomeEvidence({
+  repoRoot = defaultRepoRoot,
+  fixture = DEFAULT_FIELD_ARRAY_FIXTURE,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const priorityEvidence = await buildReactWebFieldArrayDogfoodEvidence({ repoRoot, fixture, runId });
+  const absoluteFixture = path.join(repoRoot, fixture);
+  const source = fs.readFileSync(absoluteFixture, "utf8");
+  const defaultEvaluation = evaluateBudget(priorityEvidence, "defaultBudget");
+  const wideEvaluation = evaluateBudget(priorityEvidence, "wideBudget");
+  const recommendation = recommend(defaultEvaluation, wideEvaluation);
+
+  return {
+    schemaVersion: REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    runId,
+    measurement: "react-web-field-array-deterministic-task-outcome-readiness",
+    fixture,
+    task: TASK,
+    claimBoundary:
+      "Deterministic local task-readiness evidence only: evaluates whether selected consumer anchors expose signals required for a field-array edit task. It is not live Codex/Claude model outcome proof, not task accuracy proof, not runtime authorization, and not token/cost/billing evidence.",
+    sourceSignals: {
+      containsUseFieldArray: /\buseFieldArray\b/.test(source),
+      containsFieldsMap: /\bfields\.map\s*\(/.test(source),
+      containsRegisterPath: /register\(`contacts\.\$\{index\}/.test(source) || /register\("contacts\."\s*\+\s*index/.test(source),
+      containsAppend: /\bappend\s*\(/.test(source),
+      containsRemove: /\bremove\s*\(/.test(source),
+      containsHandleSubmit: /\bhandleSubmit\s*\(/.test(source),
+    },
+    evaluations: {
+      defaultBudget: defaultEvaluation,
+      wideBudget: wideEvaluation,
+    },
+    recommendation,
+    priorityEvidenceSummary: {
+      schemaVersion: priorityEvidence.schemaVersion,
+      priorityVerdict: priorityEvidence.priorityDecision.verdict,
+      defaultUseFieldArrayPatchTargetSelected: priorityEvidence.defaultBudget.useFieldArrayPatchTargetSelected,
+      wideUseFieldArrayPatchTargetSelected: priorityEvidence.wideBudget.useFieldArrayPatchTargetSelected,
+      defaultDynamicFieldsRoleCoverage: priorityEvidence.defaultBudget.dynamicFieldsRoleCoverage,
+      wideDynamicFieldsRoleCoverage: priorityEvidence.wideBudget.dynamicFieldsRoleCoverage,
+    },
+  };
+}
+
+export function renderReactWebFieldArrayTaskOutcomeMarkdown(evidence) {
+  const rows = [evidence.evaluations.defaultBudget, evidence.evaluations.wideBudget]
+    .map((item) => `| ${item.budgetName} | ${item.maxAnchors} | ${item.readiness} | ${item.presentCount}/${item.requiredCount} | ${item.missing.map((missing) => missing.id).join(", ") || "none"} |`)
+    .join("\n");
+  const sourceSignals = Object.entries(evidence.sourceSignals)
+    .map(([key, value]) => `- ${key}: ${value ? "yes" : "no"}`)
+    .join("\n");
+  const requiredSignals = evidence.task.requiredSignals
+    .map((signal) => `- ${signal.id}: ${signal.label} — ${signal.rationale}`)
+    .join("\n");
+
+  return `# React Web field-array task-outcome dogfood evidence\n\n${evidence.claimBoundary}\n\n## Task\n\n- Task id: ${evidence.task.id}\n- Description: ${evidence.task.description}\n- Fixture: \`${evidence.fixture}\`\n\n## Source signals\n\n${sourceSignals}\n\n## Required task signals\n\n${requiredSignals}\n\n## Budget readiness\n\n| Budget | maxAnchors | readiness | present required signals | missing |\n| --- | ---: | --- | ---: | --- |\n${rows}\n\n## Recommendation\n\n- Verdict: ${evidence.recommendation.verdict}\n- Reason: ${evidence.recommendation.reason}\n- Next action: ${evidence.recommendation.nextAction}\n\n## Boundary\n\nThis artifact is deterministic task-readiness evidence. It does not claim live model edit success or provider token/cost savings.\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const fixtureArg = process.argv.find((arg) => arg.startsWith("--fixture="))?.slice("--fixture=".length);
+  const evidence = await buildReactWebFieldArrayTaskOutcomeEvidence({ repoRoot: defaultRepoRoot, runId, fixture: fixtureArg ?? DEFAULT_FIELD_ARRAY_FIXTURE });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebFieldArrayTaskOutcomeMarkdown(evidence));
+  }
+  if (!outputArg && !markdownArg) {
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  }
+}

--- a/test/react-web-field-array-task-outcome-evidence.test.mjs
+++ b/test/react-web-field-array-task-outcome-evidence.test.mjs
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION,
+  buildReactWebFieldArrayTaskOutcomeEvidence,
+  renderReactWebFieldArrayTaskOutcomeMarkdown,
+} from "../scripts/react-web-field-array-task-outcome-evidence.mjs";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+test("field-array task outcome dogfood recommends concrete patch-target promotion first", async () => {
+  const evidence = await buildReactWebFieldArrayTaskOutcomeEvidence({ repoRoot, runId: "test" });
+
+  assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION);
+  assert.equal(evidence.measurement, "react-web-field-array-deterministic-task-outcome-readiness");
+  assert.equal(evidence.sourceSignals.containsUseFieldArray, true);
+  assert.equal(evidence.sourceSignals.containsFieldsMap, true);
+  assert.equal(evidence.sourceSignals.containsRegisterPath, true);
+  assert.equal(evidence.evaluations.defaultBudget.readiness, "insufficient");
+  assert.equal(evidence.evaluations.wideBudget.readiness, "partial");
+  assert.equal(evidence.priorityEvidenceSummary.defaultUseFieldArrayPatchTargetSelected, false);
+  assert.equal(evidence.priorityEvidenceSummary.wideUseFieldArrayPatchTargetSelected, true);
+  assert.equal(evidence.recommendation.verdict, "promote-useFieldArray-patch-target-before-dynamic-role");
+  assert.match(evidence.claimBoundary, /not live Codex\/Claude model outcome proof/);
+  assert.match(evidence.claimBoundary, /not token\/cost\/billing evidence/);
+
+  const markdown = renderReactWebFieldArrayTaskOutcomeMarkdown(evidence);
+  assert.match(markdown, /field-array task-outcome dogfood evidence/);
+  assert.match(markdown, /promote-useFieldArray-patch-target-before-dynamic-role/);
+  assert.match(markdown, /defaultBudget/);
+  assert.match(markdown, /wideBudget/);
+});
+
+test("field-array task outcome dogfood CLI writes JSON and markdown", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-field-array-task-outcome-"));
+  try {
+    const outputPath = path.join(tempDir, "evidence.json");
+    const markdownPath = path.join(tempDir, "evidence.md");
+    const result = spawnSync(process.execPath, [
+      path.join(repoRoot, "scripts", "react-web-field-array-task-outcome-evidence.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ], { cwd: repoRoot, encoding: "utf8" });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    const markdown = fs.readFileSync(markdownPath, "utf8");
+    assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION);
+    assert.match(markdown, /Budget readiness/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add deterministic field-array task-readiness dogfood evidence
- evaluate default vs wide consumer budget against a concrete field-array edit task
- record that `useFieldArray` patch-target visibility should be promoted before broader `dynamic-fields` role promotion

Closes #1163

## Key result
- default maxAnchors=8: insufficient, 0/4 required signals selected
- wide maxAnchors=20: partial, 1/4 required signals selected
- recommendation: promote `useFieldArray` patch-target visibility first

## Tests
- npm run build
- node scripts/react-web-field-array-task-outcome-evidence.mjs --run-id=smoke
- node --test test/react-web-field-array-task-outcome-evidence.test.mjs test/react-web-field-array-dogfood-evidence.test.mjs test/react-web-fact-graph-consumer.test.mjs
- npm run typecheck
- npm run lint -- --pretty false
- git diff --check
