### PR TITLE
Prevent merged checkout residue from authorizing work

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -48,7 +48,7 @@ export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_ISSUE_URL = "https://gi
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_SOURCE = "operator/activity issue #1073 remote-counts-required next-action cue";
 export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE = "local git branch --merged origin/main current-checkout residue evidence";
 export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY =
-  "Read-only local git evidence only: a clean zero-divergence current checkout branch already merged into local origin/main is stale residue and not current active development; dirty or local-ahead state remains active or review-worthy.";
+  "Read-only local git evidence only: a clean current checkout branch already merged into local origin/main is stale residue and not current active development; dirty state remains active or review-worthy.";
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_CLAIM_BOUNDARY =
   "Operator-visible status/activity next-action cue only; remote counts remain explicit opt-in, the operator-check JSON boundary remains the source of truth after include-remote-counts, and this cue adds no active-development evidence, authority, telemetry, merge gate, approval, product, or frontend behavior.";
 export const OPERATOR_ACTIVITY_TMUX_CAPTURE_COMMAND = "tmux capture-pane -pt <pane_id> -S -200";
@@ -1559,14 +1559,14 @@ function readMergedBranchResidueEvidence(
       blockers: [],
     };
   }
-  const cleanZeroDivergence = worktree.clean === true && worktree.ahead === 0 && worktree.behind === 0;
-  if (!cleanZeroDivergence) {
+  const cleanMergedResidueCandidate = worktree.clean === true;
+  if (!cleanMergedResidueCandidate) {
     return {
       ...base,
       available: true,
       mergedIntoOriginMain: false,
       suppressesCurrentBranchActiveEvidence: false,
-      reason: "current branch is not clean with zero local divergence; preserve as active or review-worthy evidence",
+      reason: "current branch is not clean; preserve as active or review-worthy evidence",
       blockers: [],
     };
   }
@@ -1581,8 +1581,8 @@ function readMergedBranchResidueEvidence(
       mergedIntoOriginMain,
       suppressesCurrentBranchActiveEvidence: mergedIntoOriginMain,
       reason: mergedIntoOriginMain
-        ? "current clean zero-divergence branch is already merged into local origin/main; treat as stale merged-branch residue, not active development"
-        : "current clean zero-divergence branch is not listed as merged into local origin/main",
+        ? "current clean branch is already merged into local origin/main; treat as stale merged-branch residue, not active development"
+        : "current clean branch is not listed as merged into local origin/main",
       blockers: [],
     };
   } catch (error) {
@@ -1657,10 +1657,10 @@ function buildCurrentRunEvidence(
   }
 
   if (suppressCurrentBranchActiveEvidence) {
-    reasons.push("current branch is clean zero-divergence merged residue and is separated from active current-run evidence");
+    reasons.push("current branch is clean merged residue and is separated from active current-run evidence");
   }
 
-  const mainEchoEvidence = blockers.length === 0 && (onMain || suppressCurrentBranchActiveEvidence) && clean && noLocalDivergence && noSessions && remoteCountsIdle;
+  const mainEchoEvidence = blockers.length === 0 && (onMain || suppressCurrentBranchActiveEvidence) && clean && (noLocalDivergence || suppressCurrentBranchActiveEvidence) && noSessions && remoteCountsIdle;
   const activeWorkEvidence =
     (Boolean(worktree.branch) && worktree.branch !== "main" && !suppressCurrentBranchActiveEvidence && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||

--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -46,6 +46,9 @@ export const OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_CLAIM_BOUNDARY =
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_ISSUE = "#1073";
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_ISSUE_URL = "https://github.com/minislively/fooks/issues/1073";
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_SOURCE = "operator/activity issue #1073 remote-counts-required next-action cue";
+export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE = "local git branch --merged origin/main current-checkout residue evidence";
+export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY =
+  "Read-only local git evidence only: a clean zero-divergence current checkout branch already merged into local origin/main is stale residue and not current active development; dirty or local-ahead state remains active or review-worthy.";
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_CLAIM_BOUNDARY =
   "Operator-visible status/activity next-action cue only; remote counts remain explicit opt-in, the operator-check JSON boundary remains the source of truth after include-remote-counts, and this cue adds no active-development evidence, authority, telemetry, merge gate, approval, product, or frontend behavior.";
 export const OPERATOR_ACTIVITY_TMUX_CAPTURE_COMMAND = "tmux capture-pane -pt <pane_id> -S -200";
@@ -175,6 +178,18 @@ export type OperatorActivityRemoteCounts =
 
 export type OperatorActivityCurrentRunClassification = "mainEchoNonActive" | "activeOrUnknown";
 
+export type OperatorActivityMergedBranchResidueEvidence = {
+  source: typeof OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE;
+  claimBoundary: typeof OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY;
+  readOnly: true;
+  available: boolean;
+  branch?: string;
+  mergedIntoOriginMain: boolean;
+  suppressesCurrentBranchActiveEvidence: boolean;
+  reason: string;
+  blockers: string[];
+};
+
 export type OperatorActivityCurrentRunReceipt = {
   status: "active" | "idle";
   active: boolean;
@@ -210,6 +225,7 @@ export type OperatorActivityCurrentRunEvidence = {
   classification: OperatorActivityCurrentRunClassification;
   mainEchoEvidence: boolean;
   activeWorkEvidence: boolean;
+  mergedBranchResidueEvidence: OperatorActivityMergedBranchResidueEvidence;
   remoteCountsRequired: true;
   evidence: {
     branch?: string;
@@ -718,6 +734,7 @@ function plural(count: number, singular: string, pluralValue = `${singular}s`): 
 
 function buildCurrentRunReceipt(input: {
   worktree: OperatorActivityWorktree;
+  suppressCurrentBranchActiveEvidence: boolean;
   fooksSessionCount: number;
   openIssues?: number;
   openPullRequests?: number;
@@ -738,7 +755,7 @@ function buildCurrentRunReceipt(input: {
     evidenceKinds.push("pullRequest");
     activeParts.push(plural(input.openPullRequests, "open PR"));
   }
-  if (input.worktree.branch && input.worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(input.worktree)) {
+  if (input.worktree.branch && input.worktree.branch !== "main" && !input.suppressCurrentBranchActiveEvidence && !hasOnlyFooksSessionTaskDelta(input.worktree)) {
     evidenceKinds.push("branch");
     activeParts.push(`branch ${reportToken(input.worktree.branch) ?? "non-main"}`);
   }
@@ -1519,11 +1536,74 @@ function readPostMergeMainCiEvidence(cwd: string, options: OperatorActivityOptio
   };
 }
 
+
+function readMergedBranchResidueEvidence(
+  cwd: string,
+  worktree: OperatorActivityWorktree,
+  options: OperatorActivityOptions,
+): OperatorActivityMergedBranchResidueEvidence {
+  const branch = worktree.branch;
+  const base: Pick<OperatorActivityMergedBranchResidueEvidence, "source" | "claimBoundary" | "readOnly" | "branch"> = {
+    source: OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE,
+    claimBoundary: OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY,
+    readOnly: true,
+    branch,
+  };
+  if (!branch || branch === "main") {
+    return {
+      ...base,
+      available: true,
+      mergedIntoOriginMain: false,
+      suppressesCurrentBranchActiveEvidence: false,
+      reason: branch === "main" ? "current branch is main" : "current branch is unknown",
+      blockers: [],
+    };
+  }
+  const cleanZeroDivergence = worktree.clean === true && worktree.ahead === 0 && worktree.behind === 0;
+  if (!cleanZeroDivergence) {
+    return {
+      ...base,
+      available: true,
+      mergedIntoOriginMain: false,
+      suppressesCurrentBranchActiveEvidence: false,
+      reason: "current branch is not clean with zero local divergence; preserve as active or review-worthy evidence",
+      blockers: [],
+    };
+  }
+  const runner = options.commandRunner ?? defaultOperatorActivityCommandRunner;
+  try {
+    const output = runner("git", ["branch", "--merged", "origin/main"], cwd, DEFAULT_OPERATOR_ACTIVITY_TIMEOUT_MS);
+    const mergedBranches = new Set(output.split(/\r?\n/u).map((line) => line.replace(/^\*\s*/u, "").trim()).filter(Boolean));
+    const mergedIntoOriginMain = mergedBranches.has(branch);
+    return {
+      ...base,
+      available: true,
+      mergedIntoOriginMain,
+      suppressesCurrentBranchActiveEvidence: mergedIntoOriginMain,
+      reason: mergedIntoOriginMain
+        ? "current clean zero-divergence branch is already merged into local origin/main; treat as stale merged-branch residue, not active development"
+        : "current clean zero-divergence branch is not listed as merged into local origin/main",
+      blockers: [],
+    };
+  } catch (error) {
+    return {
+      ...base,
+      available: false,
+      mergedIntoOriginMain: false,
+      suppressesCurrentBranchActiveEvidence: false,
+      reason: "merged-branch residue evidence unavailable; preserve existing conservative branch evidence",
+      blockers: [`git merged-branch residue evidence unavailable: ${errorDetail(error)}`],
+    };
+  }
+}
+
 function buildCurrentRunEvidence(
+  cwd: string,
   worktree: OperatorActivityWorktree,
   tmux: OperatorActivityTmux,
   optionalCounts: OperatorActivityRemoteCounts,
   legacyWorktreeEvidence: OperatorActivityLegacyWorktreeEvidence,
+  options: OperatorActivityOptions,
 ): OperatorActivityCurrentRunEvidence {
   const blockers: string[] = [];
   const reasons: string[] = [];
@@ -1543,6 +1623,8 @@ function buildCurrentRunEvidence(
   const advisoryPlanningEpicPlusSingleChild = hasPlanningEpicPlusSingleChildOpenIssue(optionalCounts);
   const advisoryIssueInventory = advisoryPlanningEpicOnly || advisoryPlanningEpicPlusSingleChild;
   const remoteCountsIdle = zeroRemoteCounts || advisoryIssueInventory;
+  const mergedBranchResidueEvidence = readMergedBranchResidueEvidence(cwd, worktree, options);
+  const suppressCurrentBranchActiveEvidence = mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence;
 
   if (!optionalCounts.enabled) {
     blockers.push("remote issue/PR counts disabled; pass --include-remote-counts to prove zero open issue/PR reminder evidence");
@@ -1574,14 +1656,19 @@ function buildCurrentRunEvidence(
     reasons.push("legacy closed-artifact worktree evidence is separated from active current-run evidence");
   }
 
-  const mainEchoEvidence = blockers.length === 0 && onMain && clean && noLocalDivergence && noSessions && remoteCountsIdle;
+  if (suppressCurrentBranchActiveEvidence) {
+    reasons.push("current branch is clean zero-divergence merged residue and is separated from active current-run evidence");
+  }
+
+  const mainEchoEvidence = blockers.length === 0 && (onMain || suppressCurrentBranchActiveEvidence) && clean && noLocalDivergence && noSessions && remoteCountsIdle;
   const activeWorkEvidence =
-    (Boolean(worktree.branch) && worktree.branch !== "main" && !hasOnlyFooksSessionTaskDelta(worktree)) ||
+    (Boolean(worktree.branch) && worktree.branch !== "main" && !suppressCurrentBranchActiveEvidence && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     fooksSessionCount > 0 ||
     (optionalCounts.enabled && (((openIssues ?? 0) > 0 && !advisoryIssueInventory) || (openPullRequests ?? 0) > 0));
   const receipt = buildCurrentRunReceipt({
     worktree,
+    suppressCurrentBranchActiveEvidence,
     fooksSessionCount,
     openIssues,
     openPullRequests,
@@ -1597,6 +1684,7 @@ function buildCurrentRunEvidence(
     classification: mainEchoEvidence ? "mainEchoNonActive" : "activeOrUnknown",
     mainEchoEvidence,
     activeWorkEvidence,
+    mergedBranchResidueEvidence,
     remoteCountsRequired: true,
     evidence: {
       branch: worktree.branch,
@@ -1667,7 +1755,7 @@ export function readOperatorActivitySnapshot(cwd = process.cwd(), options: Opera
   const optionalCounts = timeDiagnosticPhase(timingPhases, "read-remote-counts", () => readRemoteCounts(cwd, options));
   const legacyWorktreeEvidence = timeDiagnosticPhase(timingPhases, "read-legacy-worktree-evidence", () => readLegacyWorktreeEvidence(cwd, options, generatedAt));
   const stagedOmxPromptEvidence = timeDiagnosticPhase(timingPhases, "build-staged-omx-prompt-evidence", () => buildStagedOmxPromptEvidence(worktree, tmux));
-  const currentRunEvidence = timeDiagnosticPhase(timingPhases, "build-current-run-evidence", () => buildCurrentRunEvidence(worktree, tmux, optionalCounts, legacyWorktreeEvidence));
+  const currentRunEvidence = timeDiagnosticPhase(timingPhases, "build-current-run-evidence", () => buildCurrentRunEvidence(cwd, worktree, tmux, optionalCounts, legacyWorktreeEvidence, options));
   const postMergeMainCiEvidence = timeDiagnosticPhase(timingPhases, "read-post-merge-main-ci-evidence", () => readPostMergeMainCiEvidence(cwd, options));
   const operatorStatusCues = timeDiagnosticPhase(timingPhases, "build-operator-status-cues", () => ({
     remoteCountsRequiredNextAction: buildRemoteCountsRequiredNextActionCue(currentRunEvidence, optionalCounts),

--- a/src/ops/operator-check.ts
+++ b/src/ops/operator-check.ts
@@ -2233,7 +2233,8 @@ function buildCleanIdleNudgeHandoffBoundary(
   const openIssueCount = activity.currentRunEvidence.evidence.openIssues;
   const openPullRequestCount = activity.currentRunEvidence.evidence.openPullRequests;
   const mappedFooksTmuxSessionCount = activity.currentRunEvidence.evidence.fooksSessionCount;
-  const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main")
+  const currentBranchSuppressesActiveEvidence = activity.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence;
+  const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main" && !currentBranchSuppressesActiveEvidence)
     || receipts.some((receipt) => receipt.kind === "worktree" && receipt.classification === "active");
   const explicitHandoffArtifactPresent = Boolean(
     (typeof openIssueCount === "number" && openIssueCount > 0)
@@ -2301,7 +2302,8 @@ function buildHandoffArtifactEvidence(
   const liveMappedFooksTmuxSessionCount = activity.tmux.sessions.filter((session) =>
     session.status !== "staleRuntimeCandidate" && session.status !== "stagedPromptOnly" && session.status !== "ancestorMaintenance"
   ).length;
-  const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main");
+  const currentBranchSuppressesActiveEvidence = activity.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence;
+  const liveNonMainWorktreePresent = Boolean(activity.worktree.branch && activity.worktree.branch !== "main" && !currentBranchSuppressesActiveEvidence);
   const activeReceiptCount = receipts.filter((receipt) => receipt.classification === "active").length;
   const adoptedLiveArtifactPresent = Boolean(
     (typeof openIssueCount === "number" && openIssueCount > 0)

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -2169,6 +2169,79 @@ test("operator activity treats clean current merged PR checkout branch residue a
   assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|gh issue create|gh pr create/.test(call)), false);
 });
 
+test("operator activity treats clean merged checkout branch without upstream as non-active residue", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-06-03T08:01:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") throw new Error("no upstream configured");
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "git" && joined === "branch --merged origin/main") return "main\npr-1133\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.worktree.upstream, undefined);
+  assert.equal(snapshot.worktree.ahead, undefined);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.available, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.mergedIntoOriginMain, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.classification, "mainEchoNonActive");
+  assert.equal(snapshot.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, false);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt.evidenceKinds, []);
+});
+
+test("operator activity preserves dirty merged checkout branch as active residue review", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-06-03T08:02:00.000Z",
+    runner: () => " M src/index.ts\0",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") throw new Error("no upstream configured");
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return " M src/index.ts\0";
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, false);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.reason, "current branch is not clean; preserve as active or review-worthy evidence");
+  assert.equal(snapshot.currentRunEvidence.classification, "activeOrUnknown");
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, true);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt.evidenceKinds, ["branch", "delta"]);
+});
+
 test("operator check does not authorize clean current merged PR checkout residue as live handoff artifact", () => {
   const tempDir = makeTempProject();
   const calls = [];

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -20,6 +20,8 @@ const {
   OPERATOR_ACTIVITY_CURRENT_RUN_SOURCE,
   OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_CLAIM_BOUNDARY,
   OPERATOR_ACTIVITY_POST_MERGE_MAIN_CI_SOURCE,
+  OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY,
+  OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE,
   OPERATOR_ACTIVITY_REMOTE_COUNTS_FLAG,
   OPERATOR_ACTIVITY_REMOTE_SOURCE,
   OPERATOR_ACTIVITY_STAGED_OMX_PROMPT_SOURCE,
@@ -862,6 +864,17 @@ test("idle activity snapshot remains zero and read-only with opt-in remote count
     classification: "activeOrUnknown",
     mainEchoEvidence: false,
     activeWorkEvidence: true,
+    mergedBranchResidueEvidence: {
+      source: OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE,
+      claimBoundary: OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY,
+      readOnly: true,
+      available: false,
+      branch: "dogfood/issue-428-idle-activity-snapshot",
+      mergedIntoOriginMain: false,
+      suppressesCurrentBranchActiveEvidence: false,
+      reason: "merged-branch residue evidence unavailable; preserve existing conservative branch evidence",
+      blockers: ["git merged-branch residue evidence unavailable: unexpected command git branch --merged origin/main"],
+    },
     remoteCountsRequired: true,
     evidence: {
       branch: "dogfood/issue-428-idle-activity-snapshot",
@@ -2104,6 +2117,107 @@ test("CLI check and status activity treat absent tmux server as zero mapped sess
     readOnly: true,
     claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
   });
+});
+
+
+test("operator activity treats clean current merged PR checkout branch residue as non-active", () => {
+  const tempDir = makeTempProject();
+  const calls = [];
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-06-03T08:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      calls.push([command, ...args].join(" "));
+      const joined = args.join(" ");
+      if (command === "git" && joined === "branch --merged origin/main") return "main\npr-1133\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.available, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.mergedIntoOriginMain, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.classification, "mainEchoNonActive");
+  assert.equal(snapshot.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, false);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt, {
+    status: "idle",
+    active: false,
+    oneLine: "Current fooks run is idle/non-active: branch pr-1133, zero divergence, no mapped fooks sessions, zero open issues/PRs.",
+    evidenceKinds: [],
+    advisoryOnly: true,
+    readOnly: true,
+    claimBoundary: OPERATOR_ACTIVITY_CURRENT_RUN_CLAIM_BOUNDARY,
+  });
+  assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|gh issue create|gh pr create/.test(call)), false);
+});
+
+test("operator check does not authorize clean current merged PR checkout residue as live handoff artifact", () => {
+  const tempDir = makeTempProject();
+  const calls = [];
+  const snapshot = readOperatorCheckSnapshot(tempDir, {
+    now: () => "2026-06-03T08:00:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      calls.push([command, ...args].join(" "));
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && joined === "issue list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number --limit 1000") return "[]";
+      if (command === "gh" && joined === "pr list --state open --json number,url,headRefName --limit 200") return "[]";
+      if (command === "gh" && joined === "pr list --state closed --json number,url,headRefName,state,closedAt --limit 200") {
+        return JSON.stringify([{ number: 1133, headRefName: "pr-1133", state: "MERGED", closedAt: "2026-06-03T07:55:00Z" }]);
+      }
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "config --get remote.origin.url") return "git@github.com:minislively/fooks.git\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "branch -r --format=%(refname:short)") return "origin/main\norigin/pr-1133\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "git" && joined === "diff --shortstat origin/main...HEAD") return "";
+      if (command === "git" && joined === "rev-list --left-right --count origin/main...HEAD") return "0 0\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.verdict, "idleRequiresActiveArtifact");
+  assert.deepEqual(snapshot.activeArtifacts, []);
+  assert.equal(snapshot.requiredActiveArtifact.required, true);
+  assert.equal(snapshot.activity.currentRunEvidence.activeWorkEvidence, false);
+  assert.equal(snapshot.activity.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, true);
+  assert.equal(snapshot.activeWorkReceipts.handoffArtifactEvidence.currentEvidence.liveNonMainWorktreePresent, false);
+  assert.equal(snapshot.activeWorkReceipts.handoffArtifactEvidence.adoptedLiveArtifactPresent, false);
+  assert.equal(snapshot.activeWorkReceipts.cleanIdleNudgeHandoffBoundary.currentEvidence.liveNonMainWorktreePresent, false);
+  assert.equal(snapshot.activeWorkReceipts.cleanIdleNudgeHandoffBoundary.requiresExplicitHandoffArtifactBeforeDevelopmentClaim, true);
+  assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|gh issue create|gh pr create/.test(call)), false);
 });
 
 test("CLI status activity receipt projection matches full active current-run receipt", () => {


### PR DESCRIPTION
## Summary

- Treat clean, zero-divergence current branches already merged into local `origin/main` as stale current-run residue instead of active work evidence.
- Preserve the conservative boundary: dirty or local-ahead branches still report as active/review-worthy.
- Add regression coverage for status/activity and operator-check projections.

## Verification

- `npm run -s typecheck -- --pretty false`
- `node --test test/operator-activity.test.mjs`
- `npm test` (1092/1092)
- `npm run -s status:activity -- --receipt-json`
- `npm run -s check -- --json`
- `npm run -s status:activity -- --include-remote-counts --json`

Resolves #1169