### PR TITLE
Surface degraded remote counts for operator activity (#1172)

### DIFF
--- a/src/ops/operator-activity.ts
+++ b/src/ops/operator-activity.ts
@@ -236,7 +236,7 @@ export type OperatorActivityRemoteCountsRequiredNextActionCue = {
   readOnly: true;
   advisoryOnly: true;
   visible: boolean;
-  classification: "remote-counts-required" | "not-required";
+  classification: "remote-counts-required" | "remote-counts-degraded" | "not-required";
   remoteCountsRequired: boolean;
   activeDevelopmentEvidence: false;
   currentEvidenceCue: string;
@@ -724,6 +724,7 @@ function buildCurrentRunReceipt(input: {
   mainEchoEvidence: boolean;
   advisoryPlanningEpicOnly: boolean;
   advisoryPlanningEpicPlusSingleChild: boolean;
+  remoteCountsUnavailable: boolean;
 }): OperatorActivityCurrentRunReceipt {
   const evidenceKinds: OperatorActivityCurrentRunReceipt["evidenceKinds"] = [];
   const activeParts: string[] = [];
@@ -757,6 +758,7 @@ function buildCurrentRunReceipt(input: {
   if (input.worktree.ahead === 0 && input.worktree.behind === 0) idleParts.push("zero divergence");
   if (input.fooksSessionCount === 0) idleParts.push("no mapped fooks sessions");
   if (input.openIssues === 0 && input.openPullRequests === 0) idleParts.push("zero open issues/PRs");
+  if (input.remoteCountsUnavailable) idleParts.push("remote issue/PR counts unavailable; remote idle unproven");
   if (input.advisoryPlanningEpicOnly) idleParts.push("only planning epic #960 is open");
   if (input.advisoryPlanningEpicPlusSingleChild) idleParts.push("planning epic #960 plus one idle child issue only");
   if (input.worktree.clean === false && hasOnlyFooksSessionTaskDelta(input.worktree)) {
@@ -1588,6 +1590,7 @@ function buildCurrentRunEvidence(
     mainEchoEvidence,
     advisoryPlanningEpicOnly,
     advisoryPlanningEpicPlusSingleChild,
+    remoteCountsUnavailable: optionalCounts.enabled && !remoteCountsAvailable,
   });
 
   return {
@@ -1625,15 +1628,26 @@ function buildRemoteCountsRequiredNextActionCue(
     && currentRunEvidence.evidence.ahead === 0
     && currentRunEvidence.evidence.behind === 0
     && currentRunEvidence.evidence.fooksSessionCount === 0;
-  const remoteCountsRequired = !optionalCounts.enabled && locallyIdleMain;
-  const currentEvidenceCue = remoteCountsRequired
+  const remoteCountsUnavailable = optionalCounts.enabled
+    && (optionalCounts.openIssues === undefined || optionalCounts.openPullRequests === undefined);
+  const remoteCountsRequired = locallyIdleMain && (!optionalCounts.enabled || remoteCountsUnavailable);
+  const currentEvidenceCue = !optionalCounts.enabled && remoteCountsRequired
     ? "local snapshot is clean main with zero divergence and no mapped fooks session; remote issue/PR counts are disabled, so remote idle state is unproven"
-    : optionalCounts.enabled
-      ? "remote issue/PR counts were explicitly requested; use operator-check-derived status cues for next-child evidence"
-      : "local active or unknown evidence means remote-counts-required idle guidance is not the current cue";
-  const nextAction = remoteCountsRequired
+    : remoteCountsUnavailable
+      ? remoteCountsRequired
+        ? `local snapshot is clean main with zero divergence and no mapped fooks session; remote issue/PR counts were requested but are unavailable (${optionalCounts.blockers.join("; ") || "no remote count detail"}), so remote idle state is unproven`
+        : `remote issue/PR counts were requested but are unavailable (${optionalCounts.blockers.join("; ") || "no remote count detail"}); local active or unknown evidence means degraded idle guidance is not the current cue`
+      : optionalCounts.enabled
+        ? "remote issue/PR counts were explicitly requested and resolved; use operator-check-derived status cues for next-child evidence"
+        : "local active or unknown evidence means remote-counts-required idle guidance is not the current cue";
+  const nextAction = !optionalCounts.enabled && remoteCountsRequired
     ? "Run fooks status activity --include-remote-counts --json or fooks check --json before treating the remote idle state as proven; concrete child issue/PR/branch/session/worktree-process/blocker evidence remains the active-work path. If source-of-truth remote counts are zero, clean main with zero divergence and no mapped fooks session is reported as clean idle without historical issue-specific closeout wording."
-    : "No default remote-counts-required next action is visible for this snapshot.";
+    : remoteCountsUnavailable && remoteCountsRequired
+      ? "Do not treat this idle receipt as proven remote idle: GitHub issue/PR counts were requested but degraded. Retry after GitHub API rate limit/auth availability recovers, or use concrete child issue/PR/branch/session/worktree-process/blocker evidence before starting active work."
+      : "No default remote-counts-required next action is visible for this snapshot.";
+  const classification = remoteCountsRequired
+    ? (remoteCountsUnavailable ? "remote-counts-degraded" : "remote-counts-required")
+    : "not-required";
 
   return {
     schemaVersion: OPERATOR_ACTIVITY_SCHEMA_VERSION,
@@ -1644,7 +1658,7 @@ function buildRemoteCountsRequiredNextActionCue(
     readOnly: true,
     advisoryOnly: true,
     visible: remoteCountsRequired,
-    classification: remoteCountsRequired ? "remote-counts-required" : "not-required",
+    classification,
     remoteCountsRequired,
     activeDevelopmentEvidence: false,
     currentEvidenceCue,

--- a/test/operator-activity.test.mjs
+++ b/test/operator-activity.test.mjs
@@ -1507,6 +1507,56 @@ test("operator activity marks clean current main with zero counts and no session
   assert.deepEqual(snapshot.currentRunEvidence.blockers, []);
 });
 
+test("operator activity surfaces degraded opt-in remote counts for locally idle main", () => {
+  const tempDir = makeTempProject();
+  const snapshot = readOperatorActivitySnapshot(tempDir, {
+    includeRemoteCounts: true,
+    now: () => "2026-05-27T14:10:00.000Z",
+    runner: () => "",
+    gitRunner: (_cwd, args) => {
+      if (args[0] === "symbolic-ref") return "main\n";
+      if (args[0] === "rev-parse") return "origin/main\n";
+      if (args[0] === "rev-list") return "0\t0\n";
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    },
+    commandRunner: (command, args) => {
+      const joined = args.join(" ");
+      if (command === "tmux") return "";
+      if (command === "gh" && args[0] === "issue") throw new Error("API rate limit exceeded for user");
+      if (command === "gh" && args[0] === "pr") throw new Error("API rate limit exceeded for user");
+      if (command === "gh" && args[0] === "run") return "[]";
+      if (command === "git" && joined === "worktree list --porcelain") {
+        return [`worktree ${tempDir}`, "HEAD degraded-main-head", "branch refs/heads/main", ""].join("\n");
+      }
+      if (command === "git" && joined === "rev-parse --verify origin/main") return "degraded-main-head\n";
+      if (command === "git" && joined === "branch --format=%(refname:short)") return "main\n";
+      if (command === "git" && joined === "branch --merged origin/main") return "main\n";
+      throw new Error(`unexpected command ${command} ${joined}`);
+    },
+    pathExists: (targetPath) => targetPath === tempDir,
+  });
+
+  assert.equal(snapshot.optionalCounts.enabled, true);
+  assert.equal(snapshot.optionalCounts.openIssues, undefined);
+  assert.equal(snapshot.optionalCounts.openPullRequests, undefined);
+  assert.match(snapshot.optionalCounts.blockers.join("\n"), /rate limit exceeded/);
+  assert.equal(snapshot.currentRunEvidence.available, false);
+  assert.equal(snapshot.currentRunEvidence.receipt.status, "idle");
+  assert.match(snapshot.currentRunEvidence.receipt.oneLine, /remote issue\/PR counts unavailable; remote idle unproven/);
+  assert.match(snapshot.currentRunEvidence.blockers.join("\n"), /remote issue\/PR counts unavailable/);
+
+  const cue = snapshot.operatorStatusCues.remoteCountsRequiredNextAction;
+  assert.equal(cue.visible, true);
+  assert.equal(cue.classification, "remote-counts-degraded");
+  assert.equal(cue.remoteCountsRequired, true);
+  assert.match(cue.currentEvidenceCue, /remote issue\/PR counts were requested but are unavailable/);
+  assert.match(cue.currentEvidenceCue, /rate limit exceeded/);
+  assert.match(cue.currentEvidenceCue, /remote idle state is unproven/);
+  assert.match(cue.nextAction, /Do not treat this idle receipt as proven remote idle/);
+  assert.match(cue.nextAction, /Retry after GitHub API rate limit\/auth availability recovers/);
+  assert.match(cue.oneLine, /Remote counts required/);
+});
+
 test("operator activity current-run receipt names dirty delta as active dogfood evidence", () => {
   const tempDir = makeTempProject();
   const snapshot = readOperatorActivitySnapshot(tempDir, {


### PR DESCRIPTION
## Summary
- distinguish unavailable opt-in remote counts from proven clean idle state
- surface degraded remote-count guidance without marking active development evidence
- add regression coverage for degraded remote counts and clean zero-count behavior

## Verification
- npm run build
- node --test --test-reporter=spec test/operator-activity.test.mjs

Fixes #1172