### PR TITLE
Handle upstreamless merged checkout residue

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -48,7 +48,7 @@ export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_ISSUE_URL = "https://gi
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_SOURCE = "operator/activity issue #1073 remote-counts-required next-action cue";
 export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_SOURCE = "local git branch --merged origin/main current-checkout residue evidence";
 export const OPERATOR_ACTIVITY_MERGED_BRANCH_RESIDUE_CLAIM_BOUNDARY =
-  "Read-only local git evidence only: a clean zero-divergence current checkout branch already merged into local origin/main is stale residue and not current active development; dirty or local-ahead state remains active or review-worthy.";
+  "Read-only local git evidence only: a clean current checkout branch already merged into local origin/main is stale residue and not current active development; dirty state remains active or review-worthy.";
 export const OPERATOR_ACTIVITY_REMOTE_COUNTS_NEXT_ACTION_CLAIM_BOUNDARY =
   "Operator-visible status/activity next-action cue only; remote counts remain explicit opt-in, the operator-check JSON boundary remains the source of truth after include-remote-counts, and this cue adds no active-development evidence, authority, telemetry, merge gate, approval, product, or frontend behavior.";
 export const OPERATOR_ACTIVITY_TMUX_CAPTURE_COMMAND = "tmux capture-pane -pt <pane_id> -S -200";
@@ -1559,14 +1559,14 @@ function readMergedBranchResidueEvidence(
       blockers: [],
     };
   }
-  const cleanZeroDivergence = worktree.clean === true && worktree.ahead === 0 && worktree.behind === 0;
-  if (!cleanZeroDivergence) {
+  const cleanMergedResidueCandidate = worktree.clean === true;
+  if (!cleanMergedResidueCandidate) {
     return {
       ...base,
       available: true,
       mergedIntoOriginMain: false,
       suppressesCurrentBranchActiveEvidence: false,
-      reason: "current branch is not clean with zero local divergence; preserve as active or review-worthy evidence",
+      reason: "current branch is not clean; preserve as active or review-worthy evidence",
       blockers: [],
     };
   }
@@ -1581,8 +1581,8 @@ function readMergedBranchResidueEvidence(
       mergedIntoOriginMain,
       suppressesCurrentBranchActiveEvidence: mergedIntoOriginMain,
       reason: mergedIntoOriginMain
-        ? "current clean zero-divergence branch is already merged into local origin/main; treat as stale merged-branch residue, not active development"
-        : "current clean zero-divergence branch is not listed as merged into local origin/main",
+        ? "current clean branch is already merged into local origin/main; treat as stale merged-branch residue, not active development"
+        : "current clean branch is not listed as merged into local origin/main",
       blockers: [],
     };
   } catch (error) {
@@ -1657,10 +1657,10 @@ function buildCurrentRunEvidence(
   }
 
   if (suppressCurrentBranchActiveEvidence) {
-    reasons.push("current branch is clean zero-divergence merged residue and is separated from active current-run evidence");
+    reasons.push("current branch is clean merged residue and is separated from active current-run evidence");
   }
 
-  const mainEchoEvidence = blockers.length === 0 && (onMain || suppressCurrentBranchActiveEvidence) && clean && noLocalDivergence && noSessions && remoteCountsIdle;
+  const mainEchoEvidence = blockers.length === 0 && (onMain || suppressCurrentBranchActiveEvidence) && clean && (noLocalDivergence || suppressCurrentBranchActiveEvidence) && noSessions && remoteCountsIdle;
   const activeWorkEvidence =
     (Boolean(worktree.branch) && worktree.branch !== "main" && !suppressCurrentBranchActiveEvidence && !hasOnlyFooksSessionTaskDelta(worktree)) ||
     (worktree.clean === false && !hasOnlyFooksSessionTaskDelta(worktree)) ||

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -2169,6 +2169,79 @@ test("operator activity treats clean current merged PR checkout branch residue a
   assert.equal(calls.some((call) => /fetch|worktree remove|branch -d|push|gh issue create|gh pr create/.test(call)), false);
 });
 
+test("operator activity treats clean merged checkout branch without upstream as non-active residue", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-06-03T08:01:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") throw new Error("no upstream configured");
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "git" && joined === "branch --merged origin/main") return "main\npr-1133\n";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return "";
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.worktree.upstream, undefined);
+  assert.equal(snapshot.worktree.ahead, undefined);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.available, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.mergedIntoOriginMain, true);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.classification, "mainEchoNonActive");
+  assert.equal(snapshot.currentRunEvidence.mainEchoEvidence, true);
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, false);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt.evidenceKinds, []);
+});
+
+test("operator activity preserves dirty merged checkout branch as active residue review", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-06-03T08:02:00.000Z",
+    runner: () => " M src/index.ts\0",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "pr-1133\n";
+      if (args[0] === "rev-parse") throw new Error("no upstream configured");
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD pr1133head", "branch refs/heads/pr-1133", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "origin-main-sha\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\npr-1133\n";
+      if (command === "git" && joined === "status --porcelain=v1 -z") return " M src/index.ts\0";
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") return "[]";
+      if (command === "gh" && args[0] === "pr") return "[]";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.suppressesCurrentBranchActiveEvidence, false);
+  assert.equal(snapshot.currentRunEvidence.mergedBranchResidueEvidence.reason, "current branch is not clean; preserve as active or review-worthy evidence");
+  assert.equal(snapshot.currentRunEvidence.classification, "activeOrUnknown");
+  assert.equal(snapshot.currentRunEvidence.activeWorkEvidence, true);
+  assert.deepEqual(snapshot.currentRunEvidence.receipt.evidenceKinds, ["branch", "delta"]);
+});
+
 test("operator check does not authorize clean current merged PR checkout residue as live handoff artifact", () => {
   const tempDir = makeTempProject();
   const calls = [];


### PR DESCRIPTION
## Summary

- Relax merged-branch residue suppression to clean current checkout branches already listed as merged into local `origin/main`, even when upstream divergence is unavailable.
- Preserve dirty merged checkout branches as active/review-worthy evidence.
- Add regression coverage for upstreamless clean merged residue and dirty merged residue.

## Verification

- `npm run -s typecheck -- --pretty false`
- `npm run -s build && node --test test/operator-activity.test.mjs`

Follow-up for #1170. Do not merge #1170 from this path; this is a stacked review fix for the PR author/reviewer to incorporate.