### PR TITLE
Add React Web field-array actual edit dogfood outcome

### DIFF
--- a/docs/dogfood/react-web-field-array-actual-edit-1167.md
+++ b/docs/dogfood/react-web-field-array-actual-edit-1167.md
@@ -1,0 +1,44 @@
+# React Web field-array actual edit dogfood
+
+Local actual-edit dogfood evidence only: applies a deterministic source edit to a copied fixture and validates field-array invariants. It is not live Codex/Claude model outcome proof, not provider-token/cost/billing evidence, and not runtime authorization.
+
+## Task
+
+- Task id: field-array-add-contact-phone-actual-edit
+- Fixture: `test/fixtures/react-web-context-expansion/field-array-contacts-form.tsx`
+- Verdict: actual-edit-passed-with-useFieldArray-visible
+- Next action: Do not promote dynamic-fields role yet; gather live model edit misses before adding broader role priority.
+
+## Pre-edit consumer
+
+- maxAnchors: 8
+- selected anchors: 8
+- useFieldArray selected rank: 1
+- useFieldArray selected priority: 110
+
+## Actual edit
+
+- Applied: yes
+- Before bytes: 1174
+- After bytes: 1370
+- Changed bytes: 196
+
+## Validation
+
+- Passed: yes
+- Failed: none
+
+- keeps-useFieldArray: pass
+- keeps-fields-map: pass
+- keeps-remove: pass
+- keeps-handleSubmit: pass
+- adds-contact-phone-type: pass
+- adds-default-phone: pass
+- adds-phone-register-path: pass
+- keeps-email-register-path: pass
+- adds-phone-label: pass
+- append-adds-phone: pass
+
+## Boundary
+
+This is local actual-edit dogfood on a copied fixture. It validates source invariants but does not prove live model task quality or provider token/cost savings.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "evidence:react-web-release-report": "npm run build && node scripts/react-web-release-report-surface.mjs",
     "evidence:react-web-live-hook-dogfood": "npm run build && node scripts/react-web-live-hook-dogfood-evidence.mjs",
     "evidence:react-web-field-array-dogfood": "npm run build && node scripts/react-web-field-array-dogfood-evidence.mjs",
-    "evidence:react-web-field-array-task-outcome": "npm run build && node scripts/react-web-field-array-task-outcome-evidence.mjs"
+    "evidence:react-web-field-array-task-outcome": "npm run build && node scripts/react-web-field-array-task-outcome-evidence.mjs",
+    "evidence:react-web-field-array-actual-edit": "npm run build && node scripts/react-web-field-array-actual-edit-dogfood.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2"

