### PR TITLE
Promote React Web useFieldArray patch-target priority

### DIFF
--- a/docs/dogfood/react-web-field-array-task-outcome-after-priority-1165.md
+++ b/docs/dogfood/react-web-field-array-task-outcome-after-priority-1165.md
@@ -1,0 +1,42 @@
+# React Web field-array task-outcome dogfood evidence
+
+Deterministic local task-readiness evidence only: evaluates whether selected consumer anchors expose signals required for a field-array edit task. It is not live Codex/Claude model outcome proof, not task accuracy proof, not runtime authorization, and not token/cost/billing evidence.
+
+## Task
+
+- Task id: field-array-add-contact-phone
+- Description: Add a phone field to each contact row while preserving useFieldArray fields.map rendering, register path shape, append/remove controls, and submit flow.
+- Fixture: `test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx`
+
+## Source signals
+
+- containsUseFieldArray: yes
+- containsFieldsMap: yes
+- containsRegisterPath: yes
+- containsAppend: yes
+- containsRemove: yes
+- containsHandleSubmit: yes
+
+## Required task signals
+
+- useFieldArray-anchor: useFieldArray patch target — The edit must recognize the component is a dynamic field-array form, not a static register-only form.
+- dynamic-fields-role: dynamic-fields form-state role — The edit should preserve array-row semantics such as fields.map, append, and remove.
+- field-registration-role: field-registration form-state role — The edit should preserve register path shape such as contacts.${index}.field.
+- submit-flow-role: submit-flow form-state role — The edit should avoid breaking handleSubmit/form submission while adding fields.
+
+## Budget readiness
+
+| Budget | maxAnchors | readiness | present required signals | missing |
+| --- | ---: | --- | ---: | --- |
+| defaultBudget | 8 | partial | 1/4 | dynamic-fields-role, field-registration-role, submit-flow-role |
+| wideBudget | 20 | partial | 1/4 | dynamic-fields-role, field-registration-role, submit-flow-role |
+
+## Recommendation
+
+- Verdict: consider-dynamic-fields-role-after-task-miss
+- Reason: The concrete useFieldArray patch target is already visible, but dynamic-fields role is still absent; only promote the role if live task outcome misses row-array semantics.
+- Next action: Keep current priority and gather live edit outcome evidence.
+
+## Boundary
+
+This artifact is deterministic task-readiness evidence. It does not claim live model edit success or provider token/cost savings.

--- a/docs/dogfood/react-web-use-field-array-priority-promotion-1165.md
+++ b/docs/dogfood/react-web-use-field-array-priority-promotion-1165.md
@@ -1,0 +1,55 @@
+# React Web field-array dogfood priority evidence
+
+Local diagnostic dogfood evidence only: checks whether React Web fact graph consumer dry-run exposes useFieldArray patch-target and dynamic-fields role coverage. It is not task-success evidence, not runtime authorization, not token/cost/billing proof, and not a claim that priority promotion improves model edits.
+
+## Fixture
+
+- Fixture: `test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx`
+- Contains useFieldArray: yes
+- Contains fields.map: yes
+- Contains append/remove: yes
+
+## Default consumer budget
+
+- maxAnchors: 8
+- selected/deferred: 8/67
+- useFieldArray patch-target selected: yes
+- dynamic-fields role selected: no
+- dynamic-fields role coverage: deferred; selected=0; deferred=1; reasons=budget-deferred
+
+## Wide inspection budget
+
+- maxAnchors: 20
+- selected/deferred: 20/55
+- useFieldArray patch-target selected: yes
+- dynamic-fields role selected: no
+- dynamic-fields role coverage: deferred; selected=0; deferred=1; reasons=budget-deferred
+
+## Priority decision
+
+- Verdict: defer-promotion-pending-task-outcome
+- Reason: useFieldArray patch-target evidence is selected, while dynamic-fields role remains budget-deferred even in the inspected wide budget; this is a measurement signal, not proof that priority promotion improves edits
+- Next action: run task-outcome dogfood before promoting dynamic-fields priority
+
+## Selected anchors sample
+
+- #1 patch-target:validation-anchor: useFieldArray (priority=110)
+- #2 targets: FieldArrayContactsForm targets FieldArrayContactsForm (priority=100)
+- #3 targets: FieldArrayContactsForm targets FieldArrayContactsForm (priority=100)
+- #4 patch-target:component: FieldArrayContactsForm (priority=100)
+- #5 targets: FieldArrayContactsForm targets useForm (priority=100)
+- #6 targets: FieldArrayContactsForm targets useForm (priority=100)
+- #7 patch-target:validation-anchor: useForm (priority=100)
+- #8 targets: FieldArrayContactsForm targets defaultValues (priority=100)
+
+## Deferred form-state role anchors under wide budget
+
+- #47 form-state-role:validation-defaults: defaultValues; reason=budget-deferred
+- #48 form-state-role:submit-flow: handleSubmit(() => undefined), form onSubmit=handleSubmit(() => undefined); reason=budget-deferred
+- #49 form-state-role:field-registration: register, form, input; reason=budget-deferred
+- #50 form-state-role:dynamic-fields: useFieldArray; reason=budget-deferred
+- #51 form-state-role:form-root: useForm; reason=budget-deferred
+
+## Boundary
+
+This artifact decides whether priority promotion is justified by consumer visibility evidence only. It does not prove model edit success.