--- a/scripts/react-web-field-array-actual-edit-dogfood.mjs
+++ b/scripts/react-web-field-array-actual-edit-dogfood.mjs
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFAULT_FIELD_ARRAY_FIXTURE } from "./react-web-field-array-dogfood-evidence.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, "..");
+
+export const REACT_WEB_FIELD_ARRAY_ACTUAL_EDIT_SCHEMA_VERSION = "react-web-field-array-actual-edit-dogfood.v1";
+
+async function loadBuiltIndex(repoRoot) {
+  return import(path.join(repoRoot, "dist", "index.js"));
+}
+
+function selectedUseFieldArrayAnchor(dryRun) {
+  return dryRun.selectedAnchors.find(
+    (anchor) => anchor.kind === "patch-target:validation-anchor" && anchor.label === "useFieldArray",
+  ) ?? null;
+}
+
+function applyPhoneFieldEdit(source) {
+  let edited = source;
+  edited = edited.replace("type Contact = { email: string };", "type Contact = { email: string; phone: string };");
+  edited = edited.replace('defaultValues: { contacts: [{ email: "" }] },', 'defaultValues: { contacts: [{ email: "", phone: "" }] },');
+  edited = edited.replace(
+    '<input id={`contacts-${index}-email`} {...register(`contacts.${index}.email`)} />',
+    '<input id={`contacts-${index}-email`} {...register(`contacts.${index}.email`)} />\n          <label htmlFor={`contacts-${index}-phone`}>Phone</label>\n          <input id={`contacts-${index}-phone`} {...register(`contacts.${index}.phone`)} />',
+  );
+  edited = edited.replace('append({ email: "" })', 'append({ email: "", phone: "" })');
+  if (edited === source) throw new Error("field-array edit did not change source");
+  return edited;
+}
+
+function validateEditedSource(source) {
+  const checks = [
+    { id: "keeps-useFieldArray", pass: /\buseFieldArray\b/.test(source) },
+    { id: "keeps-fields-map", pass: /\bfields\.map\s*\(/.test(source) },
+    { id: "keeps-remove", pass: /\bremove\s*\(index\)/.test(source) },
+    { id: "keeps-handleSubmit", pass: /\bhandleSubmit\s*\(/.test(source) },
+    { id: "adds-contact-phone-type", pass: /type Contact = \{ email: string; phone: string \};/.test(source) },
+    { id: "adds-default-phone", pass: /contacts: \[\{ email: "", phone: "" \}\]/.test(source) },
+    { id: "adds-phone-register-path", pass: /register\(`contacts\.\$\{index\}\.phone`\)/.test(source) },
+    { id: "keeps-email-register-path", pass: /register\(`contacts\.\$\{index\}\.email`\)/.test(source) },
+    { id: "adds-phone-label", pass: /contacts-\$\{index\}-phone/.test(source) && />Phone<\//.test(source) },
+    { id: "append-adds-phone", pass: /append\(\{ email: "", phone: "" \}\)/.test(source) },
+  ];
+  return {
+    checks,
+    passed: checks.every((check) => check.pass),
+    failed: checks.filter((check) => !check.pass).map((check) => check.id),
+  };
+}
+
+function byteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+export async function buildReactWebFieldArrayActualEditDogfood({
+  repoRoot = defaultRepoRoot,
+  fixture = DEFAULT_FIELD_ARRAY_FIXTURE,
+  runId = new Date().toISOString().replace(/[:.]/g, "-"),
+} = {}) {
+  const { buildReactWebFactGraphConsumerDryRun } = await loadBuiltIndex(repoRoot);
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-field-array-actual-edit-"));
+  const tempFixture = path.join(tempRoot, fixture);
+  const sourceFixture = path.join(repoRoot, fixture);
+  try {
+    fs.mkdirSync(path.dirname(tempFixture), { recursive: true });
+    fs.copyFileSync(sourceFixture, tempFixture);
+    const beforeSource = fs.readFileSync(tempFixture, "utf8");
+    const beforeDryRun = buildReactWebFactGraphConsumerDryRun(tempFixture, tempRoot);
+    const selectedUseFieldArray = selectedUseFieldArrayAnchor(beforeDryRun);
+
+    const editedSource = applyPhoneFieldEdit(beforeSource);
+    fs.writeFileSync(tempFixture, editedSource);
+    const validation = validateEditedSource(editedSource);
+    const afterDryRun = buildReactWebFactGraphConsumerDryRun(tempFixture, tempRoot);
+
+    return {
+      schemaVersion: REACT_WEB_FIELD_ARRAY_ACTUAL_EDIT_SCHEMA_VERSION,
+      generatedAt: new Date().toISOString(),
+      runId,
+      measurement: "react-web-field-array-actual-edit-dogfood",
+      fixture,
+      task: {
+        id: "field-array-add-contact-phone-actual-edit",
+        description: "Actually edit a copied field-array fixture to add a phone field while preserving array row semantics.",
+      },
+      claimBoundary:
+        "Local actual-edit dogfood evidence only: applies a deterministic source edit to a copied fixture and validates field-array invariants. It is not live Codex/Claude model outcome proof, not provider-token/cost/billing evidence, and not runtime authorization.",
+      preEditConsumer: {
+        maxAnchors: beforeDryRun.selectionPolicy.maxAnchors,
+        selectedAnchorCount: beforeDryRun.selectedAnchors.length,
+        selectedUseFieldArrayAnchor: selectedUseFieldArray,
+        selectedUseFieldArrayRank: selectedUseFieldArray?.rank ?? null,
+        selectedUseFieldArrayPriority: selectedUseFieldArray?.priority ?? null,
+      },
+      edit: {
+        beforeBytes: byteLength(beforeSource),
+        afterBytes: byteLength(editedSource),
+        changedBytes: byteLength(editedSource) - byteLength(beforeSource),
+        applied: editedSource !== beforeSource,
+      },
+      validation,
+      postEditConsumer: {
+        maxAnchors: afterDryRun.selectionPolicy.maxAnchors,
+        selectedAnchorCount: afterDryRun.selectedAnchors.length,
+        selectedUseFieldArrayAnchor: selectedUseFieldArrayAnchor(afterDryRun),
+      },
+      verdict: validation.passed && Boolean(selectedUseFieldArray)
+        ? "actual-edit-passed-with-useFieldArray-visible"
+        : "actual-edit-needs-review",
+      nextAction: validation.passed && Boolean(selectedUseFieldArray)
+        ? "Do not promote dynamic-fields role yet; gather live model edit misses before adding broader role priority."
+        : "Inspect failed validation or missing useFieldArray visibility before changing priorities.",
+    };
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export function renderReactWebFieldArrayActualEditDogfoodMarkdown(evidence) {
+  const checks = evidence.validation.checks
+    .map((check) => `- ${check.id}: ${check.pass ? "pass" : "fail"}`)
+    .join("\n");
+
+  return `# React Web field-array actual edit dogfood\n\n${evidence.claimBoundary}\n\n## Task\n\n- Task id: ${evidence.task.id}\n- Fixture: \`${evidence.fixture}\`\n- Verdict: ${evidence.verdict}\n- Next action: ${evidence.nextAction}\n\n## Pre-edit consumer\n\n- maxAnchors: ${evidence.preEditConsumer.maxAnchors}\n- selected anchors: ${evidence.preEditConsumer.selectedAnchorCount}\n- useFieldArray selected rank: ${evidence.preEditConsumer.selectedUseFieldArrayRank ?? "missing"}\n- useFieldArray selected priority: ${evidence.preEditConsumer.selectedUseFieldArrayPriority ?? "missing"}\n\n## Actual edit\n\n- Applied: ${evidence.edit.applied ? "yes" : "no"}\n- Before bytes: ${evidence.edit.beforeBytes}\n- After bytes: ${evidence.edit.afterBytes}\n- Changed bytes: ${evidence.edit.changedBytes}\n\n## Validation\n\n- Passed: ${evidence.validation.passed ? "yes" : "no"}\n- Failed: ${evidence.validation.failed.length > 0 ? evidence.validation.failed.join(", ") : "none"}\n\n${checks}\n\n## Boundary\n\nThis is local actual-edit dogfood on a copied fixture. It validates source invariants but does not prove live model task quality or provider token/cost savings.\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const runId = process.argv.find((arg) => arg.startsWith("--run-id="))?.slice("--run-id=".length) ?? "local";
+  const outputArg = process.argv.find((arg) => arg.startsWith("--output="))?.slice("--output=".length);
+  const markdownArg = process.argv.find((arg) => arg.startsWith("--markdown-output="))?.slice("--markdown-output=".length);
+  const fixtureArg = process.argv.find((arg) => arg.startsWith("--fixture="))?.slice("--fixture=".length);
+  const evidence = await buildReactWebFieldArrayActualEditDogfood({ repoRoot: defaultRepoRoot, runId, fixture: fixtureArg ?? DEFAULT_FIELD_ARRAY_FIXTURE });
+
+  if (outputArg) {
+    const outputPath = path.resolve(defaultRepoRoot, outputArg);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  if (markdownArg) {
+    const markdownPath = path.resolve(defaultRepoRoot, markdownArg);
+    fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+    fs.writeFileSync(markdownPath, renderReactWebFieldArrayActualEditDogfoodMarkdown(evidence));
+  }
+  if (!outputArg && !markdownArg) {
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  }
+}

--- a/test/react-web-field-array-actual-edit-dogfood.test.mjs
+++ b/test/react-web-field-array-actual-edit-dogfood.test.mjs
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REACT_WEB_FIELD_ARRAY_ACTUAL_EDIT_SCHEMA_VERSION,
+  buildReactWebFieldArrayActualEditDogfood,
+  renderReactWebFieldArrayActualEditDogfoodMarkdown,
+} from "../scripts/react-web-field-array-actual-edit-dogfood.mjs";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+test("field-array actual edit dogfood passes with useFieldArray visible", async () => {
+  const evidence = await buildReactWebFieldArrayActualEditDogfood({ repoRoot, runId: "test" });
+
+  assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_ACTUAL_EDIT_SCHEMA_VERSION);
+  assert.equal(evidence.measurement, "react-web-field-array-actual-edit-dogfood");
+  assert.equal(evidence.preEditConsumer.selectedUseFieldArrayRank, 1);
+  assert.equal(evidence.preEditConsumer.selectedUseFieldArrayPriority, 110);
+  assert.equal(evidence.edit.applied, true);
+  assert.equal(evidence.validation.passed, true);
+  assert.deepEqual(evidence.validation.failed, []);
+  assert.equal(evidence.verdict, "actual-edit-passed-with-useFieldArray-visible");
+  assert.match(evidence.claimBoundary, /not live Codex\/Claude model outcome proof/);
+  assert.match(evidence.claimBoundary, /not provider-token\/cost\/billing evidence/);
+
+  const markdown = renderReactWebFieldArrayActualEditDogfoodMarkdown(evidence);
+  assert.match(markdown, /actual edit dogfood/);
+  assert.match(markdown, /useFieldArray selected rank: 1/);
+  assert.match(markdown, /adds-phone-register-path: pass/);
+});
+
+test("field-array actual edit dogfood CLI writes JSON and markdown", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooks-field-array-actual-edit-cli-"));
+  try {
+    const outputPath = path.join(tempDir, "evidence.json");
+    const markdownPath = path.join(tempDir, "evidence.md");
+    const result = spawnSync(process.execPath, [
+      path.join(repoRoot, "scripts", "react-web-field-array-actual-edit-dogfood.mjs"),
+      "--run-id=cli-test",
+      `--output=${outputPath}`,
+      `--markdown-output=${markdownPath}`,
+    ], { cwd: repoRoot, encoding: "utf8" });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const evidence = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    const markdown = fs.readFileSync(markdownPath, "utf8");
+    assert.equal(evidence.schemaVersion, REACT_WEB_FIELD_ARRAY_ACTUAL_EDIT_SCHEMA_VERSION);
+    assert.match(markdown, /Validation/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add actual local edit dogfood for the field-array phone-field task
- validate that the copied fixture preserves useFieldArray, fields.map, register paths, append/remove, and handleSubmit after edit
- record that dynamic-fields role promotion should wait for live model misses

Closes #1167

## Key result
- useFieldArray selected rank: 1
- useFieldArray priority: 110
- actual copied-fixture edit: passed
- validation: all field-array invariants pass

## Tests
- npm run build
- node scripts/react-web-field-array-actual-edit-dogfood.mjs --run-id=smoke
- node --test test/react-web-field-array-actual-edit-dogfood.test.mjs test/react-web-field-array-task-outcome-evidence.test.mjs test/react-web-field-array-dogfood-evidence.test.mjs test/react-web-fact-graph-consumer.test.mjs
- npm run typecheck
- npm run lint -- --pretty false
- git diff --check