--- a/src/core/react-web-fact-graph-consumer.ts
+++ b/src/core/react-web-fact-graph-consumer.ts
@@ -132,7 +132,8 @@ function confidenceScore(confidence: FactGraphConfidence): number {
   }
 }
 
-function priorityFor(kind: string, anchorType: ReactWebFactGraphAnchorType): number {
+function priorityFor(kind: string, anchorType: ReactWebFactGraphAnchorType, label = ""): number {
+  if (kind === "patch-target:validation-anchor" && label === "useFieldArray") return 110;
   if (kind.startsWith("patch-target") || kind === "targets") return 100;
   if (kind === "component" || kind === "file" || kind === "contains") return 90;
   if (kind.startsWith("edit-target-route")) return 85;
@@ -169,7 +170,7 @@ function nodeCandidate(node: FactNode, freshnessStatus: FactGraphFreshnessStatus
     kind: node.kind,
     label: node.label,
     confidence: node.confidence,
-    priority: priorityFor(node.kind, "node"),
+    priority: priorityFor(node.kind, "node", node.label),
     reason: nodeReason(node),
     sourceRefs: node.sourceRefs,
     freshnessStatus,
@@ -194,7 +195,7 @@ function edgeCandidate(edge: FactEdge, nodesById: Map<string, FactNode>, freshne
     kind: edge.kind,
     label: edgeLabel(edge, nodesById),
     confidence: edge.confidence,
-    priority: priorityFor(edge.kind, "edge"),
+    priority: priorityFor(edge.kind, "edge", edgeLabel(edge, nodesById)),
     reason: edgeReason(edge),
     sourceRefs: edge.sourceRefs,
     freshnessStatus,

--- a/test/react-web-field-array-dogfood-evidence.test.mjs
+++ b/test/react-web-field-array-dogfood-evidence.test.mjs
@@ -19,7 +19,7 @@ test("React Web field-array dogfood evidence records priority decision boundary"
   assert.equal(evidence.measurement, "react-web-field-array-consumer-priority-dogfood");
   assert.equal(evidence.source.containsUseFieldArray, true);
   assert.equal(evidence.source.containsFieldsMap, true);
-  assert.equal(evidence.defaultBudget.useFieldArrayPatchTargetSelected, false);
+  assert.equal(evidence.defaultBudget.useFieldArrayPatchTargetSelected, true);
   assert.equal(evidence.wideBudget.useFieldArrayPatchTargetSelected, true);
   assert.equal(evidence.defaultBudget.dynamicFieldsRoleSelected, false);
   assert.equal(evidence.defaultBudget.dynamicFieldsRoleCoverage.status, "deferred");
@@ -29,9 +29,8 @@ test("React Web field-array dogfood evidence records priority decision boundary"
 
   const markdown = renderReactWebFieldArrayDogfoodMarkdown(evidence);
   assert.match(markdown, /React Web field-array dogfood priority evidence/);
-  assert.match(markdown, /useFieldArray patch-target selected: no/);
-  assert.match(markdown, /Wide inspection budget/);
   assert.match(markdown, /useFieldArray patch-target selected: yes/);
+  assert.match(markdown, /Wide inspection budget/);
   assert.match(markdown, /dynamic-fields role selected: no/);
   assert.match(markdown, /defer-promotion-pending-task-outcome/);
 });

--- a/test/react-web-field-array-task-outcome-evidence.test.mjs
+++ b/test/react-web-field-array-task-outcome-evidence.test.mjs
@@ -12,7 +12,7 @@ import {
 
 const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
 
-test("field-array task outcome dogfood recommends concrete patch-target promotion first", async () => {
+test("field-array task outcome dogfood records useFieldArray patch-target promotion", async () => {
   const evidence = await buildReactWebFieldArrayTaskOutcomeEvidence({ repoRoot, runId: "test" });
 
   assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_TASK_OUTCOME_SCHEMA_VERSION);
@@ -20,17 +20,18 @@ test("field-array task outcome dogfood recommends concrete patch-target promotio
   assert.equal(evidence.sourceSignals.containsUseFieldArray, true);
   assert.equal(evidence.sourceSignals.containsFieldsMap, true);
   assert.equal(evidence.sourceSignals.containsRegisterPath, true);
-  assert.equal(evidence.evaluations.defaultBudget.readiness, "insufficient");
+  assert.equal(evidence.evaluations.defaultBudget.readiness, "partial");
+  assert.equal(evidence.evaluations.defaultBudget.presentCount, 1);
   assert.equal(evidence.evaluations.wideBudget.readiness, "partial");
-  assert.equal(evidence.priorityEvidenceSummary.defaultUseFieldArrayPatchTargetSelected, false);
+  assert.equal(evidence.priorityEvidenceSummary.defaultUseFieldArrayPatchTargetSelected, true);
   assert.equal(evidence.priorityEvidenceSummary.wideUseFieldArrayPatchTargetSelected, true);
-  assert.equal(evidence.recommendation.verdict, "promote-useFieldArray-patch-target-before-dynamic-role");
+  assert.equal(evidence.recommendation.verdict, "consider-dynamic-fields-role-after-task-miss");
   assert.match(evidence.claimBoundary, /not live Codex\/Claude model outcome proof/);
   assert.match(evidence.claimBoundary, /not token\/cost\/billing evidence/);
 
   const markdown = renderReactWebFieldArrayTaskOutcomeMarkdown(evidence);
   assert.match(markdown, /field-array task-outcome dogfood evidence/);
-  assert.match(markdown, /promote-useFieldArray-patch-target-before-dynamic-role/);
+  assert.match(markdown, /consider-dynamic-fields-role-after-task-miss/);
   assert.match(markdown, /defaultBudget/);
   assert.match(markdown, /wideBudget/);
 });


### PR DESCRIPTION
## Summary
- raise `useFieldArray` validation-anchor priority in the React Web fact graph consumer
- keep the change narrow to the concrete patch target, not the broader `dynamic-fields` role
- refresh dogfood evidence showing default budget now selects `useFieldArray` and task readiness moves to partial

Closes #1165

## Key result
- before: default budget missed `useFieldArray` patch-target, readiness 0/4
- after: default budget selects `useFieldArray` at rank #1, readiness 1/4
- next: only consider `dynamic-fields` role promotion after live task-outcome misses row-array semantics

## Tests
- npm run build
- node scripts/react-web-field-array-dogfood-evidence.mjs --run-id=post-priority-2026-06-03
- node scripts/react-web-field-array-task-outcome-evidence.mjs --run-id=post-priority-task-2026-06-03
- node --test test/react-web-field-array-task-outcome-evidence.test.mjs test/react-web-field-array-dogfood-evidence.test.mjs test/react-web-fact-graph-consumer.test.mjs
- npm run typecheck
- npm run lint -- --pretty false
- git diff --check
